### PR TITLE
fix(web): toggle visibility button filters view instead of changing state

### DIFF
--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -39,21 +39,24 @@
 
   const handleToggleVisibility = () => {
     toggleVisibility = getNextVisibility(toggleVisibility);
-
-    for (const person of people) {
-      let isHidden = overrides.get(person.id) ?? person.isHidden;
-
-      if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
-        isHidden = true;
-      } else if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
-        isHidden = false;
-      } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
-        isHidden = true;
-      }
-
-      setHiddenOverride(person, isHidden);
-    }
   };
+
+  let filteredPeople = $derived.by(() => {
+    if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
+      return people;
+    }
+    if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
+      return people.filter((person) => {
+        const isHidden = overrides.get(person.id) ?? person.isHidden;
+        return isHidden;
+      });
+    }
+    // HIDE_UNNAMED: show only named + visible people (hide unnamed ones)
+    return people.filter((person) => {
+      const isHidden = overrides.get(person.id) ?? person.isHidden;
+      return !isHidden || person.name;
+    });
+  });
 
   const handleSaveVisibility = async () => {
     showLoadingSpinner = true;
@@ -147,7 +150,7 @@
   </div>
 
   <div class="flex flex-wrap gap-1 p-2 pb-8 md:px-8">
-    <PeopleInfiniteScroll {people} hasNextPage={true} {loadNextPage}>
+    <PeopleInfiniteScroll people={filteredPeople} hasNextPage={true} {loadNextPage}>
       {#snippet children({ person })}
         {@const hidden = overrides.get(person.id) ?? person.isHidden}
         <button


### PR DESCRIPTION
## Summary

Fixes #19956 — The eye toggle button on the "Show & Hide People" page now **filters the view** instead of **changing the hidden state** of all people.

### Problem

Clicking the eye toggle button (Show All → Hide Unnamed → Hide All) would batch-modify the `isHidden` overrides for every person in the list. When the user clicked "Done", all those overrides were saved to the database, permanently changing which people are visible/hidden.

This was confusing because:
- Users expected the toggle to **filter what's displayed** (like a view filter)
- Instead it **changed the actual state** (like a batch action)
- One accidental cycle could hide hundreds of people

### Fix

The toggle button now only controls a **view filter** — it determines which people are shown in the list based on their current visibility state, without touching the `overrides` map.

| State | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| Show All | Set all people to visible | Show all people in list |
| Hide Unnamed | Set unnamed people to hidden | Filter out unnamed hidden people |
| Hide All | Set all people to hidden | Show only hidden people |

Individual person clicks still work the same — clicking a person toggles their visibility override, and "Done" saves only those explicit changes.

### Changes

| File | Change |
|------|--------|
| `web/src/lib/components/faces-page/manage-people-visibility.svelte` | Replace `handleToggleVisibility` batch-modify with view filter; add `filteredPeople` derived state; pass filtered list to `PeopleInfiniteScroll` |