### PR TITLE
feat(mobile): add confirmation dialog to permanent delete action

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/widgets/asset_grid/permanent_delete_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 /// This delete action has the following behavior:
@@ -24,6 +25,15 @@ class DeletePermanentActionButton extends ConsumerWidget {
     if (!context.mounted) {
       return;
     }
+
+    final count = source == ActionSource.viewer ? 1 : ref.read(multiSelectProvider).selectedAssets.length;
+    final confirm =
+        await showDialog<bool>(
+          context: context,
+          builder: (context) => PermanentDeleteDialog(count: count),
+        ) ??
+        false;
+    if (!confirm) return;
 
     final result = await ref.read(actionProvider.notifier).deleteRemoteAndLocal(source);
     ref.read(multiSelectProvider.notifier).reset();

--- a/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_trash_action_button.widget.dart
@@ -5,7 +5,7 @@ import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-import 'package:immich_mobile/widgets/asset_grid/trash_delete_dialog.dart';
+import 'package:immich_mobile/widgets/asset_grid/permanent_delete_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 /// This delete action has the following behavior:
@@ -28,7 +28,7 @@ class DeleteTrashActionButton extends ConsumerWidget {
     final confirmDelete =
         await showDialog<bool>(
           context: context,
-          builder: (context) => TrashDeleteDialog(count: selectCount),
+          builder: (context) => PermanentDeleteDialog(count: selectCount),
         ) ??
         false;
     if (!confirmDelete) {

--- a/mobile/lib/widgets/asset_grid/permanent_delete_dialog.dart
+++ b/mobile/lib/widgets/asset_grid/permanent_delete_dialog.dart
@@ -3,8 +3,8 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/generated/translations.g.dart';
 import 'package:immich_ui/immich_ui.dart';
 
-class TrashDeleteDialog extends StatelessWidget {
-  const TrashDeleteDialog({super.key, required this.count});
+class PermanentDeleteDialog extends StatelessWidget {
+  const PermanentDeleteDialog({super.key, required this.count});
 
   final int count;
 


### PR DESCRIPTION
## Description

Adds confirmation dialogs to `DeletePermanentActionButton` to prevent accidental deletion. Addresses https://github.com/immich-app/immich/issues/19775.

When deleting photos/videos from grid view (multiselect), there's no confirmation dialog. This is particularly dangerous for locked folder content where deletion is permanent and irreversible. This is an opinionated change and open to discussion, but in my opinion, deletions (especially permanent, but also when sent to trash) should always have a confirmation.

Reopened from https://github.com/immich-app/immich/pull/25113 on request of @shenlong-tanwen due to unforseen close of parent branch on merge.

### Changes

Add confirmation dialog to `DeletePermanentActionButton`. Permanent deletions should always shows a confirmation, so there is no parameter to toggle it off.

## How Has This Been Tested?

- [x] Manual testing: Grid view multiselect → Delete Permanently → Confirmation dialog appears

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [N/A] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude was used to assist with implementation.