### PR TITLE
feat: enable SvelteKit CSP policy with hash-based inline script/style protection

### DIFF
--- a/misc/update-csp-hashes.mjs
+++ b/misc/update-csp-hashes.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+/**
+ * Computes SHA-256 hashes for inline <script> elements in app.html
+ * and updates the script-src CSP directive in svelte.config.js.
+ *
+ * SvelteKit's CSP hash mode only hashes inline content it generates itself,
+ * not the template content from app.html. This script fills that gap.
+ *
+ * Run this script whenever the inline scripts in app.html change.
+ *
+ * Usage: node misc/update-csp-hashes.mjs
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDirectory, '..');
+const appHtmlPath = join(repoRoot, 'web', 'src', 'app.html');
+const configPath = join(repoRoot, 'web', 'svelte.config.js');
+
+const appHtml = readFileSync(appHtmlPath, 'utf-8');
+const scriptRegex = /<script[^>]*>([\s\S]*?)<\/script>/gi;
+
+const hashes = [];
+let match;
+while ((match = scriptRegex.exec(appHtml)) !== null) {
+  const content = match[1];
+  const hash = createHash('sha256').update(content).digest('base64');
+  hashes.push(`sha256-${hash}`);
+  const preview = content.trim().slice(0, 60).replaceAll('\n', ' ');
+  console.log(`Found: ${preview}...`);
+  console.log(`  Hash: sha256-${hash}`);
+  console.log();
+}
+
+if (hashes.length === 0) {
+  console.log('No inline <script> elements found in app.html');
+  process.exit(0);
+}
+
+let config = readFileSync(configPath, 'utf-8');
+
+const scriptSrcRegex = /'script-src':\s*\[[\s\S]*?\]/;
+const scriptSrcMatch = config.match(scriptSrcRegex);
+if (!scriptSrcMatch) {
+  console.error("Could not find 'script-src' directive in svelte.config.js");
+  process.exit(1);
+}
+
+const existingEntries = [];
+const entryRegex = /'([^']+)'/g;
+let entryMatch;
+while ((entryMatch = entryRegex.exec(scriptSrcMatch[0])) !== null) {
+  const value = entryMatch[1];
+  if (value === 'script-src' || value.startsWith('sha256-')) {
+    continue;
+  }
+  existingEntries.push(value);
+}
+
+const allEntries = [...existingEntries, ...hashes];
+const formatted = allEntries.map((entry) => `          '${entry}'`).join(',\n');
+const newScriptSrc = `'script-src': [\n${formatted},\n        ]`;
+
+config = config.replace(scriptSrcRegex, newScriptSrc);
+writeFileSync(configPath, config);
+
+console.log(`Updated svelte.config.js with ${hashes.length} script hash(es)`);

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -22,6 +22,31 @@ const config = {
       fallback: 'index.html',
       precompress: true,
     }),
+    csp: {
+      mode: 'hash',
+      directives: {
+        'default-src': ['self'],
+        'script-src': [
+          'self',
+          'https://www.gstatic.com',
+          'wasm-unsafe-eval',
+          'sha256-h5wSYKWbmHcoYTdkHNNguMswVNCphpvwW+uxooXhF/Y=',
+        ],
+        'style-src': ['self', 'unsafe-inline'],
+        'img-src': ['self', 'data:', 'blob:'],
+        'connect-src': [
+          'self',
+          'blob:',
+          'https://pay.futo.org',
+          'https://static.immich.cloud',
+          'https://tiles.immich.cloud',
+        ],
+        'worker-src': ['self', 'blob:'],
+        'frame-src': ['none'],
+        'object-src': ['none'],
+        'base-uri': ['self'],
+      },
+    },
     alias: {
       $lib: 'src/lib',
       '$lib/*': 'src/lib/*',


### PR DESCRIPTION
See #25389

This adds a CSP - using HASH based script protection (vs the nonce based on in referenced PR) - and also serving the CSP via express (so it works in prod mode)

Not using nonces because the content never changes (since using adapter-static). Svelte-kit also creates the bootstrap script as part of app.html - and since this is created statically, the nonce will always be the same for each request - which defeats the purpose of a nonce. 

So, this uses hashes instead. Sveltekit actually creates hashes for all the inline scripts it generates (including the bootstrap script) and adds it as a <meta> header. 

At runtime, ApiService.ssr() and MaintanceWorkerService.ssr() will extract/remove the CSP from the file - and augment it with additional policies (websockets, payment endpoints) and sets it as a CSP header which is more secure. 

specifics of this CSP: 

script-src - `www.gstatic.com` is included for google cast support (didn't test this) 
style-src has 'unsafe-inline' - svelte components that use style directives use inline styles - there is no other option here. 
connect-src -  `https`: this is super permissive right now - because of admin-configurable tile servers - personally, I think we should proxy tiles via the backend-api. 
img-src - `data:` for JXL detection, `blob:` for canvas, and `https:` for map tiles
worker-src `self` - local only
font-src - `self` - local only
frame-src - `none` - no frames
object-src - `none` - no plugins
base-uri - `self` - best practice

Also included is a script to generate hash for inline scripts (the theme parsing/setting inline script)

As a followup - the tiles stuff should be locked down a little more
