### PR TITLE
fix(mobile): logout on upgrade

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id "kotlin-android"
   id "dev.flutter.flutter-gradle-plugin"
   id 'com.google.devtools.ksp'
+  id 'org.jetbrains.kotlin.plugin.serialization'
   id 'org.jetbrains.kotlin.plugin.compose' version '2.0.20' // this version matches your Kotlin version
 
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -17,7 +17,6 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -315,7 +314,7 @@ object HttpClientManager {
       val parsed = urls.mapNotNull { it.toHttpUrlOrNull() }
       if (parsed.map { it.host } == serverUrls.map { it.host }) return
       serverUrls = parsed
-      if (duplicateAuthCookies()) persist()
+      if (syncAuthCookies()) persist()
     }
 
     @Synchronized
@@ -327,20 +326,30 @@ object HttpClientManager {
         cookies.any { it.name == existing.name && it.domain == existing.domain && it.path == existing.path }
       }
       store.addAll(cookies)
-      val duplicated = serverUrls.any { it.host == url.host } && duplicateAuthCookies()
-      if (changed || duplicated) persist()
+      val synced = serverUrls.any { it.host == url.host } && syncAuthCookies()
+      if (changed || synced) persist()
     }
 
     @Synchronized
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
       val now = System.currentTimeMillis()
-      store.removeAll { it.expiresAt < now }
+      if (store.removeAll { it.expiresAt < now }) {
+        syncAuthCookies()
+        persist()
+      }
       return store.filter { it.matches(url) }
     }
 
