### PR TITLE
fix(mobile): resolve CR3 file download error on Android

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : FlutterFragmentActivity() {
       flutterEngine.plugins.add(BackgroundServicePlugin())
       flutterEngine.plugins.add(backgroundEngineLockImpl)
       flutterEngine.plugins.add(nativeSyncApiImpl)
+      flutterEngine.plugins.add(RawFileSaverPlugin())
     }
 
     fun cancelPlugins(flutterEngine: FlutterEngine) {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/RawFileSaverPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/RawFileSaverPlugin.kt
@@ -12,8 +12,13 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.io.FileInputStream
+import java.io.IOException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Flutter plugin that saves a RAW file (e.g. Canon CR3) to Android MediaStore
@@ -58,15 +63,21 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
             return
         }
 
-        try {
-            val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                saveToDownloads(filePath, title, relativePath, mimeType)
-            } else {
-                saveToFilesLegacy(filePath, title, mimeType)
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    saveToDownloads(filePath, title, relativePath, mimeType)
+                } else {
+                    saveToFilesLegacy(filePath, title, mimeType)
+                }
+                withContext(Dispatchers.Main) {
+                    result.success(uri?.toString())
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    result.error("SAVE_ERROR", e.message, null)
+                }
             }
-            result.success(uri?.toString())
-        } catch (e: Exception) {
-            result.error("SAVE_ERROR", e.message, null)
         }
     }
 
@@ -75,7 +86,8 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
      *
      * The Downloads collection does not validate MIME types against the OS image
      * registry, so non-standard types such as "image/x-canon-cr3" are accepted.
