### PR TITLE
fix(web): error page i18n

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1074,6 +1074,7 @@
     "failed_to_update_notification_status": "Failed to update notification status",
     "incorrect_email_or_password": "Incorrect email or password",
     "library_folder_already_exists": "This import path already exists.",
+    "page_not_found": "Page not found :/",
     "paths_validation_failed": "{paths, plural, one {# path} other {# paths}} failed validation",
     "profile_picture_transparent_pixels": "Profile pictures cannot have transparent pixels. Please zoom in and/or move the image.",
     "quota_higher_than_disk_size": "You set a quota higher than the disk size",

--- a/web/src/lib/components/pages/SharedLinkErrorPage.svelte
+++ b/web/src/lib/components/pages/SharedLinkErrorPage.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { t } from 'svelte-i18n';
 </script>
 
 <svelte:head>
-  <title>Oops! Error - Immich</title>
+  <title>{$t('error')} - Immich</title>
 </svelte:head>
 
 <section class="flex flex-col px-4 h-dvh w-dvw place-content-center place-items-center">
-  <h1 class="py-10 text-4xl text-primary">Page not found :/</h1>
+  <h1 class="py-10 text-4xl text-primary">{$t('errors.page_not_found')}</h1>
   {#if page.error?.message}
     <h2 class="text-xl text-immich-fg dark:text-immich-dark-fg">{page.error.message}</h2>
   {/if}


### PR DESCRIPTION
Fixes #22410. The other string the user mentioned are internally thrown errors, passed through `page.error.message`, and do not have i18n, like many other possible errors. I think without a complete refactor of all instances of `throw ...` , it's not feasible to fix that.