### PR TITLE
chore: always use Package Imports

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -9,7 +9,7 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-formatter:  
+formatter:
   page_width: 120
 
 linter:
@@ -33,6 +33,7 @@ linter:
     require_trailing_commas: true
     unrelated_type_equality_checks: true
     prefer_const_constructors: true
+    always_use_package_imports: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/mobile/lib/infrastructure/repositories/db.repository.dart
+++ b/mobile/lib/infrastructure/repositories/db.repository.dart
@@ -24,10 +24,9 @@ import 'package:immich_mobile/infrastructure/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/trashed_local_asset.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/user.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/user_metadata.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.steps.dart';
 import 'package:isar/isar.dart' hide Index;
-
-import 'db.repository.drift.dart';
 
 // #zoneTxn is the symbol used by Isar to mark a transaction within the current zone
 // ref: isar/isar_common.dart

--- a/mobile/lib/infrastructure/repositories/logger_db.repository.dart
+++ b/mobile/lib/infrastructure/repositories/logger_db.repository.dart
@@ -2,8 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:immich_mobile/domain/interfaces/db.interface.dart';
 import 'package:immich_mobile/infrastructure/entities/log.entity.dart';
-
-import 'logger_db.repository.drift.dart';
+import 'package:immich_mobile/infrastructure/repositories/logger_db.repository.drift.dart';
 
 @DriftDatabase(tables: [LogMessageEntity])
 class DriftLogger extends $DriftLogger implements IDatabaseRepository {

--- a/mobile/lib/pages/editing/crop.page.dart
+++ b/mobile/lib/pages/editing/crop.page.dart
@@ -7,10 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/pages/editing/edit.page.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/hooks/crop_controller_hook.dart';
-
-import 'edit.page.dart';
 
 /// A widget for cropping an image.
 /// This widget uses [HookWidget] to manage its lifecycle and state. It allows

--- a/mobile/lib/providers/infrastructure/memory.provider.dart
+++ b/mobile/lib/providers/infrastructure/memory.provider.dart
@@ -1,10 +1,9 @@
 import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/infrastructure/repositories/memory.repository.dart';
+import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'db.provider.dart';
 
 final driftMemoryRepositoryProvider = Provider<DriftMemoryRepository>(
   (ref) => DriftMemoryRepository(ref.watch(driftProvider)),

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -6,10 +6,9 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'album.provider.dart';
 
 class RemoteAlbumState {
   final List<RemoteAlbum> albums;

--- a/mobile/lib/services/share.service.dart
+++ b/mobile/lib/services/share.service.dart
@@ -6,11 +6,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:immich_mobile/services/api.service.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
-
-import 'api.service.dart';
 
 final shareServiceProvider = Provider((ref) => ShareService(ref.watch(apiServiceProvider)));
 

--- a/mobile/lib/utils/cache/widgets_binding.dart
+++ b/mobile/lib/utils/cache/widgets_binding.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
-
-import 'custom_image_cache.dart';
+import 'package:immich_mobile/utils/cache/custom_image_cache.dart';
 
 final class ImmichWidgetsBinding extends WidgetsFlutterBinding {
   @override

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -23,16 +23,15 @@ import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/tab.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/asset_grid/asset_drag_region.dart';
+import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/widgets/asset_grid/control_bottom_app_bar.dart';
+import 'package:immich_mobile/widgets/asset_grid/disable_multi_select_button.dart';
+import 'package:immich_mobile/widgets/asset_grid/draggable_scrollbar_custom.dart';
+import 'package:immich_mobile/widgets/asset_grid/group_divider_title.dart';
 import 'package:immich_mobile/widgets/asset_grid/thumbnail_image.dart';
 import 'package:immich_mobile/widgets/asset_grid/thumbnail_placeholder.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
-
-import 'asset_grid_data_structure.dart';
-import 'disable_multi_select_button.dart';
-import 'draggable_scrollbar_custom.dart';
-import 'group_divider_title.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_listitle.dart';
 
 typedef ImmichAssetGridSelectionListener = void Function(bool, Set<Asset>);
 

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -31,7 +31,7 @@ import 'package:immich_mobile/widgets/asset_grid/group_divider_title.dart';
 import 'package:immich_mobile/widgets/asset_grid/thumbnail_image.dart';
 import 'package:immich_mobile/widgets/asset_grid/thumbnail_placeholder.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_listitle.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 typedef ImmichAssetGridSelectionListener = void Function(bool, Set<Asset>);
 

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
-
-import 'photo_view_hit_corners.dart';
+import 'package:immich_mobile/widgets/photo_view/src/core/photo_view_hit_corners.dart';
 
 /// Credit to [eduribas](https://github.com/eduribas/photo_view/commit/508d9b77dafbcf88045b4a7fee737eed4064ea2c)
 /// for the gist

--- a/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
+++ b/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/widgets.dart';
-
-import '../photo_view.dart';
-import 'core/photo_view_core.dart';
-import 'photo_view_default_widgets.dart';
-import 'utils/photo_view_utils.dart';
+import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
+import 'package:immich_mobile/widgets/photo_view/src/core/photo_view_core.dart';
+import 'package:immich_mobile/widgets/photo_view/src/photo_view_default_widgets.dart';
+import 'package:immich_mobile/widgets/photo_view/src/utils/photo_view_utils.dart';
 
 class ImageWrapper extends StatefulWidget {
   const ImageWrapper({

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_settings.dart
@@ -6,10 +6,9 @@ import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
 import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
+import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_layout_settings.dart';
 import 'package:immich_mobile/widgets/settings/settings_sub_page_scaffold.dart';
 import 'package:immich_mobile/widgets/settings/settings_switch_list_tile.dart';
-
-import 'asset_list_layout_settings.dart';
 
 class AssetListSettings extends HookConsumerWidget {
   const AssetListSettings({super.key});

--- a/mobile/lib/widgets/settings/asset_viewer_settings/asset_viewer_settings.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/asset_viewer_settings.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/widgets/settings/asset_viewer_settings/image_viewer_quality_setting.dart';
 import 'package:immich_mobile/widgets/settings/asset_viewer_settings/image_viewer_tap_to_navigate_setting.dart';
+import 'package:immich_mobile/widgets/settings/asset_viewer_settings/video_viewer_settings.dart';
 import 'package:immich_mobile/widgets/settings/settings_sub_page_scaffold.dart';
-import 'video_viewer_settings.dart';
 
 class AssetViewerSettings extends StatelessWidget {
   const AssetViewerSettings({super.key});

--- a/mobile/packages/ui/lib/src/components/close_button.dart
+++ b/mobile/packages/ui/lib/src/components/close_button.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:immich_ui/src/components/icon_button.dart';
 import 'package:immich_ui/src/types.dart';
-
-import 'icon_button.dart';
 
 class ImmichCloseButton extends StatelessWidget {
   final VoidCallback? onPressed;


### PR DESCRIPTION
## Description

This PR adds the always_use_package_imports rule to the analysis_options.yaml and updates the few remaining files that were using relative paths 

While browsing the codebase, I noticed that the vast majority of the dart files already use absolute package imports. Standardizing this across the app provides a few small wins:

- IDE Support with a one-click "Auto-fix" to convert them to package imports.

- Refactoring: Moving files between folders becomes easier as package imports don't break when the source file's location changes.


I noticed this was already the "de facto" standard in the project, so I figured I’d formalize it. However, I am perfectly fine with this PR being closed if the team prefers to keep the flexibility of relative imports. It’s just a small preference :D 


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No usage
