### PR TITLE
Improve version mismatch login error guidance

### DIFF
--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -1,6 +1,6 @@
 String? getVersionCompatibilityMessage(int appMajor, int appMinor, int serverMajor, int serverMinor) {
   if (serverMajor != appMajor) {
-    return 'Your app major version is not compatible with the server!';
+    return 'Your app major version is not compatible with the server. If this happens while signing in, make sure the Server URL points to your Immich server, not an API key or shared link, and try adding /api to the end of the URL.';
   }
 
   // Add latest compat info up top

--- a/mobile/test/modules/utils/version_compatibility_test.dart
+++ b/mobile/test/modules/utils/version_compatibility_test.dart
@@ -6,7 +6,10 @@ void main() {
     String? result;
 
     result = getVersionCompatibilityMessage(1, 0, 2, 0);
-    expect(result, 'Your app major version is not compatible with the server!');
+    expect(
+      result,
+      'Your app major version is not compatible with the server. If this happens while signing in, make sure the Server URL points to your Immich server, not an API key or shared link, and try adding /api to the end of the URL.',
+    );
 
     result = getVersionCompatibilityMessage(1, 106, 1, 105);
     expect(


### PR DESCRIPTION
## Description

Clarify the mobile major-version mismatch error shown during login. During my onboarding, I ran into this, and thought it has something to do with the iOS app ("major version mismatch"), but turns out, it had nothing to do with the version.

The new message calls out a common misconfiguration from GitHub Discussion #11039: users may paste an API key or shared link instead of the server URL, or need to try the URL with /api appended.

Instead of printing
```
Your app major version is not compatible with the server!
```
We'd now print
```
Your app major version is not compatible with the server. If this happens while signing in, 
make sure the Server URL points to your Immich server, not an API key or shared link, and 
try adding /api to the end of the URL.
```
in the iOS app

Also update the corresponding unit test expectation.

Refs: https://github.com/immich-app/immich/discussions/11039
Fixes https://github.com/immich-app/immich/discussions/11039

## How Has This Been Tested?

Only executed the unit tests

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)