-     * IS_PENDING is used to make the write atomic.
+     * IS_PENDING is used to make the write atomic; the pending record is deleted
+     * on any I/O failure so no 0-byte orphan is left in the database.
      */
     private fun saveToDownloads(
         filePath: String,
@@ -85,8 +97,11 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     ): Uri? {
         val resolver = context.contentResolver
 
-        // Remap DCIM-style paths to the Download directory tree.
-        val downloadRelativePath = relativePath.replaceFirst(Regex("^DCIM"), "Download")
+        // Remap DCIM-style paths to the Download directory tree and normalise
+        // the trailing separator that MediaStore expects.
+        val downloadRelativePath = relativePath
+            .replaceFirst(Regex("^DCIM(?=[/\\\\]|$)"), "Download")
+            .trimEnd('/', '\\') + "/"
 
         val values = ContentValues().apply {
             put(MediaStore.Downloads.DISPLAY_NAME, title)
@@ -99,9 +114,10 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
         val uri = resolver.insert(collection, values) ?: return null
 
         try {
-            resolver.openOutputStream(uri)?.use { out ->
-                FileInputStream(File(filePath)).use { it.copyTo(out) }
-            }
+            val out = resolver.openOutputStream(uri)
+                ?: throw IOException("openOutputStream returned null for $uri")
+            out.use { FileInputStream(File(filePath)).use { src -> src.copyTo(out) } }
+
             val update = ContentValues().apply {
                 put(MediaStore.Downloads.IS_PENDING, 0)
             }
@@ -130,15 +146,18 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
         @Suppress("DEPRECATION")
         val dcimDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
         val destDir = File(dcimDir, "Immich")
-        destDir.mkdirs()
-        val destFile = File(destDir, title)
 
+        if (!destDir.exists() && !destDir.mkdirs()) {
+            throw IOException("Failed to create directory: ${destDir.absolutePath}")
+        }
+
+        val destFile = File(destDir, title)
         FileInputStream(File(filePath)).use { input ->
             destFile.outputStream().use { output -> input.copyTo(output) }
         }
 
         // Use application/octet-stream so the scanner does not reject the file;
-        // fall back to the provided mimeType if it is a well-known image type.
+        // keep the provided mimeType only for well-known standard image types.
         val scanMimeType = if (mimeType.startsWith("image/x-") || mimeType == "image/*") {
             "application/octet-stream"
         } else {
@@ -155,7 +174,12 @@ class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
             resultUri = uri
             latch.countDown()
         }
-        latch.await(5, TimeUnit.SECONDS)
+
+        val completed = latch.await(5, TimeUnit.SECONDS)
+        if (!completed) {
+            throw IOException("MediaScanner timed out for ${destFile.absolutePath}")
+        }
+
         return resultUri
     }
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/RawFileSaverPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/RawFileSaverPlugin.kt
@@ -1,0 +1,165 @@
+package app.alextran.immich
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileInputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Flutter plugin that saves a RAW file (e.g. Canon CR3) to Android MediaStore
+ * with an explicit MIME type, bypassing photo_manager's MimeTypeMap lookup.
+ *
+ * On Android Q+ (API 29+) the file is inserted into MediaStore.Downloads, which
+ * accepts non-standard MIME types that MediaStore.Images rejects.
+ * On older devices the file is written directly to DCIM/Immich and registered
+ * via MediaScannerConnection.
+ *
+ * Channel: immich/raw_file_saver
+ * Method:  saveRawFile({ filePath, title, relativePath, mimeType }) - returns String? (content URI)
+ */
+class RawFileSaverPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+
+    private lateinit var channel: MethodChannel
+    private lateinit var context: Context
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL)
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (call.method != "saveRawFile") {
+            result.notImplemented()
+            return
+        }
+
+        val filePath = call.argument<String>("filePath")
+        val title = call.argument<String>("title")
+        val relativePath = call.argument<String>("relativePath") ?: "DCIM/Immich"
+        val mimeType = call.argument<String>("mimeType")
+
+        if (filePath == null || title == null || mimeType == null) {
+            result.error("INVALID_ARGS", "filePath, title and mimeType are required", null)
+            return
+        }
+
+        try {
+            val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                saveToDownloads(filePath, title, relativePath, mimeType)
+            } else {
+                saveToFilesLegacy(filePath, title, mimeType)
+            }
+            result.success(uri?.toString())
+        } catch (e: Exception) {
+            result.error("SAVE_ERROR", e.message, null)
+        }
+    }
+
+    /**
+     * Android Q+ path: insert into MediaStore.Downloads.
+     *
+     * The Downloads collection does not validate MIME types against the OS image
+     * registry, so non-standard types such as "image/x-canon-cr3" are accepted.
+     * IS_PENDING is used to make the write atomic.
+     */
+    private fun saveToDownloads(
+        filePath: String,
+        title: String,
+        relativePath: String,
+        mimeType: String,
+    ): Uri? {
+        val resolver = context.contentResolver
+
+        // Remap DCIM-style paths to the Download directory tree.
+        val downloadRelativePath = relativePath.replaceFirst(Regex("^DCIM"), "Download")
+
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, title)
+            put(MediaStore.Downloads.MIME_TYPE, mimeType)
+            put(MediaStore.Downloads.RELATIVE_PATH, downloadRelativePath)
+            put(MediaStore.Downloads.IS_PENDING, 1)
+        }
+
+        val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+        val uri = resolver.insert(collection, values) ?: return null
+
+        try {
+            resolver.openOutputStream(uri)?.use { out ->
+                FileInputStream(File(filePath)).use { it.copyTo(out) }
+            }
+            val update = ContentValues().apply {
+                put(MediaStore.Downloads.IS_PENDING, 0)
+            }
+            resolver.update(uri, update, null, null)
+        } catch (e: Exception) {
+            resolver.delete(uri, null, null)
+            throw e
+        }
+
+        return uri
+    }
+
+    /**
+     * Pre-Q fallback: write the file directly to DCIM/Immich on the filesystem
+     * and register it with MediaScannerConnection so it appears in the gallery.
+     *
+     * MediaStore.Images rejects non-standard MIME types on older Android versions,
+     * so we use application/octet-stream for the scanner hint and let the OS
+     * determine the actual type from the file content.
+     */
+    private fun saveToFilesLegacy(
+        filePath: String,
+        title: String,
+        mimeType: String,
+    ): Uri? {
+        @Suppress("DEPRECATION")
+        val dcimDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
+        val destDir = File(dcimDir, "Immich")
+        destDir.mkdirs()
+        val destFile = File(destDir, title)
+
+        FileInputStream(File(filePath)).use { input ->
+            destFile.outputStream().use { output -> input.copyTo(output) }
+        }
+
+        // Use application/octet-stream so the scanner does not reject the file;
+        // fall back to the provided mimeType if it is a well-known image type.
+        val scanMimeType = if (mimeType.startsWith("image/x-") || mimeType == "image/*") {
+            "application/octet-stream"
+        } else {
+            mimeType
+        }
+
+        var resultUri: Uri? = null
+        val latch = CountDownLatch(1)
+        MediaScannerConnection.scanFile(
+            context,
+            arrayOf(destFile.absolutePath),
+            arrayOf(scanMimeType),
+        ) { _, uri ->
+            resultUri = uri
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        return resultUri
+    }
+
+    companion object {
+        private const val CHANNEL = "immich/raw_file_saver"
+    }
+}

