### PR TITLE
fix(server): restore trashed asset when duplicate is uploaded

### DIFF
--- a/server/src/dtos/asset-media-response.dto.ts
+++ b/server/src/dtos/asset-media-response.dto.ts
@@ -5,6 +5,7 @@ export enum AssetMediaStatus {
   CREATED = 'created',
   REPLACED = 'replaced',
   DUPLICATE = 'duplicate',
+  RESTORED = 'restored',
 }
 export class AssetMediaResponseDto {
   @ValidateEnum({ enum: AssetMediaStatus, name: 'AssetMediaStatus', description: 'Upload status' })

--- a/server/src/middleware/asset-upload.interceptor.ts
+++ b/server/src/middleware/asset-upload.interceptor.ts
@@ -1,7 +1,7 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Response } from 'express';
 import { of } from 'rxjs';
-import { AssetMediaResponseDto, AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
+import { AssetMediaResponseDto } from 'src/dtos/asset-media-response.dto';
 import { ImmichHeader } from 'src/enum';
 import { AuthenticatedRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
@@ -19,7 +19,7 @@ export class AssetUploadInterceptor implements NestInterceptor {
     const response = await this.service.getUploadAssetIdByChecksum(req.user, checksum);
     if (response) {
       res.status(200);
-      return of({ status: AssetMediaStatus.DUPLICATE, id: response.id });
+      return of(response);
     }
 
     return next.handle();

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -630,17 +630,20 @@ export class AssetRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.BUFFER] })
-  async getUploadAssetIdByChecksum(ownerId: string, checksum: Buffer): Promise<string | undefined> {
+  async getUploadAssetIdByChecksum(
+    ownerId: string,
+    checksum: Buffer,
+  ): Promise<{ id: string; isTrashed: boolean } | undefined> {
     const asset = await this.db
       .selectFrom('asset')
-      .select('id')
+      .select(['id', 'deletedAt'])
       .where('ownerId', '=', asUuid(ownerId))
       .where('checksum', '=', checksum)
       .where('libraryId', 'is', null)
       .limit(1)
       .executeTakeFirst();
 
-    return asset?.id;
+    return asset ? { id: asset.id, isTrashed: !!asset.deletedAt } : undefined;
   }
 
   findLivePhotoMatch(options: LivePhotoSearchOptions) {

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -218,7 +218,7 @@ describe(AssetMediaService.name, () => {
     });
 
     it('should find an existing asset', async () => {
-      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue('asset-id');
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: 'asset-id', isTrashed: false });
       await expect(sut.getUploadAssetIdByChecksum(authStub.admin, file1.toString('hex'))).resolves.toEqual({
         id: 'asset-id',
         status: AssetMediaStatus.DUPLICATE,
@@ -227,12 +227,25 @@ describe(AssetMediaService.name, () => {
     });
 
     it('should find an existing asset by base64', async () => {
-      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue('asset-id');
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: 'asset-id', isTrashed: false });
       await expect(sut.getUploadAssetIdByChecksum(authStub.admin, file1.toString('base64'))).resolves.toEqual({
         id: 'asset-id',
         status: AssetMediaStatus.DUPLICATE,
       });
       expect(mocks.asset.getUploadAssetIdByChecksum).toHaveBeenCalledWith(authStub.admin.user.id, file1);
+    });
+
+    it('should restore a trashed asset and return restored status', async () => {
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: 'asset-id', isTrashed: true });
+      await expect(sut.getUploadAssetIdByChecksum(authStub.admin, file1.toString('hex'))).resolves.toEqual({
+        id: 'asset-id',
+        status: AssetMediaStatus.RESTORED,
+      });
+      expect(mocks.trash.restoreAll).toHaveBeenCalledWith(['asset-id']);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetRestoreAll', {
+        assetIds: ['asset-id'],
+        userId: authStub.admin.user.id,
+      });
     });
   });
 
@@ -390,13 +403,45 @@ describe(AssetMediaService.name, () => {
       (error as any).constraint_name = ASSET_CHECKSUM_CONSTRAINT;
 
       mocks.asset.create.mockRejectedValue(error);
-      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue(assetEntity.id);
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: assetEntity.id, isTrashed: false });
 
       await expect(sut.uploadAsset(authStub.user1, createDto, file)).resolves.toEqual({
         id: 'id_1',
         status: AssetMediaStatus.DUPLICATE,
       });
 
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: ['fake_path/asset_1.jpeg', undefined] },
+      });
+      expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+    });
+
+    it('should restore a trashed duplicate and return restored status', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: 'fake_path/asset_1.jpeg',
+        mimeType: 'image/jpeg',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.jpeg',
+        size: 0,
+      };
+      const error = new Error('unique key violation');
+      (error as any).constraint_name = ASSET_CHECKSUM_CONSTRAINT;
+
+      mocks.asset.create.mockRejectedValue(error);
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: assetEntity.id, isTrashed: true });
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, file)).resolves.toEqual({
+        id: 'id_1',
+        status: AssetMediaStatus.RESTORED,
+      });
+
+      expect(mocks.trash.restoreAll).toHaveBeenCalledWith([assetEntity.id]);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetRestoreAll', {
+        assetIds: [assetEntity.id],
+        userId: authStub.user1.user.id,
+      });
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
         data: { files: ['fake_path/asset_1.jpeg', undefined] },
