### PR TITLE
Extract date from filename when EXIF datetime is missing

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -14,7 +14,7 @@ import {
   SourceType,
 } from 'src/enum';
 import { ImmichTags } from 'src/repositories/metadata.repository';
-import { firstDateTime, MetadataService } from 'src/services/metadata.service';
+import { extractDateFromFilename, firstDateTime, MetadataService } from 'src/services/metadata.service';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { probeStub } from 'test/fixtures/media.stub';
 import { personStub } from 'test/fixtures/person.stub';
@@ -252,6 +252,57 @@ describe(MetadataService.name, () => {
         width: null,
         height: null,
       });
+    });
+
+    it('should extract date from filename when no exif date is present', async () => {
+      const expectedDate = new Date('2023-04-15T14:30:22.000Z');
+      const asset = AssetFactory.from({ originalFileName: 'IMG_20230415_143022.jpg' }).build();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset);
+      mockReadTags();
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ dateTimeOriginal: expectedDate }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          localDateTime: expectedDate,
+          fileCreatedAt: expectedDate,
+        }),
+      );
+    });
+
+    it('should prefer exif date over filename date when both are present', async () => {
+      const exifDate = new Date('2022-06-10T08:00:00.000Z');
+      const asset = AssetFactory.from({ originalFileName: 'IMG_20230415_143022.jpg' }).build();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset);
+      mockReadTags({ DateTimeOriginal: '2022:06:10 08:00:00' });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ dateTimeOriginal: exifDate }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+    });
+
+    it('should fall back to file timestamps when filename has no recognisable date pattern', async () => {
+      const fileCreatedAt = new Date('2021-01-01T00:00:00.000Z');
+      const asset = AssetFactory.from({ originalFileName: 'random_photo.jpg' }).build();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset);
+      mocks.storage.stat.mockResolvedValue({
+        size: 123_456,
+        mtime: new Date('2022-01-01T00:00:00.000Z'),
+        mtimeMs: new Date('2022-01-01T00:00:00.000Z').valueOf(),
+        birthtimeMs: fileCreatedAt.valueOf(),
+      } as Stats);
+      mockReadTags();
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ dateTimeOriginal: fileCreatedAt }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
     });
 
     it('should determine dateTimeOriginal regardless of the server time zone', async () => {
@@ -1865,6 +1916,44 @@ describe(MetadataService.name, () => {
       const result = firstDateTime(tags);
       expect(result?.tag).toBe('CreationDate');
       expect(result?.dateTime?.toDate()?.toISOString()).toBe('2025-05-24T16:26:20.000Z');
+    });
+  });
+
+  describe('extractDateFromFilename', () => {
+    it.each([
+      // YYYYMMDD_HHMMSS (bare compact form)
+      ['20230415_143022', '2023-04-15T14:30:22.000Z'],
+      // IMG_YYYYMMDD_HHMMSS (Samsung / Android)
+      ['IMG_20230415_143022', '2023-04-15T14:30:22.000Z'],
+      // VID_YYYYMMDD_HHMMSS (Android video)
+      ['VID_20230415_143022', '2023-04-15T14:30:22.000Z'],
+      // YYYY-MM-DD_HH-MM-SS (dashes with underscore separator)
+      ['2023-04-15_14-30-22', '2023-04-15T14:30:22.000Z'],
+      // YYYY-MM-DD-HH-MM-SS (all dashes)
+      ['2023-04-15-14-30-22', '2023-04-15T14:30:22.000Z'],
+      // Screenshot_YYYY-MM-DD-HH-MM-SS (Android screenshots)
+      ['Screenshot_2023-04-15-14-30-22', '2023-04-15T14:30:22.000Z'],
+      // Screenshot_YYYY-MM-DD_HH-MM-SS (underscore between date and time)
+      ['Screenshot_2023-04-15_14-30-22', '2023-04-15T14:30:22.000Z'],
+      // WhatsApp IMG-YYYYMMDD-WAxxxx
+      ['IMG-20230415-WA0001', '2023-04-15T00:00:00.000Z'],
+      // WhatsApp VID-YYYYMMDD-WAxxxx
+      ['VID-20230415-WA0042', '2023-04-15T00:00:00.000Z'],
+    ])('should parse %s to %s', (filename, expected) => {
+      const result = extractDateFromFilename(filename);
+      expect(result).not.toBeNull();
+      expect(result!.toJSDate().toISOString()).toBe(expected);
+    });
+
+    it.each([
+      'image.jpg',
+      'photo',
+      'IMG_abc_defghi',
+      'IMG-20231399-WA0001', // invalid month 13
+      '20231301_256000', // invalid month 13 and hour 25
+      'random_file_name',
+    ])('should return null for non-matching filename: %s', (filename) => {
+      expect(extractDateFromFilename(filename)).toBeNull();
     });
   });
 });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -82,6 +82,97 @@ export function firstDateTime(tags: ImmichTags) {
   }
 }
 
