### PR TITLE
feat(web): set featured photo from selection

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/set-person-featured-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/set-person-featured-action.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { AssetAction } from '$lib/constants';
-  import { getAssetControlContext } from '$lib/utils/context';
   import { handleError } from '$lib/utils/handle-error';
   import { updatePerson, type AssetResponseDto, type PersonResponseDto } from '@immich/sdk';
   import { toastManager } from '@immich/ui';
@@ -10,50 +9,27 @@
   import type { OnAction } from './action';
 
   interface Props {
-    asset?: AssetResponseDto;
+    asset: AssetResponseDto;
     person: PersonResponseDto;
     onAction?: OnAction;
-    menuItem?: boolean;
-    onPersonUpdate?: (person: PersonResponseDto) => void;
   }
 
-  let { asset, person = $bindable(), onAction, menuItem = false, onPersonUpdate }: Props = $props();
+  let { asset, person, onAction }: Props = $props();
 
   const handleSelectFeaturePhoto = async () => {
-    let assetId: string;
-
-    if (menuItem) {
-      const { getAssets, clearSelect } = getAssetControlContext();
-      const assets = getAssets();
-      if (assets.length !== 1) {
-        return;
-      }
-      assetId = assets[0].id;
-      clearSelect();
-    } else {
-      if (!asset) {
-        return;
-      }
-      assetId = asset.id;
-    }
-
     try {
       const updatedPerson = await updatePerson({
         id: person.id,
-        personUpdateDto: { featureFaceAssetId: assetId },
+        personUpdateDto: { featureFaceAssetId: asset.id },
       });
 
-      const mergedPerson = { ...person, ...updatedPerson };
-      person = mergedPerson;
-      onPersonUpdate?.(mergedPerson);
+      person = { ...person, ...updatedPerson };
 
-      if (!menuItem && asset) {
-        onAction?.({
-          type: AssetAction.SET_PERSON_FEATURED_PHOTO,
-          asset,
-          person: mergedPerson,
-        });
-      }
+      onAction?.({
+        type: AssetAction.SET_PERSON_FEATURED_PHOTO,
+        asset,
+        person,
+      });
 
       toastManager.success($t('feature_photo_updated'));
     } catch (error) {

--- a/web/src/lib/components/asset-viewer/actions/set-person-featured-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/set-person-featured-action.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { AssetAction } from '$lib/constants';
+  import { getAssetControlContext } from '$lib/utils/context';
   import { handleError } from '$lib/utils/handle-error';
   import { updatePerson, type AssetResponseDto, type PersonResponseDto } from '@immich/sdk';
   import { toastManager } from '@immich/ui';
@@ -9,27 +10,50 @@
   import type { OnAction } from './action';
 
   interface Props {
-    asset: AssetResponseDto;
+    asset?: AssetResponseDto;
     person: PersonResponseDto;
     onAction?: OnAction;
+    menuItem?: boolean;
+    onPersonUpdate?: (person: PersonResponseDto) => void;
   }
 
-  let { asset, person, onAction }: Props = $props();
+  let { asset, person = $bindable(), onAction, menuItem = false, onPersonUpdate }: Props = $props();
 
   const handleSelectFeaturePhoto = async () => {
+    let assetId: string;
+
+    if (menuItem) {
+      const { getAssets, clearSelect } = getAssetControlContext();
+      const assets = getAssets();
+      if (assets.length !== 1) {
+        return;
+      }
+      assetId = assets[0].id;
+      clearSelect();
+    } else {
+      if (!asset) {
+        return;
+      }
+      assetId = asset.id;
+    }
+
     try {
       const updatedPerson = await updatePerson({
         id: person.id,
-        personUpdateDto: { featureFaceAssetId: asset.id },
+        personUpdateDto: { featureFaceAssetId: assetId },
       });
 
-      person = { ...person, ...updatedPerson };
+      const mergedPerson = { ...person, ...updatedPerson };
+      person = mergedPerson;
+      onPersonUpdate?.(mergedPerson);
 
-      onAction?.({
-        type: AssetAction.SET_PERSON_FEATURED_PHOTO,
-        asset,
-        person,
-      });
+      if (!menuItem && asset) {
+        onAction?.({
+          type: AssetAction.SET_PERSON_FEATURED_PHOTO,
+          asset,
+          person: mergedPerson,
+        });
+      }
 
       toastManager.success($t('feature_photo_updated'));
     } catch (error) {

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -25,7 +25,6 @@
   import SetVisibilityAction from '$lib/components/timeline/actions/SetVisibilityAction.svelte';
   import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
-  import SetFeaturedPhotoAction from '$lib/components/asset-viewer/actions/set-person-featured-action.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { PersonPageViewMode, QueryParameter, SessionStorageKey } from '$lib/constants';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
@@ -42,7 +41,13 @@
   import { isExternalUrl } from '$lib/utils/navigation';
   import { AssetVisibility, searchPerson, updatePerson, type PersonResponseDto } from '@immich/sdk';
   import { ContextMenuButton, LoadingSpinner, modalManager, toastManager, type ActionItem } from '@immich/ui';
-  import { mdiAccountBoxOutline, mdiAccountMultipleCheckOutline, mdiArrowLeft, mdiDotsVertical } from '@mdi/js';
+  import {
+    mdiAccountBoxOutline,
+    mdiAccountMultipleCheckOutline,
+    mdiArrowLeft,
+    mdiDotsVertical,
+    mdiFaceManProfile,
+  } from '@mdi/js';
   import { DateTime } from 'luxon';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
@@ -150,6 +155,19 @@
     assetInteraction.clearMultiselect();
 
     viewMode = PersonPageViewMode.VIEW_ASSETS;
+  };
+
+  const updateFeaturedPhotoUsingCurrentSelection = async () => {
+    if (assetInteraction.selectedAssets.length === 1) {
+      const [firstAsset] = assetInteraction.selectedAssets;
+      try {
+        person = await updatePerson({ id: person.id, personUpdateDto: { featureFaceAssetId: firstAsset.id } });
+        toastManager.success($t('feature_photo_updated'));
+        assetInteraction.clearMultiselect();
+      } catch (error) {
+        handleError(error, $t('errors.unable_to_set_feature_photo'));
+      }
+    }
   };
 
   const handleMergeSuggestion = async (): Promise<{ merged: boolean }> => {
@@ -474,12 +492,10 @@
         <ChangeDescription menuItem />
         <ChangeLocation menuItem />
         {#if assetInteraction.selectedAssets.length === 1}
-          <SetFeaturedPhotoAction
-            {person}
-            menuItem
-            onPersonUpdate={(updatedPerson) => {
-              data = { ...data, person: updatedPerson };
-            }}
+          <MenuOption
+            text={$t('set_as_featured_photo')}
+            icon={mdiFaceManProfile}
+            onClick={() => updateFeaturedPhotoUsingCurrentSelection()}
           />
         {/if}
         <ArchiveAction

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -25,6 +25,7 @@
   import SetVisibilityAction from '$lib/components/timeline/actions/SetVisibilityAction.svelte';
   import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
+  import SetFeaturedPhotoAction from '$lib/components/asset-viewer/actions/set-person-featured-action.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { PersonPageViewMode, QueryParameter, SessionStorageKey } from '$lib/constants';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
@@ -472,6 +473,15 @@
         <ChangeDate menuItem />
         <ChangeDescription menuItem />
         <ChangeLocation menuItem />
+        {#if assetInteraction.selectedAssets.length === 1}
+          <SetFeaturedPhotoAction
+            {person}
+            menuItem
+            onPersonUpdate={(updatedPerson) => {
+              data = { ...data, person: updatedPerson };
+            }}
+          />
+        {/if}
         <ArchiveAction
           menuItem
           unarchive={assetInteraction.isAllArchived}


### PR DESCRIPTION
**Add "Set Featured Photo" to timeline selection menu**

Shows "Set Featured Photo" when exactly one image is selected in the timeline, matching album cover behaviour.

Album cover and featured photo can both be set in three ways (navbar when viewing an asset, selection menu with one asset selected, and dedicated selection mode from page options).

opinion: we could consider reducing the number of ways to do these actions. This PR is not concerned by that, it matches features instead.

<details><summary>Screen Recording</summary>
<p>
The recording below shows those three ways, the first one shown is the one added in this PR

https://github.com/user-attachments/assets/a5d7ae54-4e26-4eed-b5ec-b41c5acce5b3



</p>
</details> 
