### PR TITLE
Add counter to storage template

### DIFF
--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -35,7 +35,7 @@ describe(StorageTemplateService.name, () => {
           newConfig: {
             storageTemplate: {
               template:
-                '{{y}}{{M}}{{W}}{{d}}{{h}}{{m}}{{s}}{{filename}}{{ext}}{{filetype}}{{filetypefull}}{{assetId}}{{#if album}}{{album}}{{else}}other{{/if}}',
+                '{{y}}{{M}}{{W}}{{d}}{{h}}{{m}}{{s}}{{filename}}{{ext}}{{filetype}}{{filetypefull}}{{assetId}}{{counter}}{{#if album}}{{album}}{{else}}other{{/if}}',
             },
           } as SystemConfig,
           oldConfig: {} as SystemConfig,
@@ -841,6 +841,114 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.asset.update).toHaveBeenCalledWith({
         id: motionAsset.id,
         originalPath: expect.stringContaining(`/${album.albumName}/`),
+      });
+    });
+  });
+
+  describe('counter token', () => {
+    it('should render counter as 0 when no duplicate exists', async () => {
+      const user = UserFactory.create();
+      const asset = AssetFactory.from({
+        fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+      })
+        .owner(user)
+        .exif()
+        .build();
+
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{y}}/{{MM}}/{{filename}}_{{counter}}';
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(asset));
+      mocks.move.create.mockResolvedValue({
+        id: '123',
+        entityId: asset.id,
+        pathType: AssetPathType.Original,
+        oldPath: asset.originalPath,
+        newPath: `/data/library/${user.id}/2022/06/${asset.originalFileName.slice(0, -4)}_0.jpg`,
+      });
+
+      await expect(sut.handleMigrationSingle({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.asset.update).toHaveBeenCalledWith({
+        id: asset.id,
+        originalPath: expect.stringContaining('_0.jpg'),
+      });
+    });
+
+    it('should increment counter when duplicate exists', async () => {
+      const user = UserFactory.create();
+      const asset = AssetFactory.from({
+        fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+      })
+        .owner(user)
+        .exif()
+        .build();
+
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{y}}/{{MM}}/{{filename}}_{{counter}}';
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(asset));
+
+      // First check (counter=0) exists, second check (counter=1) does not
+      mocks.storage.checkFileExists.mockResolvedValueOnce(true);
+      mocks.storage.checkFileExists.mockResolvedValueOnce(false);
+
+      mocks.move.create.mockResolvedValue({
+        id: '123',
+        entityId: asset.id,
+        pathType: AssetPathType.Original,
+        oldPath: asset.originalPath,
+        newPath: `/data/library/${user.id}/2022/06/${asset.originalFileName.slice(0, -4)}_1.jpg`,
+      });
+
+      await expect(sut.handleMigrationSingle({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(2);
+      expect(mocks.asset.update).toHaveBeenCalledWith({
+        id: asset.id,
+        originalPath: expect.stringContaining('_1.jpg'),
+      });
+    });
+
+    it('should increment counter multiple times for multiple duplicates', async () => {
+      const user = UserFactory.create();
+      const asset = AssetFactory.from({
+        fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+      })
+        .owner(user)
+        .exif()
+        .build();
+
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{y}}/{{MM}}/{{filename}}_{{counter}}';
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(asset));
+
+      // counter=0 exists, counter=1 exists, counter=2 does not
+      mocks.storage.checkFileExists.mockResolvedValueOnce(true);
+      mocks.storage.checkFileExists.mockResolvedValueOnce(true);
+      mocks.storage.checkFileExists.mockResolvedValueOnce(false);
+
+      mocks.move.create.mockResolvedValue({
+        id: '123',
+        entityId: asset.id,
+        pathType: AssetPathType.Original,
+        oldPath: asset.originalPath,
+        newPath: `/data/library/${user.id}/2022/06/${asset.originalFileName.slice(0, -4)}_2.jpg`,
+      });
+
+      await expect(sut.handleMigrationSingle({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(3);
+      expect(mocks.asset.update).toHaveBeenCalledWith({
+        id: asset.id,
+        originalPath: expect.stringContaining('_2.jpg'),
       });
     });
   });

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -71,6 +71,7 @@ interface RenderMetadata {
   make: string | null;
   model: string | null;
   lensModel: string | null;
+  counter?: number;
 }
 
 @Injectable()
@@ -80,6 +81,7 @@ export class StorageTemplateService extends BaseService {
     raw: string;
     needsAlbum: boolean;
     needsAlbumMetadata: boolean;
+    needsCounter: boolean;
   } | null = null;
 
   private get template() {
@@ -122,6 +124,7 @@ export class StorageTemplateService extends BaseService {
         make: 'FUJIFILM',
         model: 'X-T50',
         lensModel: 'XF27mm F2.8 R WR',
+        counter: 0,
       });
     } catch (error) {
       this.logger.warn(`Storage template validation failed: ${JSON.stringify(error)}`);
@@ -324,7 +327,7 @@ export class StorageTemplateService extends BaseService {
 
       // For motion videos that are part of live photos, use the still photo's date
       // to ensure both parts end up in the same folder
-      const storagePath = this.render(this.template.compiled, {
+      const renderOptions: RenderMetadata = {
         asset: assetForMetadata,
         filename: sanitized,
         extension,
@@ -334,15 +337,16 @@ export class StorageTemplateService extends BaseService {
         make: assetForMetadata.make,
         model: assetForMetadata.model,
         lensModel: assetForMetadata.lensModel,
-      });
-      const fullPath = path.normalize(path.join(rootPath, storagePath));
-      let destination = `${fullPath}.${extension}`;
+      };
+      const storagePath = this.render(this.template.compiled, renderOptions);
+      let fullPath = path.normalize(path.join(rootPath, storagePath));
 
       if (!fullPath.startsWith(rootPath)) {
         this.logger.warn(`Skipped attempt to access an invalid path: ${fullPath}. Path should start with ${rootPath}`);
         return source;
       }
 
+      let destination = `${fullPath}.${extension}`;
       if (source === destination) {
         return source;
       }
@@ -369,16 +373,34 @@ export class StorageTemplateService extends BaseService {
         }
       }
 
-      let duplicateCount = 0;
+      const exists = await this.storageRepository.checkFileExists(destination);
+      if (!exists) {
+        return destination;
+      }
+
+      let counter = 1;
+      let newFullPath = (counter: number): string => `${fullPath}+${counter}`;
+      if (this.template.needsCounter) {
+        newFullPath = (counter: number): string => {
+          const storagePath = this.render(this.template.compiled, { ...renderOptions, counter });
+          return path.normalize(path.join(rootPath, storagePath));
+        };
+      }
 
       while (true) {
+        fullPath = newFullPath(counter);
+        destination = `${fullPath}.${extension}`;
+
+        if (source === destination) {
+          break;
+        }
+
         const exists = await this.storageRepository.checkFileExists(destination);
         if (!exists) {
           break;
         }
 
-        duplicateCount++;
-        destination = `${fullPath}+${duplicateCount}.${extension}`;
+        counter++;
       }
 
       return destination;
@@ -394,11 +416,23 @@ export class StorageTemplateService extends BaseService {
       compiled: handlebar.compile(template, { knownHelpers: undefined, strict: true }),
       needsAlbum: template.includes('album'),
       needsAlbumMetadata: template.includes('album-startDate') || template.includes('album-endDate'),
+      needsCounter: template.includes('counter'),
     };
   }
 
   private render(template: HandlebarsTemplateDelegate<any>, options: RenderMetadata) {
-    const { filename, extension, asset, albumName, albumStartDate, albumEndDate, make, model, lensModel } = options;
+    const {
+      filename,
+      extension,
+      asset,
+      albumName,
+      albumStartDate,
+      albumEndDate,
+      make,
+      model,
+      lensModel,
+      counter = 0,
+    } = options;
     const substitutions: Record<string, string> = {
       filename,
       ext: extension,
@@ -411,6 +445,7 @@ export class StorageTemplateService extends BaseService {
       make: make ?? '',
       model: model ?? '',
       lensModel: lensModel ?? '',
+      counter: String(counter),
     };
 
     const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
+++ b/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
@@ -63,6 +63,7 @@
       make: 'FUJIFILM',
       model: 'X-T50',
       lensModel: 'XF27mm F2.8 R WR',
+      counter: '42',
     };
 
     const dt = luxon.DateTime.fromISO(new Date('2022-02-03T04:56:05.250').toISOString());

--- a/web/src/lib/components/admin-settings/SupportedVariablesPanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedVariablesPanel.svelte
@@ -52,6 +52,7 @@
         <ul>
           <li>{`{{assetId}}`} - Asset ID</li>
           <li>{`{{assetIdShort}}`} - Asset ID (last 12 characters)</li>
+          <li>{`{{counter}}`} - Counter</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Description

I'd like immich to add counter to the file name like already done for duplicates but from the beginning.

## How Has This Been Tested?

I've added unit tests and have been running this on my own instance (ghcr.io/mmlb/immich-server:commit-e987cd4e5160d3659a7dd29ab3a212d8fd8437bd) and its been pretty good so far.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used claude to figure out where to make the changes and it made the first draft. I refactored the code claude gave me in `getTemplatePath` from an `if needsCounter { loop } else { previous loop }` to what is PRd here. I also made sure to go through the tests and understand the generated code vs pre-existing tests and I think it looks right.