### PR TITLE
feat(mobile): Add slug support for shared links

### DIFF
--- a/mobile/lib/models/shared_link/shared_link.model.dart
+++ b/mobile/lib/models/shared_link/shared_link.model.dart
@@ -14,6 +14,7 @@ class SharedLink {
   final String key;
   final bool showMetadata;
   final SharedLinkSource type;
+  final String? slug;
 
   const SharedLink({
     required this.id,
@@ -27,6 +28,7 @@ class SharedLink {
     required this.key,
     required this.showMetadata,
     required this.type,
+    required this.slug,
   });
 
   SharedLink copyWith({
@@ -41,6 +43,7 @@ class SharedLink {
     String? key,
     bool? showMetadata,
     SharedLinkSource? type,
+    String? slug,
   }) {
     return SharedLink(
       id: id ?? this.id,
@@ -54,6 +57,7 @@ class SharedLink {
       key: key ?? this.key,
       showMetadata: showMetadata ?? this.showMetadata,
       type: type ?? this.type,
+      slug: slug ?? this.slug,
     );
   }
 
@@ -66,6 +70,7 @@ class SharedLink {
       expiresAt = dto.expiresAt,
       key = dto.key,
       showMetadata = dto.showMetadata,
+      slug = dto.slug,
       type = dto.type == SharedLinkType.ALBUM ? SharedLinkSource.album : SharedLinkSource.individual,
       title = dto.type == SharedLinkType.ALBUM
           ? dto.album?.albumName.toUpperCase() ?? "UNKNOWN SHARE"
@@ -78,7 +83,7 @@ class SharedLink {
 
   @override
   String toString() =>
-      'SharedLink(id=$id, title=$title, thumbAssetId=$thumbAssetId, allowDownload=$allowDownload, allowUpload=$allowUpload, description=$description, password=$password, expiresAt=$expiresAt, key=$key, showMetadata=$showMetadata, type=$type)';
+      'SharedLink(id=$id, title=$title, thumbAssetId=$thumbAssetId, allowDownload=$allowDownload, allowUpload=$allowUpload, description=$description, password=$password, expiresAt=$expiresAt, key=$key, showMetadata=$showMetadata, type=$type, slug=$slug)';
 
   @override
   bool operator ==(Object other) =>
@@ -94,7 +99,8 @@ class SharedLink {
           other.expiresAt == expiresAt &&
           other.key == key &&
           other.showMetadata == showMetadata &&
-          other.type == type;
+          other.type == type &&
+          other.slug == slug;
 
   @override
   int get hashCode =>
@@ -108,5 +114,6 @@ class SharedLink {
       expiresAt.hashCode ^
       key.hashCode ^
       showMetadata.hashCode ^
-      type.hashCode;
+      type.hashCode ^
+      slug.hashCode;
 }

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -344,6 +344,8 @@ class SharedLinkEditPage extends HookConsumerWidget {
 
       if (slugController.text != (existingLink!.slug ?? "")) {
         slug = slugController.text.isEmpty ? null : slugController.text;
+      } else {
+        slug = existingLink!.slug;
       }
 
       if (editExpiry.value) {

--- a/mobile/lib/services/shared_link.service.dart
+++ b/mobile/lib/services/shared_link.service.dart
@@ -37,6 +37,7 @@ class SharedLinkService {
     required bool allowUpload,
     String? description,
     String? password,
+    String? slug,
     String? albumId,
     List<String>? assetIds,
     DateTime? expiresAt,
@@ -54,6 +55,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
         );
       } else if (assetIds != null) {
         dto = SharedLinkCreateDto(
@@ -64,6 +66,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
           assetIds: assetIds,
         );
       }
@@ -88,6 +91,7 @@ class SharedLinkService {
     bool? changeExpiry = false,
     String? description,
     String? password,
+    String? slug,
     DateTime? expiresAt,
   }) async {
     try {
@@ -100,6 +104,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
           changeExpiryTime: changeExpiry,
         ),
       );

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -78,7 +78,10 @@ class SharedLinkItem extends ConsumerWidget {
         return;
       }
 
-      Clipboard.setData(ClipboardData(text: "${serverUrl}share/${sharedLink.key}")).then((_) {
+      final hasSlug = sharedLink.slug?.isNotEmpty == true;
+      final urlPath = hasSlug ? sharedLink.slug : sharedLink.key;
+      final basePath = hasSlug ? 's' : 'share';
+      Clipboard.setData(ClipboardData(text: "$serverUrl$basePath/$urlPath")).then((_) {
         context.scaffoldMessenger.showSnackBar(
           SnackBar(
             content: Text(


### PR DESCRIPTION
## Description

**Changes are based on https://github.com/immich-app/immich/pull/24856** 

This pull request introduces support for a new slug field in the SharedLink model

**Model and Service Enhancements:**
Added a nullable slug field to the SharedLink model, updated constructors, copyWith, equality, and hashcode methods to include slug.

## How Has This Been Tested?
- [x]  Manual testing on physical device

<details><summary><h2>Screenrecording</h2></summary>

https://github.com/user-attachments/assets/fdd064eb-1385-4248-be4c-31798001fdb4

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

GitHub Copilot for PR Summary; GitHub Copilot for separating changes from base-pr