### PR TITLE
chore: add vitest project names and fix server config root paths

### DIFF
--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    name: 'cli:unit',
     globals: true,
   },
 });

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -14,6 +14,7 @@ if (!skipDockerSetup) {
 
 export default defineConfig({
   test: {
+    name: 'e2e:server',
     retry: process.env.CI ? 4 : 0,
     include: ['src/specs/server/**/*.e2e-spec.ts'],
     globalSetup,

--- a/e2e/vitest.maintenance.config.ts
+++ b/e2e/vitest.maintenance.config.ts
@@ -14,6 +14,7 @@ if (!skipDockerSetup) {
 
 export default defineConfig({
   test: {
+    name: 'e2e:maintenance',
     retry: process.env.CI ? 4 : 0,
     include: ['src/specs/maintenance/server/**/*.e2e-spec.ts'],
     globalSetup,

--- a/server/test/vitest.config.medium.mjs
+++ b/server/test/vitest.config.medium.mjs
@@ -1,10 +1,15 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import swc from 'unplugin-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+const serverRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
 export default defineConfig({
   test: {
-    root: './',
+    name: 'server:medium',
+    root: serverRoot,
     globals: true,
     include: ['test/medium/**/*.spec.ts'],
     globalSetup: ['test/medium/globalSetup.ts'],

--- a/server/test/vitest.config.mjs
+++ b/server/test/vitest.config.mjs
@@ -1,10 +1,15 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import swc from 'unplugin-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+const serverRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
 export default defineConfig({
   test: {
-    root: './',
+    name: 'server:unit',
+    root: serverRoot,
     globals: true,
     include: ['src/**/*.spec.ts'],
     coverage: {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
     entries: ['src/**/*.{svelte,ts,html}'],
   },
   test: {
+    name: 'web:unit',
     include: ['src/**/*.{test,spec}.{js,ts}'],
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
* Add `name` fields to all vitest configs so they're easier to identify and filter in the VS Code test explorer
* Fix `root` in server vitest configs to use an absolute path resolved from `import.meta.url` instead of a relative `'./'` — this was the main fix, since the server medium tests wouldn't run properly in the IDE due to the working directory not being what vitest expected

<img width="416" height="941" alt="image" src="https://github.com/user-attachments/assets/2d6680d7-7018-4383-9a2f-d46fe34057d6" />

<img width="421" height="699" alt="image" src="https://github.com/user-attachments/assets/946d441a-ca72-4248-b879-f4bb1a45c72f" />

<img width="415" height="689" alt="image" src="https://github.com/user-attachments/assets/74e36bf8-237c-4ed1-a860-ae668415d2c6" />
