### PR TITLE
fix: bounding box coordinates returned as floats after editing

### DIFF
--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -179,10 +179,10 @@ export const transformFaceBoundingBox = (
   // Ensure x1,y1 is top-left and x2,y2 is bottom-right
   const [p1, p2] = transformedPoints;
   return {
-    boundingBoxX1: Math.min(p1.x, p2.x),
-    boundingBoxY1: Math.min(p1.y, p2.y),
-    boundingBoxX2: Math.max(p1.x, p2.x),
-    boundingBoxY2: Math.max(p1.y, p2.y),
+    boundingBoxX1: Math.round(Math.min(p1.x, p2.x)),
+    boundingBoxY1: Math.round(Math.min(p1.y, p2.y)),
+    boundingBoxX2: Math.round(Math.max(p1.x, p2.x)),
+    boundingBoxY2: Math.round(Math.max(p1.y, p2.y)),
     imageWidth: currentWidth,
     imageHeight: currentHeight,
   };


### PR DESCRIPTION
Fixes #26563. The transformFaceBoundingBox function was returning floating-point values for bounding box coordinates when image edits (crop, rotate, mirror) were applied. The API contract in AssetFaceWithoutPersonResponseDto specifies these should be integers (type: 'integer'). Added Math.round() to ensure all bounding box coordinates are rounded to integers.