### PR TITLE
feat(mobile): add playbackStyle to native sync API

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
@@ -92,7 +92,8 @@ data class PlatformAsset (
   val isFavorite: Boolean,
   val adjustmentTime: Long? = null,
   val latitude: Double? = null,
-  val longitude: Double? = null
+  val longitude: Double? = null,
+  val playbackStyle: Long
 )
  {
   companion object {
@@ -110,7 +111,8 @@ data class PlatformAsset (
       val adjustmentTime = pigeonVar_list[10] as Long?
       val latitude = pigeonVar_list[11] as Double?
       val longitude = pigeonVar_list[12] as Double?
-      return PlatformAsset(id, name, type, createdAt, updatedAt, width, height, durationInSeconds, orientation, isFavorite, adjustmentTime, latitude, longitude)
+      val playbackStyle = pigeonVar_list[13] as Long
+      return PlatformAsset(id, name, type, createdAt, updatedAt, width, height, durationInSeconds, orientation, isFavorite, adjustmentTime, latitude, longitude, playbackStyle)
     }
   }
   fun toList(): List<Any?> {
@@ -128,6 +130,7 @@ data class PlatformAsset (
       adjustmentTime,
       latitude,
       longitude,
+      playbackStyle,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
@@ -78,6 +78,21 @@ class FlutterError (
   val details: Any? = null
 ) : Throwable()
 
+enum class PlatformAssetPlaybackStyle(val raw: Int) {
+  UNKNOWN(0),
+  IMAGE(1),
+  VIDEO(2),
+  IMAGE_ANIMATED(3),
+  LIVE_PHOTO(4),
+  VIDEO_LOOPING(5);
+
+  companion object {
+    fun ofRaw(raw: Int): PlatformAssetPlaybackStyle? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
 /** Generated class from Pigeon that represents data sent in messages. */
 data class PlatformAsset (
   val id: String,
@@ -93,7 +108,7 @@ data class PlatformAsset (
   val adjustmentTime: Long? = null,
   val latitude: Double? = null,
   val longitude: Double? = null,
-  val playbackStyle: Long
+  val playbackStyle: PlatformAssetPlaybackStyle
 )
  {
   companion object {
@@ -111,7 +126,7 @@ data class PlatformAsset (
       val adjustmentTime = pigeonVar_list[10] as Long?
       val latitude = pigeonVar_list[11] as Double?
       val longitude = pigeonVar_list[12] as Double?
-      val playbackStyle = pigeonVar_list[13] as Long
+      val playbackStyle = pigeonVar_list[13] as PlatformAssetPlaybackStyle
       return PlatformAsset(id, name, type, createdAt, updatedAt, width, height, durationInSeconds, orientation, isFavorite, adjustmentTime, latitude, longitude, playbackStyle)
     }
   }
@@ -293,26 +308,31 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       129.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          PlatformAsset.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          PlatformAssetPlaybackStyle.ofRaw(it.toInt())
         }
       }
       130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PlatformAlbum.fromList(it)
+          PlatformAsset.fromList(it)
         }
       }
       131.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SyncDelta.fromList(it)
+          PlatformAlbum.fromList(it)
         }
       }
       132.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HashResult.fromList(it)
+          SyncDelta.fromList(it)
         }
       }
       133.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HashResult.fromList(it)
+        }
+      }
+      134.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           CloudIdResult.fromList(it)
         }
