### PR TITLE
fix(web): download toast showing wrong filename for motion assets

### DIFF
--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -1,9 +1,34 @@
-import { getAssetActions } from '$lib/services/asset.service';
+import { getAssetActions, handleDownloadAsset } from '$lib/services/asset.service';
 import { user as userStore } from '$lib/stores/user.store';
 import { setSharedLink } from '$lib/utils';
+import { getFormatter } from '$lib/utils/i18n';
+import { getAssetInfo } from '@immich/sdk';
+import { toastManager } from '@immich/ui';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
+import { vitest } from 'vitest';
+
+vitest.mock('@immich/ui', () => ({
+  toastManager: {
+    success: vitest.fn(),
+  },
+}));
+
+vitest.mock('$lib/utils/i18n', () => ({
+  getFormatter: vitest.fn(),
+  getPreferredLocale: vitest.fn(),
+}));
+
+vitest.mock('@immich/sdk');
+
+vitest.mock('$lib/utils', async () => {
+  const originalModule = await vitest.importActual('$lib/utils');
+  return {
+    ...originalModule,
+    sleep: vitest.fn(),
+  };
+});
 
 describe('AssetService', () => {
   describe('getAssetActions', () => {
@@ -32,6 +57,29 @@ describe('AssetService', () => {
       setSharedLink(sharedLinkFactory.build({ allowDownload: true }));
       const assetActions = getAssetActions(() => '', asset);
       expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(true);
+    });
+  });
+
+  describe('handleDownloadAsset', () => {
+    it('should use the asset originalFileName when showing toasts', async () => {
+      const $t = vitest.fn().mockReturnValue('formatter');
+      vitest.mocked(getFormatter).mockResolvedValue($t);
+      const asset = assetFactory.build({ originalFileName: 'asset.heic' });
+      await handleDownloadAsset(asset, { edited: false });
+      expect($t).toHaveBeenNthCalledWith(1, 'downloading_asset_filename', { values: { filename: 'asset.heic' } });
+      expect(toastManager.success).toHaveBeenCalledWith('formatter');
+    });
+
+    it('should use the motion asset originalFileName when showing toasts', async () => {
+      const $t = vitest.fn().mockReturnValue('formatter');
+      vitest.mocked(getFormatter).mockResolvedValue($t);
+      const motionAsset = assetFactory.build({ originalFileName: 'asset.mov' });
+      vitest.mocked(getAssetInfo).mockResolvedValue(motionAsset);
+      const asset = assetFactory.build({ originalFileName: 'asset.heic', livePhotoVideoId: '1' });
+      await handleDownloadAsset(asset, { edited: false });
+      expect($t).toHaveBeenNthCalledWith(1, 'downloading_asset_filename', { values: { filename: 'asset.heic' } });
+      expect($t).toHaveBeenNthCalledWith(2, 'downloading_asset_filename', { values: { filename: 'asset.mov' } });
+      expect(toastManager.success).toHaveBeenCalledWith('formatter');
     });
   });
 });

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -297,7 +297,6 @@ export const handleDownloadAsset = async (asset: AssetResponseDto, { edited }: {
     {
       filename: asset.originalFileName,
       id: asset.id,
-      size: asset.exifInfo?.fileSizeInByte || 0,
     },
   ];
 
@@ -311,7 +310,6 @@ export const handleDownloadAsset = async (asset: AssetResponseDto, { edited }: {
       assets.push({
         filename: motionAsset.originalFileName,
         id: asset.livePhotoVideoId,
-        size: motionAsset.exifInfo?.fileSizeInByte || 0,
       });
     }
   }
@@ -325,7 +323,7 @@ export const handleDownloadAsset = async (asset: AssetResponseDto, { edited }: {
     }
 
     try {
-      toastManager.success($t('downloading_asset_filename', { values: { filename: asset.originalFileName } }));
+      toastManager.success($t('downloading_asset_filename', { values: { filename } }));
       downloadUrl(
         getBaseUrl() +
           `/assets/${id}/original` +


### PR DESCRIPTION
## Description
Downloading an asset that also has a motion asset associated with it shows a toast per download. The toast for the motion asset, however, was showing the original asset's filename and not the motion asset's filename.

Fixes #26671

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Admittedly couldn't test motion assets organically - couldn't find motion assets that caused the downloads to be separate - but did test asset downloads.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None