### PR TITLE
fix(web): combobox dropdown positioning in modals

### DIFF
--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -180,6 +180,17 @@
     onSelect(selectedOption);
   };
 
+  // TODO: move this combobox component into @immich/ui
+  // Bits UI dialogs use `contain: layout` so fixed descendants are positioned in dialog space
+  const getModalBounds = () => {
+    const modalRoot = input?.closest('[data-dialog-content]');
+    if (!modalRoot || !getComputedStyle(modalRoot).contain.includes('layout')) {
+      return;
+    }
+
+    return modalRoot.getBoundingClientRect();
+  };
+
   const calculatePosition = (boundary: DOMRect | undefined) => {
     const visualViewport = window.visualViewport;
 
@@ -187,29 +198,35 @@
       return;
     }
 
-    const left = boundary.left + (visualViewport?.offsetLeft || 0);
-    const offsetTop = visualViewport?.offsetTop || 0;
+    const modalBounds = getModalBounds();
+    const offsetTop = modalBounds?.top || 0;
+    const offsetLeft = modalBounds?.left || 0;
+    const rootHeight = modalBounds?.height || window.innerHeight;
+
+    const top = boundary.top - offsetTop;
+    const bottom = boundary.bottom - offsetTop;
+    const left = boundary.left - offsetLeft;
 
     if (dropdownDirection === 'top') {
       return {
-        bottom: `${window.innerHeight - boundary.top - offsetTop}px`,
+        bottom: `${rootHeight - top}px`,
         left: `${left}px`,
         width: `${boundary.width}px`,
-        maxHeight: maxHeight(boundary.top - dropdownOffset),
+        maxHeight: maxHeight(top - dropdownOffset),
       };
     }
 
-    const viewportHeight = visualViewport?.height || 0;
-    const availableHeight = viewportHeight - boundary.bottom;
+    const viewportHeight = visualViewport?.height || rootHeight;
+    const availableHeight = modalBounds ? rootHeight - bottom : viewportHeight - boundary.bottom;
     return {
-      top: `${boundary.bottom + offsetTop}px`,
+      top: `${bottom}px`,
       left: `${left}px`,
       width: `${boundary.width}px`,
       maxHeight: maxHeight(availableHeight - dropdownOffset),
     };
   };
 
-  const maxHeight = (size: number) => `min(${size}px,18rem)`;
+  const maxHeight = (size: number) => `min(${Math.max(size, 0)}px,18rem)`;
 
   const onPositionChange = () => {
     if (!isOpen) {


### PR DESCRIPTION
Bits UI added `contain: layout` to their dialogs which throws off our position calculation for combobox dropdowns. Ideally this component should live in @immich/ui, but for now this fixes the issue.

| Before | After |
| - | - |
| <img width="652" height="425" alt="image" src="https://github.com/user-attachments/assets/97b5df57-11ca-449c-af12-2d7577972bb5" /> | <img width="326" height="397" alt="image" src="https://github.com/user-attachments/assets/f3722c6c-7f0a-4665-8691-a152c715cd9d" /> |


