### PR TITLE
refactor: thumbnail components

### DIFF
--- a/e2e/src/specs/web/shared-link.e2e-spec.ts
+++ b/e2e/src/specs/web/shared-link.e2e-spec.ts
@@ -45,8 +45,7 @@ test.describe('Shared Links', () => {
     await page.goto(`/share/${sharedLink.key}`);
     await page.getByRole('heading', { name: 'Test Album' }).waitFor();
     await page.locator(`[data-asset-id="${asset.id}"]`).hover();
-    await page.waitForSelector('[data-group] svg');
-    await page.getByRole('checkbox').click();
+    await page.waitForSelector(`[data-asset-id="${asset.id}"] [role="checkbox"]`);
     await Promise.all([page.waitForEvent('download'), page.getByRole('button', { name: 'Download' }).click()]);
   });
 

--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -438,7 +438,7 @@ test.describe('Timeline', () => {
       const asset = getAsset(timelineRestData, album.assetIds[0])!;
       await pageUtils.goToAsset(page, asset.fileCreatedAt);
       await thumbnailUtils.expectInViewport(page, asset.id);
-      await thumbnailUtils.expectSelectedReadonly(page, asset.id);
+      await thumbnailUtils.expectSelectedDisabled(page, asset.id);
     });
     test('Add photos to album', async ({ page }) => {
       const album = timelineRestData.album;
@@ -447,7 +447,7 @@ test.describe('Timeline', () => {
       const asset = getAsset(timelineRestData, album.assetIds[0])!;
       await pageUtils.goToAsset(page, asset.fileCreatedAt);
       await thumbnailUtils.expectInViewport(page, asset.id);
-      await thumbnailUtils.expectSelectedReadonly(page, asset.id);
+      await thumbnailUtils.expectSelectedDisabled(page, asset.id);
       await pageUtils.selectDay(page, 'Tue, Feb 27, 2024');
       const put = pageRoutePromise(page, `**/api/albums/${album.id}/assets`, async (route, request) => {
         const requestJson = request.postDataJSON();

--- a/e2e/src/ui/specs/timeline/utils.ts
+++ b/e2e/src/ui/specs/timeline/utils.ts
@@ -102,9 +102,9 @@ export const thumbnailUtils = {
   async expectThumbnailIsNotArchive(page: Page, assetId: string) {
     await expect(thumbnailUtils.withAssetId(page, assetId).locator('[data-icon-archive]')).toHaveCount(0);
   },
-  async expectSelectedReadonly(page: Page, assetId: string) {
+  async expectSelectedDisabled(page: Page, assetId: string) {
     await expect(
-      page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"][data-selected]`),
+      page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"][data-selected][data-disabled]`),
     ).toBeVisible();
   },
   async expectTimelineHasOnScreenAssets(page: Page) {

--- a/web/src/lib/components/Image.spec.ts
+++ b/web/src/lib/components/Image.spec.ts
@@ -1,0 +1,87 @@
+import Image from '$lib/components/Image.svelte';
+import { cancelImageUrl } from '$lib/utils/sw-messaging';
+import { fireEvent, render } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/sw-messaging', () => ({
+  cancelImageUrl: vi.fn(),
+}));
+
+describe('Image component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an img element when src is provided', () => {
+    const { baseElement } = render(Image, { src: '/test.jpg', alt: 'test' });
+    const img = baseElement.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('/test.jpg');
+  });
+
+  it('does not render an img element when src is undefined', () => {
+    const { baseElement } = render(Image, { src: undefined });
+    const img = baseElement.querySelector('img');
+    expect(img).toBeNull();
+  });
+
+  it('calls onStart when src is set', () => {
+    const onStart = vi.fn();
+    render(Image, { src: '/test.jpg', onStart });
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it('calls onLoad when image loads', async () => {
+    const onLoad = vi.fn();
+    const { baseElement } = render(Image, { src: '/test.jpg', onLoad });
+    const img = baseElement.querySelector('img')!;
+    await fireEvent.load(img);
+    expect(onLoad).toHaveBeenCalledOnce();
+  });
+
+  it('calls onError when image fails to load', async () => {
+    const onError = vi.fn();
+    const { baseElement } = render(Image, { src: '/test.jpg', onError });
+    const img = baseElement.querySelector('img')!;
+    await fireEvent.error(img);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onError.mock.calls[0][0].message).toBe('Failed to load image: /test.jpg');
+  });
+
+  it('calls cancelImageUrl on unmount', () => {
+    const { unmount } = render(Image, { src: '/test.jpg' });
+    expect(cancelImageUrl).not.toHaveBeenCalled();
+    unmount();
+    expect(cancelImageUrl).toHaveBeenCalledWith('/test.jpg');
+  });
+
+  it('does not call onLoad after unmount', async () => {
+    const onLoad = vi.fn();
+    const { baseElement, unmount } = render(Image, { src: '/test.jpg', onLoad });
+    const img = baseElement.querySelector('img')!;
+    unmount();
+    await fireEvent.load(img);
+    expect(onLoad).not.toHaveBeenCalled();
+  });
+
+  it('does not call onError after unmount', async () => {
+    const onError = vi.fn();
+    const { baseElement, unmount } = render(Image, { src: '/test.jpg', onError });
+    const img = baseElement.querySelector('img')!;
+    unmount();
+    await fireEvent.error(img);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('passes through additional HTML attributes', () => {
+    const { baseElement } = render(Image, {
+      src: '/test.jpg',
+      alt: 'test alt',
+      class: 'my-class',
+      draggable: false,
+    });
+    const img = baseElement.querySelector('img')!;
+    expect(img.getAttribute('alt')).toBe('test alt');
+    expect(img.getAttribute('draggable')).toBe('false');
+  });
+});

--- a/web/src/lib/components/Image.svelte
+++ b/web/src/lib/components/Image.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { imageManager } from '$lib/managers/ImageManager.svelte';
+  import { onDestroy, untrack } from 'svelte';
+  import type { HTMLImgAttributes } from 'svelte/elements';
+
+  type Props = Omit<HTMLImgAttributes, 'onload' | 'onerror'> & {
+    src: string | undefined;
+    onStart?: () => void;
+    onLoad?: () => void;
+    onError?: (error: Error) => void;
+    ref?: HTMLImageElement;
+  };
+
+  let { src, onStart, onLoad, onError, ref = $bindable(), ...rest }: Props = $props();
+
+  let capturedSource: string | undefined = $state();
+  let destroyed = false;
+
+  $effect(() => {
+    if (src !== undefined && capturedSource === undefined) {
+      capturedSource = src;
+      untrack(() => {
+        onStart?.();
+      });
+    }
+  });
+
+  onDestroy(() => {
+    destroyed = true;
+    if (capturedSource !== undefined) {
+      imageManager.cancelPreloadUrl(capturedSource);
+    }
+  });
+
+  const handleLoad = () => {
+    if (destroyed || !src) {
+      return;
+    }
+    onLoad?.();
+  };
+
+  const handleError = () => {
+    if (destroyed || !src) {
+      return;
+    }
+    onError?.(new Error(`Failed to load image: ${src}`));
+  };
+</script>
+
+{#if capturedSource}
+  {#key capturedSource}
+    <img bind:this={ref} src={capturedSource} {...rest} onload={handleLoad} onerror={handleError} />
+  {/key}
+{/if}

--- a/web/src/lib/components/assets/broken-asset.svelte
+++ b/web/src/lib/components/assets/broken-asset.svelte
@@ -2,9 +2,10 @@
   import { Icon } from '@immich/ui';
   import { mdiImageBrokenVariant } from '@mdi/js';
   import { t } from 'svelte-i18n';
+  import type { ClassValue } from 'svelte/elements';
 
   interface Props {
-    class?: string;
+    class?: ClassValue;
     hideMessage?: boolean;
     width?: string | undefined;
     height?: string | undefined;
@@ -14,7 +15,10 @@
 </script>
 
 <div
-  class="flex flex-col overflow-hidden max-h-full max-w-full justify-center items-center bg-gray-100/40 dark:bg-gray-700/40 dark:text-gray-100 p-4 {className}"
+  class={[
+    'flex flex-col overflow-hidden max-h-full max-w-full justify-center items-center bg-gray-100/40 dark:bg-gray-700/40 dark:text-gray-100 p-4',
+    className,
+  ]}
   style:width
   style:height
 >

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.spec.ts
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.spec.ts
@@ -1,0 +1,89 @@
+import ImageThumbnail from '$lib/components/assets/thumbnail/image-thumbnail.svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+
+vi.mock('$lib/utils/sw-messaging', () => ({
+  cancelImageUrl: vi.fn(),
+}));
+
+describe('ImageThumbnail component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an img element with correct attributes', () => {
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+    });
+    const img = baseElement.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('/test-thumbnail.jpg');
+    expect(img!.getAttribute('alt')).toBe('');
+  });
+
+  it('shows BrokenAsset on error', async () => {
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+    });
+    const img = baseElement.querySelector('img')!;
+    await fireEvent.error(img);
+
+    expect(baseElement.querySelector('img')).toBeNull();
+    expect(baseElement.querySelector('span')?.textContent).toEqual('error_loading_image');
+  });
+
+  it('calls onComplete with false on successful load', async () => {
+    const onComplete = vi.fn();
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+      onComplete,
+    });
+    const img = baseElement.querySelector('img')!;
+    await fireEvent.load(img);
+    expect(onComplete).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onComplete with true on error', async () => {
+    const onComplete = vi.fn();
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+      onComplete,
+    });
+    const img = baseElement.querySelector('img')!;
+    await fireEvent.error(img);
+    expect(onComplete).toHaveBeenCalledWith(true);
+  });
+
+  it('applies hidden styles when hidden is true', () => {
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+      hidden: true,
+    });
+    const img = baseElement.querySelector('img')!;
+    const style = img.getAttribute('style') ?? '';
+    expect(style).toContain('grayscale');
+    expect(style).toContain('opacity');
+  });
+
+  it('sets alt text after loading', async () => {
+    const { baseElement } = render(ImageThumbnail, {
+      url: '/test-thumbnail.jpg',
+      altText: 'Test image',
+      widthStyle: '200px',
+    });
+    const img = baseElement.querySelector('img')!;
+    expect(img.getAttribute('alt')).toBe('');
+
+    await fireEvent.load(img);
+    expect(img.getAttribute('alt')).toBe('Test image');
+  });
+});

