### PR TITLE
test(e2e): fix flakiness: optimize resetDatabase with TRUNCATE and fix selectDay selector scoping

### DIFF
--- a/e2e/src/ui/specs/timeline/utils.ts
+++ b/e2e/src/ui/specs/timeline/utils.ts
@@ -215,8 +215,9 @@ export const pageUtils = {
     await page.getByText('Confirm').click();
   },
   async selectDay(page: Page, day: string) {
-    await page.getByTitle(day).hover();
-    await page.locator('[data-group] .w-8').click();
+    const section = page.getByTitle(day).locator('xpath=ancestor::section[@data-group]');
+    await section.hover();
+    await section.locator('.w-8').click();
   },
   async pauseTestDebug() {
     console.log('NOTE: pausing test indefinately for debug');

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -177,40 +177,51 @@ export const utils = {
   },
 
   resetDatabase: async (tables?: string[]) => {
-    try {
-      client = await utils.connectDatabase();
+    client = await utils.connectDatabase();
 
-      tables = tables || [
-        // TODO e2e test for deleting a stack, since it is quite complex
-        'stack',
-        'library',
-        'shared_link',
-        'person',
-        'album',
-        'asset',
-        'asset_face',
-        'activity',
-        'api_key',
-        'session',
-        'user',
-        'system_metadata',
-        'tag',
-      ];
+    tables = tables || [
+      // TODO e2e test for deleting a stack, since it is quite complex
+      'stack',
+      'library',
+      'shared_link',
+      'person',
+      'album',
+      'asset',
+      'asset_face',
+      'activity',
+      'api_key',
+      'session',
+      'user',
+      'system_metadata',
+      'tag',
+    ];
 
-      const sql: string[] = [];
+    const truncateTables = tables.filter((table) => table !== 'system_metadata');
+    const sql: string[] = [];
 
-      for (const table of tables) {
-        if (table === 'system_metadata') {
-          sql.push(`DELETE FROM "system_metadata" where "key" NOT IN ('reverse-geocoding-state', 'system-flags');`);
-        } else {
-          sql.push(`DELETE FROM "${table}" CASCADE;`);
+    if (truncateTables.length > 0) {
+      sql.push(`TRUNCATE "${truncateTables.join('", "')}" CASCADE;`);
+    }
+
+    if (tables.includes('system_metadata')) {
+      sql.push(`DELETE FROM "system_metadata" where "key" NOT IN ('reverse-geocoding-state', 'system-flags');`);
+    }
+
+    const query = sql.join('\n');
+    const maxRetries = 3;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await client.query(query);
+        return;
+      } catch (error: any) {
+        if (error?.code === '40P01' && attempt < maxRetries) {
+          await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+          continue;
         }
+        console.error('Failed to reset database', error);
+        throw error;
       }
-
-      await client.query(sql.join('\n'));
-    } catch (error) {
-      console.error('Failed to reset database', error);
-      throw error;
     }
   },
 


### PR DESCRIPTION
Fixes occasional db deadlocks in e2e tests: 

```Error: error: deadlock detected
 ❯ ../node_modules/.pnpm/pg@8.19.0/node_modules/pg/lib/client.js:631:17
 ❯ Object.resetDatabase src/utils.ts:210:7
 ❯ src/specs/server/api/search.e2e-spec.ts:43:5

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { length: 419, severity: 'ERROR', code: '40P01', detail: 'Process 350 waits for ShareLock on transaction 3548; blocked by process 162.\nProcess 162 waits for ShareLock on transaction 3547; blocked by process 350.', hint: 'See server log for query details.', position: undefined, internalPosition: undefined, internalQuery: undefined, where: 'while deleting tuple (0,113) in relation "tag_asset"\nSQL statement "DELETE FROM ONLY "public"."tag_asset" WHERE $1 OPERATOR(pg_catalog.=) "assetId""', schema: undefined, table: undefined, dataType: undefined, constraint: undefined, file: 'deadlock.c', routine: 'DeadLockReport' }
```