@@ -322,24 +342,28 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
   }
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
     when (value) {
-      is PlatformAsset -> {
+      is PlatformAssetPlaybackStyle -> {
         stream.write(129)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw)
       }
-      is PlatformAlbum -> {
+      is PlatformAsset -> {
         stream.write(130)
         writeValue(stream, value.toList())
       }
-      is SyncDelta -> {
+      is PlatformAlbum -> {
         stream.write(131)
         writeValue(stream, value.toList())
       }
-      is HashResult -> {
+      is SyncDelta -> {
         stream.write(132)
         writeValue(stream, value.toList())
       }
-      is CloudIdResult -> {
+      is HashResult -> {
         stream.write(133)
+        writeValue(stream, value.toList())
+      }
+      is CloudIdResult -> {
+        stream.write(134)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -9,8 +9,12 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Base64
+import android.util.Log
 import androidx.core.database.getStringOrNull
 import app.alextran.immich.core.ImmichPlugin
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.ImageHeaderParser
+import com.bumptech.glide.load.ImageHeaderParserUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -25,19 +29,12 @@ import java.io.File
 import java.security.MessageDigest
 import kotlin.coroutines.cancellation.CancellationException
 
-enum class PlaybackStyle {
-  UNKNOWN,       // 0
-  IMAGE,         // 1
-  VIDEO,         // 2
-  ANIMATED,      // 3
-  LIVE_PHOTO,    // 4
-  VIDEO_LOOPING, // 5
-}
-
 sealed class AssetResult {
   data class ValidAsset(val asset: PlatformAsset, val albumId: String) : AssetResult()
   data class InvalidAsset(val assetId: String) : AssetResult()
 }
+
+private const val TAG = "NativeSyncApiImplBase"
 
 @SuppressLint("InlinedApi")
 open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
@@ -56,9 +53,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     private const val SPECIAL_FORMAT_GIF = 1
     private const val SPECIAL_FORMAT_MOTION_PHOTO = 2
     private const val SPECIAL_FORMAT_ANIMATED_WEBP = 3
-
-    // XMP column name for API 30+ fallback
-    private const val XMP_COLUMN = "xmp"
 
     const val MEDIA_SELECTION =
       "(${MediaStore.Files.FileColumns.MEDIA_TYPE} = ? OR ${MediaStore.Files.FileColumns.MEDIA_TYPE} = ?)"
@@ -80,7 +74,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       add(MediaStore.MediaColumns.HEIGHT)
       add(MediaStore.MediaColumns.DURATION)
       add(MediaStore.MediaColumns.ORIENTATION)
-      add(MediaStore.MediaColumns.MIME_TYPE)
       // IS_FAVORITE is only available on Android 11 and above
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
         add(MediaStore.MediaColumns.IS_FAVORITE)
@@ -89,7 +82,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
         add(SPECIAL_FORMAT_COLUMN)
       } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         // Fallback: read XMP from MediaStore to detect Motion Photos
-        add(XMP_COLUMN)
+        add(MediaStore.MediaColumns.XMP)
       }
     }.toTypedArray()
 
@@ -136,10 +129,9 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
         val durationColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DURATION)
         val orientationColumn =
           c.getColumnIndexOrThrow(MediaStore.MediaColumns.ORIENTATION)
-        val mimeTypeColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
         val favoriteColumn = c.getColumnIndex(MediaStore.MediaColumns.IS_FAVORITE)
         val specialFormatColumn = c.getColumnIndex(SPECIAL_FORMAT_COLUMN)
-        val xmpColumn = c.getColumnIndex(XMP_COLUMN)
+        val xmpColumn = c.getColumnIndex(MediaStore.MediaColumns.XMP)
 
         while (c.moveToNext()) {
           val numericId = c.getLong(idColumn)
@@ -174,11 +166,10 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           val duration = if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) 0L
           else c.getLong(durationColumn) / 1000
           val orientation = c.getInt(orientationColumn)
-          val mimeType = c.getStringOrNull(mimeTypeColumn)
           val isFavorite = if (favoriteColumn == -1) false else c.getInt(favoriteColumn) != 0
 
           val playbackStyle = detectPlaybackStyle(
-            numericId, rawMediaType, mimeType, specialFormatColumn, xmpColumn, c
+            numericId, rawMediaType, specialFormatColumn, xmpColumn, c
           )
 
           val asset = PlatformAsset(
@@ -192,7 +183,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
             duration,
             orientation.toLong(),
             isFavorite,
-            playbackStyle = playbackStyle.ordinal.toLong(),
+            playbackStyle = playbackStyle,
           )
           yield(AssetResult.ValidAsset(asset, bucketId))
         }
@@ -208,26 +199,29 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
   private fun detectPlaybackStyle(
     assetId: Long,
     rawMediaType: Int,
-    mimeType: String?,
     specialFormatColumn: Int,
     xmpColumn: Int,
     cursor: Cursor
-  ): PlaybackStyle {
+  ): PlatformAssetPlaybackStyle {
     // video currently has no special formats, so we can short circuit and avoid unnecessary work
     if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-      return PlaybackStyle.VIDEO
+      return PlatformAssetPlaybackStyle.VIDEO
     }
 
     // API 33+: use _special_format from cursor
     if (specialFormatColumn != -1) {
       val specialFormat = cursor.getInt(specialFormatColumn)
       return when {
-        specialFormat == SPECIAL_FORMAT_MOTION_PHOTO -> PlaybackStyle.LIVE_PHOTO
-        specialFormat == SPECIAL_FORMAT_GIF || specialFormat == SPECIAL_FORMAT_ANIMATED_WEBP -> PlaybackStyle.ANIMATED
-        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> PlaybackStyle.VIDEO // technically isn't needed, but if code above gets changed later its better to have this as safeguard
-        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> PlaybackStyle.IMAGE
-        else -> PlaybackStyle.UNKNOWN
+        specialFormat == SPECIAL_FORMAT_MOTION_PHOTO -> PlatformAssetPlaybackStyle.LIVE_PHOTO
+        specialFormat == SPECIAL_FORMAT_GIF || specialFormat == SPECIAL_FORMAT_ANIMATED_WEBP -> PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> PlatformAssetPlaybackStyle.VIDEO // technically isn't needed, but if code above gets changed later its better to have this as safeguard
+        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> PlatformAssetPlaybackStyle.IMAGE
+        else -> PlatformAssetPlaybackStyle.UNKNOWN
       }
+    }
+
+    if (rawMediaType != MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+      return PlatformAssetPlaybackStyle.UNKNOWN
     }
 
     // Pre-API 33 fallback
@@ -237,60 +231,40 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     )
 
     // Read XMP from cursor (API 30+) or ExifInterface stream (pre-30)
