### PR TITLE
feat(web): Adding zoom capabilities to video playback

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+  import { shortcuts } from '$lib/actions/shortcut';
+  import { zoomImageAction } from '$lib/actions/zoom-image';
   import FaceEditor from '$lib/components/asset-viewer/face-editor/face-editor.svelte';
+  import AssetViewerEvents from '$lib/components/AssetViewerEvents.svelte';
   import VideoRemoteViewer from '$lib/components/asset-viewer/video-remote-viewer.svelte';
   import { assetViewerFadeDuration } from '$lib/constants';
+  import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { castManager } from '$lib/managers/cast-manager.svelte';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import {
@@ -13,7 +17,7 @@
   import { getAssetMediaUrl, getAssetPlaybackUrl } from '$lib/utils';
   import { AssetMediaSize } from '@immich/sdk';
   import { LoadingSpinner } from '@immich/ui';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { useSwipe, type SwipeCustomEvent } from 'svelte-gestures';
   import { fade } from 'svelte/transition';
 
@@ -50,6 +54,13 @@
   );
   let isScrubbing = $state(false);
   let showVideo = $state(false);
+
+  $effect.pre(() => {
+    void assetId;
+    untrack(() => {
+      assetViewerManager.resetZoomState();
+    });
+  });
 
   onMount(() => {
     // Show video after mount to ensure fading in.
@@ -100,7 +111,15 @@
     }
   };
 
+  const onZoom = () => {
+    assetViewerManager.zoom = assetViewerManager.zoom > 1 ? 1 : 2;
+  };
+
   const onSwipe = (event: SwipeCustomEvent) => {
+    if (assetViewerManager.zoom > 1) {
+      return;
+    }
+
     if (event.detail.direction === 'left') {
       onNextAsset();
     }
@@ -119,6 +138,13 @@
   });
 </script>
 
+<AssetViewerEvents {onZoom} />
+
+<svelte:document
+  use:shortcuts={[
+    { shortcut: { key: 'z' }, onShortcut: onZoom, preventDefault: true },
+  ]}
+/>
 {#if showVideo}
   <div
     transition:fade={{ duration: assetViewerFadeDuration }}
@@ -136,30 +162,35 @@
         />
       </div>
     {:else}
-      <video
-        bind:this={videoPlayer}
-        loop={$loopVideoPreference && loopVideo}
-        autoplay={$autoPlayVideo}
-        playsinline
-        controls
-        disablePictureInPicture
-        class="h-full object-contain"
+      <div
+        use:zoomImageAction
         {...useSwipe(onSwipe)}
-        oncanplay={(e) => handleCanPlay(e.currentTarget)}
-        onended={onVideoEnded}
-        onvolumechange={(e) => ($videoViewerMuted = e.currentTarget.muted)}
-        onseeking={() => (isScrubbing = true)}
-        onseeked={() => (isScrubbing = false)}
-        onplaying={(e) => {
-          e.currentTarget.focus();
-        }}
-        onclose={() => onClose()}
-        muted={$videoViewerMuted}
-        bind:volume={$videoViewerVolume}
-        poster={getAssetMediaUrl({ id: assetId, size: AssetMediaSize.Preview, cacheKey })}
-        src={assetFileUrl}
+        class="h-full w-full"
       >
-      </video>
+        <video
+          bind:this={videoPlayer}
+          loop={$loopVideoPreference && loopVideo}
+          autoplay={$autoPlayVideo}
+          playsinline
+          controls
+          disablePictureInPicture
+          class="h-full w-full object-contain"
+          oncanplay={(e) => handleCanPlay(e.currentTarget)}
+          onended={onVideoEnded}
+          onvolumechange={(e) => ($videoViewerMuted = e.currentTarget.muted)}
+          onseeking={() => (isScrubbing = true)}
+          onseeked={() => (isScrubbing = false)}
+          onplaying={(e) => {
+            e.currentTarget.focus();
+          }}
+          onclose={() => onClose()}
+          muted={$videoViewerMuted}
+          bind:volume={$videoViewerVolume}
+          poster={getAssetMediaUrl({ id: assetId, size: AssetMediaSize.Preview, cacheKey })}
+          src={assetFileUrl}
+        >
+        </video>
+      </div>
 
       {#if isLoading}
         <div class="absolute flex place-content-center place-items-center">


### PR DESCRIPTION
## Description

Adds pinch/scroll zoom and pan support to the web video viewer, matching the existing photo viewer behavior. Uses the same `zoomImageAction` (powered by `@zoom-image/core`) that photos already use by wrapping the `<video>` element in a zoom container.

- `z` keyboard shortcut toggles 2x zoom (same as photos)
- Swipe navigation is disabled when zoomed in to allow panning
- Zoom state resets when switching between video assets

## How Has This Been Tested?

- [x] Opened a video asset and used scroll wheel to zoom in/out — video zooms and allows panning
- [x] Pressed `z` while viewing a video — toggles between 1x and 2x zoom
- [x] While zoomed in, swiping pans the video instead of navigating
- [x] While at 1x zoom, swiping navigates between assets as before
- [x] Navigated between different video assets — zoom resets each time
- [x] Video controls (play/pause, seek, volume) still work while zoomed

## Screenshots (if appropriate)

N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in src/repositories/ is pretty basic/simple and does not have any immich specific logic (that belongs in src/services/)

Claude opus 4.6 in Claude code was used 