### PR TITLE
feat(mobile): use material design 3 slider

### DIFF
--- a/mobile/lib/theme/theme_data.dart
+++ b/mobile/lib/theme/theme_data.dart
@@ -62,8 +62,6 @@ ThemeData getThemeData({required ColorScheme colorScheme, required Locale locale
     ),
     chipTheme: const ChipThemeData(side: BorderSide.none),
     sliderTheme: const SliderThemeData(
-      thumbShape: RoundSliderThumbShape(enabledThumbRadius: 7),
-      trackHeight: 2.0,
       // ignore: deprecated_member_use
       year2023: false,
     ),

--- a/mobile/lib/widgets/asset_viewer/video_controls.dart
+++ b/mobile/lib/widgets/asset_viewer/video_controls.dart
@@ -14,6 +14,8 @@ import 'package:immich_mobile/widgets/asset_viewer/animated_play_pause.dart';
 class VideoControls extends HookConsumerWidget {
   final String videoPlayerName;
 
+  static const List<Shadow> _controlShadows = [Shadow(color: Colors.black87, blurRadius: 6, offset: Offset(0, 1))];
+
   const VideoControls({super.key, required this.videoPlayerName});
 
   void _toggle(WidgetRef ref, bool isCasting) {
@@ -70,14 +72,17 @@ class VideoControls extends HookConsumerWidget {
         children: [
           Row(
             children: [
-              IconButton(
-                iconSize: 32,
-                padding: const EdgeInsets.all(12),
-                constraints: const BoxConstraints(),
-                icon: isFinished
-                    ? const Icon(Icons.replay, color: Colors.white, size: 32)
-                    : AnimatedPlayPause(color: Colors.white, size: 32, playing: isPlaying),
-                onPressed: () => _toggle(ref, isCasting),
+              IconTheme(
+                data: const IconThemeData(shadows: _controlShadows),
+                child: IconButton(
+                  iconSize: 32,
+                  padding: const EdgeInsets.all(12),
+                  constraints: const BoxConstraints(),
+                  icon: isFinished
+                      ? const Icon(Icons.replay, color: Colors.white, size: 32)
+                      : AnimatedPlayPause(color: Colors.white, size: 32, playing: isPlaying),
+                  onPressed: () => _toggle(ref, isCasting),
+                ),
               ),
               const Spacer(),
               Text(
@@ -86,6 +91,7 @@ class VideoControls extends HookConsumerWidget {
                   color: Colors.white,
                   fontWeight: FontWeight.w500,
                   fontFeatures: [FontFeature.tabularFigures()],
+                  shadows: _controlShadows,
                 ),
               ),
               const SizedBox(width: 16),


### PR DESCRIPTION
## Description

The new slider is easier to use, and looks more modern.

## How Has This Been Tested?

Pixel 8a.

<details><summary><h2>Before / after:</h2></summary>

<p>
<img width="350" height="2400" alt="Screenshot_20260310-193421" src="https://github.com/user-attachments/assets/ae286d0a-de88-4465-abf1-7c10beb1fb0f" />

<img width="350" height="2400" alt="Screenshot_20260310-193533" src="https://github.com/user-attachments/assets/005559e2-0db1-4f6e-9698-c67c161d6a38" />
</p>

</details>