-    var xmp: String? = if (xmpColumn != -1) {
+    val xmp: String? = if (xmpColumn != -1) {
       cursor.getBlob(xmpColumn)?.toString(Charsets.UTF_8)
-    } else null
-
-    if (xmp == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+    } else {
       try {
         ctx.contentResolver.openInputStream(uri)?.use { stream ->
-          xmp = ExifInterface(stream).getAttribute(ExifInterface.TAG_XMP)
+          ExifInterface(stream).getAttribute(ExifInterface.TAG_XMP)
         }
-      } catch (_: Exception) { }
-    }
-
-    if (xmp != null && ("GCamera:MotionPhoto" in xmp!! || "Camera:MotionPhoto" in xmp!!)) {
-      return PlaybackStyle.LIVE_PHOTO
-    }
-
-    if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-      if (mimeType == "image/gif") return PlaybackStyle.ANIMATED
-      if (mimeType == "image/webp") {
-        try {
-          ctx.contentResolver.openInputStream(uri)?.use { stream ->
-            val header = ByteArray(64)
-            if (stream.read(header) < 30) return PlaybackStyle.IMAGE
-
-            val riff = String(header, 0, 4, Charsets.US_ASCII)
-            val webp = String(header, 8, 4, Charsets.US_ASCII)
-            if (riff != "RIFF" || webp != "WEBP") return PlaybackStyle.IMAGE
-
-            var offset = 12
-            while (offset + 8 <= header.size) {
-              val chunk = String(header, offset, 4, Charsets.US_ASCII)
-              val size =
-                (header[offset + 4].toInt() and 0xFF) or
-                  ((header[offset + 5].toInt() and 0xFF) shl 8) or
-                  ((header[offset + 6].toInt() and 0xFF) shl 16) or
-                  ((header[offset + 7].toInt() and 0xFF) shl 24)
-
-              if (chunk == "VP8X") {
-                val flags = header[offset + 8].toInt() and 0xFF
-                return when {
-                  (flags and 0x02) != 0 -> PlaybackStyle.ANIMATED // Animation flag
-                  else -> PlaybackStyle.IMAGE
-                }
-              }
-
-              offset += 8 + size + (size % 2) // padding
-            }
-          }
-        } catch (_: Exception) { }
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to read XMP for asset $assetId", e)
+        null
       }
-      return PlaybackStyle.IMAGE
     }
 
-    return PlaybackStyle.UNKNOWN
+    if (xmp != null && "Camera:MotionPhoto" in xmp) {
+      return PlatformAssetPlaybackStyle.LIVE_PHOTO
+    }
+
+    try {
+      ctx.contentResolver.openInputStream(uri)?.use { stream ->
+        val glide = Glide.get(ctx)
+        val type = ImageHeaderParserUtils.getType(
+          glide.registry.imageHeaderParsers,
+          stream,
+          glide.arrayPool
+        )
+        if (type == ImageHeaderParser.ImageType.GIF || type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
+          return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+        }
+      }
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to parse image header for asset $assetId", e)
+    }
+
+    return PlatformAssetPlaybackStyle.IMAGE
   }
 
   fun getAlbums(): List<PlatformAlbum> {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import android.content.ContentUris
 import android.content.Context
 import android.database.Cursor
-import android.media.ExifInterface
+import androidx.exifinterface.media.ExifInterface
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
@@ -75,7 +75,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       add(MediaStore.MediaColumns.DURATION)
       add(MediaStore.MediaColumns.ORIENTATION)
       // IS_FAVORITE is only available on Android 11 and above
-      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         add(MediaStore.MediaColumns.IS_FAVORITE)
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -214,7 +214,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       return when {
         specialFormat == SPECIAL_FORMAT_MOTION_PHOTO -> PlatformAssetPlaybackStyle.LIVE_PHOTO
         specialFormat == SPECIAL_FORMAT_GIF || specialFormat == SPECIAL_FORMAT_ANIMATED_WEBP -> PlatformAssetPlaybackStyle.IMAGE_ANIMATED
-        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> PlatformAssetPlaybackStyle.VIDEO // technically isn't needed, but if code above gets changed later its better to have this as safeguard
         rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> PlatformAssetPlaybackStyle.IMAGE
         else -> PlatformAssetPlaybackStyle.UNKNOWN
       }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.ContentUris
 import android.content.Context
 import android.database.Cursor
+import android.media.ExifInterface
+import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Base64
@@ -23,6 +25,15 @@ import java.io.File
 import java.security.MessageDigest
 import kotlin.coroutines.cancellation.CancellationException
 
+enum class PlaybackStyle {
+  UNKNOWN,       // 0
+  IMAGE,         // 1
+  VIDEO,         // 2
+  ANIMATED,      // 3
+  LIVE_PHOTO,    // 4
+  VIDEO_LOOPING, // 5
+}
+
 sealed class AssetResult {
   data class ValidAsset(val asset: PlatformAsset, val albumId: String) : AssetResult()
   data class InvalidAsset(val assetId: String) : AssetResult()
@@ -38,6 +49,16 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     private const val MAX_CONCURRENT_HASH_OPERATIONS = 16
     private val hashSemaphore = Semaphore(MAX_CONCURRENT_HASH_OPERATIONS)
     private const val HASHING_CANCELLED_CODE = "HASH_CANCELLED"
+
+    // MediaStore.Files.FileColumns.SPECIAL_FORMAT — S Extensions 21+
+    // https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT
+    private const val SPECIAL_FORMAT_COLUMN = "_special_format"
+    private const val SPECIAL_FORMAT_GIF = 1
+    private const val SPECIAL_FORMAT_MOTION_PHOTO = 2
+    private const val SPECIAL_FORMAT_ANIMATED_WEBP = 3
+
+    // XMP column name for API 30+ fallback
+    private const val XMP_COLUMN = "xmp"
 
     const val MEDIA_SELECTION =
       "(${MediaStore.Files.FileColumns.MEDIA_TYPE} = ? OR ${MediaStore.Files.FileColumns.MEDIA_TYPE} = ?)"
@@ -63,6 +84,12 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       // IS_FAVORITE is only available on Android 11 and above
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
         add(MediaStore.MediaColumns.IS_FAVORITE)
+      }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        add(SPECIAL_FORMAT_COLUMN)
+      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        // Fallback: read XMP from MediaStore to detect Motion Photos
+        add(XMP_COLUMN)
       }
     }.toTypedArray()
 
