### PR TITLE
feat(android): enhance playback style detection using MIME type, reducing glide exposure

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -204,8 +204,8 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
   }
 
   /**
-   * Detects the playback style for an asset using _special_format (API 33+)
-   * or XMP / MIME / RIFF header fallbacks (pre-33).
+   * Detects the playback style for an asset using _special_format (SDK Extension 21+)
+   * or XMP / MIME / RIFF header fallbacks.
    */
   @SuppressLint("NewApi")
   private fun detectPlaybackStyle(

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -70,7 +70,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       add(MediaStore.MediaColumns.DATE_ADDED)
       add(MediaStore.MediaColumns.DATE_MODIFIED)
       add(MediaStore.Files.FileColumns.MEDIA_TYPE)
-      add(MediaStore.MediaColumns.MIME_TYPE)
       add(MediaStore.MediaColumns.BUCKET_ID)
       add(MediaStore.MediaColumns.WIDTH)
       add(MediaStore.MediaColumns.HEIGHT)
@@ -82,10 +81,13 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       }
       if (hasSpecialFormatColumn()) {
         add(SPECIAL_FORMAT_COLUMN)
-      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        // Fallback: read XMP from MediaStore to detect Motion Photos
-        // only needed if SPECIAL_FORMAT column isn't available
-        add(MediaStore.MediaColumns.XMP)
+      } else {
+        // fallback to mimetype and xmp for playback style detection on older Android versions
+        // both only needed if special format column is not available
+        add(MediaStore.MediaColumns.MIME_TYPE)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          add(MediaStore.MediaColumns.XMP)
+        }
       }
     }.toTypedArray()
 
@@ -132,7 +134,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
         val dateAddedColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED)
         val dateModifiedColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
         val mediaTypeColumn = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
-        val mimeTypeColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
+        val mimeTypeColumn = c.getColumnIndex(MediaStore.MediaColumns.MIME_TYPE)
         val bucketIdColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.BUCKET_ID)
         val widthColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.WIDTH)
         val heightColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.HEIGHT)
@@ -178,9 +180,8 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           val orientation = c.getInt(orientationColumn)
           val isFavorite = if (favoriteColumn == -1) false else c.getInt(favoriteColumn) != 0
 
