### PR TITLE
fix: retain asset when either asset is a favorite

### DIFF
--- a/mobile/lib/infrastructure/repositories/local_asset.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_asset.repository.dart
@@ -184,7 +184,8 @@ class DriftLocalAssetRepository extends DriftDatabaseRepository {
     }
 
     if (keepFavorites) {
-      whereClause = whereClause & _db.localAssetEntity.isFavorite.equals(false);
+      whereClause =
+          whereClause & _db.localAssetEntity.isFavorite.equals(false) & _db.remoteAssetEntity.isFavorite.equals(false);
     }
 
     query.where(whereClause);


### PR DESCRIPTION
## Description

Retains a local asset from cleanup when either the local asset or remote asset is favorited
