### PR TITLE
fix(web): single select scroll behavior

### DIFF
--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -419,11 +419,6 @@
     }
     onSelect(asset);
 
-    if (singleSelect) {
-      timelineManager.scrollTo(0);
-      return;
-    }
-
     const rangeSelection = assetInteraction.assetSelectionCandidates.length > 0;
     const deselect = assetInteraction.hasSelectedAsset(asset.id);
 


### PR DESCRIPTION
Removes the automatic scroll-to-top behavior when selecting assets in singleSelect mode.

### Problem:
When selecting an album cover or a person's featured photo, the timeline scrolled to the top after selection, interrupting browsing.
### Solution:
Removed the automatic scrollTo(0) call in Timeline.svelte when singleSelect is enabled. Users can now continue browsing from their current position after selecting.
### Affected features:
- Album cover selection (SELECT_THUMBNAIL mode)
- Person featured photo selection (SELECT_PERSON mode)

Both use singleSelect={true} to allow selecting a single representative image.
