### PR TITLE
feat(docs): Adding information about parameter c=

### DIFF
--- a/mobile/openapi/lib/model/asset_response_dto.dart
+++ b/mobile/openapi/lib/model/asset_response_dto.dart
@@ -156,7 +156,7 @@ class AssetResponseDto {
 
   List<TagResponseDto> tags;
 
-  /// Thumbhash for thumbnail generation
+  /// Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.
   String? thumbhash;
 
   /// Asset type

--- a/mobile/openapi/lib/model/asset_response_dto.dart
+++ b/mobile/openapi/lib/model/asset_response_dto.dart
@@ -156,7 +156,7 @@ class AssetResponseDto {
 
   List<TagResponseDto> tags;
 
-  /// Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.
+  /// Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache busting.
   String? thumbhash;
 
   /// Asset type

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -17100,7 +17100,7 @@
             "type": "array"
           },
           "thumbhash": {
-            "description": "Thumbhash for thumbnail generation",
+            "description": "Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.",
             "nullable": true,
             "type": "string"
           },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -17100,7 +17100,7 @@
             "type": "array"
           },
           "thumbhash": {
-            "description": "Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.",
+            "description": "Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache busting.",
             "nullable": true,
             "type": "string"
           },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -616,7 +616,7 @@ export type AssetResponseDto = {
     resized?: boolean;
     stack?: (AssetStackResponseDto) | null;
     tags?: TagResponseDto[];
-    /** Thumbhash for thumbnail generation */
+    /** Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning. */
     thumbhash: string | null;
     /** Asset type */
     "type": AssetTypeEnum;

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -616,7 +616,7 @@ export type AssetResponseDto = {
     resized?: boolean;
     stack?: (AssetStackResponseDto) | null;
     tags?: TagResponseDto[];
-    /** Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning. */
+    /** Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache busting. */
     thumbhash: string | null;
     /** Asset type */
     "type": AssetTypeEnum;

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -25,7 +25,10 @@ export class SanitizedAssetResponseDto {
   id!: string;
   @ValidateEnum({ enum: AssetType, name: 'AssetTypeEnum', description: 'Asset type' })
   type!: AssetType;
-  @ApiProperty({ description: 'Thumbhash for thumbnail generation' })
+  @ApiProperty({
+    description:
+      'Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.',
+  })
   thumbhash!: string | null;
   @ApiPropertyOptional({ description: 'Original MIME type' })
   originalMimeType?: string;

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -27,7 +27,7 @@ export class SanitizedAssetResponseDto {
   type!: AssetType;
   @ApiProperty({
     description:
-      'Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache/versioning.',
+      'Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache busting.',
   })
   thumbhash!: string | null;
   @ApiPropertyOptional({ description: 'Original MIME type' })


### PR DESCRIPTION
I recently noticed a c= parameter in my logs but wasn't sure what its purpose was.
After looking into it I realized it was related to Thumbhash and I didn't see any mention of this parameter in the documentation or in api.immich.app.
I think adding a line about this parameter is necessary.

reference: #16106
