### PR TITLE
fix: resolve medium test asset paths relative to file location

### DIFF
--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -3,6 +3,7 @@ import { Insertable, Kysely } from 'kysely';
 import { DateTime } from 'luxon';
 import { createHash, randomBytes } from 'node:crypto';
 import { Stats } from 'node:fs';
+import { resolve } from 'node:path';
 import { Writable } from 'node:stream';
 import { AssetFace } from 'src/database';
 import { AuthDto, LoginResponseDto } from 'src/dtos/auth.dto';
@@ -77,6 +78,9 @@ import { newTelemetryRepositoryMock } from 'test/repositories/telemetry.reposito
 import { factory, newDate, newEmbedding, newUuid } from 'test/small.factory';
 import { automock, wait } from 'test/utils';
 import { Mocked } from 'vitest';
+
+// eslint-disable-next-line unicorn/prefer-module
+export const testAssetsDir = resolve(__dirname, '../../e2e/test-assets');
 
 interface ClassConstructor<T = any> extends Function {
   new (...args: any[]): T;

--- a/server/test/medium/specs/exif/exif-date-time.spec.ts
+++ b/server/test/medium/specs/exif/exif-date-time.spec.ts
@@ -2,7 +2,7 @@ import { Kysely } from 'kysely';
 import { DateTime } from 'luxon';
 import { resolve } from 'node:path';
 import { DB } from 'src/schema';
-import { ExifTestContext } from 'test/medium.factory';
+import { ExifTestContext, testAssetsDir } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
 let database: Kysely<DB>;
@@ -11,7 +11,7 @@ const setup = async (testAssetPath: string) => {
   const ctx = new ExifTestContext(database);
 
   const { user } = await ctx.newUser();
-  const originalPath = resolve(`../e2e/test-assets/${testAssetPath}`);
+  const originalPath = resolve(testAssetsDir, testAssetPath);
   const { asset } = await ctx.newAsset({ ownerId: user.id, originalPath });
 
   return { ctx, sut: ctx.sut, asset };

--- a/server/test/medium/specs/exif/exif-gps.spec.ts
+++ b/server/test/medium/specs/exif/exif-gps.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { resolve } from 'node:path';
 import { DB } from 'src/schema';
-import { ExifTestContext } from 'test/medium.factory';
+import { ExifTestContext, testAssetsDir } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
 let database: Kysely<DB>;
@@ -10,7 +10,7 @@ const setup = async (testAssetPath: string) => {
   const ctx = new ExifTestContext(database);
 
   const { user } = await ctx.newUser();
-  const originalPath = resolve(`../e2e/test-assets/${testAssetPath}`);
+  const originalPath = resolve(testAssetsDir, testAssetPath);
   const { asset } = await ctx.newAsset({ ownerId: user.id, originalPath });
 
   return { ctx, sut: ctx.sut, asset };

--- a/server/test/medium/specs/exif/exif-tags.spec.ts
+++ b/server/test/medium/specs/exif/exif-tags.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { resolve } from 'node:path';
 import { DB } from 'src/schema';
-import { ExifTestContext } from 'test/medium.factory';
+import { ExifTestContext, testAssetsDir } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
 let database: Kysely<DB>;
@@ -10,7 +10,7 @@ const setup = async (testAssetPath: string) => {
   const ctx = new ExifTestContext(database);
 
   const { user } = await ctx.newUser();
-  const originalPath = resolve(`../e2e/test-assets/${testAssetPath}`);
+  const originalPath = resolve(testAssetsDir, testAssetPath);
   const { asset } = await ctx.newAsset({ ownerId: user.id, originalPath });
 
   return { ctx, sut: ctx.sut, asset };


### PR DESCRIPTION
The exif medium tests use `resolve('../e2e/test-assets/...')` which resolves relative to `process.cwd()`. 

When run via `make` or `pnpm` from the `server/` directory, `CWD` is `server/ `so the path resolves correctly to `<repo>/e2e/test-assets/.` 

But when the Vitest VSCode extension runs the tests, it launches from `server/test/`(the config file's directory), so the path resolves to `server/e2e/test-assets/` — which doesn't exist -- This causes all exif medium tests to fail with "File not found" in the IDE.

This PR adds a `testAssetsDir` constant in `medium.factory.ts` that resolves the path relative to the source file's location using `__dirname` (CWD-independent).