### PR TITLE
fix(mobile): don't pop when opening albums

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
@@ -60,8 +60,7 @@ class AppearsInDetails extends ConsumerWidget {
                       album: album,
                       isOwner: isOwner,
                       onAlbumSelected: (album) async {
-                        ref.invalidate(assetViewerProvider);
-                        unawaited(context.router.popAndPush(RemoteAlbumRoute(album: album)));
+                        unawaited(context.router.push(RemoteAlbumRoute(album: album)));
                       },
                     );
                   }).toList(),


### PR DESCRIPTION
## Description

The asset viewer closes when opening an album from the asset details. This doesn't seem desirable, and it likely a side-effect from the previous pop behaviour which would close just the bottom sheet, and not the asset viewer.

## How Has This Been Tested?

Pixel 8a.