### PR TITLE
feat(mobile): Add possibility to zoom on videos

### DIFF
--- a/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
@@ -81,29 +81,33 @@ class PhotoViewGestureDetector extends StatelessWidget {
       );
     }
 
-    gestures[DoubleTapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
-      () => DoubleTapGestureRecognizer(debugOwner: this),
-      (DoubleTapGestureRecognizer instance) {
-        instance.onDoubleTap = onDoubleTap;
-      },
-    );
+    if (onDoubleTap != null) {
+      gestures[DoubleTapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
+        () => DoubleTapGestureRecognizer(debugOwner: this),
+        (DoubleTapGestureRecognizer instance) {
+          instance.onDoubleTap = onDoubleTap;
+        },
+      );
+    }
 
-    gestures[PhotoViewGestureRecognizer] = GestureRecognizerFactoryWithHandlers<PhotoViewGestureRecognizer>(
-      () => PhotoViewGestureRecognizer(
-        hitDetector: hitDetector,
-        debugOwner: this,
-        validateAxis: axis,
-        touchSlopFactor: touchSlopFactor,
-      ),
-      (PhotoViewGestureRecognizer instance) {
-        instance
-          ..dragStartBehavior = DragStartBehavior.start
-          ..onStart = onScaleStart
-          ..onUpdate = onScaleUpdate
-          ..onEnd = onScaleEnd
-          ..disableScaleGestures = disableScaleGestures;
-      },
-    );
+    if (!disableScaleGestures) {
+      gestures[PhotoViewGestureRecognizer] = GestureRecognizerFactoryWithHandlers<PhotoViewGestureRecognizer>(
+        () => PhotoViewGestureRecognizer(
+          hitDetector: hitDetector,
+          debugOwner: this,
+          validateAxis: axis,
+          touchSlopFactor: touchSlopFactor,
+        ),
+        (PhotoViewGestureRecognizer instance) {
+          instance
+            ..dragStartBehavior = DragStartBehavior.start
+            ..onStart = onScaleStart
+            ..onUpdate = onScaleUpdate
+            ..onEnd = onScaleEnd
+            ..disableScaleGestures = disableScaleGestures;
+        },
+      );
+    }
 
     gestures[LongPressGestureRecognizer] = GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
       () => LongPressGestureRecognizer(debugOwner: this),


### PR DESCRIPTION
The outer PhotoView wrapper for videos was registering a ScaleGestureRecognizer even with scale disabled, winning the gesture arena on real devices and swallowing pinch events before the inner video PhotoView could handle them.

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A
- [X] Test B

Open a video, double tap, pinch to zoom and pan

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used LLM to help me but applied the code manually
...
