### PR TITLE
fix(web): prevent focus outlines from being clipped in sidebars

### DIFF
--- a/web/src/lib/components/layouts/AdminPageLayout.svelte
+++ b/web/src/lib/components/layouts/AdminPageLayout.svelte
@@ -27,7 +27,7 @@
     bind:open={sidebarStore.isOpen}
     class="border-none shadow-none h-full flex flex-col justify-between gap-2"
   >
-    <div class="flex flex-col pt-8 pe-4 gap-1">
+    <div class="flex flex-col pt-8 ps-1 pe-4 gap-1">
       <NavbarItem title={$t('users')} href={Route.users()} icon={mdiAccountMultipleOutline} />
       <NavbarItem title={$t('external_libraries')} href={Route.libraries()} icon={mdiBookshelf} />
       <NavbarItem title={$t('admin.queues')} href={Route.queues()} icon={mdiTrayFull} />

--- a/web/src/lib/components/sidebar/sidebar.svelte
+++ b/web/src/lib/components/sidebar/sidebar.svelte
@@ -45,7 +45,7 @@
   use:clickOutside={{ onOutclick: closeSidebar, onEscape: closeSidebar }}
   use:focusTrap={{ active: isExpanded }}
 >
-  <div class="pe-6 flex flex-col gap-1 h-max min-h-full">
+  <div class="ps-1 pe-6 flex flex-col gap-1 h-max min-h-full">
     {@render children?.()}
   </div>
 </nav>


### PR DESCRIPTION
## Problem

When using Tab to navigate through sidebar items, focus outlines appear clipped/broken because the sidebar's scrollable container (`overflow-auto`) clips CSS outlines that extend outside element boundaries.

Fixes #19498

## Root Cause

The `NavbarItem` component (from `@immich/ui`) renders anchor elements with `rounded-e-full` styling that sit flush against the left edge of the scrollable sidebar container. When focused, the outline extends outside the element's box and gets clipped by the parent's `overflow: auto`.

## Solution

Add `ps-1` (4px start padding) to the sidebar content wrappers in both:
- **`AdminPageLayout.svelte`** — the admin sidebar
- **`sidebar.svelte`** — the user sidebar

This provides just enough space for the 2px outline + 2px offset to render fully without being clipped by the overflow container.

## Changes
- `web/src/lib/components/layouts/AdminPageLayout.svelte` — added `ps-1` to nav items wrapper
- `web/src/lib/components/sidebar/sidebar.svelte` — added `ps-1` to content wrapper