@@ -922,7 +967,7 @@ describe(AssetMediaService.name, () => {
 
       mocks.asset.update.mockRejectedValue(error);
       mocks.asset.getById.mockResolvedValueOnce(sidecarAsset);
-      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue(sidecarAsset.id);
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue({ id: sidecarAsset.id, isTrashed: false });
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([sidecarAsset.id]));
       // this is the original file size
       mocks.storage.stat.mockResolvedValue({ size: 0 } as Stats);
@@ -1016,6 +1061,34 @@ describe(AssetMediaService.name, () => {
       });
 
       expect(mocks.asset.getByChecksums).toHaveBeenCalledWith(authStub.admin.user.id, [file1, file2]);
+    });
+
+    it('should restore trashed duplicates and return isTrashed as false', async () => {
+      const file1 = Buffer.from('d2947b871a706081be194569951b7db246907957', 'hex');
+
+      mocks.asset.getByChecksums.mockResolvedValue([{ id: 'asset-1', checksum: file1, deletedAt: new Date() }]);
+
+      await expect(
+        sut.bulkUploadCheck(authStub.admin, {
+          assets: [{ id: '1', checksum: file1.toString('hex') }],
+        }),
+      ).resolves.toEqual({
+        results: [
+          {
+            id: '1',
+            assetId: 'asset-1',
+            action: AssetUploadAction.REJECT,
+            reason: AssetRejectReason.DUPLICATE,
+            isTrashed: false,
+          },
+        ],
+      });
+
+      expect(mocks.trash.restoreAll).toHaveBeenCalledWith(['asset-1']);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetRestoreAll', {
+        assetIds: ['asset-1'],
+        userId: authStub.admin.user.id,
+      });
     });
   });
 

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -52,12 +52,18 @@ export class AssetMediaService extends BaseService {
       return;
     }
 
-    const assetId = await this.assetRepository.getUploadAssetIdByChecksum(auth.user.id, fromChecksum(checksum));
-    if (!assetId) {
+    const result = await this.assetRepository.getUploadAssetIdByChecksum(auth.user.id, fromChecksum(checksum));
+    if (!result) {
       return;
     }
 
-    return { id: assetId, status: AssetMediaStatus.DUPLICATE };
+    if (result.isTrashed) {
+      await this.trashRepository.restoreAll([result.id]);
+      await this.eventRepository.emit('AssetRestoreAll', { assetIds: [result.id], userId: auth.user.id });
+      return { id: result.id, status: AssetMediaStatus.RESTORED };
+    }
+
+    return { id: result.id, status: AssetMediaStatus.DUPLICATE };
   }
 
   canUploadFile({ auth, fieldName, file, body }: UploadRequest): true {
@@ -301,6 +307,15 @@ export class AssetMediaService extends BaseService {
       checksumMap[checksum.toString('hex')] = { id, isTrashed: !!deletedAt };
     }
 
+    const trashedIds = Object.values(checksumMap)
+      .filter((v) => v.isTrashed)
+      .map((v) => v.id);
+
+    if (trashedIds.length > 0) {
+      await this.trashRepository.restoreAll(trashedIds);
+      await this.eventRepository.emit('AssetRestoreAll', { assetIds: trashedIds, userId: auth.user.id });
+    }
+
     return {
       results: dto.assets.map(({ id, checksum }) => {
         const duplicate = checksumMap[fromChecksum(checksum).toString('hex')];
@@ -310,7 +325,7 @@ export class AssetMediaService extends BaseService {
             action: AssetUploadAction.REJECT,
             reason: AssetRejectReason.DUPLICATE,
             assetId: duplicate.id,
-            isTrashed: duplicate.isTrashed,
+            isTrashed: false,
           };
         }
 
@@ -336,12 +351,17 @@ export class AssetMediaService extends BaseService {
 
     // handle duplicates with a success response
     if (isAssetChecksumConstraint(error)) {
-      const duplicateId = await this.assetRepository.getUploadAssetIdByChecksum(auth.user.id, file.checksum);
-      if (!duplicateId) {
+      const result = await this.assetRepository.getUploadAssetIdByChecksum(auth.user.id, file.checksum);
+      if (!result) {
         this.logger.error(`Error locating duplicate for checksum constraint`);
         throw new InternalServerErrorException();
       }
-      return { status: AssetMediaStatus.DUPLICATE, id: duplicateId };
+      if (result.isTrashed) {
+        await this.trashRepository.restoreAll([result.id]);
+        await this.eventRepository.emit('AssetRestoreAll', { assetIds: [result.id], userId: auth.user.id });
+        return { status: AssetMediaStatus.RESTORED, id: result.id };
+      }
+      return { status: AssetMediaStatus.DUPLICATE, id: result.id };
     }
 
     this.logger.error(`Error uploading file ${error}`, error?.stack);


### PR DESCRIPTION
## Summary

- When a user deletes a photo (moves to trash) and re-uploads the same file, Immich detected it as a duplicate and rejected the upload silently, leaving the asset in the trash
- This fix automatically restores the trashed asset when a duplicate upload is detected, across all three upload code paths
- A new `AssetMediaStatus.RESTORED = 'restored'` value is added to distinguish restored assets from regular duplicates

## Code paths fixed

1. **`bulkUploadCheck`** - pre-flight check used by web/mobile/CLI: restores trashed duplicates in batch before responding
2. **`handleUploadError`** - direct upload hitting the DB unique checksum constraint: detects trashed status and restores
3. **`getUploadAssetIdByChecksum`** - interceptor path via `x-immich-checksum` header: returns `RESTORED` status
4. **`asset-upload.interceptor.ts`** - fixed bug where interceptor hardcoded `DUPLICATE` instead of using the service response

## Behaviour after fix

- Via `bulkUploadCheck` (web/CLI/mobile): asset restored server-side, client receives `isTrashed: false`
- Via direct upload: returns `status: 'restored'`, treated as success by client

## Test plan

- [ ] Upload a photo, delete it (moves to trash), re-upload the same photo, verify it appears in the library
- [ ] Unit tests updated with new cases for the trashed duplicate scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)