### PR TITLE
feat(web,server): free rotation dial and crop zoom-to-fill

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1007,6 +1007,7 @@
   "editor_edits_applied_success": "Edits applied successfully",
   "editor_flip_horizontal": "Flip horizontal",
   "editor_flip_vertical": "Flip vertical",
+  "editor_free_rotation": "Free Rotation",
   "editor_orientation": "Orientation",
   "editor_reset_all_changes": "Reset changes",
   "editor_rotate_left": "Rotate 90° counterclockwise",

--- a/server/src/controllers/asset.controller.spec.ts
+++ b/server/src/controllers/asset.controller.spec.ts
@@ -405,7 +405,7 @@ describe(AssetController.name, () => {
       expect(status).toBe(400);
       expect(body).toEqual(
         factory.responses.badRequest(
-          expect.arrayContaining([expect.stringContaining('parameters.angle must be one of the following values')]),
+          expect.arrayContaining([expect.stringContaining('parameters.angle must be a number between 0 (inclusive) and 360 (exclusive)')]),
         ),
       );
     });

--- a/server/src/dtos/editing.dto.ts
+++ b/server/src/dtos/editing.dto.ts
@@ -38,7 +38,7 @@ export class CropParameters {
 
 export class RotateParameters {
   @IsAxisAlignedRotation()
-  @ApiProperty({ description: 'Rotation angle in degrees' })
+  @ApiProperty({ description: 'Rotation angle in degrees (0-360, supports fractional values for free rotation)' })
   angle!: number;
 }
 

--- a/server/src/repositories/media.repository.spec.ts
+++ b/server/src/repositories/media.repository.spec.ts
@@ -325,6 +325,122 @@ describe(MediaRepository.name, () => {
     });
   });
 
