### PR TITLE
fix: allow clearing image description to blank

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1779,6 +1779,24 @@ describe(MetadataService.name, () => {
         'timeZone',
       ]);
     });
+
+    it('should not unlock properties with empty values that exiftool cannot persist', async () => {
+      const asset = factory.jobAssets.sidecarWrite();
+      // Override description to empty string (user cleared it)
+      asset.exifInfo.description = '';
+
+      mocks.assetJob.getLockedPropertiesForMetadataExtraction.mockResolvedValue(['description']);
+      mocks.assetJob.getForSidecarWriteJob.mockResolvedValue(asset);
+
+      await expect(sut.handleSidecarWrite({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.metadata.writeTags).toHaveBeenCalledWith(asset.files[0].path, {
+        Description: '',
+        ImageDescription: '',
+      });
+      // description should NOT be unlocked since exiftool treats empty strings as "delete tag"
+      expect(mocks.asset.unlockProperties).not.toHaveBeenCalled();
+    });
   });
 
   describe('firstDateTime', () => {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -481,7 +481,21 @@ export class MetadataService extends BaseService {
       await this.assetRepository.upsertFile({ assetId: id, type: AssetFileType.Sidecar, path: sidecarPath });
     }
 
-    await this.assetRepository.unlockProperties(asset.id, lockedProperties);
+    // Only unlock properties that were successfully written to the sidecar.
+    // ExifTool treats empty strings as "delete tag", so empty values won't actually
+    // be persisted in the sidecar file. Keep those properties locked to prevent
+    // metadata re-extraction from overwriting them with the original embedded values.
+    const emptyStringProperties = new Set(
+      lockedProperties.filter((property) => {
+        const value = { description, dateTimeOriginal, latitude, longitude, rating, tags, timeZone }[property];
+        return value === '' || value === null;
+      }),
+    );
+    const propertiesToUnlock = lockedProperties.filter((property) => !emptyStringProperties.has(property));
+
+    if (propertiesToUnlock.length > 0) {
+      await this.assetRepository.unlockProperties(asset.id, propertiesToUnlock);
+    }
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
Fixes #19168

## Summary
When a user clears an image description, the empty value wasn't being persisted because ExifTool treats empty strings as "delete tag". This caused the description to revert to the original embedded EXIF value on the next metadata extraction.

## Changes
- **metadata.service.ts**: Keep properties with empty/null values locked after sidecar write, preventing metadata re-extraction from overwriting them with original embedded values
- **metadata.service.spec.ts**: Added test verifying empty description values don't trigger property unlock