-          val mimeType = c.getString(mimeTypeColumn)
           val playbackStyle = detectPlaybackStyle(
-            numericId, rawMediaType, mimeType, specialFormatColumn, xmpColumn, c
+            numericId, rawMediaType, mimeTypeColumn, specialFormatColumn, xmpColumn, c
           )
 
           val asset = PlatformAsset(
@@ -210,7 +211,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
   private fun detectPlaybackStyle(
     assetId: Long,
     rawMediaType: Int,
-    mimeType: String,
+    mimeTypeColumn: Int,
     specialFormatColumn: Int,
     xmpColumn: Int,
     cursor: Cursor
@@ -235,18 +236,21 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       return PlatformAssetPlaybackStyle.UNKNOWN
     }
 
+    val mimeType = if (mimeTypeColumn != -1) cursor.getString(mimeTypeColumn) else null
+
     // GIFs are always animated and cannot be motion photos; no I/O needed
     if (mimeType == "image/gif") {
       return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
     }
 
+    val uri = ContentUris.withAppendedId(
+      MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
+      assetId
+    )
+
     // Only WebP needs a stream check to distinguish static vs animated;
     // WebP files are not used as motion photos, so skip XMP detection
     if (mimeType == "image/webp") {
-      val uri = ContentUris.withAppendedId(
-        MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
-        assetId
-      )
       try {
         val glide = Glide.get(ctx)
         ctx.contentResolver.openInputStream(uri)?.use { stream ->
@@ -255,21 +259,18 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
             stream,
             glide.arrayPool
           )
-          if (type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
+          // Also check for GIF just in case MIME type is incorrect; Doesn't hurt performance
+          if (type == ImageHeaderParser.ImageType.ANIMATED_WEBP || type == ImageHeaderParser.ImageType.GIF) {
             return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
           }
         }
       } catch (e: Exception) {
         Log.w(TAG, "Failed to parse image header for asset $assetId", e)
       }
+      // if mimeType is webp but not animated, its just an image.
       return PlatformAssetPlaybackStyle.IMAGE
     }
 
-    // Motion photo detection via XMP (only relevant for JPEG/HEIC)
-    val uri = ContentUris.withAppendedId(
-      MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
-      assetId
-    )
 
     // Read XMP from cursor (API 30+) or ExifInterface stream (pre-30)
     val xmp: String? = if (xmpColumn != -1) {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -16,6 +16,7 @@ import app.alextran.immich.core.ImmichPlugin
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.ImageHeaderParser
 import com.bumptech.glide.load.ImageHeaderParserUtils
+import com.bumptech.glide.load.resource.bitmap.DefaultImageHeaderParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -255,7 +256,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
         val glide = Glide.get(ctx)
         ctx.contentResolver.openInputStream(uri)?.use { stream ->
           val type = ImageHeaderParserUtils.getType(
-            glide.registry.imageHeaderParsers,
+            listOf(DefaultImageHeaderParser()),
             stream,
             glide.arrayPool
           )

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -235,7 +235,37 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       return PlatformAssetPlaybackStyle.UNKNOWN
     }
 
-    // Pre-API 33 fallback
+    // GIFs are always animated and cannot be motion photos; no I/O needed
+    if (mimeType == "image/gif") {
+      return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+    }
+
+    // Only WebP needs a stream check to distinguish static vs animated;
+    // WebP files are not used as motion photos, so skip XMP detection
+    if (mimeType == "image/webp") {
+      val uri = ContentUris.withAppendedId(
+        MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
+        assetId
+      )
+      try {
+        val glide = Glide.get(ctx)
+        ctx.contentResolver.openInputStream(uri)?.use { stream ->
+          val type = ImageHeaderParserUtils.getType(
+            glide.registry.imageHeaderParsers,
+            stream,
+            glide.arrayPool
+          )
+          if (type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
+            return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+          }
+        }
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to parse image header for asset $assetId", e)
+      }
+      return PlatformAssetPlaybackStyle.IMAGE
+    }
+
+    // Motion photo detection via XMP (only relevant for JPEG/HEIC)
     val uri = ContentUris.withAppendedId(
       MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
       assetId
@@ -257,30 +287,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
     if (xmp != null && "Camera:MotionPhoto" in xmp) {
       return PlatformAssetPlaybackStyle.LIVE_PHOTO
-    }
-
-    // Use MIME type to detect animated formats without opening file streams
-    if (mimeType == "image/gif") {
-      return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
-    }
-
-    // Only WebP needs a stream check to distinguish static vs animated
-    if (mimeType == "image/webp") {
-      try {
-        val glide = Glide.get(ctx)
-        ctx.contentResolver.openInputStream(uri)?.use { stream ->
-          val type = ImageHeaderParserUtils.getType(
-            glide.registry.imageHeaderParsers,
-            stream,
-            glide.arrayPool
-          )
-          if (type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
-            return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
-          }
-        }
-      } catch (e: Exception) {
-        Log.w(TAG, "Failed to parse image header for asset $assetId", e)
-      }
     }
 
     return PlatformAssetPlaybackStyle.IMAGE

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -272,18 +272,14 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     }
 
 
-    // Read XMP from cursor (API 30+) or ExifInterface stream (pre-30)
+    // Read XMP from cursor (API 30+)
     val xmp: String? = if (xmpColumn != -1) {
       cursor.getBlob(xmpColumn)?.toString(Charsets.UTF_8)
     } else {
-      try {
-        ctx.contentResolver.openInputStream(uri)?.use { stream ->
-          ExifInterface(stream).getAttribute(ExifInterface.TAG_XMP)
-        }
-      } catch (e: Exception) {
-        Log.w(TAG, "Failed to read XMP for asset $assetId", e)
-        null
-      }
+      // if xmp column is not available, we are on API 29 or below
+      // theoretically there were motion photos but the Camera:MotionPhoto xmp tag
+      // was only added in Android 11, so we should not have to worry about parsing XMP on older versions
+      null
     }
 
     if (xmp != null && "Camera:MotionPhoto" in xmp) {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -70,6 +70,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       add(MediaStore.MediaColumns.DATE_ADDED)
       add(MediaStore.MediaColumns.DATE_MODIFIED)
       add(MediaStore.Files.FileColumns.MEDIA_TYPE)
+      add(MediaStore.MediaColumns.MIME_TYPE)
       add(MediaStore.MediaColumns.BUCKET_ID)
       add(MediaStore.MediaColumns.WIDTH)
       add(MediaStore.MediaColumns.HEIGHT)
@@ -131,6 +132,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
         val dateAddedColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED)
         val dateModifiedColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
         val mediaTypeColumn = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
+        val mimeTypeColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
         val bucketIdColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.BUCKET_ID)
         val widthColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.WIDTH)
         val heightColumn = c.getColumnIndexOrThrow(MediaStore.MediaColumns.HEIGHT)
