### PR TITLE
feat(mobile): add support for encoded image requests in local/remote image APIs

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImages.g.kt
@@ -59,7 +59,7 @@ private open class LocalImagesPigeonCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface LocalImageApi {
-  fun requestImage(assetId: String, requestId: Long, width: Long, height: Long, isVideo: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
+  fun requestImage(assetId: String, requestId: Long, width: Long, height: Long, isVideo: Boolean, encoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
   fun cancelRequest(requestId: Long)
   fun getThumbhash(thumbhash: String, callback: (Result<Map<String, Long>>) -> Unit)
 
@@ -82,7 +82,8 @@ interface LocalImageApi {
             val widthArg = args[2] as Long
             val heightArg = args[3] as Long
             val isVideoArg = args[4] as Boolean
-            api.requestImage(assetIdArg, requestIdArg, widthArg, heightArg, isVideoArg) { result: Result<Map<String, Long>?> ->
+            val encodedArg = args[5] as Boolean
+            api.requestImage(assetIdArg, requestIdArg, widthArg, heightArg, isVideoArg, encodedArg) { result: Result<Map<String, Long>?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(LocalImagesPigeonUtils.wrapError(error))

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImages.g.kt
@@ -59,7 +59,7 @@ private open class LocalImagesPigeonCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface LocalImageApi {
-  fun requestImage(assetId: String, requestId: Long, width: Long, height: Long, isVideo: Boolean, encoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
+  fun requestImage(assetId: String, requestId: Long, width: Long, height: Long, isVideo: Boolean, preferEncoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
   fun cancelRequest(requestId: Long)
   fun getThumbhash(thumbhash: String, callback: (Result<Map<String, Long>>) -> Unit)
 
@@ -82,8 +82,8 @@ interface LocalImageApi {
             val widthArg = args[2] as Long
             val heightArg = args[3] as Long
             val isVideoArg = args[4] as Boolean
-            val encodedArg = args[5] as Boolean
-            api.requestImage(assetIdArg, requestIdArg, widthArg, heightArg, isVideoArg, encodedArg) { result: Result<Map<String, Long>?> ->
+            val preferEncodedArg = args[5] as Boolean
+            api.requestImage(assetIdArg, requestIdArg, widthArg, heightArg, isVideoArg, preferEncodedArg) { result: Result<Map<String, Long>?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(LocalImagesPigeonUtils.wrapError(error))

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
@@ -100,13 +100,13 @@ class LocalImagesImpl(context: Context) : LocalImageApi {
     width: Long,
     height: Long,
     isVideo: Boolean,
-    encoded: Boolean,
+    preferEncoded: Boolean,
     callback: (Result<Map<String, Long>?>) -> Unit
   ) {
     val signal = CancellationSignal()
     val task = threadPool.submit {
       try {
-        if (encoded) {
+        if (preferEncoded) {
           getEncodedImageInternal(assetId, callback, signal)
         } else {
           getThumbnailBufferInternal(assetId, width, height, isVideo, callback, signal)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImages.g.kt
@@ -47,7 +47,7 @@ private open class RemoteImagesPigeonCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface RemoteImageApi {
-  fun requestImage(url: String, headers: Map<String, String>, requestId: Long, callback: (Result<Map<String, Long>?>) -> Unit)
+  fun requestImage(url: String, headers: Map<String, String>, requestId: Long, encoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
   fun cancelRequest(requestId: Long)
   fun clearCache(callback: (Result<Long>) -> Unit)
 
@@ -68,7 +68,8 @@ interface RemoteImageApi {
             val urlArg = args[0] as String
             val headersArg = args[1] as Map<String, String>
             val requestIdArg = args[2] as Long
-            api.requestImage(urlArg, headersArg, requestIdArg) { result: Result<Map<String, Long>?> ->
+            val encodedArg = args[3] as Boolean
+            api.requestImage(urlArg, headersArg, requestIdArg, encodedArg) { result: Result<Map<String, Long>?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(RemoteImagesPigeonUtils.wrapError(error))

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImages.g.kt
@@ -47,7 +47,7 @@ private open class RemoteImagesPigeonCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface RemoteImageApi {
-  fun requestImage(url: String, headers: Map<String, String>, requestId: Long, encoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
+  fun requestImage(url: String, headers: Map<String, String>, requestId: Long, preferEncoded: Boolean, callback: (Result<Map<String, Long>?>) -> Unit)
   fun cancelRequest(requestId: Long)
   fun clearCache(callback: (Result<Long>) -> Unit)
 
@@ -68,8 +68,8 @@ interface RemoteImageApi {
             val urlArg = args[0] as String
             val headersArg = args[1] as Map<String, String>
             val requestIdArg = args[2] as Long
-            val encodedArg = args[3] as Boolean
-            api.requestImage(urlArg, headersArg, requestIdArg, encodedArg) { result: Result<Map<String, Long>?> ->
+            val preferEncodedArg = args[3] as Boolean
+            api.requestImage(urlArg, headersArg, requestIdArg, preferEncodedArg) { result: Result<Map<String, Long>?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(RemoteImagesPigeonUtils.wrapError(error))

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -51,7 +51,7 @@ class RemoteImagesImpl(context: Context) : RemoteImageApi {
     url: String,
     headers: Map<String, String>,
     requestId: Long,
-    @Suppress("UNUSED_PARAMETER") encoded: Boolean, // always returns encoded; setting has no effect on Android
+    @Suppress("UNUSED_PARAMETER") preferEncoded: Boolean, // always returns encoded; setting has no effect on Android
     callback: (Result<Map<String, Long>?>) -> Unit
   ) {
     val signal = CancellationSignal()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -51,6 +51,7 @@ class RemoteImagesImpl(context: Context) : RemoteImageApi {
     url: String,
     headers: Map<String, String>,
     requestId: Long,
+    @Suppress("UNUSED_PARAMETER") encoded: Boolean, // always returns encoded; setting has no effect on Android
     callback: (Result<Map<String, Long>?>) -> Unit
   ) {
     val signal = CancellationSignal()

--- a/mobile/ios/Runner/Images/LocalImages.g.swift
+++ b/mobile/ios/Runner/Images/LocalImages.g.swift
@@ -70,7 +70,7 @@ class LocalImagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol LocalImageApi {
-  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
+  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, encoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
   func cancelRequest(requestId: Int64) throws
   func getThumbhash(thumbhash: String, completion: @escaping (Result<[String: Int64], Error>) -> Void)
 }
@@ -90,7 +90,8 @@ class LocalImageApiSetup {
         let widthArg = args[2] as! Int64
         let heightArg = args[3] as! Int64
         let isVideoArg = args[4] as! Bool
-        api.requestImage(assetId: assetIdArg, requestId: requestIdArg, width: widthArg, height: heightArg, isVideo: isVideoArg) { result in
+        let encodedArg = args[5] as! Bool
+        api.requestImage(assetId: assetIdArg, requestId: requestIdArg, width: widthArg, height: heightArg, isVideo: isVideoArg, encoded: encodedArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/mobile/ios/Runner/Images/LocalImages.g.swift
+++ b/mobile/ios/Runner/Images/LocalImages.g.swift
@@ -70,7 +70,7 @@ class LocalImagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol LocalImageApi {
-  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, encoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
+  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, preferEncoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
   func cancelRequest(requestId: Int64) throws
   func getThumbhash(thumbhash: String, completion: @escaping (Result<[String: Int64], Error>) -> Void)
 }
@@ -90,8 +90,8 @@ class LocalImageApiSetup {
         let widthArg = args[2] as! Int64
         let heightArg = args[3] as! Int64
         let isVideoArg = args[4] as! Bool
-        let encodedArg = args[5] as! Bool
-        api.requestImage(assetId: assetIdArg, requestId: requestIdArg, width: widthArg, height: heightArg, isVideo: isVideoArg, encoded: encodedArg) { result in
+        let preferEncodedArg = args[5] as! Bool
+        api.requestImage(assetId: assetIdArg, requestId: requestIdArg, width: widthArg, height: heightArg, isVideo: isVideoArg, preferEncoded: preferEncodedArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/mobile/ios/Runner/Images/LocalImagesImpl.swift
+++ b/mobile/ios/Runner/Images/LocalImagesImpl.swift
@@ -64,7 +64,7 @@ class LocalImageApiImpl: LocalImageApi {
     }
   }
 
-  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, encoded: Bool, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
+  func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, preferEncoded: Bool, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
     let request = LocalImageRequest(callback: completion)
     let item = DispatchWorkItem {
       if request.isCancelled {
@@ -91,7 +91,7 @@ class LocalImageApiImpl: LocalImageApi {
         return completion(ImageProcessing.cancelledResult)
       }
 
-      if encoded {
+      if preferEncoded {
         let dataOptions = PHImageRequestOptions()
         dataOptions.isNetworkAccessAllowed = true
         dataOptions.isSynchronous = true

--- a/mobile/ios/Runner/Images/RemoteImages.g.swift
+++ b/mobile/ios/Runner/Images/RemoteImages.g.swift
@@ -70,7 +70,7 @@ class RemoteImagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable 
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol RemoteImageApi {
-  func requestImage(url: String, headers: [String: String], requestId: Int64, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
+  func requestImage(url: String, headers: [String: String], requestId: Int64, encoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
   func cancelRequest(requestId: Int64) throws
   func clearCache(completion: @escaping (Result<Int64, Error>) -> Void)
 }
@@ -88,7 +88,8 @@ class RemoteImageApiSetup {
         let urlArg = args[0] as! String
         let headersArg = args[1] as! [String: String]
         let requestIdArg = args[2] as! Int64
-        api.requestImage(url: urlArg, headers: headersArg, requestId: requestIdArg) { result in
+        let encodedArg = args[3] as! Bool
+        api.requestImage(url: urlArg, headers: headersArg, requestId: requestIdArg, encoded: encodedArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/mobile/ios/Runner/Images/RemoteImages.g.swift
+++ b/mobile/ios/Runner/Images/RemoteImages.g.swift
@@ -70,7 +70,7 @@ class RemoteImagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable 
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol RemoteImageApi {
-  func requestImage(url: String, headers: [String: String], requestId: Int64, encoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
+  func requestImage(url: String, headers: [String: String], requestId: Int64, preferEncoded: Bool, completion: @escaping (Result<[String: Int64]?, Error>) -> Void)
   func cancelRequest(requestId: Int64) throws
   func clearCache(completion: @escaping (Result<Int64, Error>) -> Void)
 }
@@ -88,8 +88,8 @@ class RemoteImageApiSetup {
         let urlArg = args[0] as! String
         let headersArg = args[1] as! [String: String]
         let requestIdArg = args[2] as! Int64
-        let encodedArg = args[3] as! Bool
-        api.requestImage(url: urlArg, headers: headersArg, requestId: requestIdArg, encoded: encodedArg) { result in
+        let preferEncodedArg = args[3] as! Bool
+        api.requestImage(url: urlArg, headers: headersArg, requestId: requestIdArg, preferEncoded: preferEncodedArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -33,7 +33,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
     kCGImageSourceCreateThumbnailFromImageAlways: true
   ] as CFDictionary
 
-  func requestImage(url: String, headers: [String : String], requestId: Int64, encoded: Bool, completion: @escaping (Result<[String : Int64]?, any Error>) -> Void) {
+  func requestImage(url: String, headers: [String : String], requestId: Int64, preferEncoded: Bool, completion: @escaping (Result<[String : Int64]?, any Error>) -> Void) {
     var urlRequest = URLRequest(url: URL(string: url)!)
     urlRequest.cachePolicy = .returnCacheDataElseLoad
     for (key, value) in headers {
@@ -41,7 +41,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
     }
 
     let task = URLSessionManager.shared.session.dataTask(with: urlRequest) { data, response, error in
-      Self.handleCompletion(requestId: requestId, encoded: encoded, data: data, response: response, error: error)
+      Self.handleCompletion(requestId: requestId, encoded: preferEncoded, data: data, response: response, error: error)
     }
 
     let request = RemoteImageRequest(id: requestId, task: task, completion: completion)

--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -8,7 +8,7 @@ class RemoteImageRequest {
   let id: Int64
   var isCancelled = false
   let completion: (Result<[String: Int64]?, any Error>) -> Void
-  
+
   init(id: Int64, task: URLSessionDataTask, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
     self.id = id
     self.task = task
@@ -32,75 +32,93 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
     kCGImageSourceCreateThumbnailWithTransform: true,
     kCGImageSourceCreateThumbnailFromImageAlways: true
   ] as CFDictionary
-  
-  func requestImage(url: String, headers: [String : String], requestId: Int64, completion: @escaping (Result<[String : Int64]?, any Error>) -> Void) {
+
+  func requestImage(url: String, headers: [String : String], requestId: Int64, encoded: Bool, completion: @escaping (Result<[String : Int64]?, any Error>) -> Void) {
     var urlRequest = URLRequest(url: URL(string: url)!)
     urlRequest.cachePolicy = .returnCacheDataElseLoad
     for (key, value) in headers {
       urlRequest.setValue(value, forHTTPHeaderField: key)
     }
-    
+
     let task = URLSessionManager.shared.session.dataTask(with: urlRequest) { data, response, error in
-      Self.handleCompletion(requestId: requestId, data: data, response: response, error: error)
+      Self.handleCompletion(requestId: requestId, encoded: encoded, data: data, response: response, error: error)
     }
-    
+
     let request = RemoteImageRequest(id: requestId, task: task, completion: completion)
-    
+
     os_unfair_lock_lock(&Self.lock)
     Self.requests[requestId] = request
     os_unfair_lock_unlock(&Self.lock)
-    
+
     task.resume()
   }
-  
-  private static func handleCompletion(requestId: Int64, data: Data?, response: URLResponse?, error: Error?) {
+
+  private static func handleCompletion(requestId: Int64, encoded: Bool, data: Data?, response: URLResponse?, error: Error?) {
     os_unfair_lock_lock(&Self.lock)
     guard let request = requests[requestId] else {
       return os_unfair_lock_unlock(&Self.lock)
     }
     requests[requestId] = nil
     os_unfair_lock_unlock(&Self.lock)
-    
+
     if let error = error {
       if request.isCancelled || (error as NSError).code == NSURLErrorCancelled {
         return request.completion(ImageProcessing.cancelledResult)
       }
       return request.completion(.failure(error))
     }
-    
+
     if request.isCancelled {
       return request.completion(ImageProcessing.cancelledResult)
     }
-    
+
     guard let data = data else {
       return request.completion(.failure(PigeonError(code: "", message: "No data received", details: nil)))
     }
-    
+
     ImageProcessing.queue.async {
       ImageProcessing.semaphore.wait()
       defer { ImageProcessing.semaphore.signal() }
-      
+
       if request.isCancelled {
         return request.completion(ImageProcessing.cancelledResult)
       }
-      
+
+      // Return raw encoded bytes when requested (for animated images)
+      if encoded {
+        let length = data.count
+        let pointer = malloc(length)!
+        data.copyBytes(to: pointer.assumingMemoryBound(to: UInt8.self), count: length)
+
+        if request.isCancelled {
+          free(pointer)
+          return request.completion(ImageProcessing.cancelledResult)
+        }
+
+        return request.completion(
+          .success([
+            "pointer": Int64(Int(bitPattern: pointer)),
+            "length": Int64(length),
+          ]))
+      }
+
       guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
             let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, decodeOptions) else {
         return request.completion(.failure(PigeonError(code: "", message: "Failed to decode image for request", details: nil)))
       }
-      
+
       if request.isCancelled {
         return request.completion(ImageProcessing.cancelledResult)
       }
-      
+
       do {
         let buffer = try vImage_Buffer(cgImage: cgImage, format: rgbaFormat)
-        
+
         if request.isCancelled {
           buffer.free()
           return request.completion(ImageProcessing.cancelledResult)
         }
-        
+
         request.completion(
           .success([
             "pointer": Int64(Int(bitPattern: buffer.data)),
@@ -113,17 +131,17 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
       }
     }
   }
-  
+
   func cancelRequest(requestId: Int64) {
     os_unfair_lock_lock(&Self.lock)
     let request = Self.requests[requestId]
     os_unfair_lock_unlock(&Self.lock)
-    
+
     guard let request = request else { return }
     request.isCancelled = true
     request.task?.cancel()
   }
-  
+
   func clearCache(completion: @escaping (Result<Int64, any Error>) -> Void) {
     Task {
       let cache = URLSessionManager.shared.session.configuration.urlCache!

--- a/mobile/lib/infrastructure/loaders/image_request.dart
+++ b/mobile/lib/infrastructure/loaders/image_request.dart
@@ -24,6 +24,8 @@ abstract class ImageRequest {
 
   Future<ImageInfo?> load(ImageDecoderCallback decode, {double scale = 1.0});
 
+  Future<ui.Codec?> loadCodec();
+
   void cancel() {
     if (_isCancelled) {
       return;
@@ -34,7 +36,7 @@ abstract class ImageRequest {
 
   void _onCancelled();
 
-  Future<ui.FrameInfo?> _fromEncodedPlatformImage(int address, int length) async {
+  Future<(ui.Codec, ui.ImageDescriptor)?> _codecFromEncodedPlatformImage(int address, int length) async {
     final pointer = Pointer<Uint8>.fromAddress(address);
     if (_isCancelled) {
       malloc.free(pointer);
@@ -67,6 +69,14 @@ abstract class ImageRequest {
       return null;
     }
 
+    return (codec, descriptor);
+  }
+
+  Future<ui.FrameInfo?> _fromEncodedPlatformImage(int address, int length) async {
+    final result = await _codecFromEncodedPlatformImage(address, length);
+    if (result == null) return null;
+
+    final (codec, descriptor) = result;
     final frame = await codec.getNextFrame();
     descriptor.dispose();
     codec.dispose();

--- a/mobile/lib/infrastructure/loaders/image_request.dart
+++ b/mobile/lib/infrastructure/loaders/image_request.dart
@@ -77,6 +77,12 @@ abstract class ImageRequest {
     if (result == null) return null;
 
     final (codec, descriptor) = result;
+    if (_isCancelled) {
+      descriptor.dispose();
+      codec.dispose();
+      return null;
+    }
+
     final frame = await codec.getNextFrame();
     descriptor.dispose();
     codec.dispose();

--- a/mobile/lib/infrastructure/loaders/local_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/local_image_request.dart
@@ -55,28 +55,14 @@ class LocalImageRequest extends ImageRequest {
       isVideo: assetType == AssetType.video,
       encoded: true,
     );
-    if (info == null || _isCancelled) {
-      // Free the native memory if the request was cancelled after the platform call returned.
-      if (info case {'pointer': int pointer}) {
-        malloc.free(Pointer<Uint8>.fromAddress(pointer));
-      }
-      return null;
-    }
+    if (info == null) return null;
 
-    return switch (info) {
-      {'pointer': int pointer, 'length': int length} => () async {
-        final result = await _codecFromEncodedPlatformImage(pointer, length);
-        if (result == null) {
-          return null;
-        }
+    final result = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!);
+    if (result == null) return null;
 
-        final (codec, descriptor) = result;
-        descriptor.dispose();
-
-        return codec;
-      }(),
-      _ => null,
-    };
+    final (codec, descriptor) = result;
+    descriptor.dispose();
+    return codec;
   }
 
   @override

--- a/mobile/lib/infrastructure/loaders/local_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/local_image_request.dart
@@ -48,11 +48,7 @@ class LocalImageRequest extends ImageRequest {
     );
     if (info == null) return null;
 
-    final result = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!);
-    if (result == null) return null;
-
-    final (codec, descriptor) = result;
-    descriptor.dispose();
+    final (codec, _) = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!) ?? (null, null);
     return codec;
   }
 

--- a/mobile/lib/infrastructure/loaders/local_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/local_image_request.dart
@@ -1,14 +1,5 @@
 part of 'image_request.dart';
 
-/// Requests a local image from the platform.
-///
-/// The [encoded] flag controls the response format from the platform:
-/// - `encoded: true` — returns raw encoded bytes as `{pointer, length}`,
-///   used for animated images where a multi-frame codec is needed.
-/// - `encoded: false` — decodes the image to RGBA pixels and returns
-///   `{pointer, width, height, rowBytes}` for direct display.
-///
-/// Both iOS and Android respect the [encoded] flag for local images.
 class LocalImageRequest extends ImageRequest {
   final String localId;
   final int width;
@@ -31,7 +22,7 @@ class LocalImageRequest extends ImageRequest {
       width: width,
       height: height,
       isVideo: assetType == AssetType.video,
-      encoded: false,
+      preferEncoded: false,
     );
     if (info == null) {
       return null;
@@ -53,7 +44,7 @@ class LocalImageRequest extends ImageRequest {
       width: width,
       height: height,
       isVideo: assetType == AssetType.video,
-      encoded: true,
+      preferEncoded: true,
     );
     if (info == null) return null;
 

--- a/mobile/lib/infrastructure/loaders/local_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/local_image_request.dart
@@ -56,6 +56,10 @@ class LocalImageRequest extends ImageRequest {
       encoded: true,
     );
     if (info == null || _isCancelled) {
+      // Free the native memory if the request was cancelled after the platform call returned.
+      if (info case {'pointer': int pointer}) {
+        malloc.free(Pointer<Uint8>.fromAddress(pointer));
+      }
       return null;
     }
 

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -1,5 +1,16 @@
 part of 'image_request.dart';
 
+/// Requests a remote image from the platform via HTTP.
+///
+/// The [encoded] flag controls the response format from the platform:
+/// - `encoded: true` — returns raw encoded bytes as `{pointer, length}`,
+///   used for animated images where a multi-frame codec is needed.
+/// - `encoded: false` — on iOS, decodes the image to RGBA pixels and returns
+///   `{pointer, width, height, rowBytes}`. On Android, the flag is ignored and
+///   raw encoded bytes are always returned as `{pointer, length}`.
+///
+/// The [load] method handles both response shapes via pattern matching to
+/// account for this platform difference.
 class RemoteImageRequest extends ImageRequest {
   final String uri;
   final Map<String, String> headers;
@@ -12,7 +23,7 @@ class RemoteImageRequest extends ImageRequest {
       return null;
     }
 
-    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId);
+    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: false);
     final frame = switch (info) {
       {'pointer': int pointer, 'length': int length} => await _fromEncodedPlatformImage(pointer, length),
       {'pointer': int pointer, 'width': int width, 'height': int height, 'rowBytes': int rowBytes} =>
@@ -20,6 +31,31 @@ class RemoteImageRequest extends ImageRequest {
       _ => null,
     };
     return frame == null ? null : ImageInfo(image: frame.image, scale: scale);
+  }
+
+  @override
+  Future<ui.Codec?> loadCodec() async {
+    if (_isCancelled) {
+      return null;
+    }
+
+    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: true);
+    if (info == null || _isCancelled) {
+      return null;
+    }
+
+    return switch (info) {
+      {'pointer': int pointer, 'length': int length} => () async {
+        final result = await _codecFromEncodedPlatformImage(pointer, length);
+        if (result == null) return null;
+
+        final (codec, descriptor) = result;
+        descriptor.dispose();
+
+        return codec;
+      }(),
+      _ => null,
+    };
   }
 
   @override

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -1,16 +1,5 @@
 part of 'image_request.dart';
 
-/// Requests a remote image from the platform via HTTP.
-///
-/// The [encoded] flag controls the response format from the platform:
-/// - `encoded: true` — returns raw encoded bytes as `{pointer, length}`,
-///   used for animated images where a multi-frame codec is needed.
-/// - `encoded: false` — on iOS, decodes the image to RGBA pixels and returns
-///   `{pointer, width, height, rowBytes}`. On Android, the flag is ignored and
-///   raw encoded bytes are always returned as `{pointer, length}`.
-///
-/// The [load] method handles both response shapes via pattern matching to
-/// account for this platform difference.
 class RemoteImageRequest extends ImageRequest {
   final String uri;
   final Map<String, String> headers;
@@ -23,7 +12,7 @@ class RemoteImageRequest extends ImageRequest {
       return null;
     }
 
-    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: false);
+    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, preferEncoded: false);
     // Android always returns encoded data, so we need to check for both shapes of the response.
     final frame = switch (info) {
       {'pointer': int pointer, 'length': int length} => await _fromEncodedPlatformImage(pointer, length),
@@ -40,7 +29,7 @@ class RemoteImageRequest extends ImageRequest {
       return null;
     }
 
-    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: true);
+    final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, preferEncoded: true);
     if (info == null) return null;
 
     final result = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!);

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -41,6 +41,9 @@ class RemoteImageRequest extends ImageRequest {
 
     final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: true);
     if (info == null || _isCancelled) {
+      if (info case {'pointer': int pointer}) {
+        malloc.free(Pointer<Uint8>.fromAddress(pointer));
+      }
       return null;
     }
 

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -24,6 +24,7 @@ class RemoteImageRequest extends ImageRequest {
     }
 
     final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: false);
+    // Android always returns encoded data, so we need to check for both shapes of the response.
     final frame = switch (info) {
       {'pointer': int pointer, 'length': int length} => await _fromEncodedPlatformImage(pointer, length),
       {'pointer': int pointer, 'width': int width, 'height': int height, 'rowBytes': int rowBytes} =>
@@ -40,25 +41,14 @@ class RemoteImageRequest extends ImageRequest {
     }
 
     final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, encoded: true);
-    if (info == null || _isCancelled) {
-      if (info case {'pointer': int pointer}) {
-        malloc.free(Pointer<Uint8>.fromAddress(pointer));
-      }
-      return null;
-    }
+    if (info == null) return null;
 
-    return switch (info) {
-      {'pointer': int pointer, 'length': int length} => () async {
-        final result = await _codecFromEncodedPlatformImage(pointer, length);
-        if (result == null) return null;
+    final result = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!);
+    if (result == null) return null;
 
-        final (codec, descriptor) = result;
-        descriptor.dispose();
-
-        return codec;
-      }(),
-      _ => null,
-    };
+    final (codec, descriptor) = result;
+    descriptor.dispose();
+    return codec;
   }
 
   @override

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -32,11 +32,7 @@ class RemoteImageRequest extends ImageRequest {
     final info = await remoteImageApi.requestImage(uri, headers: headers, requestId: requestId, preferEncoded: true);
     if (info == null) return null;
 
-    final result = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!);
-    if (result == null) return null;
-
-    final (codec, descriptor) = result;
-    descriptor.dispose();
+    final (codec, _) = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!) ?? (null, null);
     return codec;
   }
 

--- a/mobile/lib/infrastructure/loaders/thumbhash_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/thumbhash_image_request.dart
@@ -17,5 +17,8 @@ class ThumbhashImageRequest extends ImageRequest {
   }
 
   @override
+  Future<ui.Codec?> loadCodec() => throw UnsupportedError('Thumbhash does not support codec loading');
+
+  @override
   void _onCancelled() {}
 }

--- a/mobile/lib/platform/local_image_api.g.dart
+++ b/mobile/lib/platform/local_image_api.g.dart
@@ -55,6 +55,7 @@ class LocalImageApi {
     required int width,
     required int height,
     required bool isVideo,
+    required bool encoded,
   }) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.LocalImageApi.requestImage$pigeonVar_messageChannelSuffix';
@@ -69,6 +70,7 @@ class LocalImageApi {
       width,
       height,
       isVideo,
+      encoded,
     ]);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/mobile/lib/platform/local_image_api.g.dart
+++ b/mobile/lib/platform/local_image_api.g.dart
@@ -55,7 +55,7 @@ class LocalImageApi {
     required int width,
     required int height,
     required bool isVideo,
-    required bool encoded,
+    required bool preferEncoded,
   }) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.LocalImageApi.requestImage$pigeonVar_messageChannelSuffix';
@@ -70,7 +70,7 @@ class LocalImageApi {
       width,
       height,
       isVideo,
-      encoded,
+      preferEncoded,
     ]);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/mobile/lib/platform/remote_image_api.g.dart
+++ b/mobile/lib/platform/remote_image_api.g.dart
@@ -53,6 +53,7 @@ class RemoteImageApi {
     String url, {
     required Map<String, String> headers,
     required int requestId,
+    required bool encoded,
   }) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.RemoteImageApi.requestImage$pigeonVar_messageChannelSuffix';
@@ -61,7 +62,7 @@ class RemoteImageApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[url, headers, requestId]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[url, headers, requestId, encoded]);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);

--- a/mobile/lib/platform/remote_image_api.g.dart
+++ b/mobile/lib/platform/remote_image_api.g.dart
@@ -53,7 +53,7 @@ class RemoteImageApi {
     String url, {
     required Map<String, String> headers,
     required int requestId,
-    required bool encoded,
+    required bool preferEncoded,
   }) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.RemoteImageApi.requestImage$pigeonVar_messageChannelSuffix';
@@ -62,7 +62,12 @@ class RemoteImageApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[url, headers, requestId, encoded]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      url,
+      headers,
+      requestId,
+      preferEncoded,
+    ]);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -86,7 +86,12 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
     try {
       final codec = await request.loadCodec();
-      if (codec == null || isCancelled) {
+      if (codec == null) {
+        PaintingBinding.instance.imageCache.evict(this);
+        return null;
+      }
+      if(isCancelled){
+        codec.dispose();
         PaintingBinding.instance.imageCache.evict(this);
         return null;
       }

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -86,12 +86,8 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
     try {
       final codec = await request.loadCodec();
-      if (codec == null) {
-        PaintingBinding.instance.imageCache.evict(this);
-        return null;
-      }
-      if (isCancelled) {
-        codec.dispose();
+      if (codec == null || isCancelled) {
+        codec?.dispose();
         PaintingBinding.instance.imageCache.evict(this);
         return null;
       }

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -90,7 +90,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
-      if(isCancelled){
+      if (isCancelled) {
         codec.dispose();
         PaintingBinding.instance.imageCache.evict(this);
         return null;

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:async/async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -70,6 +72,28 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         rethrow;
       }
       _log.warning('Non-fatal image load error', e, stack);
+    } finally {
+      this.request = null;
+    }
+  }
+
+  Future<ui.Codec?> loadCodecRequest(ImageRequest request) async {
+    if (isCancelled) {
+      this.request = null;
+      PaintingBinding.instance.imageCache.evict(this);
+      return null;
+    }
+
+    try {
+      final codec = await request.loadCodec();
+      if (codec == null || isCancelled) {
+        PaintingBinding.instance.imageCache.evict(this);
+        return null;
+      }
+      return codec;
+    } catch (e) {
+      PaintingBinding.instance.imageCache.evict(this);
+      rethrow;
     } finally {
       this.request = null;
     }

--- a/mobile/pigeon/local_image_api.dart
+++ b/mobile/pigeon/local_image_api.dart
@@ -21,6 +21,7 @@ abstract class LocalImageApi {
     required int width,
     required int height,
     required bool isVideo,
+    required bool encoded,
   });
 
   void cancelRequest(int requestId);

--- a/mobile/pigeon/local_image_api.dart
+++ b/mobile/pigeon/local_image_api.dart
@@ -21,7 +21,7 @@ abstract class LocalImageApi {
     required int width,
     required int height,
     required bool isVideo,
-    required bool encoded,
+    required bool preferEncoded,
   });
 
   void cancelRequest(int requestId);

--- a/mobile/pigeon/remote_image_api.dart
+++ b/mobile/pigeon/remote_image_api.dart
@@ -19,6 +19,7 @@ abstract class RemoteImageApi {
     String url, {
     required Map<String, String> headers,
     required int requestId,
+    required bool encoded,
   });
 
   void cancelRequest(int requestId);

--- a/mobile/pigeon/remote_image_api.dart
+++ b/mobile/pigeon/remote_image_api.dart
@@ -19,7 +19,7 @@ abstract class RemoteImageApi {
     String url, {
     required Map<String, String> headers,
     required int requestId,
-    required bool encoded,
+    required bool preferEncoded,
   });
 
   void cancelRequest(int requestId);


### PR DESCRIPTION
This PR adds support for loading encoded images. This is also part of #26148 

The "Call" pipeline looks like that: 

- `image_provider.dart - loadCodecRequest` calls `loadCoded` on ImageRequests
- `loadCoded` is implemented by `RemoteImageRequest` and `LocalImageRequest` these call -> `_codecFromEncodedPlatformImage` which is implemented in the base `ImageRequest.dart`
- then there is a encoded parameter which tells the native side to not return decoded images. The RemoteImage implementation on android already returns encoded images, so there the parameter is ignored. But for Local Images on IOS and Android and Remote Images on IOS there is a new code path that returns different values if the bool is set.


This PR adds the foundation of supporting animated images, because without the full coded we can't use the `MultiFrameImageStreamCompleter`.

when #26541 is merged, I then can:

- Persist playbackStyle in local asset database

And if this here gets merged we then can based on the playbackStyle decide if we want to show normal images like its currently implemented, or load the codec and show animated images.