@@ -111,9 +138,12 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           c.getColumnIndexOrThrow(MediaStore.MediaColumns.ORIENTATION)
         val mimeTypeColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
         val favoriteColumn = c.getColumnIndex(MediaStore.MediaColumns.IS_FAVORITE)
+        val specialFormatColumn = c.getColumnIndex(SPECIAL_FORMAT_COLUMN)
+        val xmpColumn = c.getColumnIndex(XMP_COLUMN)
 
         while (c.moveToNext()) {
-          val id = c.getLong(idColumn).toString()
+          val numericId = c.getLong(idColumn)
+          val id = numericId.toString()
           val name = c.getStringOrNull(nameColumn)
           val bucketId = c.getStringOrNull(bucketIdColumn)
           val path = c.getStringOrNull(dataColumn)
@@ -127,10 +157,11 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
             continue
           }
 
-          val mediaType = when (c.getInt(mediaTypeColumn)) {
-            MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> 1
-            MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> 2
-            else -> 0
+          val rawMediaType = c.getInt(mediaTypeColumn)
+          val assetType: Long = when (rawMediaType) {
+            MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> 1L
+            MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> 2L
+            else -> 0L
           }
           // Date taken is milliseconds since epoch, Date added is seconds since epoch
           val createdAt = (c.getLong(dateTakenColumn).takeIf { it > 0 }?.div(1000))
@@ -140,22 +171,20 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           val width = c.getInt(widthColumn).toLong()
           val height = c.getInt(heightColumn).toLong()
           // Duration is milliseconds
-          val duration = if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) 0
+          val duration = if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) 0L
           else c.getLong(durationColumn) / 1000
           val orientation = c.getInt(orientationColumn)
           val mimeType = c.getStringOrNull(mimeTypeColumn)
           val isFavorite = if (favoriteColumn == -1) false else c.getInt(favoriteColumn) != 0
 
-          val playbackStyle: Long = when {
-            mediaType == 2 -> 1L           // video
-            mimeType == "image/gif" -> 2L  // animated
-            else -> 0L                     // static image
-          }
+          val playbackStyle = detectPlaybackStyle(
+            numericId, rawMediaType, mimeType, specialFormatColumn, xmpColumn, c
+          )
 
           val asset = PlatformAsset(
             id,
             name,
-            mediaType.toLong(),
+            assetType,
             createdAt,
             modifiedAt,
             width,
@@ -163,12 +192,105 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
             duration,
             orientation.toLong(),
             isFavorite,
-            playbackStyle = playbackStyle,
+            playbackStyle = playbackStyle.ordinal.toLong(),
           )
           yield(AssetResult.ValidAsset(asset, bucketId))
         }
       }
     }
