### PR TITLE
fix(server): add max execution time

### DIFF
--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -55,7 +55,7 @@ export const probes: Record<VectorIndex, number> = {
 
 @Injectable()
 export class DatabaseRepository {
-  private readonly asyncLock = new AsyncLock();
+  private readonly asyncLock = new AsyncLock({ maxExecutionTime: 60000 });
 
   constructor(
     @InjectKysely() private db: Kysely<DB>,

--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -55,7 +55,7 @@ export const probes: Record<VectorIndex, number> = {
 
 @Injectable()
 export class DatabaseRepository {
-  private readonly asyncLock = new AsyncLock({ maxExecutionTime: 60000 });
+  private readonly asyncLock = new AsyncLock({ maxExecutionTime: 60_000 });
 
   constructor(
     @InjectKysely() private db: Kysely<DB>,

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -20,7 +20,7 @@ type RepoDeps = {
   logger: LoggingRepository;
 };
 
-const asyncLock = new AsyncLock();
+const asyncLock = new AsyncLock({ maxExecutionTime: 60000 });
 let config: SystemConfig | null = null;
 let lastUpdated: number | null = null;
 

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -20,7 +20,7 @@ type RepoDeps = {
   logger: LoggingRepository;
 };
 
-const asyncLock = new AsyncLock({ maxExecutionTime: 60000 });
+const asyncLock = new AsyncLock({ maxExecutionTime: 60_000 });
 let config: SystemConfig | null = null;
 let lastUpdated: number | null = null;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a first attempt to improve https://github.com/immich-app/immich/issues/26018

The way async-lock is coded, it will execute the next task in queue only when the current one is done executing https://github.com/rogierschouten/async-lock/blob/master/lib/index.js#L122

Debugging for #26018 is still in progress but somehow the config task gets stuck and hangs forever, as such no more lock can be obtained and all api endpoints requiring this lock also hangs forever.

By adding max execution time we ensure the task will be finished at some point and that other tasks in the queue can be processed. Atm I set an arbitrary 60s limit, this should be good enough by handling the hanging case described in #26018 and should interfere with normal configs.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Couldn't really test it for now as debugging in #26018 is still in progress

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
