### PR TITLE
fix(web): recalculate face bounding boxes

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -75,7 +75,7 @@
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    containerWidth, containerHeight; // trigger recomputation on resize
+    (containerWidth, containerHeight); // trigger recomputation on resize
 
     const { contentWidth, contentHeight, offsetX, offsetY } = getContentMetrics(assetViewerManager.imgRef);
     const { currentZoom, currentPositionX, currentPositionY } = assetViewerManager.zoomState;

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -74,6 +74,9 @@
       return { contentWidth: 0, contentHeight: 0, offsetX: 0, offsetY: 0 };
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    containerWidth, containerHeight; // trigger recomputation on resize
+
     const { contentWidth, contentHeight, offsetX, offsetY } = getContentMetrics(assetViewerManager.imgRef);
     const { currentZoom, currentPositionX, currentPositionY } = assetViewerManager.zoomState;
 

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -15,7 +15,7 @@
   import { SlideshowLook, SlideshowState, slideshowLookCssMapping, slideshowStore } from '$lib/stores/slideshow.store';
   import { getAssetUrl, targetImageSize as getTargetImageSize, handlePromiseError } from '$lib/utils';
   import { canCopyImageToClipboard, copyImageToClipboard } from '$lib/utils/asset-utils';
-  import { type ContentMetrics, getContentMetrics } from '$lib/utils/container-utils';
+  import { getContentMetrics, type ContentMetrics } from '$lib/utils/container-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { getOcrBoundingBoxes } from '$lib/utils/ocr-utils';
   import { getBoundingBox } from '$lib/utils/people-utils';
@@ -75,7 +75,7 @@
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    (containerWidth, containerHeight); // trigger recomputation on resize
+    [containerWidth, containerHeight]; // trigger recomputation on resize
 
     const { contentWidth, contentHeight, offsetX, offsetY } = getContentMetrics(assetViewerManager.imgRef);
     const { currentZoom, currentPositionX, currentPositionY } = assetViewerManager.zoomState;


### PR DESCRIPTION
## Description
Apparently with #26310 there is a regression so face bounding boxes are not recalculated if browser window is resized.
I had opened #26688 but could not reproduce it until I realized that I only had seen it in the dev-setup (docker-compose.de.yaml). Thought first it was introduced by my bounding box feature (#26667), but in the end the commit before the refactor was the last that worked for me.
As far as I understand the easiest way to trigger recalculation if there is no other interaction besides browser resize is by just accessing the variables, thus triggering a recalculation. Open for input, if this should be done differently.

## How Has This Been Tested?
### Before
- Open a photo
- Hover over a person/face to see the bounding box
- Resize the browser
- Hover over a person/face again, bounding box is still at the old position.
### After
- Open a photo
- Hover over a person/face to see the bounding box
- Resize the browser
- Hover over a person/face again, bounding box is correctly over the person/face.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM used.
