### PR TITLE
chore(mobile): remove redundant assignment

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -197,7 +197,6 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     PhotoViewControllerBase controller,
     PhotoViewScaleStateController scaleStateController,
   ) {
-    _viewController = controller;
     if (!_showingDetails && _isZoomed) return;
     _beginDrag(details);
   }


### PR DESCRIPTION
## Description

The view controller is already assigned during page build. Reassigning it for every drag doesn't really make any sense.

## How Has This Been Tested?

Pixel 8a.