### PR TITLE
feat(mobile): prompt when deleting from trash

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1705,6 +1705,8 @@
   "permanently_delete": "Permanently delete",
   "permanently_delete_assets_count": "Permanently delete {count, plural, one {asset} other {assets}}",
   "permanently_delete_assets_prompt": "Are you sure you want to permanently delete {count, plural, one {this asset?} other {these <b>#</b> assets?}} This will also remove {count, plural, one {it from its} other {them from their}} album(s).",
+  "permanently_delete_from_trash": "Permanently delete from trash",
+  "permanently_delete_from_trash_prompt": "Are you sure you want to permanently delete these assets from the trash? This action cannot be undone.",
   "permanently_deleted_asset": "Permanently deleted asset",
   "permanently_deleted_assets_count": "Permanently deleted {count, plural, one {# asset} other {# assets}}",
   "permission": "Permission",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1705,8 +1705,6 @@
   "permanently_delete": "Permanently delete",
   "permanently_delete_assets_count": "Permanently delete {count, plural, one {asset} other {assets}}",
   "permanently_delete_assets_prompt": "Are you sure you want to permanently delete {count, plural, one {this asset?} other {these <b>#</b> assets?}} This will also remove {count, plural, one {it from its} other {them from their}} album(s).",
-  "permanently_delete_from_trash": "Permanently delete from trash",
-  "permanently_delete_from_trash_prompt": "Are you sure you want to permanently delete these assets from the trash? This action cannot be undone.",
   "permanently_deleted_asset": "Permanently deleted asset",
   "permanently_deleted_assets_count": "Permanently deleted {count, plural, one {# asset} other {# assets}}",
   "permission": "Permission",

--- a/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
@@ -23,9 +23,14 @@ class DeleteTrashActionButton extends ConsumerWidget {
       return;
     }
 
-    final confirmDelete =
-        await showDialog<bool>(context: context, builder: (context) => const TrashDeleteDialog()) ?? false;
+    final selectCount = ref.watch(multiSelectProvider.select((s) => s.selectedAssets.length));
 
+    final confirmDelete =
+        await showDialog<bool>(
+          context: context,
+          builder: (context) => TrashDeleteDialog(count: selectCount),
+        ) ??
+        false;
     if (!confirmDelete) {
       return;
     }

--- a/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/widgets/asset_grid/trash_delete_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 /// This delete action has the following behavior:
@@ -19,6 +20,13 @@ class DeleteTrashActionButton extends ConsumerWidget {
 
   void _onTap(BuildContext context, WidgetRef ref) async {
     if (!context.mounted) {
+      return;
+    }
+
+    final confirmDelete =
+        await showDialog<bool>(context: context, builder: (context) => const TrashDeleteDialog()) ?? false;
+
+    if (!confirmDelete) {
       return;
     }
 

--- a/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
+++ b/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 class TrashDeleteDialog extends StatelessWidget {
-  const TrashDeleteDialog({super.key});
+  const TrashDeleteDialog({super.key, required this.count});
+
+  final int count;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
-      title: const Text("permanently_delete_from_trash").t(context: context),
-      content: const Text("permanently_delete_from_trash_prompt").t(context: context),
+      title: const Text("permanently_delete").t(context: context),
+      content: ImmichHtmlText(
+        "permanently_delete_assets_prompt".t(context: context, args: {'count': count.toString()}),
+      ),
       actions: [
         SizedBox(
           width: double.infinity,

--- a/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
+++ b/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+
+class TrashDeleteDialog extends StatelessWidget {
+  const TrashDeleteDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
+      title: const Text("permanently_delete_from_trash").t(context: context),
+      content: const Text("permanently_delete_from_trash_prompt").t(context: context),
+      actions: [
+        SizedBox(
+          width: double.infinity,
+          height: 48,
+          child: FilledButton(
+            onPressed: () => context.pop(false),
+            style: FilledButton.styleFrom(
+              backgroundColor: context.colorScheme.surfaceDim,
+              foregroundColor: context.primaryColor,
+            ),
+            child: const Text("cancel", style: TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+          ),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: double.infinity,
+          height: 48,
+
+          child: FilledButton(
+            onPressed: () => context.pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: context.colorScheme.errorContainer,
+              foregroundColor: context.colorScheme.onErrorContainer,
+            ),
+            child: const Text("delete", style: TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
+++ b/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/generated/translations.g.dart';
 import 'package:immich_ui/immich_ui.dart';
 
 class TrashDeleteDialog extends StatelessWidget {
@@ -12,10 +13,8 @@ class TrashDeleteDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
-      title: const Text("permanently_delete").t(context: context),
-      content: ImmichHtmlText(
-        "permanently_delete_assets_prompt".t(context: context, args: {'count': count.toString()}),
-      ),
+      title: Text(context.t.permanently_delete),
+      content: ImmichHtmlText(context.t.permanently_delete_assets_prompt(count: count)),
       actions: [
         SizedBox(
           width: double.infinity,
@@ -26,7 +25,7 @@ class TrashDeleteDialog extends StatelessWidget {
               backgroundColor: context.colorScheme.surfaceDim,
               foregroundColor: context.primaryColor,
             ),
-            child: const Text("cancel", style: TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+            child: Text(context.t.cancel, style: const TextStyle(fontWeight: FontWeight.bold)).t(context: context),
           ),
         ),
         const SizedBox(height: 8),
@@ -40,7 +39,7 @@ class TrashDeleteDialog extends StatelessWidget {
               backgroundColor: context.colorScheme.errorContainer,
               foregroundColor: context.colorScheme.onErrorContainer,
             ),
-            child: const Text("delete", style: TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+            child: Text(context.t.delete, style: const TextStyle(fontWeight: FontWeight.bold)).t(context: context),
           ),
         ),
       ],

--- a/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
+++ b/mobile/lib/widgets/asset_grid/trash_delete_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
-import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/generated/translations.g.dart';
 import 'package:immich_ui/immich_ui.dart';
 
@@ -25,7 +24,7 @@ class TrashDeleteDialog extends StatelessWidget {
               backgroundColor: context.colorScheme.surfaceDim,
               foregroundColor: context.primaryColor,
             ),
-            child: Text(context.t.cancel, style: const TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+            child: Text(context.t.cancel, style: const TextStyle(fontWeight: FontWeight.bold)),
           ),
         ),
         const SizedBox(height: 8),
@@ -39,7 +38,7 @@ class TrashDeleteDialog extends StatelessWidget {
               backgroundColor: context.colorScheme.errorContainer,
               foregroundColor: context.colorScheme.onErrorContainer,
             ),
-            child: Text(context.t.delete, style: const TextStyle(fontWeight: FontWeight.bold)).t(context: context),
+            child: Text(context.t.delete, style: const TextStyle(fontWeight: FontWeight.bold)),
           ),
         ),
       ],


### PR DESCRIPTION
## Description

Shows a confirmation dialog when deleting permanently from trash on mobile

<details><summary><h2>Screenshot</h2></summary>

<img height="600" alt="image" src="https://github.com/user-attachments/assets/3017f268-f352-4998-a55d-29c4e53c34c7" />

</details>

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No AI was used.
