### PR TITLE
fix(mobile): prevent video freezing/restarting when toggling favorite

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -343,7 +343,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     }
 
     return PhotoView.customChild(
-      key: ValueKey(displayAsset.heroTag),
+      key: ValueKey((displayAsset.heroTag, '_video_gesture_layer')),
       onDragStart: _onDragStart,
       onDragUpdate: _onDragUpdate,
       onDragEnd: _onDragEnd,
@@ -359,7 +359,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
       enablePanAlways: true,
       backgroundDecoration: backgroundDecoration,
       child: NativeVideoViewer(
-        key: ValueKey(displayAsset.heroTag),
+        key: ValueKey((displayAsset.heroTag, '_video_platform_view')),
         asset: displayAsset,
         scaleStateNotifier: _videoScaleStateNotifier,
         disableScaleGestures: showingDetails,

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -343,7 +343,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     }
 
     return PhotoView.customChild(
-      key: ValueKey(displayAsset),
+      key: ValueKey(displayAsset.heroTag),
       onDragStart: _onDragStart,
       onDragUpdate: _onDragUpdate,
       onDragEnd: _onDragEnd,
@@ -359,7 +359,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
       enablePanAlways: true,
       backgroundDecoration: backgroundDecoration,
       child: NativeVideoViewer(
-        key: ValueKey(displayAsset),
+        key: ValueKey(displayAsset.heroTag),
         asset: displayAsset,
         scaleStateNotifier: _videoScaleStateNotifier,
         disableScaleGestures: showingDetails,

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -431,10 +431,10 @@ class NativeVideoViewer extends HookConsumerWidget {
           if (!isVisible.value || controller.value == null) Center(key: ValueKey(asset.heroTag), child: image),
           if (aspectRatio.value != null && !isCasting && isCurrent)
             Visibility.maintain(
-              key: ValueKey('${asset.heroTag}_video'),
+              key: ValueKey((asset.heroTag, '_video_layer')),
               visible: isVisible.value,
               child: PhotoView.customChild(
-                key: ValueKey('${asset.heroTag}_video_photoview'),
+                key: ValueKey((asset.heroTag, '_video_gesture_layer')),
                 enableRotation: false,
                 disableScaleGestures: disableScaleGestures,
                 // Transparent to avoid a black flash when viewer becomes visible but video isn't loaded yet.
@@ -442,7 +442,7 @@ class NativeVideoViewer extends HookConsumerWidget {
                 scaleStateChangedCallback: (state) => scaleStateNotifier?.value = state,
                 childSize: videoContextSize(aspectRatio.value, context),
                 child: NativeVideoPlayerView(
-                  key: ValueKey('${asset.heroTag}_video_player'),
+                  key: ValueKey((asset.heroTag, '_video_platform_view')),
                   onViewReady: initController,
                 ),
               ),

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -335,13 +335,21 @@ class NativeVideoViewer extends HookConsumerWidget {
     }
 
     ref.listen(currentAssetNotifier, (_, value) {
+      final isCurrent = _isCurrentAsset(asset, value);
+      // This is the same asset with different metadata (e.g. isFavorite changed), update the ref
+      if (value != null && value != asset && isCurrent) {
+        currentAsset.value = value;
+        isVisible.value = isCurrent;
+        return;
+      }
+
       final playerController = controller.value;
       if (playerController != null && value != asset) {
         removeListeners(playerController);
       }
 
       if (value != null) {
-        isVisible.value = _isCurrentAsset(value, asset);
+        isVisible.value = isCurrent;
       }
       final curAsset = currentAsset.value;
       if (curAsset == asset) {
@@ -423,17 +431,20 @@ class NativeVideoViewer extends HookConsumerWidget {
           if (!isVisible.value || controller.value == null) Center(key: ValueKey(asset.heroTag), child: image),
           if (aspectRatio.value != null && !isCasting && isCurrent)
             Visibility.maintain(
-              key: ValueKey(asset),
+              key: ValueKey('${asset.heroTag}_video'),
               visible: isVisible.value,
               child: PhotoView.customChild(
-                key: ValueKey(asset),
+                key: ValueKey('${asset.heroTag}_video_photoview'),
                 enableRotation: false,
                 disableScaleGestures: disableScaleGestures,
                 // Transparent to avoid a black flash when viewer becomes visible but video isn't loaded yet.
                 backgroundDecoration: const BoxDecoration(color: Colors.transparent),
                 scaleStateChangedCallback: (state) => scaleStateNotifier?.value = state,
                 childSize: videoContextSize(aspectRatio.value, context),
-                child: NativeVideoPlayerView(key: ValueKey(asset), onViewReady: initController),
+                child: NativeVideoPlayerView(
+                  key: ValueKey('${asset.heroTag}_video_player'),
+                  onViewReady: initController,
+                ),
               ),
             ),
           if (showControls) const Center(child: VideoViewerControls()),


### PR DESCRIPTION
## Description

Addresses and fixes #25981. The nature of the problem changed after pulling today's latest changes from `main`. The root cause is the same though.

Essentially, the video player experienced a lifecycle break whenever an asset's metadata (such as the `isFavorite` status) was toggled during playback.

**Previous behavior (before today)**: The UI would completely freeze due to a `MissingPluginException` (caused by attempting to use a disposed controller).

**Current behavior (after today's changes from `main`)**: The video player silently disposes and recreates itself, causing the video to restart from the beginning.

The root case of the problem:
The video subtree was using `ValueKey(asset)` as its `key`. Since the asset object's equality includes its metadata properties, toggling a favorite flag results in a new `ValueKey`, which to Flutter is a different widget entirely, leading to the destruction and recreation of the `NativeVideoPlayerView`.

## How Has This Been Tested?

I tested the changes on my Pixel 9 Pro.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Freezing:

https://github.com/user-attachments/assets/ae140bb3-53f3-4815-8fea-74df23aeb5a5

Restarting:

https://github.com/user-attachments/assets/d293b270-44db-4b39-a248-4e874b039ed5

After Fix:

https://github.com/user-attachments/assets/f9509df3-312c-43d4-aa61-d46147fc0d58


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used it to edit the description for the PR. The one above.