### PR TITLE
fix(mobile): incorrect asset dimensions in search

### DIFF
--- a/mobile/lib/domain/services/search.service.dart
+++ b/mobile/lib/domain/services/search.service.dart
@@ -70,13 +70,14 @@ extension on AssetResponseDto {
         _ => AssetVisibility.timeline,
       },
       durationInSeconds: duration.toDuration()?.inSeconds ?? 0,
-      height: exifInfo?.exifImageHeight?.toInt(),
-      width: exifInfo?.exifImageWidth?.toInt(),
+      height: height?.toInt(),
+      width: width?.toInt(),
       isFavorite: isFavorite,
       livePhotoVideoId: livePhotoVideoId,
       thumbHash: thumbhash,
       localId: null,
       type: type.toAssetType(),
+      stackId: stack?.id,
       isEdited: isEdited,
     );
   }


### PR DESCRIPTION
## Description

Search results use a different provider than the main timeline, and they appear appear to have diverged a bit. This means that assets can sometimes look wrong or different in search compared to the main timeline or albums.

## How Has This Been Tested?

Pixel 8a.