### PR TITLE
fix(server): clean up edited thumbnail when deleting asset

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -566,6 +566,8 @@ describe(AssetService.name, () => {
         .file({ type: AssetFileType.Thumbnail })
         .file({ type: AssetFileType.Preview })
         .file({ type: AssetFileType.FullSize })
+        .file({ type: AssetFileType.Preview, isEdited: true })
+        .file({ type: AssetFileType.Thumbnail, isEdited: true })
         .build();
       mocks.assetJob.getForAssetDeletion.mockResolvedValue(asset);
 

--- a/server/src/utils/asset.util.ts
+++ b/server/src/utils/asset.util.ts
@@ -25,7 +25,7 @@ export const getAssetFiles = (files: AssetFile[]) => ({
 
   editedFullsizeFile: getAssetFile(files, AssetFileType.FullSize, { isEdited: true }),
   editedPreviewFile: getAssetFile(files, AssetFileType.Preview, { isEdited: true }),
-  editedThumbnailFile: getAssetFile(files, AssetFileType.Preview, { isEdited: true }),
+  editedThumbnailFile: getAssetFile(files, AssetFileType.Thumbnail, { isEdited: true }),
 });
 
 export const addAssets = async (


### PR DESCRIPTION
Permanently deleting an asset now cleans up its associated `*_thumbnail_edited.webp` file from disk. Previously edited thumbnail files were left orphaned.
