### PR TITLE
fix(mobile): use correct delete action

### DIFF
--- a/mobile/lib/domain/models/asset/remote_asset.model.dart
+++ b/mobile/lib/domain/models/asset/remote_asset.model.dart
@@ -11,6 +11,7 @@ class RemoteAsset extends BaseAsset {
   final String ownerId;
   final String? stackId;
   final DateTime? uploadedAt;
+  final DateTime? deletedAt;
 
   const RemoteAsset({
     required this.id,
@@ -31,6 +32,7 @@ class RemoteAsset extends BaseAsset {
     super.livePhotoVideoId,
     this.stackId,
     required super.isEdited,
+    this.deletedAt,
   }) : localAssetId = localId;
 
   @override
@@ -47,6 +49,8 @@ class RemoteAsset extends BaseAsset {
 
   @override
   bool get isEditable => isImage && !isMotionPhoto && !isAnimatedImage;
+
+  bool get isTrashed => deletedAt != null;
 
   @override
   String toString() {
@@ -86,7 +90,8 @@ class RemoteAsset extends BaseAsset {
         thumbHash == other.thumbHash &&
         visibility == other.visibility &&
         stackId == other.stackId &&
-        uploadedAt == other.uploadedAt;
+        uploadedAt == other.uploadedAt &&
+        deletedAt == other.deletedAt;
   }
 
   @override
@@ -98,7 +103,8 @@ class RemoteAsset extends BaseAsset {
       thumbHash.hashCode ^
       visibility.hashCode ^
       stackId.hashCode ^
-      uploadedAt.hashCode;
+      uploadedAt.hashCode ^
+      deletedAt.hashCode;
 
   RemoteAsset copyWith({
     String? id,
@@ -119,6 +125,7 @@ class RemoteAsset extends BaseAsset {
     String? livePhotoVideoId,
     String? stackId,
     bool? isEdited,
+    DateTime? deletedAt,
   }) {
     return RemoteAsset(
       id: id ?? this.id,
@@ -139,6 +146,7 @@ class RemoteAsset extends BaseAsset {
       livePhotoVideoId: livePhotoVideoId ?? this.livePhotoVideoId,
       stackId: stackId ?? this.stackId,
       isEdited: isEdited ?? this.isEdited,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 }
@@ -156,6 +164,7 @@ class RemoteAssetExif extends RemoteAsset {
     required super.createdAt,
     required super.updatedAt,
     super.uploadedAt,
+    super.deletedAt,
     super.width,
     super.height,
     super.durationMs,
@@ -193,6 +202,7 @@ class RemoteAssetExif extends RemoteAsset {
     DateTime? createdAt,
     DateTime? updatedAt,
     DateTime? uploadedAt,
+    DateTime? deletedAt,
     int? width,
     int? height,
     int? durationMs,
@@ -214,6 +224,7 @@ class RemoteAssetExif extends RemoteAsset {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       uploadedAt: uploadedAt ?? this.uploadedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
       width: width ?? this.width,
       height: height ?? this.height,
       durationMs: durationMs ?? this.durationMs,

--- a/mobile/lib/infrastructure/entities/remote_asset.entity.dart
+++ b/mobile/lib/infrastructure/entities/remote_asset.entity.dart
@@ -74,5 +74,6 @@ extension RemoteAssetEntityDataDomainEx on RemoteAssetEntityData {
     localId: localId,
     stackId: stackId,
     isEdited: isEdited,
+    deletedAt: deletedAt,
   );
 }

--- a/mobile/lib/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart
@@ -18,8 +18,15 @@ class DeletePermanentActionButton extends ConsumerWidget {
   final ActionSource source;
   final bool iconOnly;
   final bool menuItem;
+  final bool useShortLabel;
 
-  const DeletePermanentActionButton({super.key, required this.source, this.iconOnly = false, this.menuItem = false});
+  const DeletePermanentActionButton({
+    super.key,
+    required this.source,
+    this.iconOnly = false,
+    this.menuItem = false,
+    this.useShortLabel = false,
+  });
 
   void _onTap(BuildContext context, WidgetRef ref) async {
     if (!context.mounted) {
@@ -64,7 +71,7 @@ class DeletePermanentActionButton extends ConsumerWidget {
     return BaseActionButton(
       maxWidth: 110.0,
       iconData: Icons.delete_forever,
-      label: "delete_permanently".t(context: context),
+      label: useShortLabel ? "delete".t(context: context) : "delete_permanently".t(context: context),
       iconOnly: iconOnly,
       menuItem: menuItem,
       onPressed: () => _onTap(context, ref),

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/add_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_image_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/restore_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
@@ -55,9 +56,12 @@ class ViewerBottomBar extends ConsumerWidget {
           if (asset.hasRemote) AddActionButton(originalTheme: originalTheme),
         ],
         if (isOwner) ...[
-          asset.isLocalOnly
-              ? const DeleteLocalActionButton(source: ActionSource.viewer)
-              : const DeleteActionButton(source: ActionSource.viewer, showConfirmation: true),
+          if (asset.isLocalOnly)
+            const DeleteLocalActionButton(source: ActionSource.viewer)
+          else if (asset.isTrashed)
+            const DeletePermanentActionButton(source: ActionSource.viewer, useShortLabel: true)
+          else
+            const DeleteActionButton(source: ActionSource.viewer, showConfirmation: true),
         ],
       ],
     ];

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -123,9 +123,8 @@ enum ActionButtonType {
             context.timelineOrigin == TimelineOrigin.trash,
       ActionButtonType.deletePermanent =>
         context.isOwner && //
-                context.asset.hasRemote && //
-                !context.isTrashEnabled ||
-            context.isInLockedView,
+            context.asset.hasRemote && //
+            (!context.isTrashEnabled || context.timelineOrigin == TimelineOrigin.trash || context.isInLockedView),
       ActionButtonType.delete =>
         context.isOwner && //
             !context.isInLockedView && //
@@ -324,6 +323,7 @@ class ActionButtonBuilder {
     ActionButtonType.archive,
     ActionButtonType.unarchive,
     ActionButtonType.restoreTrash,
+    ActionButtonType.deletePermanent,
   };
 
   static List<Widget> build(ActionButtonContext context) {

--- a/mobile/test/utils_legacy/action_button_utils_test.dart
+++ b/mobile/test/utils_legacy/action_button_utils_test.dart
@@ -38,6 +38,7 @@ RemoteAsset createRemoteAsset({
   DateTime? updatedAt,
   DateTime? uploadedAt,
   bool isFavorite = false,
+  DateTime? deletedAt,
 }) {
   return RemoteAsset(
     id: 'remote-id',
@@ -51,6 +52,7 @@ RemoteAsset createRemoteAsset({
     uploadedAt: uploadedAt ?? DateTime.now(),
     isFavorite: isFavorite,
     isEdited: false,
+    deletedAt: deletedAt,
   );
 }
 
@@ -459,6 +461,24 @@ void main() {
 
         expect(ActionButtonType.trash.shouldShow(context), isFalse);
       });
+
+      test('should not show when asset is already trashed', () {
+        final remoteAsset = createRemoteAsset(deletedAt: DateTime(2024));
+        final context = ActionButtonContext(
+          asset: remoteAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: true,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: false,
+          isStacked: false,
+          source: ActionSource.viewer,
+          timelineOrigin: TimelineOrigin.trash,
+        );
+
+        expect(ActionButtonType.trash.shouldShow(context), isFalse);
+      });
     });
 
     group('restoreTrash button', () {
@@ -532,6 +552,24 @@ void main() {
         );
 
         expect(ActionButtonType.deletePermanent.shouldShow(context), isFalse);
+      });
+
+      test('should show when asset is trashed even with trash enabled', () {
+        final remoteAsset = createRemoteAsset(deletedAt: DateTime(2024));
+        final context = ActionButtonContext(
+          asset: remoteAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: true,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: false,
+          isStacked: false,
+          source: ActionSource.viewer,
+          timelineOrigin: TimelineOrigin.trash,
+        );
+
+        expect(ActionButtonType.deletePermanent.shouldShow(context), isTrue);
       });
     });
 


### PR DESCRIPTION
## Description

When viewing a trashed asset in the image viewer (library > trash > image viewer), a few things were broken:

1. The bottom bar showed `DeleteActionButton` (move to trash) instead of `DeletePermanentActionButton`. Pressing it did nothing since the asset is already trashed.
2. The kebab menu also showed "Move to Trash" instead of "Delete Permanently" for the same reason.
3. After permanently deleting an asset, the viewer didn't advance to the next asset. I believe that this is due to both the server sync event and the local DB delete firing a `TimelineReloadEvent`. The first one still has the asset in the buffer, so the reload flag doesnt do anything (no-op heroTag match). The second one sees the asset is gone but the flag is already false.

Changes:

- Added `deletedAt` field to `RemoteAsset` domain model (mapped from the entity) so the viewer can check if an asset is trashed
- Viewer bottom bar checks `asset.deletedAt != null` and shows `DeletePermanentActionButton` for trashed assets
- Added `useShortLabel` parameter to `DeletePermanentActionButton` to show "Delete" instead of "Delete permanently" in the viewer (the longer text broke into two lines and looked uneven)
- Kebap-Menu adjustments:
    - `ActionButtonType.trash.shouldShow` now returns false for already-trashed assets
    - `ActionButtonType.deletePermanent.shouldShow` now returns true for trashed assets
- `_onTimelineReloadEvent` always advances when `getIndex` returns null (-> which means asset gone from timeline) instead of relying on the reload flag

Parts of this PR were already reviewed in https://github.com/immich-app/immich/pull/25111, which was closed accidentally while waiting for some other stuff to get merged. Also related to https://github.com/immich-app/immich/pull/26442.

I believe this fixes https://github.com/immich-app/immich/issues/21949
Fixes https://github.com/immich-app/immich/issues/20587
Fixes #21148

## How Has This Been Tested?

- [x] Open an image from the trash page
- [x] Verify the delete button does not bring up the old dialog
- [x] Verify tapping delete permanently removes the asset
- [x] Verify normal (non-trashed) images still show "Move to bin" behavior

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] [N/A] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude was used to explore some of the related code.