### PR TITLE
fix: always show library scan button

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -80,6 +80,10 @@ There is an automatic scan job that is scheduled to run once a day. Its schedule
 
 This job also cleans up any libraries stuck in deletion. It is possible to trigger the cleanup by clicking "Scan all libraries" in the library management page.
 
+### Deleting a Library
+
+When deleting an external library, all assets inside are immediately deleted along with the library. Note that while a library can take a long time to fully delete in the background, it is immediately removed from the library list. If the deletion process is interrupted (for example, due to server restart), it will be cleaned up in the next nightly cron job. The cleanup process can also be manually initiated by clicking the "Scan All Libraries" button in the library list.
+
 ## Usage
 
 Let's show a concrete example where we add an existing gallery to Immich. Here, we have the following folders we want to add:

--- a/web/src/lib/services/library.service.ts
+++ b/web/src/lib/services/library.service.ts
@@ -30,7 +30,6 @@ export const getLibrariesActions = ($t: MessageFormatter, libraries: LibraryResp
     icon: mdiSync,
     onAction: () => handleScanAllLibraries(),
     shortcuts: { shift: true, key: 'r' },
-    $if: () => libraries.length > 0,
   };
 
   const Create: ActionItem = {

--- a/web/src/lib/services/library.service.ts
+++ b/web/src/lib/services/library.service.ts
@@ -23,7 +23,7 @@ import { modalManager, toastManager, type ActionItem } from '@immich/ui';
 import { mdiInformationOutline, mdiPencilOutline, mdiPlusBoxOutline, mdiSync, mdiTrashCanOutline } from '@mdi/js';
 import type { MessageFormatter } from 'svelte-i18n';
 
-export const getLibrariesActions = ($t: MessageFormatter, libraries: LibraryResponseDto[]) => {
+export const getLibrariesActions = ($t: MessageFormatter) => {
   const ScanAll: ActionItem = {
     title: $t('scan_all_libraries'),
     type: $t('command'),

--- a/web/src/routes/admin/library-management/(list)/+layout.svelte
+++ b/web/src/routes/admin/library-management/(list)/+layout.svelte
@@ -58,7 +58,7 @@
     delete owners[id];
   };
 
-  const { Create, ScanAll } = $derived(getLibrariesActions($t, libraries));
+  const { Create, ScanAll } = $derived(getLibrariesActions($t));
 
   const getActionsForLibrary = (library: LibraryResponseDto) => {
     const { Detail, Scan, Edit, Delete } = getLibraryActions($t, library);


### PR DESCRIPTION
After the library admin view refactor a while ago, the "Scan All LIbraries" button no longer appears when there are no libraries in the system.

While it appears logical to not show this button when there are no libraries, it does perform an important function: when a library is deleted the deletion process starts and that is a surprisingly slow and fragile process. Clicking the button is an intended way for the user to not only scan, but also clean up deleted libraries. The other only way is to wait for the nightly cron job.

tl; dr the button should always be there