### PR TITLE
fix(mobile): birthday picker shows limited months when no date exists

### DIFF
--- a/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
@@ -90,6 +90,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
             selectedDate: _selectedDate,
             locale: context.locale,
             minimumDate: DateTime(1800, 1, 1),
+            maximumDate: DateTime(DateTime.now().year, 12, 31),
             onDateTimeChanged: (DateTime value) {
               setState(() {
                 _selectedDate = value;

--- a/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
@@ -25,7 +25,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
   @override
   void initState() {
     super.initState();
-    _selectedDate = widget.person.birthDate ?? DateTime.now();
+    _selectedDate = widget.person.birthDate ?? DateTime(DateTime.now().year - 30, 1, 1);
   }
 
   void saveBirthday() async {
@@ -90,7 +90,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
             selectedDate: _selectedDate,
             locale: context.locale,
             minimumDate: DateTime(1800, 1, 1),
-            maximumDate: DateTime(DateTime.now().year, 12, 31),
+            maximumDate: DateTime.now(),
             onDateTimeChanged: (DateTime value) {
               setState(() {
                 _selectedDate = value;


### PR DESCRIPTION
## Description

`ScrollDatePicker` defaults `maximumDate` to `DateTime.now()`. When no birthday exists, the picker starts at today (Feb 2026) with max also Feb 2026 — so only Jan–Feb are available for the current year.

**Fix:** Added `maximumDate: DateTime(DateTime.now().year, 12, 31)` at `person_edit_birthday_modal.widget.dart:93`, allowing all 12 months to be selected while still preventing future-year birthdays.

## How Has This Been Tested?

- [x] Manually tested adding a new birthday (no prior date) — all 12 months now selectable
- [x] Manually tested editing an existing birthday — still works correctly

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Cascade) was used to identify the root cause and generate the one-line fix.

# Screenshot of tested fix, before vs after
![IMG_6733](https://github.com/user-attachments/assets/ef29d638-5b46-404a-b1d9-aa018285d764)
![IMG_6735](https://github.com/user-attachments/assets/b966a185-7f6f-42d9-8ddb-be6c2bf1d8ae)


