### PR TITLE
fix(web): small thumbnail issues

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -283,8 +283,7 @@
         </div>
       {:else if asset.isImage && asset.duration && !asset.duration.includes('0:00:00.000') && mouseOver}
         <!-- GIF -->
-        <div class="absolute top-0 h-full w-full pointer-events-none">
-          <div class="absolute h-full w-full bg-linear-to-b from-black/25 via-[transparent_25%]"></div>
+        <div class="absolute h-full w-full pointer-events-none">
           <ImageThumbnail
             class={imageClass}
             {brokenAssetClass}
@@ -294,11 +293,6 @@
             heightStyle="{height}px"
             curve={selected}
           />
-          <div class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
-            <span class="pe-2 pt-2">
-              <Icon data-icon-playable-pause icon={mdiMotionPauseOutline} size="24" />
-            </span>
-          </div>
         </div>
       {/if}
 
@@ -318,7 +312,7 @@
       <!-- icon overlay -->
       <div class="z-2 absolute inset-0">
         <!-- Gradient overlay on hover -->
-        {#if !usingMobileDevice && !disabled}
+        {#if !usingMobileDevice && !disabled && !asset.isVideo}
           <div
             class={[
               'absolute h-full w-full bg-linear-to-b from-black/25 via-[transparent_25%] opacity-0 transition-opacity group-hover:opacity-100 ',
@@ -354,7 +348,7 @@
         {/if}
 
         {#if !authManager.isSharedLink && showArchiveIcon && asset.visibility === AssetVisibility.Archive}
-          <div class={['z-2  absolute start-2', asset.isFavorite ? 'bottom-10' : 'bottom-2']}>
+          <div class={['z-2 absolute start-2', asset.isFavorite ? 'bottom-10' : 'bottom-2']}>
             <Icon data-icon-archive icon={mdiArchiveArrowDownOutline} size="24" class="text-white" />
           </div>
         {/if}
@@ -362,7 +356,7 @@
         {#if asset.isImage && asset.projectionType === ProjectionType.EQUIRECTANGULAR}
           <div class="z-2 absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
             <span class="pe-2 pt-2">
-              <Icon data-icon-equirectangular icon={mdiRotate360} size="24" />
+              <Icon icon={mdiRotate360} size="24" />
             </span>
           </div>
         {/if}
@@ -370,7 +364,7 @@
         {#if asset.isImage && asset.duration && !asset.duration.includes('0:00:00.000')}
           <div class="z-2 absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
             <span class="pe-2 pt-2">
-              <Icon data-icon-playable icon={mdiFileGifBox} size="24" />
+              <Icon icon={mouseOver ? mdiMotionPauseOutline : mdiFileGifBox} size="24" />
             </span>
           </div>
         {/if}
@@ -385,7 +379,7 @@
           >
             <span class="pe-2 pt-2 flex place-items-center gap-1">
               <p>{asset.stack.assetCount.toLocaleString($locale)}</p>
-              <Icon data-icon-stack icon={mdiCameraBurst} size="24" />
+              <Icon icon={mdiCameraBurst} size="24" />
             </span>
           </div>
         {/if}

--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -107,7 +107,7 @@
   <span class="pe-2 pt-2 drop-shadow-[1px_1px_6px_rgb(0_0_0)]" onmouseenter={onMouseEnter} onmouseleave={onMouseLeave}>
     {#if enablePlayback}
       {#if loading}
-        <LoadingSpinner />
+        <LoadingSpinner size="large" />
       {:else if error}
         <Icon icon={mdiAlertCircleOutline} size="24" class="text-red-600" />
       {:else}


### PR DESCRIPTION
### Description
- Animated image original overlay also had old/unnecessary fade and icon leading to those showing double (gif + pause icon overlayed on hover)
- Current behavior on main is to show the fade on hover also on videos.
  - This was not the case in the last release and I think it was added as a mistake
  - The pause icon and time remaining are under the fade and thus darker than they should be
- Increased video loading spinner size to `large` which is 24, just like the other icons.
- Removed some unused `data-icon-*` that I assume were added for testing purposes but weren't used after all

| | Before | After |
|---|---|---|
| Gif icon | <img width="272" height="132" alt="image" src="https://github.com/user-attachments/assets/8963c682-f746-4b10-b148-d2fc3d323f23" /> | <img width="272" height="132" alt="image" src="https://github.com/user-attachments/assets/4377354c-acaa-4508-bcf7-c5b9a4788fdf" /> |
| Video | <img width="331" height="134" alt="image" src="https://github.com/user-attachments/assets/c58f802c-7584-47bb-b289-262a3a63b672" /> | <img width="223" height="119" alt="image" src="https://github.com/user-attachments/assets/22e03200-13d2-4e09-a046-1112280d6547" /> |
