### PR TITLE
chore(mobile): nudge users to switch to the new timeline

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -109,9 +109,43 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
     if (context.router.current.name == SplashScreenRoute.name) {
       final needBetaMigration = Store.get(StoreKey.needBetaMigration, false);
       if (needBetaMigration) {
+        bool migrate =
+            (await showDialog<bool>(
+              context: context,
+              builder: (ctx) => AlertDialog(
+                title: const Text("New Timeline Experience"),
+                content: const Text(
+                  "The old timeline has been deprecated and will be removed in an upcoming release. Would you like to switch to the new timeline now?",
+                ),
+                actions: [
+                  TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: const Text("No")),
+                  ElevatedButton(onPressed: () => Navigator.of(ctx).pop(true), child: const Text("Yes")),
+                ],
+              ),
+            )) ??
+            false;
+        if (migrate != true) {
+          migrate =
+              (await showDialog<bool>(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text("Are you sure?"),
+                  content: const Text(
+                    "If you choose to remain on the old timeline, you will be automatically migrated to the new timeline in an upcoming release. Would you like to switch now?",
+                  ),
+                  actions: [
+                    TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: const Text("No")),
+                    ElevatedButton(onPressed: () => Navigator.of(ctx).pop(true), child: const Text("Yes")),
+                  ],
+                ),
+              )) ??
+              false;
+        }
         await Store.put(StoreKey.needBetaMigration, false);
-        unawaited(context.router.replaceAll([ChangeExperienceRoute(switchingToBeta: true)]));
-        return;
+        if (migrate) {
+          unawaited(context.router.replaceAll([ChangeExperienceRoute(switchingToBeta: true)]));
+          return;
+        }
       }
 
       unawaited(context.replaceRoute(Store.isBetaTimelineEnabled ? const TabShellRoute() : const TabControllerRoute()));

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -30,11 +30,10 @@ import 'package:immich_mobile/utils/datetime_helpers.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:immich_mobile/utils/diff.dart';
 import 'package:isar/isar.dart';
-
 // ignore: import_rule_photo_manager
 import 'package:photo_manager/photo_manager.dart';
 
-const int targetVersion = 21;
+const int targetVersion = 22;
 
 Future<void> migrateDatabaseIfNeeded(Isar db, Drift drift) async {
   final hasVersion = Store.tryGet(StoreKey.version) != null;
@@ -98,6 +97,10 @@ Future<void> migrateDatabaseIfNeeded(Isar db, Drift drift) async {
     if (certData != null) {
       await networkApi.addCertificate(ClientCertData(data: certData.data, password: certData.password ?? ""));
     }
+  }
+
+  if (version < 22 && !Store.isBetaTimelineEnabled) {
+    await Store.put(StoreKey.needBetaMigration, true);
   }
 
   if (targetVersion >= 12) {

--- a/mobile/lib/widgets/settings/advanced_settings.dart
+++ b/mobile/lib/widgets/settings/advanced_settings.dart
@@ -135,7 +135,7 @@ class AdvancedSettings extends HookConsumerWidget {
           title: "advanced_settings_enable_alternate_media_filter_title".tr(),
           subtitle: "advanced_settings_enable_alternate_media_filter_subtitle".tr(),
         ),
-      const BetaTimelineListTile(),
+      if (!Store.isBetaTimelineEnabled) const BetaTimelineListTile(),
       if (Store.isBetaTimelineEnabled)
         SettingsSwitchListTile(
           valueNotifier: readonlyModeEnabled,


### PR DESCRIPTION
## Description

- Prompt users on old timeline one last time to migrate to the new timeline on startup

## How Has This Been Tested?

- Upgrading from new timeline and ensured that the user is not prompted
- Accepting the prompt on old timeline does the migration
- Rejecting the prompt does not re-prompt the user again and keeps them on the old-timeline

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

First Prompt | Second Prompt if first is rejected
:-: | :-:
<img width="300" height="768" alt="First" src="https://github.com/user-attachments/assets/582f0a5b-261a-4a27-ab72-a2805687ef20" /> | <img width="300" height="768" alt="Second" src="https://github.com/user-attachments/assets/6cac0f06-1a8f-443e-a41e-22c8315de9dc" />