@@ -176,8 +178,9 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           val orientation = c.getInt(orientationColumn)
           val isFavorite = if (favoriteColumn == -1) false else c.getInt(favoriteColumn) != 0
 
+          val mimeType = c.getString(mimeTypeColumn)
           val playbackStyle = detectPlaybackStyle(
-            numericId, rawMediaType, specialFormatColumn, xmpColumn, c
+            numericId, rawMediaType, mimeType, specialFormatColumn, xmpColumn, c
           )
 
           val asset = PlatformAsset(
@@ -207,6 +210,7 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
   private fun detectPlaybackStyle(
     assetId: Long,
     rawMediaType: Int,
+    mimeType: String,
     specialFormatColumn: Int,
     xmpColumn: Int,
     cursor: Cursor
@@ -255,20 +259,28 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
       return PlatformAssetPlaybackStyle.LIVE_PHOTO
     }
 
-    try {
-      ctx.contentResolver.openInputStream(uri)?.use { stream ->
+    // Use MIME type to detect animated formats without opening file streams
+    if (mimeType == "image/gif") {
+      return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+    }
+
+    // Only WebP needs a stream check to distinguish static vs animated
+    if (mimeType == "image/webp") {
+      try {
         val glide = Glide.get(ctx)
-        val type = ImageHeaderParserUtils.getType(
-          glide.registry.imageHeaderParsers,
-          stream,
-          glide.arrayPool
-        )
-        if (type == ImageHeaderParser.ImageType.GIF || type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
-          return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+        ctx.contentResolver.openInputStream(uri)?.use { stream ->
+          val type = ImageHeaderParserUtils.getType(
+            glide.registry.imageHeaderParsers,
+            stream,
+            glide.arrayPool
+          )
+          if (type == ImageHeaderParser.ImageType.ANIMATED_WEBP) {
+            return PlatformAssetPlaybackStyle.IMAGE_ANIMATED
+          }
         }
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to parse image header for asset $assetId", e)
       }
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to parse image header for asset $assetId", e)
     }
 
     return PlatformAssetPlaybackStyle.IMAGE


### PR DESCRIPTION
@mertalev and @alextran1502  
I did some testing, and found pigeon + casting isn't an issue in the playbackStyle migration. I generated 10k PlatformAsset objects in kotlin, returned them all and did the casting in dart (+ accessed properties). This took a few milliseconds. Nothing to worry about. 

It seems the actual culprit, is using glide on every asset thats not a video or motion photo to detect its playbackStyle.  

This PR changes that we use the MIME_TYPE column for GIF/webp detection, and really just run glide if the mimetype is `image/webp` to detect animated webp. Other useful information isn't returned by glide.

Theoretically glide is the more trustful source, as it's reading the first few bytes of a file. But yeah... thats also the issue why performance is slow.   
I think it's better to have good performance here, than to run glide for every image asset especially for these large migrations. 

**My take after the tests is**: we don't have to remove the migration of the trashed assets, but just not run glide for every image.
 

---

For testing with/without glide, I downloaded 500 images from my gallery onto my emulator and ran multiple timing test. Each test got ran 10 times. 

- SPECIAL_FORMAT column is available (no glide)
- SPECIAL_FORMAT column isn't available without changes from this PR
- SPECIAL_FORMAT column isn't available with changes from this PR


The multiple runs of a test were done in a single for loop, so you will see that after the first MediaStore query, the internal cache etc. was available and the timings go down. But thats not really important for this test. 

Special Column available (glide skipped):

```
[MIGRATION]  query:   [160, 97, 96, 93, 93, 91, 86, 106, 105, 105]ms, avg=103ms
[MIGRATION]  db update:  [33, 13, 11, 8, 7, 7, 4, 6, 4, 3]ms, avg=9ms
```

SPECIAL_FORMAT column not available before this PR (glide ran for every asset thats not a motion photo or video): 

```
[MIGRATION]   query:   [1126, 622, 567, 542, 538, 539, 527, 530, 533, 538]ms, avg=606ms
[MIGRATION]   db update:  [21, 10, 7, 7, 12, 5, 5, 4, 5, 4]ms, avg=8ms
```


SPECIAL_FORMAT column not available with changes in this PR (glide only ran for like 5 webp images):

```
[MIGRATION]   local query:   [156, 110, 96, 94, 99, 101, 98, 111, 118, 114]ms, avg=109ms
[MIGRATION]   local update:  [22, 8, 8, 12, 8, 7, 8, 11, 6, 7]ms, avg=9ms
```


Important: 
This is on an emulator on my laptop, so don't take the absolute timings too serious, important is just the difference between the tests. On actual phones this would probably be a bit faster. 
 
**Generally I think on a phone most users won't have multiple thousands webp images, so reducing the total exposure to glide, is enough for bigger syncs.**

---

### Further Improvement?

I actually ran all tests again, while removing the check if the queried assets from MediaStore actually exists on the disk: 
Removed `|| !File(path).exists()` from [here](https://github.com/immich-app/immich/blob/6e9a425592c66cba5e8713462e4f306641bf625a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt#L154)

And I found that this actually also impacts sync performance quite a bit. Found that quite interesting. But that was already in the code before my changes, and I am not sure how trust full the media store is, and if we can remove that actually. @shenlong-tanwen was there a reason this check was added, like bug reports or did you notice issues with the reliability of media store? 

And I am actually not sure if the improvement of removing this check outweighs the risk for this change.


Special Column available without checking if file actually exists: 

```
[MIGRATION]  query:   [54, 16, 16, 26, 20, 19, 20, 16, 16, 13]ms, avg=21ms
[MIGRATION]  db update:  [23, 8, 14, 8, 9, 7, 7, 5, 8, 5]ms, avg=9ms
```

Before this PR without checking if file exists on disk:

```
[MIGRATION]  query:   [821, 590, 466, 492, 459, 475, 463, 458, 467, 478]ms, avg=516ms
[MIGRATION]  db update:  [26, 7, 6, 10, 7, 5, 5, 4, 5, 5]ms, avg=8ms
```

With changes in this PR + not checking if file exists:

```
[MIGRATION]  query:   [64, 18, 20, 22, 21, 17, 16, 18, 28, 17]ms, avg=24ms
[MIGRATION]  db update:  [30, 11, 21, 9, 9, 8, 5, 4, 3, 4]ms, avg=10ms
```