--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -2,6 +2,7 @@
   import { Icon, LoadingSpinner } from '@immich/ui';
   import { mdiAlertCircleOutline, mdiPauseCircleOutline, mdiPlayCircleOutline } from '@mdi/js';
   import { Duration } from 'luxon';
+  import type { ClassValue } from 'svelte/elements';
 
   interface Props {
     url: string;
@@ -12,6 +13,7 @@
     curve?: boolean;
     playIcon?: string;
     pauseIcon?: string;
+    class?: ClassValue;
   }
 
   let {
@@ -23,6 +25,7 @@
     curve = false,
     playIcon = mdiPlayCircleOutline,
     pauseIcon = mdiPauseCircleOutline,
+    class: className = undefined,
   }: Props = $props();
 
   let remainingSeconds = $state(durationInSeconds);
@@ -57,7 +60,7 @@
 {#if enablePlayback}
   <video
     bind:this={player}
-    class="h-full w-full object-cover"
+    class={['h-full w-full object-cover', className]}
     class:rounded-xl={curve}
     muted
     autoplay


### PR DESCRIPTION
Split thumbnail specific portion from #26305 26305

Before: (Showing broken images)
<img width="1026" height="285" alt="image" src="https://github.com/user-attachments/assets/a16b8379-9747-44e3-90a2-0ad2fb863733" />

After: (Broken images)
<img width="1034" height="289" alt="image" src="https://github.com/user-attachments/assets/81883c89-0790-420e-bd0d-54d7a2b3b9b6" />

Here is it with unbroken images
<img width="1029" height="291" alt="image" src="https://github.com/user-attachments/assets/e36caa52-b413-4e12-b4e1-5ec7c3f3a9c8" />

Key things to notice:
- when an image is selected, it has rounded corners. Previously the outline was squared. Now, for selected images with round corners, the outline matches. 
- The broken asset text is not loaded on top of the thumbnail. 

