### PR TITLE
fix(web): video stealing focus when it plays again when looping

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -60,6 +60,7 @@
   $effect(() => {
     // reactive on `assetFileUrl` changes
     if (assetFileUrl) {
+      hasFocused = false;
       videoPlayer?.load();
     }
   });
@@ -152,6 +153,7 @@
         onseeking={() => (isScrubbing = true)}
         onseeked={() => (isScrubbing = false)}
         onplaying={(e) => {
+          console.log(`playing - ${hasFocused ? 'focused' : ''}`);
           if (!hasFocused) {
             e.currentTarget.focus();
             hasFocused = true;

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -50,6 +50,7 @@
   );
   let isScrubbing = $state(false);
   let showVideo = $state(false);
+  let hasFocused = $state(false);
 
   onMount(() => {
     // Show video after mount to ensure fading in.
@@ -151,7 +152,10 @@
         onseeking={() => (isScrubbing = true)}
         onseeked={() => (isScrubbing = false)}
         onplaying={(e) => {
-          e.currentTarget.focus();
+          if (!hasFocused) {
+            e.currentTarget.focus();
+            hasFocused = true;
+          }
         }}
         onclose={() => onClose()}
         muted={$videoViewerMuted}

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -153,7 +153,6 @@
         onseeking={() => (isScrubbing = true)}
         onseeked={() => (isScrubbing = false)}
         onplaying={(e) => {
-          console.log(`playing - ${hasFocused ? 'focused' : ''}`);
           if (!hasFocused) {
             e.currentTarget.focus();
             hasFocused = true;


### PR DESCRIPTION
## Description
Prevent the video stealing focus every time it loops back to the beginning. This fixes things like modal combo boxes clearing when the video plays from the beginning.

Fixes #22892, but undoes #16860 (reintroduces the "bug" in https://github.com/immich-app/immich/issues/16778)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Open the tags modal from the asset viewer when viewing a looping video
- [x] Played looping videos in an album consisting solely of videos, navigated between assets
- [x] Played a slideshow in an album consisting solely of videos, ensuring escape still worked

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
