### PR TITLE
fix(mobile): android detect supported version for special format column

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -92,7 +92,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
     // _special_format requires S Extensions 21+
     // https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT
-    fun hasSpecialFormatColumn(): Boolean =
+    private fun hasSpecialFormatColumn(): Boolean =
       Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
         SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 21
   }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -7,6 +7,7 @@ import android.database.Cursor
 import androidx.exifinterface.media.ExifInterface
 import android.os.Build
 import android.os.Bundle
+import android.os.ext.SdkExtensions
 import android.provider.MediaStore
 import android.util.Base64
 import android.util.Log
@@ -78,15 +79,23 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         add(MediaStore.MediaColumns.IS_FAVORITE)
       }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      if (hasSpecialFormatColumn()) {
         add(SPECIAL_FORMAT_COLUMN)
       } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         // Fallback: read XMP from MediaStore to detect Motion Photos
+        // only needed if SPECIAL_FORMAT column isn't available
         add(MediaStore.MediaColumns.XMP)
       }
     }.toTypedArray()
 
     const val HASH_BUFFER_SIZE = 2 * 1024 * 1024
+
+    // _special_format requires S Extensions 21+
+    // https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT
+    @SuppressLint("NewApi")
+    fun hasSpecialFormatColumn(): Boolean =
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+        SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 21
   }
 
   protected fun getCursor(

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -92,7 +92,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
     // _special_format requires S Extensions 21+
     // https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT
-    @SuppressLint("NewApi")
     fun hasSpecialFormatColumn(): Boolean =
       Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
         SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 21


### PR DESCRIPTION
Also fixes IllegalArgumentException in native kotlin code  (like #26618 )

```
I/flutter (10370): Error: PlatformException(IllegalArgumentException, java.lang.IllegalArgumentException: Invalid column _special_format, Cause: null, Stacktrace: java.lang.IllegalArgumentException: Invalid column _special_format
I/flutter (10370):     at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:183)
```

This PR follows the actual android documentation on in which version the column becomes available. 

---

Feel free to either merge this or #26618 to fix the bug.
This is probably cleaner, but that means even if the column is available but the version is not met, we directly fallback to the xmp playbackStyle detection.