+  }
+
+  /**
+   * Detects the playback style for an asset using _special_format (API 33+)
+   * or XMP / MIME / RIFF header fallbacks (pre-33).
+   */
+  @SuppressLint("NewApi")
+  private fun detectPlaybackStyle(
+    assetId: Long,
+    rawMediaType: Int,
+    mimeType: String?,
+    specialFormatColumn: Int,
+    xmpColumn: Int,
+    cursor: Cursor
+  ): PlaybackStyle {
+    // video currently has no special formats, so we can short circuit and avoid unnecessary work
+    if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+      return PlaybackStyle.VIDEO
+    }
+
+    // API 33+: use _special_format from cursor
+    if (specialFormatColumn != -1) {
+      val specialFormat = cursor.getInt(specialFormatColumn)
+      return when {
+        specialFormat == SPECIAL_FORMAT_MOTION_PHOTO -> PlaybackStyle.LIVE_PHOTO
+        specialFormat == SPECIAL_FORMAT_GIF || specialFormat == SPECIAL_FORMAT_ANIMATED_WEBP -> PlaybackStyle.ANIMATED
+        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> PlaybackStyle.VIDEO // technically isn't needed, but if code above gets changed later its better to have this as safeguard
+        rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> PlaybackStyle.IMAGE
+        else -> PlaybackStyle.UNKNOWN
+      }
+    }
+
+    // Pre-API 33 fallback
+    val uri = ContentUris.withAppendedId(
+      MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
+      assetId
+    )
+
+    // Read XMP from cursor (API 30+) or ExifInterface stream (pre-30)
+    var xmp: String? = if (xmpColumn != -1) {
+      cursor.getBlob(xmpColumn)?.toString(Charsets.UTF_8)
+    } else null
+
+    if (xmp == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      try {
+        ctx.contentResolver.openInputStream(uri)?.use { stream ->
+          xmp = ExifInterface(stream).getAttribute(ExifInterface.TAG_XMP)
+        }
+      } catch (_: Exception) { }
+    }
+
+    if (xmp != null && ("GCamera:MotionPhoto" in xmp!! || "Camera:MotionPhoto" in xmp!!)) {
+      return PlaybackStyle.LIVE_PHOTO
+    }
+
+    if (rawMediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+      if (mimeType == "image/gif") return PlaybackStyle.ANIMATED
+      if (mimeType == "image/webp") {
+        try {
+          ctx.contentResolver.openInputStream(uri)?.use { stream ->
+            val header = ByteArray(64)
+            if (stream.read(header) < 30) return PlaybackStyle.IMAGE
+
+            val riff = String(header, 0, 4, Charsets.US_ASCII)
+            val webp = String(header, 8, 4, Charsets.US_ASCII)
+            if (riff != "RIFF" || webp != "WEBP") return PlaybackStyle.IMAGE
+
+            var offset = 12
+            while (offset + 8 <= header.size) {
+              val chunk = String(header, offset, 4, Charsets.US_ASCII)
+              val size =
+                (header[offset + 4].toInt() and 0xFF) or
+                  ((header[offset + 5].toInt() and 0xFF) shl 8) or
+                  ((header[offset + 6].toInt() and 0xFF) shl 16) or
+                  ((header[offset + 7].toInt() and 0xFF) shl 24)
+
+              if (chunk == "VP8X") {
+                val flags = header[offset + 8].toInt() and 0xFF
+                return when {
+                  (flags and 0x02) != 0 -> PlaybackStyle.ANIMATED // Animation flag
+                  else -> PlaybackStyle.IMAGE
+                }
+              }
+
+              offset += 8 + size + (size % 2) // padding
+            }
+          }
+        } catch (_: Exception) { }
+      }
+      return PlaybackStyle.IMAGE
+    }
+
+    return PlaybackStyle.UNKNOWN
   }
 
   fun getAlbums(): List<PlatformAlbum> {

--- a/mobile/ios/Runner/Sync/Messages.g.swift
+++ b/mobile/ios/Runner/Sync/Messages.g.swift
@@ -143,6 +143,7 @@ struct PlatformAsset: Hashable {
   var adjustmentTime: Int64? = nil
   var latitude: Double? = nil
   var longitude: Double? = nil
+  var playbackStyle: Int64
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -160,6 +161,7 @@ struct PlatformAsset: Hashable {
     let adjustmentTime: Int64? = nilOrValue(pigeonVar_list[10])
     let latitude: Double? = nilOrValue(pigeonVar_list[11])
     let longitude: Double? = nilOrValue(pigeonVar_list[12])
+    let playbackStyle = pigeonVar_list[13] as! Int64
 
     return PlatformAsset(
       id: id,
@@ -174,7 +176,8 @@ struct PlatformAsset: Hashable {
       isFavorite: isFavorite,
       adjustmentTime: adjustmentTime,
       latitude: latitude,
-      longitude: longitude
+      longitude: longitude,
+      playbackStyle: playbackStyle
     )
   }
   func toList() -> [Any?] {
@@ -192,6 +195,7 @@ struct PlatformAsset: Hashable {
       adjustmentTime,
       latitude,
       longitude,
+      playbackStyle,
     ]
   }
   static func == (lhs: PlatformAsset, rhs: PlatformAsset) -> Bool {

--- a/mobile/ios/Runner/Sync/Messages.g.swift
+++ b/mobile/ios/Runner/Sync/Messages.g.swift
@@ -128,6 +128,15 @@ func deepHashMessages(value: Any?, hasher: inout Hasher) {
 
     
 
+enum PlatformAssetPlaybackStyle: Int {
+  case unknown = 0
+  case image = 1
+  case video = 2
+  case imageAnimated = 3
+  case livePhoto = 4
+  case videoLooping = 5
+}
+
 /// Generated class from Pigeon that represents data sent in messages.
 struct PlatformAsset: Hashable {
   var id: String
@@ -143,7 +152,7 @@ struct PlatformAsset: Hashable {
   var adjustmentTime: Int64? = nil
   var latitude: Double? = nil
   var longitude: Double? = nil
-  var playbackStyle: Int64
+  var playbackStyle: PlatformAssetPlaybackStyle
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -161,7 +170,7 @@ struct PlatformAsset: Hashable {
     let adjustmentTime: Int64? = nilOrValue(pigeonVar_list[10])
     let latitude: Double? = nilOrValue(pigeonVar_list[11])
     let longitude: Double? = nilOrValue(pigeonVar_list[12])
-    let playbackStyle = pigeonVar_list[13] as! Int64
+    let playbackStyle = pigeonVar_list[13] as! PlatformAssetPlaybackStyle
 
     return PlatformAsset(
       id: id,
@@ -353,14 +362,20 @@ private class MessagesPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      return PlatformAsset.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return PlatformAssetPlaybackStyle(rawValue: enumResultAsInt)
+      }
+      return nil
     case 130:
-      return PlatformAlbum.fromList(self.readValue() as! [Any?])
+      return PlatformAsset.fromList(self.readValue() as! [Any?])
     case 131:
-      return SyncDelta.fromList(self.readValue() as! [Any?])
+      return PlatformAlbum.fromList(self.readValue() as! [Any?])
     case 132:
-      return HashResult.fromList(self.readValue() as! [Any?])
+      return SyncDelta.fromList(self.readValue() as! [Any?])
     case 133:
+      return HashResult.fromList(self.readValue() as! [Any?])
+    case 134:
       return CloudIdResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -370,20 +385,23 @@ private class MessagesPigeonCodecReader: FlutterStandardReader {
 
 private class MessagesPigeonCodecWriter: FlutterStandardWriter {
   override func writeValue(_ value: Any) {
-    if let value = value as? PlatformAsset {
+    if let value = value as? PlatformAssetPlaybackStyle {
       super.writeByte(129)
-      super.writeValue(value.toList())
-    } else if let value = value as? PlatformAlbum {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? PlatformAsset {
       super.writeByte(130)
       super.writeValue(value.toList())
-    } else if let value = value as? SyncDelta {
+    } else if let value = value as? PlatformAlbum {
       super.writeByte(131)
       super.writeValue(value.toList())
-    } else if let value = value as? HashResult {
+    } else if let value = value as? SyncDelta {
       super.writeByte(132)
       super.writeValue(value.toList())
-    } else if let value = value as? CloudIdResult {
+    } else if let value = value as? HashResult {
       super.writeByte(133)
+      super.writeValue(value.toList())
+    } else if let value = value as? CloudIdResult {
+      super.writeByte(134)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -173,7 +173,8 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
             type: 0,
             durationInSeconds: 0,
             orientation: 0,
-            isFavorite: false
+            isFavorite: false,
+            playbackStyle: 0
           )
           if (updatedAssets.contains(AssetWrapper(with: predicate))) {
             continue

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -174,7 +174,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
             durationInSeconds: 0,
             orientation: 0,
             isFavorite: false,
-            playbackStyle: 0
+            playbackStyle: .unknown
           )
           if (updatedAssets.contains(AssetWrapper(with: predicate))) {
             continue

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -1,6 +1,19 @@
 import Photos
 
 extension PHAsset {
+  var playbackStyleValue: Int64 {
+    if #available(iOS 11, *) {
+      switch playbackStyle {
+      case .image: return 0
+      case .imageAnimated: return 2
+      case .livePhoto: return 3
+      case .video, .videoLooping: return 1
+      default: return 0
+      }
+    }
+    return 0
+  }
+
   func toPlatformAsset() -> PlatformAsset {
     return PlatformAsset(
       id: localIdentifier,
@@ -15,7 +28,8 @@ extension PHAsset {
       isFavorite: isFavorite,
       adjustmentTime: adjustmentTimestamp,
       latitude: location?.coordinate.latitude,
-      longitude: location?.coordinate.longitude
+      longitude: location?.coordinate.longitude,
+      playbackStyle: playbackStyleValue
     )
   }
 

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -1,14 +1,14 @@
 import Photos
 
 extension PHAsset {
-  var playbackStyleValue: Int64 {
+  var platformPlaybackStyle: PlatformAssetPlaybackStyle {
     switch playbackStyle {
-    case .image: return 1
-    case .imageAnimated: return 3
-    case .livePhoto: return 4
-    case .video: return 2
-    case .videoLooping: return 5
-    @unknown default: return 0
+    case .image: return .image
+    case .imageAnimated: return .imageAnimated
+    case .livePhoto: return .livePhoto
+    case .video: return .video
+    case .videoLooping: return .videoLooping
+    @unknown default: return .unknown
     }
   }
 
@@ -27,7 +27,7 @@ extension PHAsset {
       adjustmentTime: adjustmentTimestamp,
       latitude: location?.coordinate.latitude,
       longitude: location?.coordinate.longitude,
-      playbackStyle: playbackStyleValue
+      playbackStyle: platformPlaybackStyle
     )
   }
 

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -7,7 +7,8 @@ extension PHAsset {
       case .image: return 0
       case .imageAnimated: return 2
       case .livePhoto: return 3
-      case .video, .videoLooping: return 1
+      case .video: return 1
+      case .videoLooping: return 4
       default: return 0
       }
     }

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -2,17 +2,14 @@ import Photos
 
 extension PHAsset {
   var playbackStyleValue: Int64 {
-    if #available(iOS 11, *) {
-      switch playbackStyle {
-      case .image: return 0
-      case .imageAnimated: return 2
-      case .livePhoto: return 3
-      case .video: return 1
-      case .videoLooping: return 4
-      @unknown default: return 0
-      }
+    switch playbackStyle {
+    case .image: return 0
+    case .imageAnimated: return 2
+    case .livePhoto: return 3
+    case .video: return 1
+    case .videoLooping: return 4
+    @unknown default: return 0
     }
-    return 0
   }
 
   func toPlatformAsset() -> PlatformAsset {
@@ -41,7 +38,7 @@ extension PHAsset {
   var filename: String? {
     return value(forKey: "filename") as? String
   }
-  
+
   var adjustmentTimestamp: Int64? {
     if let date = value(forKey: "adjustmentTimestamp") as? Date {
       return Int64(date.timeIntervalSince1970)

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -3,11 +3,11 @@ import Photos
 extension PHAsset {
   var playbackStyleValue: Int64 {
     switch playbackStyle {
-    case .image: return 0
-    case .imageAnimated: return 2
-    case .livePhoto: return 3
-    case .video: return 1
-    case .videoLooping: return 4
+    case .image: return 1
+    case .imageAnimated: return 3
+    case .livePhoto: return 4
+    case .video: return 2
+    case .videoLooping: return 5
     @unknown default: return 0
     }
   }

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -9,7 +9,7 @@ extension PHAsset {
       case .livePhoto: return 3
       case .video: return 1
       case .videoLooping: return 4
-      default: return 0
+      @unknown default: return 0
       }
     }
     return 0

--- a/mobile/lib/platform/native_sync_api.g.dart
+++ b/mobile/lib/platform/native_sync_api.g.dart
@@ -44,6 +44,7 @@ class PlatformAsset {
     this.adjustmentTime,
     this.latitude,
     this.longitude,
+    required this.playbackStyle,
   });
 
   String id;
@@ -72,6 +73,8 @@ class PlatformAsset {
 
   double? longitude;
 
+  int playbackStyle;
+
   List<Object?> _toList() {
     return <Object?>[
       id,
@@ -87,6 +90,7 @@ class PlatformAsset {
       adjustmentTime,
       latitude,
       longitude,
+      playbackStyle,
     ];
   }
 
@@ -110,6 +114,7 @@ class PlatformAsset {
       adjustmentTime: result[10] as int?,
       latitude: result[11] as double?,
       longitude: result[12] as double?,
+      playbackStyle: result[13]! as int,
     );
   }
 

--- a/mobile/lib/platform/native_sync_api.g.dart
+++ b/mobile/lib/platform/native_sync_api.g.dart
@@ -29,6 +29,8 @@ bool _deepEquals(Object? a, Object? b) {
   return a == b;
 }
 
+enum PlatformAssetPlaybackStyle { unknown, image, video, imageAnimated, livePhoto, videoLooping }
+
 class PlatformAsset {
   PlatformAsset({
     required this.id,
@@ -73,7 +75,7 @@ class PlatformAsset {
 
   double? longitude;
 
-  int playbackStyle;
+  PlatformAssetPlaybackStyle playbackStyle;
 
   List<Object?> _toList() {
     return <Object?>[
@@ -114,7 +116,7 @@ class PlatformAsset {
       adjustmentTime: result[10] as int?,
       latitude: result[11] as double?,
       longitude: result[12] as double?,
-      playbackStyle: result[13]! as int,
+      playbackStyle: result[13]! as PlatformAssetPlaybackStyle,
     );
   }
 
@@ -321,20 +323,23 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is PlatformAsset) {
+    } else if (value is PlatformAssetPlaybackStyle) {
       buffer.putUint8(129);
-      writeValue(buffer, value.encode());
-    } else if (value is PlatformAlbum) {
+      writeValue(buffer, value.index);
+    } else if (value is PlatformAsset) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is SyncDelta) {
+    } else if (value is PlatformAlbum) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is HashResult) {
+    } else if (value is SyncDelta) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is CloudIdResult) {
+    } else if (value is HashResult) {
       buffer.putUint8(133);
+      writeValue(buffer, value.encode());
+    } else if (value is CloudIdResult) {
+      buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -345,14 +350,17 @@ class _PigeonCodec extends StandardMessageCodec {
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
       case 129:
-        return PlatformAsset.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : PlatformAssetPlaybackStyle.values[value];
       case 130:
-        return PlatformAlbum.decode(readValue(buffer)!);
+        return PlatformAsset.decode(readValue(buffer)!);
       case 131:
-        return SyncDelta.decode(readValue(buffer)!);
+        return PlatformAlbum.decode(readValue(buffer)!);
       case 132:
-        return HashResult.decode(readValue(buffer)!);
+        return SyncDelta.decode(readValue(buffer)!);
       case 133:
+        return HashResult.decode(readValue(buffer)!);
+      case 134:
         return CloudIdResult.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -31,6 +31,9 @@ class PlatformAsset {
   final double? latitude;
   final double? longitude;
 
+  // Follows AssetPlaybackStyle enum: 0=image, 1=video, 2=animated, 3=livePhoto
+  final int playbackStyle;
+
   const PlatformAsset({
     required this.id,
     required this.name,
@@ -45,6 +48,7 @@ class PlatformAsset {
     this.adjustmentTime,
     this.latitude,
     this.longitude,
+    this.playbackStyle = 0,
   });
 }
 

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -11,6 +11,15 @@ import 'package:pigeon/pigeon.dart';
     dartPackageName: 'immich_mobile',
   ),
 )
+enum PlatformAssetPlaybackStyle {
+  unknown,
+  image,
+  video,
+  imageAnimated,
+  livePhoto,
+  videoLooping,
+}
+
 class PlatformAsset {
   final String id;
   final String name;
@@ -31,8 +40,7 @@ class PlatformAsset {
   final double? latitude;
   final double? longitude;
 
-  // Follows AssetPlaybackStyle enum: 0=unknown, 1=image, 2=video, 3=animated, 4=livePhoto, 5=videoLooping
-  final int playbackStyle;
+  final PlatformAssetPlaybackStyle playbackStyle;
 
   const PlatformAsset({
     required this.id,
@@ -48,7 +56,7 @@ class PlatformAsset {
     this.adjustmentTime,
     this.latitude,
     this.longitude,
-    this.playbackStyle = 0,
+    this.playbackStyle = PlatformAssetPlaybackStyle.unknown,
   });
 }
 

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -31,7 +31,7 @@ class PlatformAsset {
   final double? latitude;
   final double? longitude;
 
-  // Enum: 0=image, 1=video, 2=animated, 3=livePhoto, 4=videoLooping
+  // Follows AssetPlaybackStyle enum: 0=unknown, 1=image, 2=video, 3=animated, 4=livePhoto, 5=videoLooping
   final int playbackStyle;
 
   const PlatformAsset({

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -31,7 +31,7 @@ class PlatformAsset {
   final double? latitude;
   final double? longitude;
 
-  // Follows AssetPlaybackStyle enum: 0=image, 1=video, 2=animated, 3=livePhoto
+  // Enum: 0=image, 1=video, 2=animated, 3=livePhoto, 4=videoLooping
   final int playbackStyle;
 
   const PlatformAsset({

--- a/mobile/test/domain/services/local_sync_service_test.dart
+++ b/mobile/test/domain/services/local_sync_service_test.dart
@@ -131,6 +131,7 @@ void main() {
         durationInSeconds: 0,
         orientation: 0,
         isFavorite: false,
+        playbackStyle: AssetPlaybackStyle.image.index
       );
 
       final assetsToRestore = [LocalAssetStub.image1];
@@ -214,6 +215,7 @@ void main() {
         isFavorite: false,
         createdAt: 1700000000,
         updatedAt: 1732000000,
+        playbackStyle: AssetPlaybackStyle.image.index
       );
 
       final localAsset = platformAsset.toLocalAsset();

--- a/mobile/test/domain/services/local_sync_service_test.dart
+++ b/mobile/test/domain/services/local_sync_service_test.dart
@@ -131,7 +131,7 @@ void main() {
         durationInSeconds: 0,
         orientation: 0,
         isFavorite: false,
-        playbackStyle: 1
+        playbackStyle: PlatformAssetPlaybackStyle.image
       );
 
       final assetsToRestore = [LocalAssetStub.image1];
@@ -215,7 +215,7 @@ void main() {
         isFavorite: false,
         createdAt: 1700000000,
         updatedAt: 1732000000,
-        playbackStyle: 1
+        playbackStyle: PlatformAssetPlaybackStyle.image
       );
 
       final localAsset = platformAsset.toLocalAsset();

--- a/mobile/test/domain/services/local_sync_service_test.dart
+++ b/mobile/test/domain/services/local_sync_service_test.dart
@@ -131,7 +131,7 @@ void main() {
         durationInSeconds: 0,
         orientation: 0,
         isFavorite: false,
-        playbackStyle: AssetPlaybackStyle.image.index
+        playbackStyle: 0
       );
 
       final assetsToRestore = [LocalAssetStub.image1];
@@ -215,7 +215,7 @@ void main() {
         isFavorite: false,
         createdAt: 1700000000,
         updatedAt: 1732000000,
-        playbackStyle: AssetPlaybackStyle.image.index
+        playbackStyle: 0
       );
 
       final localAsset = platformAsset.toLocalAsset();

--- a/mobile/test/domain/services/local_sync_service_test.dart
+++ b/mobile/test/domain/services/local_sync_service_test.dart
@@ -131,7 +131,7 @@ void main() {
         durationInSeconds: 0,
         orientation: 0,
         isFavorite: false,
-        playbackStyle: 0
+        playbackStyle: 1
       );
 
       final assetsToRestore = [LocalAssetStub.image1];
@@ -215,7 +215,7 @@ void main() {
         isFavorite: false,
         createdAt: 1700000000,
         updatedAt: 1732000000,
-        playbackStyle: 0
+        playbackStyle: 1
       );
 
       final localAsset = platformAsset.toLocalAsset();


### PR DESCRIPTION
As requested, smaller PRs for #26148 

The first step which is easy to uncouple from all other changes in the native sync of the playbackstyle.
After this PR I will continue with:

- PR2: Persist playbackStyle in local asset database
- PR3: And finally Animated image rendering support :D

---

Adds a `playbackStyle` field to `PlatformAsset` in the pigeon sync API so native platforms can communicate the asset's playback style (image, video, animated, livePhoto) to Flutter during sync.

Whats important to know:
- iOS there now is the `playbackStyleValue` in the PHAsset where we use iOS provides, but in android there is no such thing as a playback style value, thus we have to "guess" when playbackStyle is of animation (if you don't have other ideas). Currently this happens via MimeType of "image/gif"
- also in iOS there is another playback style called `videoLooping`. I wasn't sure if we also want to report that back. So I currently didn't include it and it just report playback style video for it.