### PR TITLE
Fix/docker db env

### DIFF
--- a/docker/docker-compose.rootless.yml
+++ b/docker/docker-compose.rootless.yml
@@ -92,6 +92,8 @@ services:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     shm_size: 128mb
+    env_file:
+      - .env
     restart: always
     healthcheck:
       disable: false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,6 +57,8 @@ services:
   database:
     container_name: immich_postgres
     image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    env_file:
+      - .env
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
## Description
this pr fixes the missing import of the .env file for the database service/container which seems to be missing in [docker/docker-compose.yml ](https://github.com/immich-app/immich/blob/01050a3d54084fb8eed585ec9188061c3be4006d/docker/docker-compose.yml) and  [docker/docker-compose.rootless.yml](https://github.com/immich-app/immich/blob/01050a3d54084fb8eed585ec9188061c3be4006d/docker/docker-compose.rootless.yml). Interestingly in the other two docker compose files, namely [docker/docker-compose.dev.yml](https://github.com/immich-app/immich/blob/01050a3d54084fb8eed585ec9188061c3be4006d/docker/docker-compose.dev.yml) and [docker/docker-compose.prod.yml](https://github.com/immich-app/immich/blob/01050a3d54084fb8eed585ec9188061c3be4006d/docker/docker-compose.prod.yml), it is correct. 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #26374

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A
did a fresh install (following the [quick install guide](https://docs.immich.app/overview/quick-start/)) and adding the changes from this PR to the docker-compose.yml so that the values i set in .env are actually being populated to the container and it won't try to authenticate with default values.
result: it works


<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
none