--- a/mobile/lib/repositories/file_media.repository.dart
+++ b/mobile/lib/repositories/file_media.repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/entities/asset.entity.dart' hide AssetType;
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:photo_manager/photo_manager.dart' hide AssetType;
 import 'package:path/path.dart' as path;
@@ -22,11 +23,12 @@ class FileMediaRepository {
     return path.extension(filePath).toLowerCase() == '.cr3';
   }
 
-  /// Returns the MIME type to use when saving [filePath] to Android MediaStore.
+  /// Returns the MIME type to pass to the native save channel for [filePath].
   ///
-  /// Android's [MimeTypeMap] has no entry for `.cr3`, so [photo_manager] would
-  /// fall back to the wildcard `image/*`, which MediaStore rejects. This method
-  /// maps known unsupported extensions to their correct specific MIME types.
+  /// `.cr3` files are mapped to `image/x-canon-cr3` so the native plugin can
+  /// insert them into MediaStore.Downloads with a concrete type. All other
+  /// extensions return `image/*`, which photo_manager resolves correctly via
+  /// its own MimeTypeMap lookup for standard formats.
   @visibleForTesting
   String mimeTypeForFile(String filePath) {
     if (isCR3File(filePath)) return 'image/x-canon-cr3';
@@ -55,7 +57,7 @@ class FileMediaRepository {
     // CR3 files have no entry in Android's MimeTypeMap, so photo_manager falls back
     // to the wildcard "image/*" which MediaStore rejects. Use a dedicated native
     // channel that inserts the file with an explicit MIME type instead.
-    if (Platform.isAndroid && isCR3File(filePath)) {
+    if (CurrentPlatform.isAndroid && isCR3File(filePath)) {
       return _saveRawFileOnAndroid(
         filePath,
         title: title ?? path.basename(filePath),

--- a/mobile/lib/repositories/file_media.repository.dart
+++ b/mobile/lib/repositories/file_media.repository.dart
@@ -1,16 +1,38 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/entities/asset.entity.dart' hide AssetType;
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:photo_manager/photo_manager.dart' hide AssetType;
+import 'package:path/path.dart' as path;
 
 final fileMediaRepositoryProvider = Provider((ref) => const FileMediaRepository());
 
 class FileMediaRepository {
   const FileMediaRepository();
+
+  static const _rawFileSaverChannel = MethodChannel('immich/raw_file_saver');
+
+  /// Returns true when [filePath] is a Canon CR3 RAW file.
+  @visibleForTesting
+  bool isCR3File(String filePath) {
+    return path.extension(filePath).toLowerCase() == '.cr3';
+  }
+
+  /// Returns the MIME type to use when saving [filePath] to Android MediaStore.
+  ///
+  /// Android's [MimeTypeMap] has no entry for `.cr3`, so [photo_manager] would
+  /// fall back to the wildcard `image/*`, which MediaStore rejects. This method
+  /// maps known unsupported extensions to their correct specific MIME types.
+  @visibleForTesting
+  String mimeTypeForFile(String filePath) {
+    if (isCR3File(filePath)) return 'image/x-canon-cr3';
+    return 'image/*';
+  }
+
   Future<Asset?> saveImage(Uint8List data, {required String title, String? relativePath}) async {
     final entity = await PhotoManager.editor.saveImage(data, filename: title, title: title, relativePath: relativePath);
     return AssetMediaRepository.toAsset(entity);
@@ -30,7 +52,46 @@ class FileMediaRepository {
   }
 
   Future<Asset?> saveImageWithFile(String filePath, {String? title, String? relativePath}) async {
+    // CR3 files have no entry in Android's MimeTypeMap, so photo_manager falls back
+    // to the wildcard "image/*" which MediaStore rejects. Use a dedicated native
+    // channel that inserts the file with an explicit MIME type instead.
+    if (Platform.isAndroid && isCR3File(filePath)) {
+      return _saveRawFileOnAndroid(
+        filePath,
+        title: title ?? path.basename(filePath),
+        relativePath: relativePath ?? 'DCIM/Immich',
+      );
+    }
+
     final entity = await PhotoManager.editor.saveImageWithPath(filePath, title: title, relativePath: relativePath);
+    return AssetMediaRepository.toAsset(entity);
+  }
+
+  /// Saves a RAW file on Android via [_rawFileSaverChannel], which inserts the
+  /// file into MediaStore with an explicit MIME type to avoid the
+  /// "Unsupported MIME type image/*" error from photo_manager.
+  Future<Asset?> _saveRawFileOnAndroid(
+    String filePath, {
+    required String title,
+    required String relativePath,
+  }) async {
+    final String? uriString = await _rawFileSaverChannel.invokeMethod<String>(
+      'saveRawFile',
+      {
+        'filePath': filePath,
+        'title': title,
+        'relativePath': relativePath,
+        'mimeType': mimeTypeForFile(filePath),
+      },
+    );
+
+    if (uriString == null) return null;
+
+    // Extract the numeric MediaStore ID from the content URI so we can look up
+    // the AssetEntity that photo_manager already knows about.
+    final uri = Uri.parse(uriString);
+    final assetId = uri.pathSegments.last;
+    final entity = await AssetEntity.fromId(assetId);
     return AssetMediaRepository.toAsset(entity);
   }
 

--- a/mobile/test/repositories/file_media_repository_test.dart
+++ b/mobile/test/repositories/file_media_repository_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/repositories/file_media.repository.dart';
+
+void main() {
+  late FileMediaRepository repository;
+
+  setUp(() {
+    repository = const FileMediaRepository();
+  });
+
+  group('FileMediaRepository.isCR3File', () {
+    test('returns true for lowercase .cr3 extension', () {
+      expect(repository.isCR3File('/path/to/image.cr3'), isTrue);
+    });
+
+    test('returns true for uppercase .CR3 extension', () {
+      expect(repository.isCR3File('/path/to/image.CR3'), isTrue);
+    });
+
+    test('returns true for mixed-case .Cr3 extension', () {
+      expect(repository.isCR3File('/path/to/image.Cr3'), isTrue);
+    });
+
+    test('returns true for real-world Canon filename', () {
+      expect(repository.isCR3File('/path/to/IMG_5500.CR3'), isTrue);
+    });
+
+    test('returns false for .jpg', () {
+      expect(repository.isCR3File('/path/to/image.jpg'), isFalse);
+    });
+
+    test('returns false for .png', () {
+      expect(repository.isCR3File('/path/to/image.png'), isFalse);
+    });
+
+    test('returns false for .heic', () {
+      expect(repository.isCR3File('/path/to/image.heic'), isFalse);
+    });
+
+    test('returns false for .cr2 (older Canon RAW)', () {
+      expect(repository.isCR3File('/path/to/image.cr2'), isFalse);
+    });
+
+    test('returns false for .raw', () {
+      expect(repository.isCR3File('/path/to/image.raw'), isFalse);
+    });
+
+    test('returns false for file with no extension', () {
+      expect(repository.isCR3File('/path/to/image'), isFalse);
+    });
+  });
+
+  group('FileMediaRepository.mimeTypeForFile', () {
+    test('returns image/x-canon-cr3 for .cr3 files', () {
+      expect(
+        repository.mimeTypeForFile('/path/to/image.cr3'),
+        equals('image/x-canon-cr3'),
+      );
+    });
+
+    test('returns image/x-canon-cr3 for .CR3 files (case-insensitive)', () {
+      expect(
+        repository.mimeTypeForFile('/path/to/IMG_5500.CR3'),
+        equals('image/x-canon-cr3'),
+      );
+    });
+
+    test('returns image/* for .jpg files', () {
+      expect(
+        repository.mimeTypeForFile('/path/to/image.jpg'),
+        equals('image/*'),
+      );
+    });
+
+    test('returns image/* for .png files', () {
+      expect(
+        repository.mimeTypeForFile('/path/to/image.png'),
+        equals('image/*'),
+      );
+    });
+
+    test('returns image/* for .heic files', () {
+      expect(
+        repository.mimeTypeForFile('/path/to/image.heic'),
+        equals('image/*'),
+      );
+    });
+
+    test('CR3 MIME type is a specific type, not a wildcard', () {
+      final mimeType = repository.mimeTypeForFile('/path/to/IMG_5500.CR3');
+      expect(mimeType, isNot(equals('image/*')));
+      expect(mimeType, isNot(contains('*')));
+    });
+
+    test('CR3 MIME type is passed to native plugin unchanged (Downloads handles it)', () {
+      // MediaStore.Images rejects image/x-canon-cr3 at the OS level.
+      // The native plugin routes CR3 to MediaStore.Downloads instead, which
+      // accepts non-standard MIME types. The Dart layer still supplies the
+      // semantically correct MIME type to the plugin.
+      final mimeType = repository.mimeTypeForFile('/sdcard/DCIM/IMG_5500.CR3');
+      expect(mimeType, equals('image/x-canon-cr3'));
+    });
+  });
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR resolves the issue where downloading `.cr3` (Canon RAW) files on Android shows the progress bar reaching 100%, but ultimately fails to save to the device, throwing a `PlatformException` with `java.lang.IllegalArgumentException: Unsupported MIME type image/*`.

**Root Cause:**
Android's `MimeTypeMap` has no registered entry for the `.cr3` extension. When `photo_manager` internally resolves the MIME type, it gets `null` and falls back to the wildcard `"image/*"`. Android's `ContentResolver.insert()` rejects this wildcard because MediaStore requires a concrete MIME type.

**The Fix:**
Because `photo_manager` provides no public API to override this internal lookup, this PR handles `.cr3` files through a dedicated native channel (`immich/raw_file_saver`), completely bypassing `photo_manager` just for this specific file type on Android.

- **Android Q+ (API 29+):** Saves directly to `MediaStore.Downloads`. The Downloads collection does **not** perform strict OS-level MIME validation, safely accepting `image/x-canon-cr3` or `application/octet-stream`.
- **Pre-Q (API < 29):** Writes the file directly to `DCIM/Immich/` on the filesystem and registers it via `MediaScannerConnection.scanFile()` so it appears in the gallery correctly.

<details>
<summary><h3>📖 Historical Context: Why previous attempts failed</h3></summary>

Other developers have tried to fix this before. Here is a summary of why those attempts failed and how this PR avoids those pitfalls:

1. **First attempt (`22f83c49e`):** Tried calling `saveImage(bytes)` instead of `saveImageWithPath`. Failed because `photo_manager` still derives the MIME from the filename string, resulting in the same `image/*` fallback.
2. **Second attempt (`80524c35a`):** Created the native plugin but left a Kotlin nested-comment syntax error (a literal `/*` inside a KDoc block), causing a compilation failure (`MissingPluginException`).
3. **Third attempt (My initial test):** Fixed the syntax error and routed to `MediaStore.Images.Media`. Failed at runtime because Android's `MediaStore.Images` strictly validates MIME types against the OS registry and rejects `image/x-canon-cr3`. 
**Final Solution:** Routing to `MediaStore.Downloads` bypasses the OS validation entirely.
</details>

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #20112

## How Has This Been Tested?

- [x] **Dart Unit Tests:** Added 17 unit tests in `test/repositories/file_media_repository_test.dart` to validate extension parsing (`isCR3File`) and MIME type generation (`mimeTypeForFile`), including case insensitivity and fake extensions. All 17 tests passed.
- [x] **Native Compilation Check:** Verified via `classes25.dex` that the Kotlin plugin compiles correctly.
- [x] **Physical Android Verification:** Verified that the file is correctly routed to `MediaStore.Downloads` on API 29+ without crashing.
- [x] **Regression Testing (Zero Impact):** Verified that the new `MethodChannel` is ONLY invoked for `.cr3` files on Android. Standard image types (`jpg`, `png`, `heic`, etc.) and non-Android platforms continue to use `PhotoManager.editor.saveImageWithPath` exactly as before.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


![Screenshot_20260304_011417](https://github.com/user-attachments/assets/903eb7b1-db05-4c87-8634-509e25162c66)
![Screenshot_20260304_011427_My Files](https://github.com/user-attachments/assets/a20e4cb8-325a-4372-9591-7522a6c626cc)

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI coding agent (Open Hands) with Claude Sonnet 4.6 was used to assist in writing the boilerplate Kotlin bridging code (`RawFileSaverPlugin.kt`), fixing legacy KDoc syntax errors, and formatting the Dart unit tests. However, the core architectural decision—discovering that `MediaStore.Images` rejects standard RAW MIME types on Android and pivoting the logic to use `MediaStore.Downloads` and legacy `MediaScannerConnection`—was investigated, directed, and manually verified by me.