### PR TITLE
fix(cli): delete sidecar files after upload if requested

### DIFF
--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -7,7 +7,15 @@ import { describe, expect, it, MockedFunction, vi } from 'vitest';
 import { Action, checkBulkUpload, defaults, getSupportedMediaTypes, Reason } from '@immich/sdk';
 import createFetchMock from 'vitest-fetch-mock';
 
-import { checkForDuplicates, deleteFiles, findSidecar, getAlbumName, startWatch, uploadFiles, UploadOptionsDto } from 'src/commands/asset';
+import {
+  checkForDuplicates,
+  deleteFiles,
+  findSidecar,
+  getAlbumName,
+  startWatch,
+  uploadFiles,
+  UploadOptionsDto,
+} from 'src/commands/asset';
 
 vi.mock('@immich/sdk');
 

--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -359,9 +359,9 @@ describe('findSidecar', () => {
     expect(result).toBe(sidecarPath1);
   });
 
-  it('should return null when no sidecar file exists', async () => {
+  it('should return undefined when no sidecar file exists', async () => {
     const result = await findSidecar(testFilePath);
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
   });
 });
 

--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -332,35 +332,35 @@ describe('findSidecar', () => {
     fs.rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('should find sidecar file with photo.xmp naming convention', async () => {
+  it('should find sidecar file with photo.xmp naming convention', () => {
     const sidecarPath = path.join(testDir, 'test.xmp');
     fs.writeFileSync(sidecarPath, 'xmp data');
 
-    const result = await findSidecar(testFilePath);
+    const result = findSidecar(testFilePath);
     expect(result).toBe(sidecarPath);
   });
 
-  it('should find sidecar file with photo.ext.xmp naming convention', async () => {
+  it('should find sidecar file with photo.ext.xmp naming convention', () => {
     const sidecarPath = path.join(testDir, 'test.jpg.xmp');
     fs.writeFileSync(sidecarPath, 'xmp data');
 
-    const result = await findSidecar(testFilePath);
+    const result = findSidecar(testFilePath);
     expect(result).toBe(sidecarPath);
   });
 
-  it('should prefer photo.ext.xmp over photo.xmp when both exist', async () => {
+  it('should prefer photo.ext.xmp over photo.xmp when both exist', () => {
     const sidecarPath1 = path.join(testDir, 'test.xmp');
     const sidecarPath2 = path.join(testDir, 'test.jpg.xmp');
     fs.writeFileSync(sidecarPath1, 'xmp data 1');
     fs.writeFileSync(sidecarPath2, 'xmp data 2');
 
-    const result = await findSidecar(testFilePath);
+    const result = findSidecar(testFilePath);
     // Should return the first one found (photo.xmp) based on the order in the code
     expect(result).toBe(sidecarPath1);
   });
 
-  it('should return undefined when no sidecar file exists', async () => {
-    const result = await findSidecar(testFilePath);
+  it('should return undefined when no sidecar file exists', () => {
+    const result = findSidecar(testFilePath);
     expect(result).toBeUndefined();
   });
 });

--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it, MockedFunction, vi } from 'vitest';
 import { Action, checkBulkUpload, defaults, getSupportedMediaTypes, Reason } from '@immich/sdk';
 import createFetchMock from 'vitest-fetch-mock';
 
-import { checkForDuplicates, getAlbumName, startWatch, uploadFiles, UploadOptionsDto } from 'src/commands/asset';
+import { checkForDuplicates, deleteFiles, findSidecar, getAlbumName, startWatch, uploadFiles, UploadOptionsDto } from 'src/commands/asset';
 
 vi.mock('@immich/sdk');
 
@@ -307,5 +307,87 @@ describe('startWatch', () => {
 
   afterEach(async () => {
     await fs.promises.rm(testFolder, { recursive: true, force: true });
+  });
+});
+
+describe('findSidecar', () => {
+  let testDir: string;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-sidecar-'));
+    testFilePath = path.join(testDir, 'test.jpg');
+    fs.writeFileSync(testFilePath, 'test');
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should find sidecar file with photo.xmp naming convention', async () => {
+    const sidecarPath = path.join(testDir, 'test.xmp');
+    fs.writeFileSync(sidecarPath, 'xmp data');
+
+    const result = await findSidecar(testFilePath);
+    expect(result).toBe(sidecarPath);
+  });
+
+  it('should find sidecar file with photo.ext.xmp naming convention', async () => {
+    const sidecarPath = path.join(testDir, 'test.jpg.xmp');
+    fs.writeFileSync(sidecarPath, 'xmp data');
+
+    const result = await findSidecar(testFilePath);
+    expect(result).toBe(sidecarPath);
+  });
+
+  it('should prefer photo.ext.xmp over photo.xmp when both exist', async () => {
+    const sidecarPath1 = path.join(testDir, 'test.xmp');
+    const sidecarPath2 = path.join(testDir, 'test.jpg.xmp');
+    fs.writeFileSync(sidecarPath1, 'xmp data 1');
+    fs.writeFileSync(sidecarPath2, 'xmp data 2');
+
+    const result = await findSidecar(testFilePath);
+    // Should return the first one found (photo.xmp) based on the order in the code
+    expect(result).toBe(sidecarPath1);
+  });
+
+  it('should return null when no sidecar file exists', async () => {
+    const result = await findSidecar(testFilePath);
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteFiles', () => {
+  let testDir: string;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-delete-'));
+    testFilePath = path.join(testDir, 'test.jpg');
+    fs.writeFileSync(testFilePath, 'test');
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should delete asset and sidecar file when main file is deleted', async () => {
+    const sidecarPath = path.join(testDir, 'test.xmp');
+    fs.writeFileSync(sidecarPath, 'xmp data');
+
+    await deleteFiles([{ id: 'test-id', filepath: testFilePath }], [], { delete: true, concurrency: 1 });
+
+    expect(fs.existsSync(testFilePath)).toBe(false);
+    expect(fs.existsSync(sidecarPath)).toBe(false);
+  });
+
+  it('should not delete sidecar file when delete option is false', async () => {
+    const sidecarPath = path.join(testDir, 'test.xmp');
+    fs.writeFileSync(sidecarPath, 'xmp data');
+
+    await deleteFiles([{ id: 'test-id', filepath: testFilePath }], [], { delete: false, concurrency: 1 });
+
+    expect(fs.existsSync(testFilePath)).toBe(true);
+    expect(fs.existsSync(sidecarPath)).toBe(true);
   });
 });

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -446,7 +446,7 @@ const uploadFile = async (input: string, stats: Stats): Promise<AssetMediaRespon
   return response.json();
 };
 
-export const findSidecar = async (filepath: string): Promise<string | null> => {
+export const findSidecar = async (filepath: string): Promise<string | undefined> => {
   const assetPath = path.parse(filepath);
   const noExtension = path.join(assetPath.dir, assetPath.name);
 
@@ -456,7 +456,7 @@ export const findSidecar = async (filepath: string): Promise<string | null> => {
       return sidecarPath;
     }
   }
-  return null;
+  return undefined;
 };
 
 export const deleteFiles = async (uploaded: Asset[], duplicates: Asset[], options: UploadOptionsDto): Promise<void> => {


### PR DESCRIPTION
Introduced a new function, findSidecar, to locate XMP sidecar files based on specified naming conventions. Updated the deleteFiles function to delete associated sidecar files when the main asset file is deleted. Added unit tests for findSidecar to ensure correct functionality.

side note: error handling could be improved overall, like in https://github.com/timonrieger/immichpy/blob/main/immichpy/client/utils/upload.py#L415