-    private fun duplicateAuthCookies(): Boolean {
-      val sourceCookies = store.filter { it.name in AUTH_COOKIE_NAMES }.associateBy { it.name }
-      if (sourceCookies.isEmpty()) return false
+    private fun syncAuthCookies(): Boolean {
+      val serverHosts = serverUrls.map { it.host }.toSet()
+      val now = System.currentTimeMillis()
+      val sourceCookies = store
+        .filter { it.name in AUTH_COOKIE_NAMES && it.domain in serverHosts && it.expiresAt > now }
+        .associateBy { it.name }
+
+      if (sourceCookies.isEmpty()) {
+        return store.removeAll { it.name in AUTH_COOKIE_NAMES && it.domain in serverHosts }
+      }
 
       var changed = false
       for (url in serverUrls) {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -38,7 +38,6 @@ private const val CERT_ALIAS = "client_cert"
 private const val PREFS_NAME = "immich.ssl"
 private const val PREFS_CERT_ALIAS = "immich.client_cert"
 private const val PREFS_HEADERS = "immich.request_headers"
-private const val PREFS_SERVER_URL = "immich.server_url"
 private const val PREFS_SERVER_URLS = "immich.server_urls"
 private const val PREFS_COOKIES = "immich.cookies"
 
@@ -177,17 +176,15 @@ object HttpClientManager {
       val newHeaders = builder.build()
 
       val headersChanged = headers != newHeaders
-      val newUrl = serverUrls.firstOrNull()
-      val urlChanged = newUrl != prefs.getString(PREFS_SERVER_URL, null)
+      val urlsChanged = Json.encodeToString(serverUrls) != prefs.getString(PREFS_SERVER_URLS, null)
 
       headers = newHeaders
       cookieJar.setServerUrls(serverUrls)
 
-      if (headersChanged || urlChanged) {
+      if (headersChanged || urlsChanged) {
         prefs.edit {
           putString(PREFS_HEADERS, Json.encodeToString(headerMap))
           putString(PREFS_SERVER_URLS, Json.encodeToString(serverUrls))
-          if (newUrl != null) putString(PREFS_SERVER_URL, newUrl) else remove(PREFS_SERVER_URL)
         }
       }
     }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -8,11 +8,17 @@ import app.alextran.immich.BuildConfig
 import app.alextran.immich.NativeBuffer
 import okhttp3.Cache
 import okhttp3.ConnectionPool
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.Credentials
 import okhttp3.Dispatcher
 import okhttp3.Headers
-import okhttp3.Credentials
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
-import org.json.JSONObject
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.Socket
@@ -33,6 +39,8 @@ private const val PREFS_NAME = "immich.ssl"
 private const val PREFS_CERT_ALIAS = "immich.client_cert"
 private const val PREFS_HEADERS = "immich.request_headers"
 private const val PREFS_SERVER_URL = "immich.server_url"
+private const val PREFS_SERVER_URLS = "immich.server_urls"
+private const val PREFS_COOKIES = "immich.cookies"
 
 /**
  * Manages a shared OkHttpClient with SSL configuration support.
@@ -58,6 +66,8 @@ object HttpClientManager {
   var headers: Headers = Headers.headersOf()
     private set
 
+  private val cookieJar = PersistentCookieJar()
+
   val isMtls: Boolean get() = keyChainAlias != null || keyStore.containsAlias(CERT_ALIAS)
 
   fun initialize(context: Context) {
@@ -69,14 +79,21 @@ object HttpClientManager {
       prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
       keyChainAlias = prefs.getString(PREFS_CERT_ALIAS, null)
 
+      cookieJar.init(prefs)
+
       val savedHeaders = prefs.getString(PREFS_HEADERS, null)
       if (savedHeaders != null) {
-        val json = JSONObject(savedHeaders)
+        val map = Json.decodeFromString<Map<String, String>>(savedHeaders)
         val builder = Headers.Builder()
-        for (key in json.keys()) {
-          builder.add(key, json.getString(key))
+        for ((key, value) in map) {
+          builder.add(key, value)
         }
         headers = builder.build()
+      }
+
+      val serverUrlsJson = prefs.getString(PREFS_SERVER_URLS, null)
+      if (serverUrlsJson != null) {
+        cookieJar.setServerUrls(Json.decodeFromString<List<String>>(serverUrlsJson))
       }
 
       val cacheDir = File(File(context.cacheDir, "okhttp"), "api")
@@ -158,18 +175,44 @@ object HttpClientManager {
       val builder = Headers.Builder()
       headerMap.forEach { (key, value) -> builder[key] = value }
       val newHeaders = builder.build()
+
       val headersChanged = headers != newHeaders
       val newUrl = serverUrls.firstOrNull()
       val urlChanged = newUrl != prefs.getString(PREFS_SERVER_URL, null)
-      if (!headersChanged && !urlChanged) return
+
       headers = newHeaders
-      prefs.edit {
-        if (headersChanged) putString(PREFS_HEADERS, JSONObject(headerMap).toString())
-        if (urlChanged) {
+      cookieJar.setServerUrls(serverUrls)
+
+      if (headersChanged || urlChanged) {
+        prefs.edit {
+          putString(PREFS_HEADERS, Json.encodeToString(headerMap))
+          putString(PREFS_SERVER_URLS, Json.encodeToString(serverUrls))
           if (newUrl != null) putString(PREFS_SERVER_URL, newUrl) else remove(PREFS_SERVER_URL)
         }
       }
     }
+  }
+
+  fun bootstrapCookies(token: String, serverUrls: List<String>) {
+    val url = serverUrls.firstNotNullOfOrNull { it.toHttpUrlOrNull() } ?: return
+    val expiry = System.currentTimeMillis() + 400L * 24 * 60 * 60 * 1000
+    fun cookie(name: String, value: String, httpOnly: Boolean) =
+      Cookie.Builder().name(name).value(value).domain(url.host).path("/").expiresAt(expiry)
+        .apply {
+          if (url.isHttps) secure()
+          if (httpOnly) httpOnly()
+        }.build()
+    cookieJar.saveFromResponse(url, listOf(
+      cookie("immich_access_token", token, httpOnly = true),
+      cookie("immich_is_authenticated", "true", httpOnly = false),
+      cookie("immich_auth_type", "password", httpOnly = true),
+    ))
+  }
+
+  fun loadCookieHeader(url: String): String? {
+    val httpUrl = url.toHttpUrlOrNull() ?: return null
+    return cookieJar.loadForRequest(httpUrl).takeIf { it.isNotEmpty() }
+      ?.joinToString("; ") { "${it.name}=${it.value}" }
   }
 
   private fun build(cacheDir: File): OkHttpClient {
@@ -188,6 +231,7 @@ object HttpClientManager {
     HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
 
     return OkHttpClient.Builder()
+      .cookieJar(cookieJar)
       .addInterceptor {
         val request = it.request()
         val builder = request.newBuilder()
@@ -248,5 +292,125 @@ object HttpClientManager {
       issuers: Array<Principal>?,
       socket: Socket?
     ): String? = null
+  }
+
+  /**
+   * Persistent CookieJar that duplicates auth cookies across equivalent server URLs.
+   * When the server sets cookies for one domain, copies are created for all other known
+   * server domains (for URL switching between local/remote endpoints of the same server).
+   */
+  private class PersistentCookieJar : CookieJar {
+    private val store = mutableListOf<Cookie>()
+    private var serverUrls = listOf<HttpUrl>()
+    private var prefs: SharedPreferences? = null
+
+    companion object {
+      val AUTH_COOKIE_NAMES = setOf("immich_access_token", "immich_is_authenticated", "immich_auth_type")
+    }
+
+    fun init(prefs: SharedPreferences) {
+      this.prefs = prefs
+      restore()
+    }
+
+    @Synchronized
+    fun setServerUrls(urls: List<String>) {
+      val parsed = urls.mapNotNull { it.toHttpUrlOrNull() }
+      if (parsed.map { it.host } == serverUrls.map { it.host }) return
+      serverUrls = parsed
+      if (duplicateAuthCookies()) persist()
+    }
+
+    @Synchronized
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+      val changed = cookies.any { new ->
+        store.none { it.name == new.name && it.domain == new.domain && it.path == new.path && it.value == new.value }
+      }
+      store.removeAll { existing ->
+        cookies.any { it.name == existing.name && it.domain == existing.domain && it.path == existing.path }
+      }
+      store.addAll(cookies)
+      val duplicated = serverUrls.any { it.host == url.host } && duplicateAuthCookies()
+      if (changed || duplicated) persist()
+    }
+
+    @Synchronized
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+      val now = System.currentTimeMillis()
+      store.removeAll { it.expiresAt < now }
+      return store.filter { it.matches(url) }
+    }
+
+    private fun duplicateAuthCookies(): Boolean {
+      val sourceCookies = store.filter { it.name in AUTH_COOKIE_NAMES }.associateBy { it.name }
+      if (sourceCookies.isEmpty()) return false
+
+      var changed = false
+      for (url in serverUrls) {
+        for ((_, source) in sourceCookies) {
+          if (store.any { it.name == source.name && it.domain == url.host && it.value == source.value }) continue
+          store.removeAll { it.name == source.name && it.domain == url.host }
+          store.add(rebuildCookie(source, url))
+          changed = true
+        }
+      }
+      return changed
+    }
+
+    private fun rebuildCookie(source: Cookie, url: HttpUrl): Cookie {
+      return Cookie.Builder()
+        .name(source.name).value(source.value)
+        .domain(url.host).path("/")
+        .expiresAt(source.expiresAt)
+        .apply {
+          if (url.isHttps) secure()
+          if (source.httpOnly) httpOnly()
+        }
+        .build()
+    }
+
+    private fun persist() {
+      val p = prefs ?: return
+      p.edit { putString(PREFS_COOKIES, Json.encodeToString(store.map { SerializedCookie.from(it) })) }
+    }
+
+    private fun restore() {
+      val p = prefs ?: return
+      val jsonStr = p.getString(PREFS_COOKIES, null) ?: return
+      try {
+        store.addAll(Json.decodeFromString<List<SerializedCookie>>(jsonStr).map { it.toCookie() })
+      } catch (_: Exception) {
+        store.clear()
+      }
+    }
+  }
+
+  @Serializable
+  private data class SerializedCookie(
+    val name: String,
+    val value: String,
+    val domain: String,
+    val path: String,
+    val expiresAt: Long,
+    val secure: Boolean,
+    val httpOnly: Boolean,
+    val hostOnly: Boolean,
+  ) {
+    fun toCookie(): Cookie = Cookie.Builder()
+      .name(name).value(value).path(path).expiresAt(expiresAt)
+      .apply {
+        if (hostOnly) hostOnlyDomain(domain) else domain(domain)
+        if (secure) secure()
+        if (httpOnly) httpOnly()
+      }
+      .build()
+
+    companion object {
+      fun from(cookie: Cookie) = SerializedCookie(
+        name = cookie.name, value = cookie.value, domain = cookie.domain,
+        path = cookie.path, expiresAt = cookie.expiresAt, secure = cookie.secure,
+        httpOnly = cookie.httpOnly, hostOnly = cookie.hostOnly,
+      )
+    }
   }
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -168,7 +168,7 @@ object HttpClientManager {
     synchronized(this) { clientChangedListeners.add(listener) }
   }
 
-  fun setRequestHeaders(headerMap: Map<String, String>, serverUrls: List<String>) {
+  fun setRequestHeaders(headerMap: Map<String, String>, serverUrls: List<String>, token: String?) {
     synchronized(this) {
       val builder = Headers.Builder()
       headerMap.forEach { (key, value) -> builder[key] = value }
@@ -186,23 +186,23 @@ object HttpClientManager {
           putString(PREFS_SERVER_URLS, Json.encodeToString(serverUrls))
         }
       }
-    }
-  }
 
-  fun bootstrapCookies(token: String, serverUrls: List<String>) {
-    val url = serverUrls.firstNotNullOfOrNull { it.toHttpUrlOrNull() } ?: return
-    val expiry = System.currentTimeMillis() + 400L * 24 * 60 * 60 * 1000
-    fun cookie(name: String, value: String, httpOnly: Boolean) =
-      Cookie.Builder().name(name).value(value).domain(url.host).path("/").expiresAt(expiry)
-        .apply {
-          if (url.isHttps) secure()
-          if (httpOnly) httpOnly()
-        }.build()
-    cookieJar.saveFromResponse(url, listOf(
-      cookie("immich_access_token", token, httpOnly = true),
-      cookie("immich_is_authenticated", "true", httpOnly = false),
-      cookie("immich_auth_type", "password", httpOnly = true),
-    ))
+      if (token != null) {
+        val url = serverUrls.firstNotNullOfOrNull { it.toHttpUrlOrNull() } ?: return
+        val expiry = System.currentTimeMillis() + 400L * 24 * 60 * 60 * 1000
+        fun cookie(name: String, value: String, httpOnly: Boolean) =
+          Cookie.Builder().name(name).value(value).domain(url.host).path("/").expiresAt(expiry)
+            .apply {
+              if (url.isHttps) secure()
+              if (httpOnly) httpOnly()
+            }.build()
+        cookieJar.saveFromResponse(url, listOf(
+          cookie("immich_access_token", token, httpOnly = true),
+          cookie("immich_is_authenticated", "true", httpOnly = false),
+          cookie("immich_auth_type", "password", httpOnly = true),
+        ))
+      }
+    }
   }
 
   fun loadCookieHeader(url: String): String? {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -39,6 +39,17 @@ private const val PREFS_CERT_ALIAS = "immich.client_cert"
 private const val PREFS_HEADERS = "immich.request_headers"
 private const val PREFS_SERVER_URLS = "immich.server_urls"
 private const val PREFS_COOKIES = "immich.cookies"
+private const val COOKIE_EXPIRY_DAYS = 400L
+
+private enum class AuthCookie(val cookieName: String, val httpOnly: Boolean) {
+  ACCESS_TOKEN("immich_access_token", httpOnly = true),
+  IS_AUTHENTICATED("immich_is_authenticated", httpOnly = false),
+  AUTH_TYPE("immich_auth_type", httpOnly = true);
+
+  companion object {
+    val names = entries.map { it.cookieName }.toSet()
+  }
+}
 
 /**
  * Manages a shared OkHttpClient with SSL configuration support.
@@ -189,18 +200,19 @@ object HttpClientManager {
 
       if (token != null) {
         val url = serverUrls.firstNotNullOfOrNull { it.toHttpUrlOrNull() } ?: return
-        val expiry = System.currentTimeMillis() + 400L * 24 * 60 * 60 * 1000
-        fun cookie(name: String, value: String, httpOnly: Boolean) =
-          Cookie.Builder().name(name).value(value).domain(url.host).path("/").expiresAt(expiry)
+        val expiry = System.currentTimeMillis() + COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+        val values = mapOf(
+          AuthCookie.ACCESS_TOKEN to token,
+          AuthCookie.IS_AUTHENTICATED to "true",
+          AuthCookie.AUTH_TYPE to "password",
+        )
+        cookieJar.saveFromResponse(url, values.map { (cookie, value) ->
+          Cookie.Builder().name(cookie.cookieName).value(value).domain(url.host).path("/").expiresAt(expiry)
             .apply {
               if (url.isHttps) secure()
-              if (httpOnly) httpOnly()
+              if (cookie.httpOnly) httpOnly()
             }.build()
-        cookieJar.saveFromResponse(url, listOf(
-          cookie("immich_access_token", token, httpOnly = true),
-          cookie("immich_is_authenticated", "true", httpOnly = false),
-          cookie("immich_auth_type", "password", httpOnly = true),
-        ))
+        })
       }
     }
   }
@@ -300,9 +312,6 @@ object HttpClientManager {
     private var serverUrls = listOf<HttpUrl>()
     private var prefs: SharedPreferences? = null
 
-    companion object {
-      val AUTH_COOKIE_NAMES = setOf("immich_access_token", "immich_is_authenticated", "immich_auth_type")
-    }
 
     fun init(prefs: SharedPreferences) {
       this.prefs = prefs
@@ -344,11 +353,11 @@ object HttpClientManager {
       val serverHosts = serverUrls.map { it.host }.toSet()
       val now = System.currentTimeMillis()
       val sourceCookies = store
-        .filter { it.name in AUTH_COOKIE_NAMES && it.domain in serverHosts && it.expiresAt > now }
+        .filter { it.name in AuthCookie.names && it.domain in serverHosts && it.expiresAt > now }
         .associateBy { it.name }
 
       if (sourceCookies.isEmpty()) {
-        return store.removeAll { it.name in AUTH_COOKIE_NAMES && it.domain in serverHosts }
+        return store.removeAll { it.name in AuthCookie.names && it.domain in serverHosts }
       }
 
       var changed = false

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
@@ -185,6 +185,7 @@ interface NetworkApi {
   fun hasCertificate(): Boolean
   fun getClientPointer(): Long
   fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>)
+  fun bootstrapCookies(token: String, serverUrls: List<String>)
 
   companion object {
     /** The codec used by NetworkApi. */
@@ -289,6 +290,25 @@ interface NetworkApi {
             val serverUrlsArg = args[1] as List<String>
             val wrapped: List<Any?> = try {
               api.setRequestHeaders(headersArg, serverUrlsArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              NetworkPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val tokenArg = args[0] as String
+            val serverUrlsArg = args[1] as List<String>
+            val wrapped: List<Any?> = try {
+              api.bootstrapCookies(tokenArg, serverUrlsArg)
               listOf(null)
             } catch (exception: Throwable) {
               NetworkPigeonUtils.wrapError(exception)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
@@ -184,8 +184,7 @@ interface NetworkApi {
   fun removeCertificate(callback: (Result<Unit>) -> Unit)
   fun hasCertificate(): Boolean
   fun getClientPointer(): Long
-  fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>)
-  fun bootstrapCookies(token: String, serverUrls: List<String>)
+  fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>, token: String?)
 
   companion object {
     /** The codec used by NetworkApi. */
@@ -288,27 +287,9 @@ interface NetworkApi {
             val args = message as List<Any?>
             val headersArg = args[0] as Map<String, String>
             val serverUrlsArg = args[1] as List<String>
+            val tokenArg = args[2] as String?
             val wrapped: List<Any?> = try {
-              api.setRequestHeaders(headersArg, serverUrlsArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              NetworkPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val tokenArg = args[0] as String
-            val serverUrlsArg = args[1] as List<String>
-            val wrapped: List<Any?> = try {
-              api.bootstrapCookies(tokenArg, serverUrlsArg)
+              api.setRequestHeaders(headersArg, serverUrlsArg, tokenArg)
               listOf(null)
             } catch (exception: Throwable) {
               NetworkPigeonUtils.wrapError(exception)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
@@ -39,7 +39,7 @@ class NetworkApiPlugin : FlutterPlugin, ActivityAware {
   }
 }
 
-private class NetworkApiImpl() : NetworkApi {
+private class NetworkApiImpl : NetworkApi {
   var activity: Activity? = null
 
   override fun addCertificate(clientData: ClientCertData, callback: (Result<Unit>) -> Unit) {
@@ -81,5 +81,9 @@ private class NetworkApiImpl() : NetworkApi {
 
   override fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>) {
     HttpClientManager.setRequestHeaders(headers, serverUrls)
+  }
+
+  override fun bootstrapCookies(token: String, serverUrls: List<String>) {
+    HttpClientManager.bootstrapCookies(token, serverUrls)
   }
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
@@ -79,11 +79,7 @@ private class NetworkApiImpl : NetworkApi {
     return HttpClientManager.getClientPointer()
   }
 
-  override fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>) {
-    HttpClientManager.setRequestHeaders(headers, serverUrls)
-  }
-
-  override fun bootstrapCookies(token: String, serverUrls: List<String>) {
-    HttpClientManager.bootstrapCookies(token, serverUrls)
+  override fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>, token: String?) {
+    HttpClientManager.setRequestHeaders(headers, serverUrls, token)
   }
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -192,6 +192,7 @@ private class CronetImageFetcher(context: Context, cacheDir: File) : ImageFetche
     val callback = FetchCallback(onSuccess, onFailure, ::onComplete)
     val requestBuilder = engine.newUrlRequestBuilder(url, callback, executor)
     HttpClientManager.headers.forEach { (key, value) -> requestBuilder.addHeader(key, value) }
+    HttpClientManager.loadCookieHeader(url)?.let { requestBuilder.addHeader("Cookie", it) }
     url.toHttpUrlOrNull()?.let { httpUrl ->
       if (httpUrl.username.isNotEmpty()) {
         requestBuilder.addHeader("Authorization", Credentials.basic(httpUrl.username, httpUrl.password))

--- a/mobile/ios/Runner/Core/Network.g.swift
+++ b/mobile/ios/Runner/Core/Network.g.swift
@@ -225,8 +225,7 @@ protocol NetworkApi {
   func removeCertificate(completion: @escaping (Result<Void, Error>) -> Void)
   func hasCertificate() throws -> Bool
   func getClientPointer() throws -> Int64
-  func setRequestHeaders(headers: [String: String], serverUrls: [String]) throws
-  func bootstrapCookies(token: String, serverUrls: [String]) throws
+  func setRequestHeaders(headers: [String: String], serverUrls: [String], token: String?) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -316,8 +315,9 @@ class NetworkApiSetup {
         let args = message as! [Any?]
         let headersArg = args[0] as! [String: String]
         let serverUrlsArg = args[1] as! [String]
+        let tokenArg: String? = nilOrValue(args[2])
         do {
-          try api.setRequestHeaders(headers: headersArg, serverUrls: serverUrlsArg)
+          try api.setRequestHeaders(headers: headersArg, serverUrls: serverUrlsArg, token: tokenArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
@@ -325,22 +325,6 @@ class NetworkApiSetup {
       }
     } else {
       setRequestHeadersChannel.setMessageHandler(nil)
-    }
-    let bootstrapCookiesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      bootstrapCookiesChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let tokenArg = args[0] as! String
-        let serverUrlsArg = args[1] as! [String]
-        do {
-          try api.bootstrapCookies(token: tokenArg, serverUrls: serverUrlsArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      bootstrapCookiesChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Core/Network.g.swift
+++ b/mobile/ios/Runner/Core/Network.g.swift
@@ -226,6 +226,7 @@ protocol NetworkApi {
   func hasCertificate() throws -> Bool
   func getClientPointer() throws -> Int64
   func setRequestHeaders(headers: [String: String], serverUrls: [String]) throws
+  func bootstrapCookies(token: String, serverUrls: [String]) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -324,6 +325,22 @@ class NetworkApiSetup {
       }
     } else {
       setRequestHeadersChannel.setMessageHandler(nil)
+    }
+    let bootstrapCookiesChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      bootstrapCookiesChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let tokenArg = args[0] as! String
+        let serverUrlsArg = args[1] as! [String]
+        do {
+          try api.bootstrapCookies(token: tokenArg, serverUrls: serverUrlsArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      bootstrapCookiesChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -62,27 +62,27 @@ class NetworkApiImpl: NetworkApi {
     URLSessionManager.setServerUrls(serverUrls)
 
     if let token = token {
-      let expiry = Date().addingTimeInterval(400 * 24 * 60 * 60)
+      let expiry = Date().addingTimeInterval(COOKIE_EXPIRY_DAYS * 24 * 60 * 60)
       for serverUrl in serverUrls {
         guard let url = URL(string: serverUrl), let domain = url.host else { continue }
         let isSecure = serverUrl.hasPrefix("https")
-        let cookies: [(String, String, Bool)] = [
-          ("immich_access_token", token, true),
-          ("immich_is_authenticated", "true", false),
-          ("immich_auth_type", "password", true),
+        let values: [AuthCookie: String] = [
+          .accessToken: token,
+          .isAuthenticated: "true",
+          .authType: "password",
         ]
-        for (name, value, httpOnly) in cookies {
+        for (cookie, value) in values {
           var properties: [HTTPCookiePropertyKey: Any] = [
-            .name: name,
+            .name: cookie.name,
             .value: value,
             .domain: domain,
             .path: "/",
             .expires: expiry,
           ]
           if isSecure { properties[.secure] = "TRUE" }
-          if httpOnly { properties[.init("HttpOnly")] = "TRUE" }
-          if let cookie = HTTPCookie(properties: properties) {
-            URLSessionManager.cookieStorage.setCookie(cookie)
+          if cookie.httpOnly { properties[.init("HttpOnly")] = "TRUE" }
+          if let httpCookie = HTTPCookie(properties: properties) {
+            URLSessionManager.cookieStorage.setCookie(httpCookie)
           }
         }
       }

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -59,41 +59,42 @@ class NetworkApiImpl: NetworkApi {
   }
   
   func setRequestHeaders(headers: [String : String], serverUrls: [String]) throws {
-    var headers = headers
-    if let token = headers.removeValue(forKey: "x-immich-user-token") {
-      for serverUrl in serverUrls {
-        guard let url = URL(string: serverUrl), let domain = url.host else { continue }
-        let isSecure = serverUrl.hasPrefix("https")
-        let cookies: [(String, String, Bool)] = [
-          ("immich_access_token", token, true),
-          ("immich_is_authenticated", "true", false),
-          ("immich_auth_type", "password", true),
-        ]
-        let expiry = Date().addingTimeInterval(400 * 24 * 60 * 60)
-        for (name, value, httpOnly) in cookies {
-          var properties: [HTTPCookiePropertyKey: Any] = [
-            .name: name,
-            .value: value,
-            .domain: domain,
-            .path: "/",
-            .expires: expiry,
-          ]
-          if isSecure { properties[.secure] = "TRUE" }
-          if httpOnly { properties[.init("HttpOnly")] = "TRUE" }
-          if let cookie = HTTPCookie(properties: properties) {
-            URLSessionManager.cookieStorage.setCookie(cookie)
-          }
-        }
-      }
-    }
-
     if serverUrls.first != UserDefaults.group.string(forKey: SERVER_URL_KEY) {
       UserDefaults.group.set(serverUrls.first, forKey: SERVER_URL_KEY)
     }
 
+    URLSessionManager.duplicateAuthCookies(serverUrls: serverUrls)
+
     if headers != UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] {
       UserDefaults.group.set(headers, forKey: HEADERS_KEY)
-      URLSessionManager.shared.recreateSession() // Recreate session to apply custom headers without app restart
+      URLSessionManager.shared.recreateSession()
+    }
+  }
+
+  func bootstrapCookies(token: String, serverUrls: [String]) throws {
+    let expiry = Date().addingTimeInterval(400 * 24 * 60 * 60)
+    for serverUrl in serverUrls {
+      guard let url = URL(string: serverUrl), let domain = url.host else { continue }
+      let isSecure = serverUrl.hasPrefix("https")
+      let cookies: [(String, String, Bool)] = [
+        ("immich_access_token", token, true),
+        ("immich_is_authenticated", "true", false),
+        ("immich_auth_type", "password", true),
+      ]
+      for (name, value, httpOnly) in cookies {
+        var properties: [HTTPCookiePropertyKey: Any] = [
+          .name: name,
+          .value: value,
+          .domain: domain,
+          .path: "/",
+          .expires: expiry,
+        ]
+        if isSecure { properties[.secure] = "TRUE" }
+        if httpOnly { properties[.init("HttpOnly")] = "TRUE" }
+        if let cookie = HTTPCookie(properties: properties) {
+          URLSessionManager.cookieStorage.setCookie(cookie)
+        }
+      }
     }
   }
 }

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -58,39 +58,39 @@ class NetworkApiImpl: NetworkApi {
     return Int64(Int(bitPattern: pointer))
   }
   
-  func setRequestHeaders(headers: [String : String], serverUrls: [String]) throws {
+  func setRequestHeaders(headers: [String : String], serverUrls: [String], token: String?) throws {
     URLSessionManager.setServerUrls(serverUrls)
+
+    if let token = token {
+      let expiry = Date().addingTimeInterval(400 * 24 * 60 * 60)
+      for serverUrl in serverUrls {
+        guard let url = URL(string: serverUrl), let domain = url.host else { continue }
+        let isSecure = serverUrl.hasPrefix("https")
+        let cookies: [(String, String, Bool)] = [
+          ("immich_access_token", token, true),
+          ("immich_is_authenticated", "true", false),
+          ("immich_auth_type", "password", true),
+        ]
+        for (name, value, httpOnly) in cookies {
+          var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+            .expires: expiry,
+          ]
+          if isSecure { properties[.secure] = "TRUE" }
+          if httpOnly { properties[.init("HttpOnly")] = "TRUE" }
+          if let cookie = HTTPCookie(properties: properties) {
+            URLSessionManager.cookieStorage.setCookie(cookie)
+          }
+        }
+      }
+    }
 
     if headers != UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] {
       UserDefaults.group.set(headers, forKey: HEADERS_KEY)
       URLSessionManager.shared.recreateSession()
-    }
-  }
-
-  func bootstrapCookies(token: String, serverUrls: [String]) throws {
-    let expiry = Date().addingTimeInterval(400 * 24 * 60 * 60)
-    for serverUrl in serverUrls {
-      guard let url = URL(string: serverUrl), let domain = url.host else { continue }
-      let isSecure = serverUrl.hasPrefix("https")
-      let cookies: [(String, String, Bool)] = [
-        ("immich_access_token", token, true),
-        ("immich_is_authenticated", "true", false),
-        ("immich_auth_type", "password", true),
-      ]
-      for (name, value, httpOnly) in cookies {
-        var properties: [HTTPCookiePropertyKey: Any] = [
-          .name: name,
-          .value: value,
-          .domain: domain,
-          .path: "/",
-          .expires: expiry,
-        ]
-        if isSecure { properties[.secure] = "TRUE" }
-        if httpOnly { properties[.init("HttpOnly")] = "TRUE" }
-        if let cookie = HTTPCookie(properties: properties) {
-          URLSessionManager.cookieStorage.setCookie(cookie)
-        }
-      }
     }
   }
 }

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -63,7 +63,7 @@ class NetworkApiImpl: NetworkApi {
       UserDefaults.group.set(serverUrls.first, forKey: SERVER_URL_KEY)
     }
 
-    URLSessionManager.duplicateAuthCookies(serverUrls: serverUrls)
+    URLSessionManager.setServerUrls(serverUrls)
 
     if headers != UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] {
       UserDefaults.group.set(headers, forKey: HEADERS_KEY)

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -59,10 +59,6 @@ class NetworkApiImpl: NetworkApi {
   }
   
   func setRequestHeaders(headers: [String : String], serverUrls: [String]) throws {
-    if serverUrls.first != UserDefaults.group.string(forKey: SERVER_URL_KEY) {
-      UserDefaults.group.set(serverUrls.first, forKey: SERVER_URL_KEY)
-    }
-
     URLSessionManager.setServerUrls(serverUrls)
 
     if headers != UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] {

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -3,7 +3,6 @@ import native_video_player
 
 let CLIENT_CERT_LABEL = "app.alextran.immich.client_identity"
 let HEADERS_KEY = "immich.request_headers"
-let SERVER_URL_KEY = "immich.server_url"
 let SERVER_URLS_KEY = "immich.server_urls"
 let APP_GROUP = "group.app.immich.share"
 
@@ -36,7 +35,7 @@ class URLSessionManager: NSObject {
   }()
   static let cookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: APP_GROUP)
   private static var serverUrls: [String] = []
-  private static var isDuplicating = false
+  private static var isSyncing = false
 
   var sessionPointer: UnsafeMutableRawPointer {
     Unmanaged.passUnretained(session).toOpaque()
@@ -63,29 +62,40 @@ class URLSessionManager: NSObject {
     guard urls != serverUrls else { return }
     serverUrls = urls
     UserDefaults.group.set(urls, forKey: SERVER_URLS_KEY)
-    duplicateAuthCookies()
+    syncAuthCookies()
   }
 
   @objc private static func cookiesDidChange(_ notification: Notification) {
-    guard !isDuplicating, !serverUrls.isEmpty else { return }
-    duplicateAuthCookies()
+    guard !isSyncing, !serverUrls.isEmpty else { return }
+    syncAuthCookies()
   }
 
-  private static func duplicateAuthCookies() {
+  private static func syncAuthCookies() {
     let authCookieNames: Set<String> = ["immich_access_token", "immich_is_authenticated", "immich_auth_type"]
+    let serverHosts = Set(serverUrls.compactMap { URL(string: $0)?.host })
     let allCookies = cookieStorage.cookies ?? []
+    let now = Date()
+
+    let serverAuthCookies = allCookies.filter {
+      authCookieNames.contains($0.name) && serverHosts.contains($0.domain)
+    }
 
     var sourceCookies: [String: HTTPCookie] = [:]
-    for cookie in allCookies {
-      if authCookieNames.contains(cookie.name) {
+    for cookie in serverAuthCookies {
+      if cookie.expiresDate.map({ $0 > now }) ?? true {
         sourceCookies[cookie.name] = cookie
       }
     }
 
-    guard !sourceCookies.isEmpty else { return }
+    isSyncing = true
+    defer { isSyncing = false }
 
-    isDuplicating = true
-    defer { isDuplicating = false }
+    if sourceCookies.isEmpty {
+      for cookie in serverAuthCookies {
+        cookieStorage.deleteCookie(cookie)
+      }
+      return
+    }
 
     for serverUrl in serverUrls {
       guard let url = URL(string: serverUrl), let domain = url.host else { continue }

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -49,6 +49,45 @@ class URLSessionManager: NSObject {
     session = Self.buildSession(delegate: delegate)
   }
 
+  static func duplicateAuthCookies(serverUrls: [String]) {
+    let authCookieNames: Set<String> = ["immich_access_token", "immich_is_authenticated", "immich_auth_type"]
+    let allCookies = cookieStorage.cookies ?? []
+
+    var sourceCookies: [String: HTTPCookie] = [:]
+    for cookie in allCookies {
+      if authCookieNames.contains(cookie.name) {
+        sourceCookies[cookie.name] = cookie
+      }
+    }
+
+    guard !sourceCookies.isEmpty else { return }
+
+    for serverUrl in serverUrls {
+      guard let url = URL(string: serverUrl), let domain = url.host else { continue }
+      let isSecure = serverUrl.hasPrefix("https")
+
+      for (_, source) in sourceCookies {
+        if allCookies.contains(where: { $0.name == source.name && $0.domain == domain && $0.value == source.value }) {
+          continue
+        }
+
+        var properties: [HTTPCookiePropertyKey: Any] = [
+          .name: source.name,
+          .value: source.value,
+          .domain: domain,
+          .path: "/",
+          .expires: source.expiresDate ?? Date().addingTimeInterval(400 * 24 * 60 * 60),
+        ]
+        if isSecure { properties[.secure] = "TRUE" }
+        if source.isHTTPOnly { properties[.init("HttpOnly")] = "TRUE" }
+
+        if let cookie = HTTPCookie(properties: properties) {
+          cookieStorage.setCookie(cookie)
+        }
+      }
+    }
+  }
+
   private static func buildSession(delegate: URLSessionManagerDelegate) -> URLSession {
     let config = URLSessionConfiguration.default
     config.urlCache = urlCache

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -4,6 +4,7 @@ import native_video_player
 let CLIENT_CERT_LABEL = "app.alextran.immich.client_identity"
 let HEADERS_KEY = "immich.request_headers"
 let SERVER_URL_KEY = "immich.server_url"
+let SERVER_URLS_KEY = "immich.server_urls"
 let APP_GROUP = "group.app.immich.share"
 
 extension UserDefaults {
@@ -34,22 +35,43 @@ class URLSessionManager: NSObject {
     return "Immich_iOS_\(version)"
   }()
   static let cookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: APP_GROUP)
-  
+  private static var serverUrls: [String] = []
+  private static var isDuplicating = false
+
   var sessionPointer: UnsafeMutableRawPointer {
     Unmanaged.passUnretained(session).toOpaque()
   }
-  
+
   private override init() {
     delegate = URLSessionManagerDelegate()
     session = Self.buildSession(delegate: delegate)
     super.init()
+    Self.serverUrls = UserDefaults.group.stringArray(forKey: SERVER_URLS_KEY) ?? []
+    NotificationCenter.default.addObserver(
+      Self.self,
+      selector: #selector(cookiesDidChange),
+      name: NSHTTPCookieManagerCookiesChangedNotification,
+      object: cookieStorage
+    )
   }
 
   func recreateSession() {
     session = Self.buildSession(delegate: delegate)
   }
 
-  static func duplicateAuthCookies(serverUrls: [String]) {
+  static func setServerUrls(_ urls: [String]) {
+    guard urls != serverUrls else { return }
+    serverUrls = urls
+    UserDefaults.group.set(urls, forKey: SERVER_URLS_KEY)
+    duplicateAuthCookies()
+  }
+
+  @objc private static func cookiesDidChange(_ notification: Notification) {
+    guard !isDuplicating, !serverUrls.isEmpty else { return }
+    duplicateAuthCookies()
+  }
+
+  private static func duplicateAuthCookies() {
     let authCookieNames: Set<String> = ["immich_access_token", "immich_is_authenticated", "immich_auth_type"]
     let allCookies = cookieStorage.cookies ?? []
 
@@ -61,6 +83,9 @@ class URLSessionManager: NSObject {
     }
 
     guard !sourceCookies.isEmpty else { return }
+
+    isDuplicating = true
+    defer { isDuplicating = false }
 
     for serverUrl in serverUrls {
       guard let url = URL(string: serverUrl), let domain = url.host else { continue }

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -5,6 +5,28 @@ let CLIENT_CERT_LABEL = "app.alextran.immich.client_identity"
 let HEADERS_KEY = "immich.request_headers"
 let SERVER_URLS_KEY = "immich.server_urls"
 let APP_GROUP = "group.app.immich.share"
+let COOKIE_EXPIRY_DAYS: TimeInterval = 400
+
+enum AuthCookie: CaseIterable {
+  case accessToken, isAuthenticated, authType
+
+  var name: String {
+    switch self {
+    case .accessToken: return "immich_access_token"
+    case .isAuthenticated: return "immich_is_authenticated"
+    case .authType: return "immich_auth_type"
+    }
+  }
+
+  var httpOnly: Bool {
+    switch self {
+    case .accessToken, .authType: return true
+    case .isAuthenticated: return false
+    }
+  }
+
+  static let names: Set<String> = Set(allCases.map(\.name))
+}
 
 extension UserDefaults {
   static let group = UserDefaults(suiteName: APP_GROUP)!
@@ -48,9 +70,9 @@ class URLSessionManager: NSObject {
     Self.serverUrls = UserDefaults.group.stringArray(forKey: SERVER_URLS_KEY) ?? []
     NotificationCenter.default.addObserver(
       Self.self,
-      selector: #selector(cookiesDidChange),
+      selector: #selector(Self.cookiesDidChange),
       name: NSHTTPCookieManagerCookiesChangedNotification,
-      object: cookieStorage
+      object: Self.cookieStorage
     )
   }
 
@@ -71,13 +93,12 @@ class URLSessionManager: NSObject {
   }
 
   private static func syncAuthCookies() {
-    let authCookieNames: Set<String> = ["immich_access_token", "immich_is_authenticated", "immich_auth_type"]
     let serverHosts = Set(serverUrls.compactMap { URL(string: $0)?.host })
     let allCookies = cookieStorage.cookies ?? []
     let now = Date()
 
     let serverAuthCookies = allCookies.filter {
-      authCookieNames.contains($0.name) && serverHosts.contains($0.domain)
+      AuthCookie.names.contains($0.name) && serverHosts.contains($0.domain)
     }
 
     var sourceCookies: [String: HTTPCookie] = [:]
@@ -111,7 +132,7 @@ class URLSessionManager: NSObject {
           .value: source.value,
           .domain: domain,
           .path: "/",
-          .expires: source.expiresDate ?? Date().addingTimeInterval(400 * 24 * 60 * 60),
+          .expires: source.expiresDate ?? Date().addingTimeInterval(COOKIE_EXPIRY_DAYS * 24 * 60 * 60),
         ]
         if isSecure { properties[.secure] = "TRUE" }
         if source.isHTTPOnly { properties[.init("HttpOnly")] = "TRUE" }

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -71,7 +71,7 @@ class URLSessionManager: NSObject {
     NotificationCenter.default.addObserver(
       Self.self,
       selector: #selector(Self.cookiesDidChange),
-      name: NSHTTPCookieManagerCookiesChangedNotification,
+      name: NSNotification.Name.NSHTTPCookieManagerCookiesChanged,
       object: Self.cookieStorage
     )
   }

--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -26,8 +26,8 @@ class NetworkRepository {
     }
   }
 
-  static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls) async {
-    await networkApi.setRequestHeaders(headers, serverUrls);
+  static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls, {String? token}) async {
+    await networkApi.setRequestHeaders(headers, serverUrls, token);
     if (Platform.isIOS) {
       await init();
     }

--- a/mobile/lib/platform/network_api.g.dart
+++ b/mobile/lib/platform/network_api.g.dart
@@ -301,37 +301,14 @@ class NetworkApi {
     }
   }
 
-  Future<void> setRequestHeaders(Map<String, String> headers, List<String> serverUrls) async {
+  Future<void> setRequestHeaders(Map<String, String> headers, List<String> serverUrls, String? token) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.setRequestHeaders$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[headers, serverUrls]);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
-    if (pigeonVar_replyList == null) {
-      throw _createConnectionError(pigeonVar_channelName);
-    } else if (pigeonVar_replyList.length > 1) {
-      throw PlatformException(
-        code: pigeonVar_replyList[0]! as String,
-        message: pigeonVar_replyList[1] as String?,
-        details: pigeonVar_replyList[2],
-      );
-    } else {
-      return;
-    }
-  }
-
-  Future<void> bootstrapCookies(String token, List<String> serverUrls) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[token, serverUrls]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[headers, serverUrls, token]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/mobile/lib/platform/network_api.g.dart
+++ b/mobile/lib/platform/network_api.g.dart
@@ -14,39 +14,47 @@ PlatformException _createConnectionError(String channelName) {
     message: 'Unable to establish connection on channel: "$channelName".',
   );
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
-    return a.length == b.length && a.indexed.every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+    return a.length == b.length &&
+        a.indexed
+        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length &&
-        a.entries.every(
-          (MapEntry<Object?, Object?> entry) =>
-              (b as Map<Object?, Object?>).containsKey(entry.key) && _deepEquals(entry.value, b[entry.key]),
-        );
+    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
+        (b as Map<Object?, Object?>).containsKey(entry.key) &&
+        _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
 
+
 class ClientCertData {
-  ClientCertData({required this.data, required this.password});
+  ClientCertData({
+    required this.data,
+    required this.password,
+  });
 
   Uint8List data;
 
   String password;
 
   List<Object?> _toList() {
-    return <Object?>[data, password];
+    return <Object?>[
+      data,
+      password,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static ClientCertData decode(Object result) {
     result as List<Object?>;
-    return ClientCertData(data: result[0]! as Uint8List, password: result[1]! as String);
+    return ClientCertData(
+      data: result[0]! as Uint8List,
+      password: result[1]! as String,
+    );
   }
 
   @override
@@ -63,11 +71,17 @@ class ClientCertData {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class ClientCertPrompt {
-  ClientCertPrompt({required this.title, required this.message, required this.cancel, required this.confirm});
+  ClientCertPrompt({
+    required this.title,
+    required this.message,
+    required this.cancel,
+    required this.confirm,
+  });
 
   String title;
 
@@ -78,12 +92,16 @@ class ClientCertPrompt {
   String confirm;
 
   List<Object?> _toList() {
-    return <Object?>[title, message, cancel, confirm];
+    return <Object?>[
+      title,
+      message,
+      cancel,
+      confirm,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static ClientCertPrompt decode(Object result) {
     result as List<Object?>;
@@ -109,8 +127,10 @@ class ClientCertPrompt {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -119,10 +139,10 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is ClientCertData) {
+    }    else if (value is ClientCertData) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is ClientCertPrompt) {
+    }    else if (value is ClientCertPrompt) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else {
@@ -133,9 +153,9 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return ClientCertData.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return ClientCertPrompt.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -148,8 +168,8 @@ class NetworkApi {
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
   NetworkApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-    : pigeonVar_binaryMessenger = binaryMessenger,
-      pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -157,15 +177,15 @@ class NetworkApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> addCertificate(ClientCertData clientData) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.addCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.addCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[clientData]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -180,15 +200,15 @@ class NetworkApi {
   }
 
   Future<void> selectCertificate(ClientCertPrompt promptText) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.selectCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.selectCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[promptText]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -203,15 +223,15 @@ class NetworkApi {
   }
 
   Future<void> removeCertificate() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.removeCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.removeCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -226,15 +246,15 @@ class NetworkApi {
   }
 
   Future<bool> hasCertificate() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.hasCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.hasCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -254,15 +274,15 @@ class NetworkApi {
   }
 
   Future<int> getClientPointer() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.getClientPointer$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.getClientPointer$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -282,15 +302,38 @@ class NetworkApi {
   }
 
   Future<void> setRequestHeaders(Map<String, String> headers, List<String> serverUrls) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.NetworkApi.setRequestHeaders$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.setRequestHeaders$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[headers, serverUrls]);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> bootstrapCookies(String token, List<String> serverUrls) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.bootstrapCookies$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[token, serverUrls]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/mobile/lib/platform/network_api.g.dart
+++ b/mobile/lib/platform/network_api.g.dart
@@ -14,47 +14,39 @@ PlatformException _createConnectionError(String channelName) {
     message: 'Unable to establish connection on channel: "$channelName".',
   );
 }
+
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
-    return a.length == b.length &&
-        a.indexed
-        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+    return a.length == b.length && a.indexed.every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
-        (b as Map<Object?, Object?>).containsKey(entry.key) &&
-        _deepEquals(entry.value, b[entry.key]));
+    return a.length == b.length &&
+        a.entries.every(
+          (MapEntry<Object?, Object?> entry) =>
+              (b as Map<Object?, Object?>).containsKey(entry.key) && _deepEquals(entry.value, b[entry.key]),
+        );
   }
   return a == b;
 }
 
-
 class ClientCertData {
-  ClientCertData({
-    required this.data,
-    required this.password,
-  });
+  ClientCertData({required this.data, required this.password});
 
   Uint8List data;
 
   String password;
 
   List<Object?> _toList() {
-    return <Object?>[
-      data,
-      password,
-    ];
+    return <Object?>[data, password];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static ClientCertData decode(Object result) {
     result as List<Object?>;
-    return ClientCertData(
-      data: result[0]! as Uint8List,
-      password: result[1]! as String,
-    );
+    return ClientCertData(data: result[0]! as Uint8List, password: result[1]! as String);
   }
 
   @override
@@ -71,17 +63,11 @@ class ClientCertData {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class ClientCertPrompt {
-  ClientCertPrompt({
-    required this.title,
-    required this.message,
-    required this.cancel,
-    required this.confirm,
-  });
+  ClientCertPrompt({required this.title, required this.message, required this.cancel, required this.confirm});
 
   String title;
 
@@ -92,16 +78,12 @@ class ClientCertPrompt {
   String confirm;
 
   List<Object?> _toList() {
-    return <Object?>[
-      title,
-      message,
-      cancel,
-      confirm,
-    ];
+    return <Object?>[title, message, cancel, confirm];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static ClientCertPrompt decode(Object result) {
     result as List<Object?>;
@@ -127,10 +109,8 @@ class ClientCertPrompt {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -139,10 +119,10 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is ClientCertData) {
+    } else if (value is ClientCertData) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    }    else if (value is ClientCertPrompt) {
+    } else if (value is ClientCertPrompt) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
     } else {
@@ -153,9 +133,9 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         return ClientCertData.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return ClientCertPrompt.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -168,8 +148,8 @@ class NetworkApi {
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
   NetworkApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+    : pigeonVar_binaryMessenger = binaryMessenger,
+      pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -177,15 +157,15 @@ class NetworkApi {
   final String pigeonVar_messageChannelSuffix;
 
   Future<void> addCertificate(ClientCertData clientData) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.addCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.addCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[clientData]);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -200,15 +180,15 @@ class NetworkApi {
   }
 
   Future<void> selectCertificate(ClientCertPrompt promptText) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.selectCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.selectCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[promptText]);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -223,15 +203,15 @@ class NetworkApi {
   }
 
   Future<void> removeCertificate() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.removeCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.removeCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -246,15 +226,15 @@ class NetworkApi {
   }
 
   Future<bool> hasCertificate() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.hasCertificate$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.hasCertificate$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -274,15 +254,15 @@ class NetworkApi {
   }
 
   Future<int> getClientPointer() async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.getClientPointer$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.getClientPointer$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {
@@ -302,15 +282,15 @@ class NetworkApi {
   }
 
   Future<void> setRequestHeaders(Map<String, String> headers, List<String> serverUrls, String? token) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.immich_mobile.NetworkApi.setRequestHeaders$pigeonVar_messageChannelSuffix';
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.setRequestHeaders$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[headers, serverUrls, token]);
-    final List<Object?>? pigeonVar_replyList =
-        await pigeonVar_sendFuture as List<Object?>?;
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
     } else if (pigeonVar_replyList.length > 1) {

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -123,7 +123,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   Future<bool> saveAuthInfo({required String accessToken}) async {
-    await _apiService.setAccessToken(accessToken);
+    await Store.put(StoreKey.accessToken, accessToken);
     await _apiService.updateHeaders();
 
     final serverEndpoint = Store.get(StoreKey.serverEndpoint);
@@ -145,7 +145,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
         user = serverUser;
         await Store.put(StoreKey.deviceId, deviceId);
         await Store.put(StoreKey.deviceIdHash, fastHash(deviceId));
-        await Store.put(StoreKey.accessToken, accessToken);
       }
     } on ApiException catch (error, stackTrace) {
       if (error.code == 401) {

--- a/mobile/lib/repositories/auth.repository.dart
+++ b/mobile/lib/repositories/auth.repository.dart
@@ -38,10 +38,6 @@ class AuthRepository extends DatabaseRepository {
     });
   }
 
-  String getAccessToken() {
-    return Store.get(StoreKey.accessToken);
-  }
-
   bool getEndpointSwitchingFeature() {
     return Store.tryGet(StoreKey.autoEndpointSwitching) ?? false;
   }

--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -201,7 +201,7 @@ class ApiService {
       return const {};
     }
 
-    return jsonDecode(customHeadersStr) as Map<String, String>;
+    return (jsonDecode(customHeadersStr) as Map).cast<String, String>();
   }
 
   ApiClient get apiClient => _apiClient;

--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -11,7 +11,7 @@ import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 
-class ApiService implements Authentication {
+class ApiService {
   late ApiClient _apiClient;
 
   late UsersApi usersApi;
@@ -45,7 +45,6 @@ class ApiService implements Authentication {
       setEndpoint(endpoint);
     }
   }
-  String? _accessToken;
   final _log = Logger("ApiService");
 
   Future<void> updateHeaders() async {
@@ -54,11 +53,8 @@ class ApiService implements Authentication {
   }
 
   setEndpoint(String endpoint) {
-    _apiClient = ApiClient(basePath: endpoint, authentication: this);
+    _apiClient = ApiClient(basePath: endpoint);
     _apiClient.client = NetworkRepository.client;
-    if (_accessToken != null) {
-      setAccessToken(_accessToken!);
-    }
     usersApi = UsersApi(_apiClient);
     authenticationApi = AuthenticationApi(_apiClient);
     oAuthApi = AuthenticationApi(_apiClient);
@@ -157,11 +153,6 @@ class ApiService implements Authentication {
     return "";
   }
 
-  Future<void> setAccessToken(String accessToken) async {
-    _accessToken = accessToken;
-    await Store.put(StoreKey.accessToken, accessToken);
-  }
-
   Future<void> setDeviceInfoHeader() async {
     DeviceInfoPlugin deviceInfoPlugin = DeviceInfoPlugin();
 
@@ -205,28 +196,12 @@ class ApiService implements Authentication {
   }
 
   static Map<String, String> getRequestHeaders() {
-    var accessToken = Store.get(StoreKey.accessToken, "");
     var customHeadersStr = Store.get(StoreKey.customHeaders, "");
-    var header = <String, String>{};
-    if (accessToken.isNotEmpty) {
-      header['x-immich-user-token'] = accessToken;
-    }
-
     if (customHeadersStr.isEmpty) {
-      return header;
+      return const {};
     }
 
-    var customHeaders = jsonDecode(customHeadersStr) as Map;
-    customHeaders.forEach((key, value) {
-      header[key] = value;
-    });
-
-    return header;
-  }
-
-  @override
-  Future<void> applyToParams(List<QueryParam> queryParams, Map<String, String> headerParams) {
-    return Future.value();
+    return jsonDecode(customHeadersStr) as Map<String, String>;
   }
 
   ApiClient get apiClient => _apiClient;

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -340,7 +340,6 @@ class BackgroundService {
       ],
     );
 
-    await ref.read(apiServiceProvider).setAccessToken(Store.get(StoreKey.accessToken));
     await ref.read(authServiceProvider).setOpenApiServiceEndpoint();
     dPrint(() => "[BG UPLOAD] Using endpoint: ${ref.read(apiServiceProvider).apiClient.basePath}");
 

--- a/mobile/lib/services/backup_verification.service.dart
+++ b/mobile/lib/services/backup_verification.service.dart
@@ -74,7 +74,6 @@ class BackupVerificationService {
       final lower = compute(_computeSaveToDelete, (
         deleteCandidates: deleteCandidates.slice(0, half),
         originals: originals.slice(0, half),
-        auth: Store.get(StoreKey.accessToken),
         endpoint: Store.get(StoreKey.serverEndpoint),
         rootIsolateToken: isolateToken,
         fileMediaRepository: _fileMediaRepository,
@@ -82,7 +81,6 @@ class BackupVerificationService {
       final upper = compute(_computeSaveToDelete, (
         deleteCandidates: deleteCandidates.slice(half),
         originals: originals.slice(half),
-        auth: Store.get(StoreKey.accessToken),
         endpoint: Store.get(StoreKey.serverEndpoint),
         rootIsolateToken: isolateToken,
         fileMediaRepository: _fileMediaRepository,
@@ -92,7 +90,6 @@ class BackupVerificationService {
       toDelete = await compute(_computeSaveToDelete, (
         deleteCandidates: deleteCandidates,
         originals: originals,
-        auth: Store.get(StoreKey.accessToken),
         endpoint: Store.get(StoreKey.serverEndpoint),
         rootIsolateToken: isolateToken,
         fileMediaRepository: _fileMediaRepository,
@@ -105,7 +102,6 @@ class BackupVerificationService {
     ({
       List<Asset> deleteCandidates,
       List<Asset> originals,
-      String auth,
       String endpoint,
       RootIsolateToken rootIsolateToken,
       FileMediaRepository fileMediaRepository,
@@ -120,7 +116,6 @@ class BackupVerificationService {
     await tuple.fileMediaRepository.enableBackgroundAccess();
     final ApiService apiService = ApiService();
     apiService.setEndpoint(tuple.endpoint);
-    await apiService.setAccessToken(tuple.auth);
     for (int i = 0; i < tuple.deleteCandidates.length; i++) {
       if (await _compareAssets(tuple.deleteCandidates[i], tuple.originals[i], apiService)) {
         result.add(tuple.deleteCandidates[i]);

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -27,6 +27,7 @@ import 'package:immich_mobile/infrastructure/repositories/sync_stream.repository
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:immich_mobile/platform/network_api.g.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
+import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/datetime_helpers.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
@@ -35,7 +36,7 @@ import 'package:isar/isar.dart';
 // ignore: import_rule_photo_manager
 import 'package:photo_manager/photo_manager.dart';
 
-const int targetVersion = 24;
+const int targetVersion = 25;
 
 Future<void> migrateDatabaseIfNeeded(Isar db, Drift drift) async {
   final hasVersion = Store.tryGet(StoreKey.version) != null;
@@ -107,6 +108,16 @@ Future<void> migrateDatabaseIfNeeded(Isar db, Drift drift) async {
 
   if (version < 24 && Store.isBetaTimelineEnabled) {
     await _applyLocalAssetOrientation(drift);
+  }
+
+  if (version < 25) {
+    final accessToken = Store.tryGet(StoreKey.accessToken);
+    if (accessToken != null && accessToken.isNotEmpty) {
+      final serverUrls = ApiService.getServerUrls();
+      if (serverUrls.isNotEmpty) {
+        await networkApi.bootstrapCookies(accessToken, serverUrls);
+      }
+    }
   }
 
   if (version < 22 && !Store.isBetaTimelineEnabled) {

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -25,6 +25,7 @@ import 'package:immich_mobile/infrastructure/entities/user.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/sync_stream.repository.dart';
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
 import 'package:immich_mobile/platform/network_api.g.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
@@ -115,7 +116,7 @@ Future<void> migrateDatabaseIfNeeded(Isar db, Drift drift) async {
     if (accessToken != null && accessToken.isNotEmpty) {
       final serverUrls = ApiService.getServerUrls();
       if (serverUrls.isNotEmpty) {
-        await networkApi.bootstrapCookies(accessToken, serverUrls);
+        await NetworkRepository.setHeaders(ApiService.getRequestHeaders(), serverUrls, token: accessToken);
       }
     }
   }

--- a/mobile/pigeon/network_api.dart
+++ b/mobile/pigeon/network_api.dart
@@ -44,4 +44,6 @@ abstract class NetworkApi {
   int getClientPointer();
 
   void setRequestHeaders(Map<String, String> headers, List<String> serverUrls);
+
+  void bootstrapCookies(String token, List<String> serverUrls);
 }

--- a/mobile/pigeon/network_api.dart
+++ b/mobile/pigeon/network_api.dart
@@ -43,7 +43,5 @@ abstract class NetworkApi {
 
   int getClientPointer();
 
-  void setRequestHeaders(Map<String, String> headers, List<String> serverUrls);
-
-  void bootstrapCookies(String token, List<String> serverUrls);
+  void setRequestHeaders(Map<String, String> headers, List<String> serverUrls, String? token);
 }


### PR DESCRIPTION
## Description

This PR moves the Android implementation to have the same behavior as iOS with cookie-based authentication. Auth is now a platform-side affair handled automatically when receiving Set-Cookie headers from the server, similar to web. There's no longer a need to call `setHeaders` on bootstrap, just as a one-time migration or when settings are changed by the user.

## How Has This Been Tested?

Tested on Android and iOS, confirming no logout when upgrading from 2.5.6.