### PR TITLE
fix(web): toast warning when trying to upload unsupported file type

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2307,6 +2307,7 @@
   "unstack_action_prompt": "{count} unstacked",
   "unstacked_assets_count": "Un-stacked {count, plural, one {# asset} other {# assets}}",
   "unsupported_field_type": "Unsupported field type",
+  "unsupported_file_type": "File {file} can't be uploaded because its file type {type} is not supported.",
   "untagged": "Untagged",
   "untitled_workflow": "Untitled workflow",
   "up_next": "Up next",

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -15,6 +15,7 @@ import {
   getBaseUrl,
   type AssetMediaResponseDto,
 } from '@immich/sdk';
+import { toastManager } from '@immich/ui';
 import { tick } from 'svelte';
 import { t } from 'svelte-i18n';
 import { get } from 'svelte/store';
@@ -112,6 +113,10 @@ export const fileUploadHandler = async ({
       promises.push(
         uploadExecutionQueue.addTask(() => fileUploader({ assetFile: file, deviceAssetId, albumId, isLockedAssets })),
       );
+    } else {
+      toastManager.warning(get(t)('unsupported_file_type', { values: { file: file.name, type: file.type } }), {
+        timeout: 10_000,
+      });
     }
   }
 


### PR DESCRIPTION
While the file picker which opens a dialog can have a list of supported file types, the drag and drop action can of course not filter by that. Also, in the file picker dialog you can just select 'all file types' and try to upload a txt file for example. Currently, unsupported files are silently rejected without any feedback to the user.

<img width="538" height="348" alt="image" src="https://github.com/user-attachments/assets/93943ad4-5413-4700-886d-8731501915e7" />

One caveat: the file uploader checks for file extensions, while `file.type` is its mime type. This could be confusing.