### PR TITLE
fix(mobile): Deduplicate assets in person view timeline

### DIFF
--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -424,23 +424,22 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
   }
 
   Stream<List<Bucket>> _watchPersonBucket(String userId, String personId, {GroupAssetsBy groupBy = GroupAssetsBy.day}) {
+    final idQuery = _db.assetFaceEntity.selectOnly()
+      ..addColumns([_db.assetFaceEntity.assetId])
+      ..where(
+        _db.assetFaceEntity.personId.equals(personId) &
+            _db.assetFaceEntity.isVisible.equals(true) &
+            _db.assetFaceEntity.deletedAt.isNull(),
+      );
+
     if (groupBy == GroupAssetsBy.none) {
       final query = _db.remoteAssetEntity.selectOnly()
         ..addColumns([_db.remoteAssetEntity.id.count()])
-        ..join([
-          innerJoin(
-            _db.assetFaceEntity,
-            _db.assetFaceEntity.assetId.equalsExp(_db.remoteAssetEntity.id),
-            useColumns: false,
-          ),
-        ])
         ..where(
-          _db.remoteAssetEntity.deletedAt.isNull() &
+          _db.remoteAssetEntity.id.isInQuery(idQuery) &
+              _db.remoteAssetEntity.deletedAt.isNull() &
               _db.remoteAssetEntity.ownerId.equals(userId) &
-              _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
-              _db.assetFaceEntity.personId.equals(personId) &
-              _db.assetFaceEntity.isVisible.equals(true) &
-              _db.assetFaceEntity.deletedAt.isNull(),
+              _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline),
         );
 
       return query.map((row) {
@@ -454,20 +453,11 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
 
     final query = _db.remoteAssetEntity.selectOnly()
       ..addColumns([assetCountExp, dateExp])
-      ..join([
-        innerJoin(
-          _db.assetFaceEntity,
-          _db.assetFaceEntity.assetId.equalsExp(_db.remoteAssetEntity.id),
-          useColumns: false,
-        ),
-      ])
       ..where(
-        _db.remoteAssetEntity.deletedAt.isNull() &
+        _db.remoteAssetEntity.id.isInQuery(idQuery) &
             _db.remoteAssetEntity.ownerId.equals(userId) &
             _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
-            _db.assetFaceEntity.personId.equals(personId) &
-            _db.assetFaceEntity.isVisible.equals(true) &
-            _db.assetFaceEntity.deletedAt.isNull(),
+            _db.remoteAssetEntity.deletedAt.isNull(),
       )
       ..groupBy([dateExp])
       ..orderBy([OrderingTerm.desc(dateExp)]);
@@ -485,26 +475,26 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     required int offset,
     required int count,
   }) {
-    final query =
-        _db.remoteAssetEntity.select().join([
-            innerJoin(
-              _db.assetFaceEntity,
-              _db.assetFaceEntity.assetId.equalsExp(_db.remoteAssetEntity.id),
-              useColumns: false,
-            ),
-          ])
-          ..where(
-            _db.remoteAssetEntity.deletedAt.isNull() &
-                _db.remoteAssetEntity.ownerId.equals(userId) &
-                _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
-                _db.assetFaceEntity.personId.equals(personId) &
-                _db.assetFaceEntity.isVisible.equals(true) &
-                _db.assetFaceEntity.deletedAt.isNull(),
-          )
-          ..orderBy([OrderingTerm.desc(_db.remoteAssetEntity.createdAt)])
-          ..limit(count, offset: offset);
+    final idQuery = _db.assetFaceEntity.selectOnly()
+      ..addColumns([_db.assetFaceEntity.assetId])
+      ..where(
+        _db.assetFaceEntity.personId.equals(personId) &
+            _db.assetFaceEntity.isVisible.equals(true) &
+            _db.assetFaceEntity.deletedAt.isNull(),
+      );
 
-    return query.map((row) => row.readTable(_db.remoteAssetEntity).toDto()).get();
+    final query = _db.remoteAssetEntity.select()
+      ..where(
+        (row) =>
+            row.id.isInQuery(idQuery) &
+            row.deletedAt.isNull() &
+            row.ownerId.equals(userId) &
+            row.visibility.equalsValue(AssetVisibility.timeline),
+      )
+      ..orderBy([(row) => OrderingTerm.desc(row.createdAt)])
+      ..limit(count, offset: offset);
+
+    return query.map((row) => row.toDto()).get();
   }
 
   TimelineQuery map(List<String> userIds, TimelineMapOptions options, GroupAssetsBy groupBy) => (


### PR DESCRIPTION
## Description

When an asset has multiple face records for the same person (e.g. one manually imported via Digikam and another detected by Immich ML), the local drift query in TimelineRepository returned the asset multiple times. This happened because of the db query in `_getPersonBucketAssets` with the _innerJoin_ on the _assetFaceEntity_ without grouping.

Grouping the _assetFaceEntity_ then ensures that each asset will returned and rendered only once, independent of the number of duplicate face records.

Additional filters in `_watchPersonBucket` ensure that the asset count in the timeline headers only counts correctly the deduplicated, unique assets.

Fixes # ([25295](https://github.com/immich-app/immich/issues/25295)) 

## How Has This Been Tested?

- Use one photo and a create a face record manually which will be stored in a sidecar .xmp file (e.g. via Digikam)
- Put this image to a location which can be imported as external library 
- Let Immich AI do its AI things to recognize the face, so that there are two face records in this photo.
- Open you mobile app > `Library > Persons > Choose Person` (for which you want to see all asset entries)
- [just FYI: via `Search > Persons > Choose Person` it does NOT show up twice]

EDIT1:
- I set up flutter and Android SDK built a debug version of immich and pushed it to my Pixel 10 Pro phone (with `flutter run`)


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
- Screenshot from Web-Version to see, that there are two face records in this foto
  <img width="2685" height="1346" alt="Screenshot 2026-03-05 at 20 23 48" src="https://github.com/user-attachments/assets/6fef3128-7fdd-4139-8158-50f2c2287383" />

- Screenshot from Mobile-Version to see that there is a duplicate via `Library > Persons > Choose Person` (for which you want all asset entries)
  ![Screenshot_20260305-202443 copy](https://github.com/user-attachments/assets/838d707b-4e87-4235-b65f-5bbc2e5bf9fe)


- Screenshot from Mobile-Version to see that there is NO duplicate via `Search > Persons > Choose Person` (for which you want all asset entries)
  EDIT2: Update Screenshot
  <img width="1080" height="2410" alt="Screenshot_20260305-204240" src="https://github.com/user-attachments/assets/776afe12-c854-462b-aefe-baa206e722b6" />


- Screenshot from DEBUG Mobile-Version on my Pixel 10 Pro to see that the code change from this PR works (at least superficially for now) 
  
  ![Screenshot_20260305-205031 copy](https://github.com/user-attachments/assets/85c96c62-7609-4173-88c7-a856802a32a2)

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] [N/A] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] [N/A] I have written tests for new code (if applicable) (was not applicable?!)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] [N/A] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Gemini was used to understand immich code and especially design (focus on`server` and `mobile` part to find where and how DB queries are made)

EDIT1: Added a sentence of how it was tested with `flutter run`
EDIT2: Update screenshot for `Search > Persons > Choose Person`. No duplicate there