### PR TITLE
fix(mobile): implement dynamic asset projection based on device capabilities

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -1,6 +1,7 @@
 package app.alextran.immich.sync
 
 import android.annotation.SuppressLint
+import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
 import android.database.Cursor

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -115,6 +115,11 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
     val ASSET_PROJECTION = buildList {
       addAll(ASSET_PROJECTION_FALLBACK)
+      // XMP is only needed for the fallback path (no _special_format);
+      // if special_format is supported, we don't need it
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        remove(MediaStore.MediaColumns.XMP)
+      }
       add(SPECIAL_FORMAT_COLUMN)
     }.toTypedArray()
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -43,9 +43,9 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
   private var hashTask: Job? = null
 
-  // Probed lazily on first use (typically a background thread) whether _special_format
-  // is supported. Officially available at S Extensions level 21+, but actual support
-  // varies across devices regardless of the reported extension level — so we probe at
+  // Probed lazily on first use whether _special_format is supported.
+  // Officially available at S Extensions level 21+, but actual support
+  // varies across devices regardless of the reported extension level -> So we probe at
   // runtime. Falls back safely on older Android or if the probe fails (e.g. permissions
   // not yet granted); the correct projection is picked up on the next app start.
   protected val assetProjection: Array<String> by lazy {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -43,26 +43,32 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
   private var hashTask: Job? = null
 
-  // Probe once at construction time whether _special_format is supported.
-  // Officially available at S Extensions level 21+, but actual support varies across
-  // devices regardless of the reported extension level -> so we probe at runtime.
-  // Falls back safely if permissions aren't granted yet; after the user grants access
-  // the correct projection will be picked up on the next app start.
-  protected val assetProjection: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+  // Probed lazily on first use (typically a background thread) whether _special_format
+  // is supported. Officially available at S Extensions level 21+, but actual support
+  // varies across devices regardless of the reported extension level — so we probe at
+  // runtime. Falls back safely on older Android or if the probe fails (e.g. permissions
+  // not yet granted); the correct projection is picked up on the next app start.
+  protected val assetProjection: Array<String> by lazy {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return@lazy ASSET_PROJECTION_FALLBACK
     try {
       val queryArgs = Bundle().apply { putInt(ContentResolver.QUERY_ARG_LIMIT, 1) }
-      ctx.contentResolver.query(
+      val cursor = ctx.contentResolver.query(
         MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
         arrayOf(SPECIAL_FORMAT_COLUMN),
         queryArgs,
         null
-      )?.close()
-      ASSET_PROJECTION
+      )
+      if(cursor == null){
+        return@lazy ASSET_PROJECTION_FALLBACK
+      }else {
+        cursor.close()
+        ASSET_PROJECTION
+      }
     } catch (e: Exception) {
-      Log.d(TAG, "Failed to probe _special_format support, using fallback projection", e)
+      Log.w(TAG, "Failed to probe _special_format support, using fallback projection", e)
       ASSET_PROJECTION_FALLBACK
     }
-  } else ASSET_PROJECTION_FALLBACK
+  }
 
   companion object {
     private const val MAX_CONCURRENT_HASH_OPERATIONS = 16

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -42,6 +42,27 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
   private var hashTask: Job? = null
 
+  // Probe once at construction time whether _special_format is supported.
+  // Officially available at S Extensions level 21+, but actual support varies across
+  // devices regardless of the reported extension level -> so we probe at runtime.
+  // Falls back safely if permissions aren't granted yet; after the user grants access
+  // the correct projection will be picked up on the next app start.
+  protected val assetProjection: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    try {
+      val queryArgs = Bundle().apply { putInt(ContentResolver.QUERY_ARG_LIMIT, 1) }
+      ctx.contentResolver.query(
+        MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
+        arrayOf(SPECIAL_FORMAT_COLUMN),
+        queryArgs,
+        null
+      )?.close()
+      ASSET_PROJECTION
+    } catch (e: Exception) {
+      Log.d(TAG, "Failed to probe _special_format support, using fallback projection", e)
+      ASSET_PROJECTION_FALLBACK
+    }
+  } else ASSET_PROJECTION_FALLBACK
+
   companion object {
     private const val MAX_CONCURRENT_HASH_OPERATIONS = 16
     private val hashSemaphore = Semaphore(MAX_CONCURRENT_HASH_OPERATIONS)
@@ -61,7 +82,11 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString()
     )
     const val BUCKET_SELECTION = "(${MediaStore.Files.FileColumns.BUCKET_ID} = ?)"
-    val ASSET_PROJECTION = buildList {
+
+    // Projection without _special_format, used when the device doesn't support the column.
+    // _special_format is officially available at S Extensions level 21+, but some devices
+    // without that extension also support it, and some with it may not.
+    val ASSET_PROJECTION_FALLBACK = buildList {
       add(MediaStore.MediaColumns._ID)
       add(MediaStore.MediaColumns.DATA)
       add(MediaStore.MediaColumns.DISPLAY_NAME)
@@ -74,16 +99,16 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       add(MediaStore.MediaColumns.HEIGHT)
       add(MediaStore.MediaColumns.DURATION)
       add(MediaStore.MediaColumns.ORIENTATION)
-      // IS_FAVORITE is only available on Android 11 and above
+      // IS_FAVORITE, XMP is only available on Android 11 and above
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         add(MediaStore.MediaColumns.IS_FAVORITE)
-      }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        add(SPECIAL_FORMAT_COLUMN)
-      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        // Fallback: read XMP from MediaStore to detect Motion Photos
         add(MediaStore.MediaColumns.XMP)
       }
+    }.toTypedArray()
+
+    val ASSET_PROJECTION = buildList {
+      addAll(ASSET_PROJECTION_FALLBACK)
+      add(SPECIAL_FORMAT_COLUMN)
     }.toTypedArray()
 
     const val HASH_BUFFER_SIZE = 2 * 1024 * 1024
@@ -93,7 +118,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     volume: String,
     selection: String,
     selectionArgs: Array<String>,
-    projection: Array<String> = ASSET_PROJECTION,
+    projection: Array<String> = assetProjection,
     sortOrder: String? = null
   ): Cursor? = ctx.contentResolver.query(
     MediaStore.Files.getContentUri(volume),
@@ -108,7 +133,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     queryArgs: Bundle
   ): Cursor? = ctx.contentResolver.query(
     MediaStore.Files.getContentUri(volume),
-    ASSET_PROJECTION,
+    assetProjection,
     queryArgs,
     null
   )


### PR DESCRIPTION
Fixes: IllegalArgumentException in native kotlin code

```
I/flutter (10370): Error: PlatformException(IllegalArgumentException, java.lang.IllegalArgumentException: Invalid column _special_format, Cause: null, Stacktrace: java.lang.IllegalArgumentException: Invalid column _special_format
I/flutter (10370):     at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:183)
```

---

Seems like the `_special_format` column is available on some devices but not on others. 
So I added a runtime check which tries to query a single image meta data, with the `special` format column. 
If it works, we continue to use it else we don't. 


With a pixel on Android 16 API Level 36 this also breaks for me, just as @shenlong-tanwen reported. With the runtime check it works again, and fallbacks to the xmp playbackStyle detection.