+  describe('applyEdits (free rotation)', () => {
+    it('should produce no black corners when free-rotating a solid color image', async () => {
+      const solidRed = sharp({
+        create: { width: 1000, height: 1000, channels: 4, background: { r: 255, g: 0, b: 0, alpha: 1 } },
+      }).png();
+
+      const result = await sut['applyEdits'](solidRed, [
+        { action: AssetEditAction.Rotate, parameters: { angle: 15 } },
+      ]);
+
+      const buffer = await result.png().toBuffer();
+      const metadata = await sharp(buffer).metadata();
+      const w = metadata.width!;
+      const h = metadata.height!;
+
+      // Check center and near-corner pixels are still red (not black)
+      const centerColor = await getPixelColor(buffer, Math.round(w / 2), Math.round(h / 2));
+      expect(centerColor).toEqual({ r: 255, g: 0, b: 0 });
+
+      // Near top-left corner (with margin)
+      const margin = 10;
+      const tlColor = await getPixelColor(buffer, margin, margin);
+      expect(tlColor).toEqual({ r: 255, g: 0, b: 0 });
+
+      // Near bottom-right corner
+      const brColor = await getPixelColor(buffer, w - margin - 1, h - margin - 1);
+      expect(brColor).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it('should produce dimensions smaller than original (inscribed rect cropping)', async () => {
+      const result = await sut['applyEdits'](
+        sharp({
+          create: { width: 1000, height: 1000, channels: 4, background: { r: 128, g: 128, b: 128, alpha: 1 } },
+        }).png(),
+        [{ action: AssetEditAction.Rotate, parameters: { angle: 10 } }],
+      );
+
+      const buffer = await result.png().toBuffer();
+      const metadata = await sharp(buffer).metadata();
+
+      // Inscribed rectangle must be smaller than original
+      expect(metadata.width!).toBeLessThan(1000);
+      expect(metadata.height!).toBeLessThan(1000);
+      // But still a reasonable size (not degenerate)
+      expect(metadata.width!).toBeGreaterThan(800);
+      expect(metadata.height!).toBeGreaterThan(800);
+    });
+
+    it('should handle mixed 90° + free rotation (e.g. 95°)', async () => {
+      const solidGreen = sharp({
+        create: { width: 500, height: 1000, channels: 4, background: { r: 0, g: 255, b: 0, alpha: 1 } },
+      }).png();
+
+      const result = await sut['applyEdits'](solidGreen, [
+        { action: AssetEditAction.Rotate, parameters: { angle: 95 } },
+      ]);
+
+      const buffer = await result.png().toBuffer();
+      const metadata = await sharp(buffer).metadata();
+
+      // 90° component swaps dimensions, then 5° free rotation crops inscribed rect
+      // Width should be close to original height, height close to original width, both slightly smaller
+      expect(metadata.width!).toBeGreaterThan(900);
+      expect(metadata.height!).toBeLessThan(500);
+
+      // No black corners — center pixel should be green
+      const centerColor = await getPixelColor(buffer, Math.round(metadata.width! / 2), Math.round(metadata.height! / 2));
+      expect(centerColor).toEqual({ r: 0, g: 255, b: 0 });
+    });
+
+    it('should handle crop then free rotation', async () => {
+      const result = await sut['applyEdits'](
+        sharp({
+          create: { width: 1000, height: 1000, channels: 4, background: { r: 0, g: 0, b: 255, alpha: 1 } },
+        }).png(),
+        [
+          { action: AssetEditAction.Crop, parameters: { x: 100, y: 100, width: 800, height: 600 } },
+          { action: AssetEditAction.Rotate, parameters: { angle: 5 } },
+        ],
+      );
+
+      const buffer = await result.png().toBuffer();
+      const metadata = await sharp(buffer).metadata();
+
+      // After crop (800x600), free rotation inscribed rect is smaller
+      expect(metadata.width!).toBeLessThan(800);
+      expect(metadata.height!).toBeLessThan(600);
+      expect(metadata.width!).toBeGreaterThan(700);
+      expect(metadata.height!).toBeGreaterThan(500);
+
+      // No black corners
+      const centerColor = await getPixelColor(buffer, Math.round(metadata.width! / 2), Math.round(metadata.height! / 2));
+      expect(centerColor).toEqual({ r: 0, g: 0, b: 255 });
+    });
+  });
+
+  describe('generateThumbhash (dimension safety)', () => {
+    it('should stay within 100x100 after free rotation', async () => {
+      const solidImage = sharp({
+        create: { width: 500, height: 500, channels: 4, background: { r: 200, g: 100, b: 50, alpha: 1 } },
+      }).png();
+
+      const inputBuffer = await solidImage.toBuffer();
+
+      // Should not throw — thumbhash must handle the extra canvas from rotation
+      const thumbhash = await sut.generateThumbhash(inputBuffer, {
+        colorspace: 'srgb',
+        processInvalidImages: false,
+        edits: [{ action: AssetEditAction.Rotate, parameters: { angle: 15 } }],
+      });
+
+      expect(thumbhash).toBeInstanceOf(Buffer);
+      expect(thumbhash.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('checkFaceVisibility', () => {
     const baseFace: AssetFace = {
       id: 'face-1',

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -146,29 +146,88 @@ export class MediaRepository {
   }
 
   private async applyEdits(pipeline: sharp.Sharp, edits: AssetEditActionItem[]): Promise<sharp.Sharp> {
-    const affineEditOperations = edits.filter((edit) => edit.action !== 'crop');
-    const matrix = createAffineMatrix(affineEditOperations);
-
     const crop = edits.find((edit) => edit.action === 'crop');
-    const dimensions = await pipeline.metadata();
+    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
+    const mirrorEdits = edits.filter((edit) => edit.action === 'mirror');
 
+    // 1. Apply crop
     if (crop) {
       pipeline = pipeline.extract({
-        left: crop ? Math.round(crop.parameters.x) : 0,
-        top: crop ? Math.round(crop.parameters.y) : 0,
-        width: crop ? Math.round(crop.parameters.width) : dimensions.width || 0,
-        height: crop ? Math.round(crop.parameters.height) : dimensions.height || 0,
+        left: Math.round(crop.parameters.x),
+        top: Math.round(crop.parameters.y),
+        width: Math.round(crop.parameters.width),
+        height: Math.round(crop.parameters.height),
       });
     }
 
-    const { a, b, c, d } = matrix;
-    pipeline = pipeline.affine(
-      [
-        [a, b],
-        [c, d],
-      ],
-      { background: { r: 0, g: 0, b: 0, alpha: 0 } },
-    );
+    // 2. Apply mirrors
+    for (const mirror of mirrorEdits) {
+      if (mirror.parameters.axis === 'horizontal') {
+        pipeline = pipeline.flop();
+      } else {
+        pipeline = pipeline.flip();
+      }
+    }
+
+    // 3. Apply rotation
+    if (rotateEdit) {
+      const totalAngle = rotateEdit.parameters.angle;
+      const normalizedAngle = ((totalAngle % 360) + 360) % 360;
+      const angle90 = Math.round(normalizedAngle / 90) * 90;
+      const freeAngle = normalizedAngle - angle90;
+
+      // Apply 90° component (no canvas expansion)
+      if (angle90 !== 0) {
+        pipeline = pipeline.rotate(angle90);
+      }
+
+      // Apply free rotation component
+      if (Math.abs(freeAngle) > 0.01) {
+        // Materialize to get actual dimensions before free rotation
+        const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
+        const W = info.width;
+        const H = info.height;
+
+        // Rotate with black background, then crop inscribed rectangle
+        const theta = Math.abs(freeAngle) * (Math.PI / 180);
+        const cosT = Math.cos(theta);
+        const sinT = Math.sin(theta);
+
+        // Bounding box after rotation
+        const bbW = Math.round(W * cosT + H * sinT);
+        const bbH = Math.round(W * sinT + H * cosT);
+
+        // Inscribed rectangle (no black corners)
+        const cos2T = Math.cos(2 * theta);
+        let iW: number;
+        let iH: number;
+        if (Math.abs(cos2T) > 0.001) {
+          iW = Math.max(1, (W * cosT - H * sinT) / cos2T);
+          iH = Math.max(1, (H * cosT - W * sinT) / cos2T);
+        } else {
+          const minDim = Math.min(W, H);
+          iW = minDim / (cosT + sinT);
+          iH = iW;
+        }
+
+        // Rotate and extract inscribed rectangle
+        pipeline = sharp(data, { raw: { width: W, height: H, channels: info.channels } })
+          .rotate(freeAngle, { background: { r: 0, g: 0, b: 0 } });
+
+        // Get actual rotated dimensions and extract centered inscribed rect
+        const rotated = await pipeline.raw().toBuffer({ resolveWithObject: true });
+        const rW = rotated.info.width;
+        const rH = rotated.info.height;
+
+        const extractW = Math.min(Math.round(iW), rW);
+        const extractH = Math.min(Math.round(iH), rH);
+        const left = Math.max(0, Math.round((rW - extractW) / 2));
+        const top = Math.max(0, Math.round((rH - extractH) / 2));
+
+        pipeline = sharp(rotated.data, { raw: { width: rW, height: rH, channels: rotated.info.channels } })
+          .extract({ left, top, width: extractW, height: extractH });
+      }
+    }
 
     return pipeline;
   }
@@ -229,9 +288,19 @@ export class MediaRepository {
       }),
     ]);
 
-    const pipeline = decodingPipeline.resize(100, 100, { fit: 'inside', withoutEnlargement: true }).raw().ensureAlpha();
+    const pipeline = decodingPipeline.resize(100, 100, { fit: 'inside' }).raw().ensureAlpha();
 
     const { data, info } = await pipeline.toBuffer({ resolveWithObject: true });
+
+    // Ensure dimensions are within thumbhash limits (100x100) after affine transforms
+    if (info.width > 100 || info.height > 100) {
+      const resized = sharp(data, { raw: { width: info.width, height: info.height, channels: info.channels } })
+        .resize(100, 100, { fit: 'inside' })
+        .raw()
+        .ensureAlpha();
+      const result = await resized.toBuffer({ resolveWithObject: true });
+      return Buffer.from(rgbaToThumbHash(result.info.width, result.info.height, result.data));
+    }
 
     return Buffer.from(rgbaToThumbHash(info.width, info.height, data));
   }

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -162,10 +162,13 @@ export class MediaRepository {
     }
 
     const { a, b, c, d } = matrix;
-    pipeline = pipeline.affine([
-      [a, b],
-      [c, d],
-    ]);
+    pipeline = pipeline.affine(
+      [
+        [a, b],
+        [c, d],
+      ],
+      { background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    );
 
     return pipeline;
   }

--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -18,9 +18,13 @@ export const getOutputDimensions = (
   for (const edit of edits) {
     if (edit.action === AssetEditAction.Rotate) {
       const angleDegrees = edit.parameters.angle;
-      if (angleDegrees === 90 || angleDegrees === 270) {
-        [width, height] = [height, width];
-      }
+      const angleRadians = (angleDegrees * Math.PI) / 180;
+      const cos = Math.abs(Math.cos(angleRadians));
+      const sin = Math.abs(Math.sin(angleRadians));
+      const newWidth = Math.round(width * cos + height * sin);
+      const newHeight = Math.round(width * sin + height * cos);
+      width = newWidth;
+      height = newHeight;
     }
   }
 
@@ -104,8 +108,10 @@ export const transformPoints = (
     if (edit.action === 'rotate') {
       const angleDegrees = edit.parameters.angle;
       const angleRadians = (angleDegrees * Math.PI) / 180;
-      const newWidth = angleDegrees === 90 || angleDegrees === 270 ? currentHeight : currentWidth;
-      const newHeight = angleDegrees === 90 || angleDegrees === 270 ? currentWidth : currentHeight;
+      const cos = Math.abs(Math.cos(angleRadians));
+      const sin = Math.abs(Math.sin(angleRadians));
+      const newWidth = Math.round(currentWidth * cos + currentHeight * sin);
+      const newHeight = Math.round(currentWidth * sin + currentHeight * cos);
 
       matrix = compose(
         translate(newWidth / 2, newHeight / 2),
@@ -189,15 +195,17 @@ export const transformFaceBoundingBox = (
 };
 
 const reorderQuadPointsForRotation = (points: Point[], rotationDegrees: number): Point[] => {
+  // Normalize to nearest 90-degree increment for point reordering
+  const normalized = Math.round(rotationDegrees / 90) % 4;
   const [p1, p2, p3, p4] = points;
-  switch (rotationDegrees) {
-    case 90: {
+  switch (normalized) {
+    case 1: {
       return [p4, p1, p2, p3];
     }
-    case 180: {
+    case 2: {
       return [p3, p4, p1, p2];
     }
-    case 270: {
+    case 3: {
       return [p2, p3, p4, p1];
     }
     default: {

--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -17,14 +17,31 @@ export const getOutputDimensions = (
 
   for (const edit of edits) {
     if (edit.action === AssetEditAction.Rotate) {
-      const angleDegrees = edit.parameters.angle;
-      const angleRadians = (angleDegrees * Math.PI) / 180;
-      const cos = Math.abs(Math.cos(angleRadians));
-      const sin = Math.abs(Math.sin(angleRadians));
-      const newWidth = Math.round(width * cos + height * sin);
-      const newHeight = Math.round(width * sin + height * cos);
-      width = newWidth;
-      height = newHeight;
+      const totalAngle = ((edit.parameters.angle % 360) + 360) % 360;
+      const quadrant = Math.floor(totalAngle / 90);
+      const freeAngle = totalAngle - quadrant * 90;
+
+      // Apply 90° component (swaps dimensions)
+      if (quadrant % 2 !== 0) {
+        [width, height] = [height, width];
+      }
+
+      // Apply free rotation component → inscribed rectangle
+      if (freeAngle > 0.01) {
+        const theta = (freeAngle * Math.PI) / 180;
+        const cosT = Math.cos(theta);
+        const sinT = Math.sin(theta);
+        const cos2T = Math.cos(2 * theta);
+
+        if (Math.abs(cos2T) > 0.001 && width * cosT > height * sinT && height * cosT > width * sinT) {
+          width = Math.round((width * cosT - height * sinT) / cos2T);
+          height = Math.round((height * cosT - width * sinT) / cos2T);
+        } else {
+          const minDim = Math.min(width, height);
+          width = Math.round(minDim / (cosT + sinT));
+          height = Math.round(minDim / (cosT + sinT));
+        }
+      }
     }
   }
 

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -88,10 +88,10 @@ export function IsAxisAlignedRotation() {
       name: 'isAxisAlignedRotation',
       validator: {
         validate(value: any) {
-          return [0, 90, 180, 270].includes(value);
+          return typeof value === 'number' && value >= 0 && value < 360;
         },
         defaultMessage: buildMessage(
-          (eachPrefix) => eachPrefix + '$property must be one of the following values: 0, 90, 180, 270',
+          (eachPrefix) => eachPrefix + '$property must be a number between 0 (inclusive) and 360 (exclusive)',
           {},
         ),
       },

--- a/web/src/lib/components/asset-viewer/editor/transform-tool/crop-area.svelte
+++ b/web/src/lib/components/asset-viewer/editor/transform-tool/crop-area.svelte
@@ -4,6 +4,7 @@
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
   import { AssetMediaSize, type AssetResponseDto } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
 
   interface Props {
     asset: AssetResponseDto;
@@ -17,8 +18,42 @@
     getAssetMediaUrl({ id: asset.id, cacheKey: asset.thumbhash, edited: false, size: AssetMediaSize.Preview }),
   );
 
+  /**
+   * Calculate the scale factor needed so the rotated image fully covers the crop frame.
+   * Given image W×H rotated by θ, the crop frame (W×H) must be fully inscribed.
+   * Scale = max(cosθ + (H/W)·sinθ, (W/H)·sinθ + cosθ)
+   */
+  let imageScale = $derived.by(() => {
+    const theta = Math.abs(transformManager.freeRotation * Math.PI / 180);
+    if (theta === 0) return 1;
+
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+    const img = transformManager.imgElement;
+    if (!img || img.width === 0 || img.height === 0) return 1;
+
+    const W = img.width;
+    const H = img.height;
+
+    // Two constraints from the 4 corners of the crop frame fitting inside the rotated image
+    const s1 = cosT + (H / W) * sinT;
+    const s2 = (W / H) * sinT + cosT;
+
+    return Math.max(s1, s2);
+  });
+
   let imageTransform = $derived.by(() => {
     const transforms: string[] = [];
+
+    // Scale up so rotated image fully covers the crop frame
+    if (imageScale !== 1) {
+      transforms.push(`scale(${imageScale})`);
+    }
+
+    // Free rotation applied to the image only (frame stays static)
+    if (transformManager.freeRotation !== 0) {
+      transforms.push(`rotate(${transformManager.freeRotation}deg)`);
+    }
 
     if (transformManager.mirrorHorizontal) {
       transforms.push('scaleX(-1)');
@@ -45,39 +80,154 @@
       resizeObserver.disconnect();
     };
   });
+
+  // Use matching transform function list so CSS transitions interpolate.
+  // During interaction, use frozen anchor region for translate to prevent coordinate drift.
+  // Disable transition during interaction so zoom adjustments are instant.
+  let cropAreaStyle = $derived.by(() => {
+    const zoom = transformManager.cropZoom;
+    const rotation = transformManager.imageRotation;
+    const interacting = transformManager.isInteracting;
+    const transition = interacting ? 'transition: none;' : 'transition: transform 0.3s ease;';
+
+    if (zoom <= 1) {
+      return `${transition} transform: translate(0px, 0px) rotate(${rotation}deg) scale(1)`;
+    }
+
+    const el = transformManager.cropAreaEl;
+    if (!el) return `${transition} transform: translate(0px, 0px) rotate(${rotation}deg) scale(1)`;
+
+    const W = el.clientWidth;
+    const H = el.clientHeight;
+
+    // Use anchor region during drag so translate stays stable
+    const r = transformManager.zoomAnchorRegion ?? transformManager.region;
+    const cx = r.x + r.width / 2;
+    const cy = r.y + r.height / 2;
+
+    const dx = cx - W / 2;
+    const dy = cy - H / 2;
+
+    const theta = (rotation * Math.PI) / 180;
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+
+    const tx = -(zoom * dx * cosT - zoom * dy * sinT);
+    const ty = -(zoom * dx * sinT + zoom * dy * cosT);
+
+    return `${transition} transform: translate(${tx}px, ${ty}px) rotate(${rotation}deg) scale(${zoom})`;
+  });
+
+  // Show grid when free rotating or interacting
+  let showGrid = $derived(transformManager.freeRotation !== 0 || transformManager.isInteracting);
+
+  // Counter-scale so crop frame border/corners stay visually consistent when zoomed
+  let frameScale = $derived(transformManager.cropZoom > 1 ? 1 / transformManager.cropZoom : 1);
+
+  // --- Rotation dial ---
+  const DIAL_MIN = -45;
+  const DIAL_MAX = 45;
+  const PX_PER_DEGREE = 6;
+
+  let isDraggingDial = $state(false);
+  let dragStartX = $state(0);
+  let dragStartAngle = $state(0);
+
+  const ZERO_TICK_CENTER = (0 - DIAL_MIN) * PX_PER_DEGREE + PX_PER_DEGREE / 2;
+  let dialOffset = $derived(-ZERO_TICK_CENTER - transformManager.freeRotation * PX_PER_DEGREE);
+  let freeRotationDisplay = $derived(Math.round(transformManager.freeRotation));
+
+  function handleDialPointerDown(e: PointerEvent) {
+    isDraggingDial = true;
+    dragStartX = e.clientX;
+    dragStartAngle = transformManager.freeRotation;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  function handleDialPointerMove(e: PointerEvent) {
+    if (!isDraggingDial) return;
+    const dx = e.clientX - dragStartX;
+    const angleDelta = -dx / PX_PER_DEGREE;
+    const newAngle = Math.max(DIAL_MIN, Math.min(DIAL_MAX, Math.round(dragStartAngle + angleDelta)));
+    transformManager.setFreeRotation(newAngle);
+  }
+
+  function handleDialPointerUp() {
+    isDraggingDial = false;
+  }
+
+  const ticks: { degree: number; isMajor: boolean }[] = [];
+  for (let d = DIAL_MIN; d <= DIAL_MAX; d++) {
+    ticks.push({ degree: d, isMajor: d % 10 === 0 });
+  }
 </script>
 
 <div class="canvas-container" bind:this={canvasContainer}>
-  <button
-    class={`crop-area ${transformManager.orientationChanged ? 'changedOriention' : ''}`}
-    style={`rotate:${transformManager.imageRotation}deg`}
-    bind:this={transformManager.cropAreaEl}
-    onmousedown={(e) => transformManager.handleMouseDown(e)}
-    onmouseup={() => transformManager.handleMouseUp()}
-    aria-label="Crop area"
-    type="button"
-  >
-    <img
-      draggable="false"
-      src={imageSrc}
-      alt={$getAltText(toTimelineAsset(asset))}
-      style={imageTransform ? `transform: ${imageTransform}` : ''}
-    />
-    <div
-      class={`${transformManager.isInteracting ? 'resizing' : ''} crop-frame`}
-      bind:this={transformManager.cropFrame}
+  <div class="crop-viewport">
+    <button
+      class={`crop-area ${transformManager.orientationChanged ? 'changedOriention' : ''}`}
+      style={cropAreaStyle}
+      bind:this={transformManager.cropAreaEl}
+      onmousedown={(e) => transformManager.handleMouseDown(e)}
+      onmouseup={() => transformManager.handleMouseUp()}
+      aria-label="Crop area"
+      type="button"
     >
-      <div class="grid"></div>
-      <div class="corner top-left"></div>
-      <div class="corner top-right"></div>
-      <div class="corner bottom-left"></div>
-      <div class="corner bottom-right"></div>
+      <img
+        draggable="false"
+        src={imageSrc}
+        alt={$getAltText(toTimelineAsset(asset))}
+        style={imageTransform ? `transform: ${imageTransform}` : ''}
+      />
+      <div
+        class={`${showGrid ? 'resizing' : ''} crop-frame`}
+        bind:this={transformManager.cropFrame}
+        style:--s={frameScale}
+      >
+        <div class="grid"></div>
+        <div class="corner top-left"></div>
+        <div class="corner top-right"></div>
+        <div class="corner bottom-left"></div>
+        <div class="corner bottom-right"></div>
+      </div>
+      <div
+        class={`${transformManager.isInteracting ? 'light' : ''} overlay`}
+        bind:this={transformManager.overlayEl}
+      ></div>
+    </button>
+  </div>
+
+  <!-- Rotation dial below the image -->
+  <div class="rotation-dial-wrapper">
+    <span class="rotation-value {freeRotationDisplay !== 0 ? 'active' : ''}">{freeRotationDisplay}°</span>
+    <div class="dial-container">
+      <div class="dial-indicator"></div>
+      <div
+        class="dial-track"
+        onpointerdown={handleDialPointerDown}
+        onpointermove={handleDialPointerMove}
+        onpointerup={handleDialPointerUp}
+        onpointercancel={handleDialPointerUp}
+        role="slider"
+        aria-label={$t('editor_free_rotation')}
+        aria-valuemin={DIAL_MIN}
+        aria-valuemax={DIAL_MAX}
+        aria-valuenow={freeRotationDisplay}
+        tabindex="0"
+      >
+        <div class="dial-ruler" style="transform: translateX({dialOffset}px)">
+          {#each ticks as tick (tick.degree)}
+            <div class="tick {tick.isMajor ? 'major' : ''} {tick.degree === 0 ? 'zero' : ''}">
+              <div class="tick-line"></div>
+              {#if tick.isMajor}
+                <span class="tick-label">{tick.degree}</span>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </div>
     </div>
-    <div
-      class={`${transformManager.isInteracting ? 'light' : ''} overlay`}
-      bind:this={transformManager.overlayEl}
-    ></div>
-  </button>
+  </div>
 </div>
 
 <style>
@@ -90,16 +240,27 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    position: relative;
+  }
+
+  .crop-viewport {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
   }
 
   .crop-area {
     position: relative;
     display: inline-block;
     outline: none;
-    transition: rotate 0.15s ease;
     max-height: 100%;
     max-width: 100%;
     width: max-content;
+    /* No overflow:hidden — the rotated/scaled image should be visible beyond the frame */
   }
   .crop-area.changedOriention {
     max-width: 92vh;
@@ -130,12 +291,10 @@
     left: 0;
     right: 0;
     bottom: 0;
-    --color: white;
-    --shadow: #00000057;
     background-image:
-      linear-gradient(var(--color) 1px, transparent 0), linear-gradient(90deg, var(--color) 1px, transparent 0),
-      linear-gradient(var(--shadow) 3px, transparent 0), linear-gradient(90deg, var(--shadow) 3px, transparent 0);
-    background-size: calc(100% / 3) calc(100% / 3);
+      linear-gradient(rgba(255, 255, 255, 0.3) 0.5px, transparent 0),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.3) 0.5px, transparent 0);
+    background-size: calc(100% / 6) calc(100% / 6);
     opacity: 0;
     transition: opacity 0.1s ease;
   }
@@ -150,20 +309,22 @@
     height: 100%;
     user-select: none;
     transition: transform 0.15s ease;
+    transform-origin: center center;
   }
 
   .crop-frame {
     position: absolute;
-    border: 2px solid white;
+    border: max(1px, calc(2px * var(--s, 1))) solid white;
     box-sizing: border-box;
     pointer-events: none;
+    z-index: 1;
   }
 
   .corner {
     position: absolute;
-    width: 20px;
-    height: 20px;
-    --size: 5.2px;
+    width: max(10px, calc(20px * var(--s, 1)));
+    height: max(10px, calc(20px * var(--s, 1)));
+    --size: max(2px, calc(5.2px * var(--s, 1)));
     --mSize: calc(-0.5 * var(--size));
     border: var(--size) solid white;
     box-sizing: border-box;
@@ -195,5 +356,107 @@
     right: var(--mSize);
     border-left: none;
     border-top: none;
+  }
+
+  /* Rotation dial */
+  .rotation-dial-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    margin-top: 16px;
+    width: 100%;
+    max-width: 320px;
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  .rotation-value {
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+    color: rgba(255, 255, 255, 0.4);
+    transition: color 0.15s;
+  }
+
+  .rotation-value.active {
+    color: white;
+  }
+
+  .dial-container {
+    position: relative;
+    width: 100%;
+    height: 40px;
+    overflow: hidden;
+  }
+
+  .dial-indicator {
+    position: absolute;
+    left: 50%;
+    top: 4px;
+    width: 2px;
+    height: 18px;
+    background: white;
+    transform: translateX(-50%);
+    z-index: 2;
+    border-radius: 1px;
+  }
+
+  .dial-track {
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    touch-action: none;
+    user-select: none;
+    display: flex;
+    align-items: flex-start;
+    padding-top: 4px;
+  }
+
+  .dial-track:active {
+    cursor: grabbing;
+  }
+
+  .dial-ruler {
+    display: flex;
+    align-items: flex-start;
+    margin-left: 50%;
+  }
+
+  .tick {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 6px;
+    flex-shrink: 0;
+  }
+
+  .tick-line {
+    width: 1px;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.25);
+    border-radius: 0.5px;
+  }
+
+  .tick.major .tick-line {
+    height: 14px;
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  .tick.zero .tick-line {
+    height: 16px;
+    width: 2px;
+    background: rgba(255, 255, 255, 0.7);
+  }
+
+  .tick-label {
+    font-size: 9px;
+    color: rgba(255, 255, 255, 0.4);
+    margin-top: 2px;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .tick.zero .tick-label {
+    color: rgba(255, 255, 255, 0.7);
   }
 </style>

--- a/web/src/lib/managers/edit/edit-manager.svelte.ts
+++ b/web/src/lib/managers/edit/edit-manager.svelte.ts
@@ -146,7 +146,8 @@ export class EditManager {
       this.hasAppliedEdits = true;
 
       return true;
-    } catch {
+    } catch (error) {
+      console.error('Edit apply failed:', error);
       toastManager.danger(t('editor_edits_applied_error'));
       return false;
     } finally {

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -62,12 +62,25 @@ class TransformManager implements EditToolManager {
     height: this.cropImageSize.height * this.cropImageScale,
   });
 
+  // CSS zoom applied after crop resize so the crop fills the editing area
+  cropZoom = $state(1);
+  // Frozen region used for zoom centering during drag — prevents coordinate drift
+  zoomAnchorRegion: Region | null = $state(null);
+
   imageRotation = $state(0);
+  freeRotation = $state(0);
+  isRotating = $state(false);
+  rotateStartAngle = $state(0);
+  rotateStartMouseAngle = $state(0);
   mirrorHorizontal = $state(false);
   mirrorVertical = $state(false);
   normalizedRotation = $derived.by(() => {
     const newAngle = this.imageRotation % 360;
     return newAngle < 0 ? newAngle + 360 : newAngle;
+  });
+  totalRotation = $derived.by(() => {
+    const total = (this.normalizedRotation + this.freeRotation) % 360;
+    return total < 0 ? total + 360 : total;
   });
   orientationChanged = $derived.by(() => this.normalizedRotation % 180 > 0);
 
@@ -81,10 +94,12 @@ class TransformManager implements EditToolManager {
       return;
     }
 
+    this.cropZoom = 1;
     const newCrop = transformManager.recalculateCrop(aspectRatio);
     if (newCrop) {
       transformManager.animateCropChange(this.cropAreaEl, this.region, newCrop);
       this.region = newCrop;
+      setTimeout(() => this.zoomToFillCrop(), 150);
     }
   }
 
@@ -94,7 +109,8 @@ class TransformManager implements EditToolManager {
       Math.abs(this.previewImageSize.height - this.region.height) > 2 ||
       this.mirrorHorizontal ||
       this.mirrorVertical ||
-      this.normalizedRotation !== 0
+      this.normalizedRotation !== 0 ||
+      this.freeRotation !== 0
     );
   }
 
@@ -153,11 +169,11 @@ class TransformManager implements EditToolManager {
       });
     }
 
-    if (this.normalizedRotation !== 0) {
+    if (this.totalRotation !== 0) {
       edits.push({
         action: AssetEditAction.Rotate,
         parameters: {
-          angle: this.normalizedRotation,
+          angle: this.totalRotation,
         },
       });
     }
@@ -167,8 +183,11 @@ class TransformManager implements EditToolManager {
 
   async resetAllChanges() {
     this.imageRotation = 0;
+    this.freeRotation = 0;
+    this.cropZoom = 1;
     this.mirrorHorizontal = false;
     this.mirrorVertical = false;
+
     await tick();
 
     this.onImageLoad([]);
@@ -200,7 +219,11 @@ class TransformManager implements EditToolManager {
     // Normalize rotation and mirror edits to single rotation and mirror state
     // This allows edits to be imported in any order and still produce correct state
     const normalizedTransformation = normalizeTransformEdits(transformEdits);
-    this.imageRotation = normalizedTransformation.rotation;
+    // Split into axis-aligned (90° increments) and free rotation parts
+    const totalRotation = normalizedTransformation.rotation;
+    const axisAligned = Math.round(totalRotation / 90) * 90;
+    this.imageRotation = axisAligned % 360;
+    this.freeRotation = totalRotation - axisAligned;
     this.mirrorHorizontal = normalizedTransformation.mirrorHorizontal;
     this.mirrorVertical = normalizedTransformation.mirrorVertical;
 
@@ -229,8 +252,12 @@ class TransformManager implements EditToolManager {
     document.body.style.cursor = '';
     this.cropAreaEl = null;
     this.isDragging = false;
+    this.isRotating = false;
     this.overlayEl = null;
     this.imageRotation = 0;
+    this.freeRotation = 0;
+    this.cropZoom = 1;
+    this.zoomAnchorRegion = null;
     this.mirrorHorizontal = false;
     this.mirrorVertical = false;
     this.region = { x: 0, y: 0, width: 100, height: 100 };
@@ -238,6 +265,7 @@ class TransformManager implements EditToolManager {
     this.originalImageSize = { width: 1000, height: 1000 };
     this.cropImageScale = 1;
     this.cropAspectRatio = 'free';
+
     this.hasChanges = false;
   }
 
@@ -263,6 +291,11 @@ class TransformManager implements EditToolManager {
     this.onImageLoad();
   }
 
+  setFreeRotation(angle: number) {
+    this.hasChanges = true;
+    this.freeRotation = angle;
+  }
+
   recalculateCrop(aspectRatio: string = this.cropAspectRatio): Region {
     if (!this.cropAreaEl) {
       return this.region;
@@ -271,25 +304,32 @@ class TransformManager implements EditToolManager {
     const canvasW = this.cropAreaEl.clientWidth;
     const canvasH = this.cropAreaEl.clientHeight;
 
-    // Calculate new dimensions with aspect ratio
-    const { newWidth: w, newHeight: h } = this.keepAspectRatio(this.region.width, this.region.height, aspectRatio);
+    const [widthRatio, heightRatio] = aspectRatio.split(':').map(Number);
 
-    // Scale down if needed to fit in canvas
-    let newWidth = w;
-    let newHeight = h;
-
-    if (w > canvasW) {
-      newWidth = canvasW;
-      newHeight = canvasW / (w / h);
-    } else if (h > canvasH) {
-      newHeight = canvasH;
-      newWidth = canvasH * (w / h);
+    if (!widthRatio || !heightRatio) {
+      // Free crop — return full canvas
+      return { x: 0, y: 0, width: canvasW, height: canvasH };
     }
 
-    // Constrain position to keep crop area within canvas
+    const ratio = widthRatio / heightRatio;
+    let newWidth: number;
+    let newHeight: number;
+
+    // Inscribe within full canvas so crop fills the editing area
+    if (canvasW / canvasH > ratio) {
+      // Canvas is wider than ratio — height fills, width shrinks
+      newHeight = canvasH;
+      newWidth = newHeight * ratio;
+    } else {
+      // Canvas is taller than ratio — width fills, height shrinks
+      newWidth = canvasW;
+      newHeight = newWidth / ratio;
+    }
+
+    // Center in canvas
     return {
-      x: Math.max(0, Math.min(this.region.x, canvasW - newWidth)),
-      y: Math.max(0, Math.min(this.region.y, canvasH - newHeight)),
+      x: (canvasW - newWidth) / 2,
+      y: (canvasH - newHeight) / 2,
       width: newWidth,
       height: newHeight,
     };
@@ -458,6 +498,7 @@ class TransformManager implements EditToolManager {
       return;
     }
 
+    this.cropZoom = 1;
     this.cropImageSize = { width: img.width, height: img.height };
     const scale = this.calculateScale();
 
@@ -582,6 +623,12 @@ class TransformManager implements EditToolManager {
       return;
     }
 
+    // Freeze the current region for zoom centering so the transform
+    // stays stable during the drag (prevents coordinate drift)
+    if (this.cropZoom !== 1) {
+      this.zoomAnchorRegion = { ...this.region };
+    }
+
     const { mouseX, mouseY } = this.getMousePosition(e);
 
     const {
@@ -636,10 +683,67 @@ class TransformManager implements EditToolManager {
     globalThis.removeEventListener('mouseup', this.handleMouseUp);
     document.body.style.userSelect = '';
 
+    const wasResizing = this.resizeSide !== '';
+    const wasDragging = this.isDragging;
+
     this.isInteracting = false;
     this.isDragging = false;
     this.resizeSide = '';
-    this.fadeOverlay(true); // Darken the background
+    this.zoomAnchorRegion = null;
+    this.fadeOverlay(true);
+
+    // After crop resize or drag, zoom to fill the editing area
+    if (wasResizing || wasDragging) {
+      setTimeout(() => this.zoomToFillCrop(), 200);
+    }
+  }
+
+  zoomToFillCrop() {
+    const cropArea = this.cropAreaEl;
+    if (!cropArea) return;
+
+    // Parent is the crop-viewport which excludes the dial
+    const viewport = cropArea.parentElement;
+    if (!viewport) return;
+
+    const containerW = viewport.clientWidth;
+    const containerH = viewport.clientHeight;
+    const { width: cropW, height: cropH } = this.region;
+
+    if (cropW <= 0 || cropH <= 0) return;
+
+    // Leave padding so dimmed image is visible around the crop (like Google Photos)
+    const padding = 40;
+    const zoom = Math.min((containerW - padding * 2) / cropW, (containerH - padding * 2) / cropH);
+    if (zoom <= 1.05) {
+      this.cropZoom = 1;
+      return;
+    }
+
+    this.cropZoom = Math.min(zoom, 5);
+    this.draw();
+  }
+
+  // During drag, reduce zoom if the crop has grown beyond what fits with padding
+  adjustZoomDuringInteraction() {
+    if (this.cropZoom <= 1) return;
+
+    const viewport = this.cropAreaEl?.parentElement;
+    if (!viewport) return;
+
+    const containerW = viewport.clientWidth;
+    const containerH = viewport.clientHeight;
+    const { width: cropW, height: cropH } = this.region;
+
+    const padding = 40;
+    const neededZoom = Math.min((containerW - padding * 2) / cropW, (containerH - padding * 2) / cropH);
+
+    // Only reduce zoom (never increase during drag)
+    if (neededZoom < this.cropZoom) {
+      this.cropZoom = Math.max(1, neededZoom);
+      // Update anchor to current region so centering follows the crop
+      this.zoomAnchorRegion = { ...this.region };
+    }
   }
 
   getMousePosition(e: MouseEvent) {
@@ -647,7 +751,6 @@ class TransformManager implements EditToolManager {
     let offsetY = e.clientY;
     const clienRect = this.cropAreaEl?.getBoundingClientRect();
     const rotateDeg = this.normalizedRotation;
-
     if (rotateDeg == 90) {
       offsetX = e.clientY - (clienRect?.top ?? 0);
       offsetY = window.innerWidth - e.clientX - (window.innerWidth - (clienRect?.right ?? 0));
@@ -661,6 +764,13 @@ class TransformManager implements EditToolManager {
       offsetX -= clienRect?.left ?? 0;
       offsetY -= clienRect?.top ?? 0;
     }
+
+    // Convert from visual (CSS-scaled) coordinates to layout coordinates
+    if (this.cropZoom !== 1) {
+      offsetX /= this.cropZoom;
+      offsetY /= this.cropZoom;
+    }
+
     return { mouseX: offsetX, mouseY: offsetY };
   }
 
@@ -782,6 +892,7 @@ class TransformManager implements EditToolManager {
     };
 
     this.draw();
+    this.adjustZoomDuringInteraction();
   }
 
   resizeCrop(mouseX: number, mouseY: number) {
@@ -950,6 +1061,7 @@ class TransformManager implements EditToolManager {
     };
 
     this.draw();
+    this.adjustZoomDuringInteraction();
   }
 
   updateCursor(mouseX: number, mouseY: number) {
@@ -1043,6 +1155,7 @@ class TransformManager implements EditToolManager {
 
   resetCrop() {
     this.cropAspectRatio = 'free';
+    this.cropZoom = 1;
     this.region = {
       x: 0,
       y: 0,

--- a/web/src/lib/utils/editor.ts
+++ b/web/src/lib/utils/editor.ts
@@ -12,12 +12,20 @@ export const normalizeTransformEdits = (
   mirrorVertical: boolean;
 } => {
   const { a, b, c, d } = buildAffineFromEdits(edits);
-  const rotation = ((isCloseToZero(a) ? Math.asin(c) : Math.acos(a)) * 180) / Math.PI;
+
+  // Use atan2 for robust angle extraction that works with arbitrary angles
+  // The matrix encodes rotation as: a=cos, b=-sin, c=sin, d=cos (negated due to coordinate system)
+  const rotation = ((-Math.atan2(c, a)) * 180) / Math.PI;
+  const normalizedRotation = rotation < 0 ? 360 + rotation : rotation;
+
+  // Detect mirroring by checking if the determinant is negative
+  const det = a * d - b * c;
+  const isMirrored = det < 0;
 
   return {
-    rotation: rotation < 0 ? 360 + rotation : rotation,
+    rotation: normalizedRotation,
     mirrorHorizontal: false,
-    mirrorVertical: isCloseToZero(a) ? b === c : a === -d,
+    mirrorVertical: isMirrored,
   };
 };
 


### PR DESCRIPTION
## Description

Adds two new features to the photo editor:

1. **Free rotation dial** — A draggable dial control (-45° to +45°) below the crop area for arbitrary-angle image rotation. The rotated image auto-scales to fully cover the crop frame, so no black corners are visible in the editor.

2. **Crop zoom-to-fill** — Google Photos-style behavior where after resizing the crop frame, the view smoothly zooms so the crop nearly fills the editing area with ~40px padding of dimmed image visible. Expanding the crop while zoomed dynamically reduces the zoom level.

Server-side changes:
- Rotation validation now accepts any angle 0–360 (not just 90° increments)
- `applyEdits` splits rotation into 90° (via `sharp.rotate()`, no canvas expansion) + free component with inscribed rectangle extraction to eliminate black corner triangles
- Fixed thumbhash generation for rotated images that exceed 100×100 after affine transforms

## How Has This Been Tested?

- [x] Tested free rotation at various angles (-45° to +45°) — crop frame stays fully covered
- [x] Tested crop zoom-to-fill with landscape, portrait, and square images
- [x] Tested combined operations: crop → rotate → mirror → save
- [x] Tested server-side output: saved images have no black corners at arbitrary angles
- [x] Tested 90° rotation increments still work correctly
- [x] Tested on self-hosted immich instance (Docker, linux/amd64)
- [x] Existing controller spec updated and passing

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was developed with significant assistance from Claude (Anthropic). Claude helped with:
- Implementing the free rotation dial UI and zoom-to-fill crop behavior
- Server-side rotation pipeline (splitting into 90° + free components, inscribed rectangle extraction)
- Debugging CSS transform interactions with Svelte reactivity
- Writing this PR description

All code was reviewed, tested, and validated by the author on a self-hosted immich instance.