### PR TITLE
chore(web): deduplicate storage template examples

### DIFF
--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -15,7 +15,7 @@
 
 </script>
 
-{#snippet example(title: string, options: Array)}
+{#snippet example(title: string, options: Array<string>)}
   <div>
     <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{title}</Text>
     <ul>

--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -12,7 +12,6 @@
   let { options }: Props = $props();
 
   const getExampleDate = () => DateTime.fromISO('2022-02-15T20:03:05.250Z', { locale: $locale });
-
 </script>
 
 {#snippet example(title: string, options: Array<string>)}
@@ -32,7 +31,7 @@
   <CardHeader>
     <Text class="mb-1">{$t('admin.storage_template_date_time_description')}</Text>
     <Text color="primary"
-      >{$t('admin.storage_template_date_time_sample', { values: { date: getExampleDate().toISO() }})}</Text
+      >{$t('admin.storage_template_date_time_sample', { values: { date: getExampleDate().toISO() } })}</Text
     >
   </CardHeader>
   <CardBody>

--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -11,85 +11,39 @@
 
   let { options }: Props = $props();
 
-  const getLuxonExample = (format: string) => {
-    return DateTime.fromISO('2022-02-15T20:03:05.250Z', { locale: $locale }).toFormat(format);
-  };
+  const getExampleDate = () => DateTime.fromISO('2022-02-15T20:03:05.250Z', { locale: $locale });
+
 </script>
+
+{#snippet example(title: string, options: Array)}
+  <div>
+    <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{title}</Text>
+    <ul>
+      {#each options as format, index (index)}
+        <li>{`{{${format}}} - ${getExampleDate().toFormat(format)}`}</li>
+      {/each}
+    </ul>
+  </div>
+{/snippet}
 
 <Text size="small">{$t('date_and_time')}</Text>
 
-<!-- eslint-disable svelte/no-useless-mustaches -->
 <Card class="mt-2 text-sm bg-light-50 shadow-none">
   <CardHeader>
     <Text class="mb-1">{$t('admin.storage_template_date_time_description')}</Text>
     <Text color="primary"
-      >{$t('admin.storage_template_date_time_sample', { values: { date: '2022-02-15T20:03:05.250+00:00' } })}</Text
+      >{$t('admin.storage_template_date_time_sample', { values: { date: getExampleDate().toISO() }})}</Text
     >
   </CardHeader>
   <CardBody>
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-3 md:grid-cols-4">
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('year')}</Text>
-        <ul>
-          {#each options.yearOptions as yearFormat, index (index)}
-            <li>{'{{'}{yearFormat}{'}}'} - {getLuxonExample(yearFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('month')}</Text>
-        <ul>
-          {#each options.monthOptions as monthFormat, index (index)}
-            <li>{'{{'}{monthFormat}{'}}'} - {getLuxonExample(monthFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('week')}</Text>
-        <ul>
-          {#each options.weekOptions as weekFormat, index (index)}
-            <li>{'{{'}{weekFormat}{'}}'} - {getLuxonExample(weekFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('day')}</Text>
-        <ul>
-          {#each options.dayOptions as dayFormat, index (index)}
-            <li>{'{{'}{dayFormat}{'}}'} - {getLuxonExample(dayFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('hour')}</Text>
-        <ul>
-          {#each options.hourOptions as dayFormat, index (index)}
-            <li>{'{{'}{dayFormat}{'}}'} - {getLuxonExample(dayFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('minute')}</Text>
-        <ul>
-          {#each options.minuteOptions as dayFormat, index (index)}
-            <li>{'{{'}{dayFormat}{'}}'} - {getLuxonExample(dayFormat)}</li>
-          {/each}
-        </ul>
-      </div>
-
-      <div>
-        <Text fontWeight="medium" size="tiny" color="primary" class="mb-1">{$t('second')}</Text>
-        <ul>
-          {#each options.secondOptions as dayFormat, index (index)}
-            <li>{'{{'}{dayFormat}{'}}'} - {getLuxonExample(dayFormat)}</li>
-          {/each}
-        </ul>
-      </div>
+      {@render example($t('year'), options.yearOptions)}
+      {@render example($t('month'), options.monthOptions)}
+      {@render example($t('week'), options.weekOptions)}
+      {@render example($t('day'), options.dayOptions)}
+      {@render example($t('hour'), options.hourOptions)}
+      {@render example($t('minute'), options.minuteOptions)}
+      {@render example($t('second'), options.secondOptions)}
     </div>
   </CardBody>
 </Card>


### PR DESCRIPTION
## Description
Deduplicate storage template examples and re-use the same date. The only difference post-refactor is that the browser's time zone will be used to display the example.

Continuation of #26424.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Viewed the Storage Template examples

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="1052" height="720" alt="image" src="https://github.com/user-attachments/assets/7b08c5b8-c74c-4176-b071-532600aeac6a" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
