### PR TITLE
fix(web): show shared link download button when logged in

### DIFF
--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -1,0 +1,37 @@
+import { getAssetActions } from '$lib/services/asset.service';
+import { user as userStore } from '$lib/stores/user.store';
+import { setSharedLink } from '$lib/utils';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
+import { userAdminFactory } from '@test-data/factories/user-factory';
+
+describe('AssetService', () => {
+  describe('getAssetActions', () => {
+    it('should allow shared link downloads if the user owns the asset and shared link downloads are disabled', () => {
+      const ownerId = 'owner';
+      const user = userAdminFactory.build({ id: ownerId });
+      const asset = assetFactory.build({ ownerId });
+      userStore.set(user);
+      setSharedLink(sharedLinkFactory.build({ allowDownload: false }));
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(true);
+    });
+
+    it('should not allow shared link downloads if the user does not own the asset and shared link downloads are disabled', () => {
+      const ownerId = 'owner';
+      const user = userAdminFactory.build({ id: 'non-owner' });
+      const asset = assetFactory.build({ ownerId });
+      userStore.set(user);
+      setSharedLink(sharedLinkFactory.build({ allowDownload: false }));
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(false);
+    });
+
+    it('should allow shared link downloads if shared link downloads are enabled regardless of user', () => {
+      const asset = assetFactory.build();
+      setSharedLink(sharedLinkFactory.build({ allowDownload: true }));
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(true);
+    });
+  });
+});

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -100,7 +100,7 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
   const sharedLink = getSharedLink();
   const currentAuthUser = get(authUser);
   const userPreferences = get(preferences);
-  const isOwner = currentAuthUser && currentAuthUser.id === asset.ownerId;
+  const isOwner = !!(currentAuthUser && currentAuthUser.id === asset.ownerId);
 
   const Share: ActionItem = {
     title: $t('share'),
@@ -129,7 +129,7 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
 
   const SharedLinkDownload: ActionItem = {
     ...Download,
-    $if: () => isOwner || Boolean(sharedLink?.allowDownload),
+    $if: () => isOwner || !!sharedLink?.allowDownload,
   };
 
   const PlayMotionPhoto: ActionItem = {

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -100,13 +100,13 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
   const sharedLink = getSharedLink();
   const currentAuthUser = get(authUser);
   const userPreferences = get(preferences);
-  const isOwner = !!(currentAuthUser && currentAuthUser.id === asset.ownerId);
+  const isOwner = currentAuthUser && currentAuthUser.id === asset.ownerId;
 
   const Share: ActionItem = {
     title: $t('share'),
     icon: mdiShareVariantOutline,
     type: $t('assets'),
-    $if: () => !!(get(authUser) && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked),
+    $if: () => !!(currentAuthUser && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked),
     onAction: () => modalManager.show(SharedLinkCreateModal, { assetIds: [asset.id] }),
   };
 
@@ -129,7 +129,7 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
 
   const SharedLinkDownload: ActionItem = {
     ...Download,
-    $if: () => !currentAuthUser && sharedLink && sharedLink.allowDownload,
+    $if: () => isOwner || Boolean(sharedLink?.allowDownload),
   };
 
   const PlayMotionPhoto: ActionItem = {


### PR DESCRIPTION
## Description
Show the shared link download button when the shared link download setting is enabled, or when the user viewing the asset is the owner.

Fixes #26624

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Wrote tests
- [x] Viewed user A's shared asset as user A
- [x] Viewed user B's shared asset as user A, when shared link downloads are enabled
- [x] Viewed user B's shared asset as user A, when shared link downloads are disabled

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
