### PR TITLE
feat(web): bounding box for faces when hovering over the face in photo view

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -11,7 +11,7 @@
   import { imageManager } from '$lib/managers/ImageManager.svelte';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { ocrManager } from '$lib/stores/ocr.svelte';
-  import { boundingBoxesArray } from '$lib/stores/people.store';
+  import { boundingBoxesArray, type Faces } from '$lib/stores/people.store';
   import { SlideshowLook, SlideshowState, slideshowLookCssMapping, slideshowStore } from '$lib/stores/slideshow.store';
   import { getAssetUrl, targetImageSize as getTargetImageSize, handlePromiseError } from '$lib/utils';
   import { canCopyImageToClipboard, copyImageToClipboard } from '$lib/utils/asset-utils';
@@ -195,6 +195,42 @@
     }
     lastUrl = imageLoaderUrl;
   });
+
+  const faceToNameMap = $derived.by(() => {
+    const map = new Map<Faces, string>();
+    for (const person of asset.people ?? []) {
+      for (const face of person.faces ?? []) {
+        map.set(face, person.name);
+      }
+    }
+    return map;
+  });
+
+  const faces = $derived(Array.from(faceToNameMap.keys()));
+
+  const handleImageMouseMove = (event: MouseEvent) => {
+    $boundingBoxesArray = [];
+    if (!assetViewerManager.imgRef || !element || isFaceEditMode.value || ocrManager.showOverlay) {
+      return;
+    }
+
+    const containerRect = element.getBoundingClientRect();
+    const mouseX = event.clientX - containerRect.left;
+    const mouseY = event.clientY - containerRect.top;
+
+    const faceBoxes = getBoundingBox(faces, overlayMetrics);
+
+    const hoveredFaceIndices: number[] = [];
+    for (const [index, box] of faceBoxes.entries()) {
+      if (mouseX >= box.left && mouseX <= box.left + box.width && mouseY >= box.top && mouseY <= box.top + box.height) {
+        $boundingBoxesArray.push(faces[index]);
+      }
+    }
+  };
+
+  const handleImageMouseLeave = () => {
+    $boundingBoxesArray = [];
+  };
 </script>
 
 <AssetViewerEvents {onCopy} {onZoom} />
@@ -218,6 +254,9 @@
   class="relative h-full w-full select-none"
   bind:clientWidth={containerWidth}
   bind:clientHeight={containerHeight}
+  role="presentation"
+  onmousemove={handleImageMouseMove}
+  onmouseleave={handleImageMouseLeave}
 >
   {#if !imageLoaded}
     <div id="spinner" class="flex h-full items-center justify-center">
@@ -248,11 +287,20 @@
           : slideshowLookCssMapping[$slideshowLook]}"
         draggable="false"
       />
-      {#each getBoundingBox($boundingBoxesArray, overlayMetrics) as boundingbox (boundingbox.id)}
+      {#each getBoundingBox($boundingBoxesArray, overlayMetrics) as boundingbox, index (boundingbox.id)}
         <div
           class="absolute border-solid border-white border-3 rounded-lg"
           style="top: {boundingbox.top}px; left: {boundingbox.left}px; height: {boundingbox.height}px; width: {boundingbox.width}px;"
         ></div>
+        {#if faceToNameMap.get($boundingBoxesArray[index])}
+          <div
+            class="absolute bg-white/90 text-black px-2 py-1 rounded text-sm font-medium whitespace-nowrap pointer-events-none shadow-lg"
+            style="top: {boundingbox.top + boundingbox.height + 4}px; left: {boundingbox.left +
+              boundingbox.width}px; transform: translateX(-100%);"
+          >
+            {faceToNameMap.get($boundingBoxesArray[index])}
+          </div>
+        {/if}
       {/each}
 
       {#each ocrBoxes as ocrBox (ocrBox.id)}

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -221,7 +221,6 @@
 
     const faceBoxes = getBoundingBox(faces, overlayMetrics);
 
-    const hoveredFaceIndices: number[] = [];
     for (const [index, box] of faceBoxes.entries()) {
       if (mouseX >= box.left && mouseX <= box.left + box.width && mouseY >= box.top && mouseY <= box.top + box.height) {
         $boundingBoxesArray.push(faces[index]);

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -197,6 +197,7 @@
   });
 
   const faceToNameMap = $derived.by(() => {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
     const map = new Map<Faces, string>();
     for (const person of asset.people ?? []) {
       for (const face of person.faces ?? []) {


### PR DESCRIPTION
## Description
As I accidently closed the first one (#26423), here is the cleaned up new PR.
This extends the bounding box feature already available for the details pane.
As requested in #3489 (part 2) and #17986 if you hover over a face in the photo viewer the same bounding box is shown, that is already shown if you hover over the person in the details pane.
When dealing with lots of images it is hard to know, if all people in an image were already correctly marked.
With this change one can simply hover over all faces and quickly check.

As discussed on discord I checked for the OCR overlay but decided to go with the bounding boxes alreadyy there for person hovering. Feels more consistent for me this way.
As a next step I could imagine to extend this with a button similar to the OCR button in the lower right, to show bounding boxes for all faces at once to further help when mass tagging people.

Fixes #3489 (2nd part which never was actually solved).

## How Has This Been Tested?
Checked in multiple browsers and resolutions that the bounding box is at the correct place.
Also switched images back and forth to check, that no bounding is left over.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
[face_mouse_over.mov](https://github.com/user-attachments/assets/42baf37b-c657-4742-a861-81d10815a056)
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Used a LLM to get the code explained which already displays the bounding box when hovering over the person. Also in comparison to the new ocr overlays.