### PR TITLE
chore(mobile): simplify pop logic

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -61,7 +61,6 @@ class _AssetPageState extends ConsumerState<AssetPage> {
   DragStartDetails? _dragStart;
   _DragIntent _dragIntent = _DragIntent.none;
   Drag? _drag;
-  bool _shouldPopOnDrag = false;
 
   @override
   void initState() {
@@ -120,7 +119,6 @@ class _AssetPageState extends ConsumerState<AssetPage> {
 
   void _beginDrag(DragStartDetails details) {
     _dragStart = details;
-    _shouldPopOnDrag = false;
     _lastScrollOffset = _proxyScrollController.hasClients ? _proxyScrollController.offset : 0.0;
 
     if (_viewController != null) {
@@ -163,6 +161,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
   void _endDrag(DragEndDetails details) {
     if (_dragStart == null) return;
 
+    final start = _dragStart;
     _dragStart = null;
 
     final intent = _dragIntent;
@@ -178,7 +177,8 @@ class _AssetPageState extends ConsumerState<AssetPage> {
         _drag?.end(details);
         _drag = null;
       case _DragIntent.dismiss:
-        if (_shouldPopOnDrag) {
+        const popThreshold = 75.0;
+        if (details.localPosition.dy - start!.localPosition.dy > popThreshold) {
           context.maybePop();
           return;
         }
@@ -211,12 +211,8 @@ class _AssetPageState extends ConsumerState<AssetPage> {
 
   void _handleDragDown(BuildContext context, Offset delta) {
     const dragRatio = 0.2;
-    const popThreshold = 75.0;
-
-    _shouldPopOnDrag = delta.dy > popThreshold;
 
     final distance = delta.dy.abs();
-
     final maxScaleDistance = context.height * 0.5;
     final scaleReduction = (distance / maxScaleDistance).clamp(0.0, dragRatio);
     final initialScale = _viewController?.initialScale ?? _initialPhotoViewState.scale;


### PR DESCRIPTION
## Description

We have all the information we need to decide on whether we should pop or not at the end of a drag. There's no need to track that separately, and update the value constantly.

## How Has This Been Tested?

Pixel 8a.