+/**
+ * Reject obviously out-of-range date/time components before handing them to
+ * Luxon.  Without this guard Luxon silently overflows (e.g. month 13 → January
+ * of the following year), so `DateTime.isValid` would be `true` even for values
+ * that could never appear in a real camera filename.
+ */
+const isValidDateComponents = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): boolean =>
+  year >= 1000 &&
+  year <= 9999 &&
+  month >= 1 &&
+  month <= 12 &&
+  day >= 1 &&
+  day <= 31 &&
+  hour >= 0 &&
+  hour <= 23 &&
+  minute >= 0 &&
+  minute <= 59 &&
+  second >= 0 &&
+  second <= 59;
+
+/** Ordered list of regex patterns to extract date/time from filenames */
+const FILENAME_DATE_PATTERNS: ReadonlyArray<{
+  /** Pattern must contain capture groups for: year, month, day, [hour, minute, second] */
+  regex: RegExp;
+  extract: (match: RegExpMatchArray) => DateTime | null;
+}> = [
+  // YYYY-MM-DD_HH-MM-SS or YYYY-MM-DD-HH-MM-SS
+  // Matches: Screenshot_2023-04-15_14-30-22, 2023-04-15_14-30-22, Screenshot_2023-04-15-14-30-22
+  {
+    regex: /(\d{4})-(\d{2})-(\d{2})[-_](\d{2})-(\d{2})-(\d{2})/,
+    extract: (m) => {
+      const [year, month, day, hour, minute, second] = [+m[1], +m[2], +m[3], +m[4], +m[5], +m[6]];
+      return isValidDateComponents(year, month, day, hour, minute, second)
+        ? DateTime.fromObject({ year, month, day, hour, minute, second }, { zone: 'UTC' })
+        : null;
+    },
+  },
+  // YYYYMMDD_HHMMSS
+  // Matches: IMG_20230415_143022, VID_20230415_143022, 20230415_143022
+  {
+    regex: /(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})/,
+    extract: (m) => {
+      const [year, month, day, hour, minute, second] = [+m[1], +m[2], +m[3], +m[4], +m[5], +m[6]];
+      return isValidDateComponents(year, month, day, hour, minute, second)
+        ? DateTime.fromObject({ year, month, day, hour, minute, second }, { zone: 'UTC' })
+        : null;
+    },
+  },
+  // WhatsApp: IMG-YYYYMMDD-WAxxxx or VID-YYYYMMDD-WAxxxx (date only, no time)
+  // Matches: IMG-20230415-WA0001, VID-20230415-WA0042
+  {
+    regex: /[A-Za-z]{2,4}-(\d{4})(\d{2})(\d{2})-WA\d+/,
+    extract: (m) => {
+      const [year, month, day] = [+m[1], +m[2], +m[3]];
+      return isValidDateComponents(year, month, day)
+        ? DateTime.fromObject({ year, month, day }, { zone: 'UTC' })
+        : null;
+    },
+  },
+];
+
+/**
+ * Attempt to extract a date/time from a filename stem (without extension) by
+ * trying each of the common camera/device naming patterns in order.
+ *
+ * Returns the first valid {@link DateTime} found, or `null` if no pattern matches
+ * or the matched values do not form a valid calendar date.
+ */
+export function extractDateFromFilename(filename: string): DateTime | null {
+  for (const { regex, extract } of FILENAME_DATE_PATTERNS) {
+    const match = filename.match(regex);
+    if (!match) {
+      continue;
+    }
+
+    const dateTime = extract(match);
+    if (dateTime?.isValid) {
+      return dateTime;
+    }
+  }
+
+  return null;
+}
+
 const validate = <T>(value: T): NonNullable<T> | null => {
   // handle lists of numbers
   if (Array.isArray(value)) {
@@ -947,18 +1038,27 @@ export class MetadataService extends BaseService {
     let localDateTime = dateTimeOriginal?.setZone('UTC', { keepLocalTime: true });
 
     if (!localDateTime || !dateTimeOriginal) {
-      // FileCreateDate is not available on linux, likely because exiftool hasn't integrated the statx syscall yet
-      // birthtime is not available in Docker on macOS, so it appears as 0
-      const earliestDate = DateTime.fromMillis(
-        Math.min(
-          asset.fileCreatedAt.getTime(),
-          stats.birthtimeMs ? Math.min(stats.mtimeMs, stats.birthtimeMs) : stats.mtime.getTime(),
-        ),
-      );
-      this.logger.debug(
-        `No exif date time found, falling back on ${earliestDate.toISO()}, earliest of file creation and modification for asset ${asset.id}: ${asset.originalPath}`,
-      );
-      dateTimeOriginal = localDateTime = earliestDate;
+      const filenameStem = parse(asset.originalPath).name;
+      const fromFilename = extractDateFromFilename(filenameStem);
+      if (fromFilename) {
+        this.logger.debug(
+          `No exif date time found, extracted ${fromFilename.toISO()} from filename for asset ${asset.id}: ${asset.originalPath}`,
+        );
+        dateTimeOriginal = localDateTime = fromFilename;
+      } else {
+        // FileCreateDate is not available on linux, likely because exiftool hasn't integrated the statx syscall yet
+        // birthtime is not available in Docker on macOS, so it appears as 0
+        const earliestDate = DateTime.fromMillis(
+          Math.min(
+            asset.fileCreatedAt.getTime(),
+            stats.birthtimeMs ? Math.min(stats.mtimeMs, stats.birthtimeMs) : stats.mtime.getTime(),
+          ),
+        );
+        this.logger.debug(
+          `No exif date time found, falling back on ${earliestDate.toISO()}, earliest of file creation and modification for asset ${asset.id}: ${asset.originalPath}`,
+        );
+        dateTimeOriginal = localDateTime = earliestDate;
+      }
     }
 
     this.logger.verbose(`Found local date time ${localDateTime.toISO()} for asset ${asset.id}: ${asset.originalPath}`);


### PR DESCRIPTION
## Summary

- Adds `extractDateFromFilename()` to `metadata.service.ts` that parses a filename stem against a prioritised list of common camera/device naming patterns
- Inserts filename-based extraction as a fallback step between EXIF tags and file system timestamps in `getDates()`, giving the fallback chain: **EXIF → filename → file birthtime/mtime**
- Adds a pre-validation guard to reject out-of-range components (e.g. month 13) before constructing a Luxon `DateTime`, since `DateTime.fromObject` silently overflows invalid values

### Supported patterns

| Pattern | Example |
|---|---|
| `YYYYMMDD_HHMMSS` | `IMG_20230415_143022.jpg`, `VID_20230415_143022.mp4` |
| `YYYY-MM-DD_HH-MM-SS` | `2023-04-15_14-30-22.jpg` |
| `YYYY-MM-DD-HH-MM-SS` | `Screenshot_2023-04-15-14-30-22.png` |
| `IMG-YYYYMMDD-WAxxxx` | `IMG-20230415-WA0001.jpg` (WhatsApp) |
| `VID-YYYYMMDD-WAxxxx` | `VID-20230415-WA0042.mp4` (WhatsApp) |

## Test plan

- [x] Unit tests for `extractDateFromFilename` covering all 9 supported patterns plus 6 non-matching/invalid cases
- [x] Integration tests in `handleMetadataExtraction` verifying filename date is used when EXIF is absent, EXIF takes priority when present, and file timestamps are still used as a last resort
- [x] All 122 existing + new tests pass (`npm run test`)

