### PR TITLE
fix(web): prevent `state_unsafe_mutation` error on people page

### DIFF
--- a/web/src/lib/actions/focus-outside.ts
+++ b/web/src/lib/actions/focus-outside.ts
@@ -1,4 +1,4 @@
-import { on } from "svelte/events";
+import { on } from 'svelte/events';
 
 interface Options {
   onFocusOut?: (event: FocusEvent) => void;

--- a/web/src/lib/actions/focus-outside.ts
+++ b/web/src/lib/actions/focus-outside.ts
@@ -1,3 +1,5 @@
+import { on } from "svelte/events";
+
 interface Options {
   onFocusOut?: (event: FocusEvent) => void;
 }
@@ -19,11 +21,11 @@ export function focusOutside(node: HTMLElement, options: Options = {}) {
     }
   };
 
-  node.addEventListener('focusout', handleFocusOut);
+  const off = on(node, 'focusout', handleFocusOut);
 
   return {
     destroy() {
-      node.removeEventListener('focusout', handleFocusOut);
+      off();
     },
   };
 }


### PR DESCRIPTION
Chromium browsers fire focusout/blur events during element removal, causing this error when navigating from `/people` to `/people/<id>`:

```
Uncaught Svelte error: state_unsafe_mutation
Updating state inside `$derived(...)`, `$inspect(...)` or a template expression is forbidden. If the value should not be reactive, declare it without `$state`
https://svelte.dev/e/state_unsafe_mutation
    at state_unsafe_mutation (errors.js:486:17)
    at Module.set (sources.js:156:5)
    at onFocusOut (people-card.svelte:42:33)
    at HTMLDivElement.handleFocusOut (focus-outside.ts:18:7)
```

Fixes #24086 by using Svelte's `on` function to register the event which guards against this