### PR TITLE
fix(mobile): buffer width/height referenced after recycling

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
@@ -48,7 +48,6 @@ fun Bitmap.toNativeBuffer(): Map<String, Long>  {
   try {
     val buffer = NativeBuffer.wrap(pointer, size)
     copyPixelsToBuffer(buffer)
-    recycle()
     return mapOf(
       "pointer" to pointer,
       "width" to width.toLong(),
@@ -57,8 +56,9 @@ fun Bitmap.toNativeBuffer(): Map<String, Long>  {
     )
   } catch (e: Exception) {
     NativeBuffer.free(pointer)
-    recycle()
     throw e
+  } finally {
+    recycle()
   }
 }
 


### PR DESCRIPTION
## Description

Using the getters after recycling is UB, so recycling at the end is better.