### PR TITLE
fix(mobile): restrict trashed asset migration to Android platform

### DIFF
--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -430,9 +430,10 @@ Future<void> _populateLocalAssetPlaybackStyle(Drift db) async {
           }
         });
       }
+      dPrint(() => "[MIGRATION] Successfully populated playbackStyle for local and trashed assets");
+    } else {
+      dPrint(() => "[MIGRATION] Successfully populated playbackStyle for local assets");
     }
-
-    dPrint(() => "[MIGRATION] Successfully populated playbackStyle for local and trashed assets");
   } catch (error) {
     dPrint(() => "[MIGRATION] Error while populating playbackStyle: $error");
   }

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -416,18 +416,20 @@ Future<void> _populateLocalAssetPlaybackStyle(Drift db) async {
       });
     }
 
-    final trashedAssetMap = await nativeApi.getTrashedAssets();
-    for (final entry in trashedAssetMap.cast<String, List<Object?>>().entries) {
-      final assets = entry.value.cast<PlatformAsset>();
-      await db.batch((batch) {
-        for (final asset in assets) {
-          batch.update(
-            db.trashedLocalAssetEntity,
-            TrashedLocalAssetEntityCompanion(playbackStyle: Value(_toPlaybackStyle(asset.playbackStyle))),
-            where: (t) => t.id.equals(asset.id),
-          );
-        }
-      });
+    if (Platform.isAndroid) {
+      final trashedAssetMap = await nativeApi.getTrashedAssets();
+      for (final entry in trashedAssetMap.cast<String, List<Object?>>().entries) {
+        final assets = entry.value.cast<PlatformAsset>();
+        await db.batch((batch) {
+          for (final asset in assets) {
+            batch.update(
+              db.trashedLocalAssetEntity,
+              TrashedLocalAssetEntityCompanion(playbackStyle: Value(_toPlaybackStyle(asset.playbackStyle))),
+              where: (t) => t.id.equals(asset.id),
+            );
+          }
+        });
+      }
     }
 
     dPrint(() => "[MIGRATION] Successfully populated playbackStyle for local and trashed assets");


### PR DESCRIPTION
After @alextran1502 PR #26718 I looked at the code again, and I just saw trashed assets are only available on Android, on IOS the native code throws an unsupported exception.

This is fix is theoretically not needed, as this is the last part of the migration, and everything is wrapped in a try{}catch{}, but I think it's cleaner.