### PR TITLE
fix: use correct original URL for 360 video panorama playback

### DIFF
--- a/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getAssetPlaybackUrl, getAssetMediaUrl } from '$lib/utils';
-  import { AssetMediaSize, type AssetResponseDto } from '@immich/sdk';
+  import { getAssetPlaybackUrl, getAssetUrl } from '$lib/utils';
+  import type { AssetResponseDto } from '@immich/sdk';
   import { LoadingSpinner } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
@@ -25,7 +25,7 @@
   {:then [PhotoSphereViewer, adapter, videoPlugin]}
     <PhotoSphereViewer
       panorama={{ source: getAssetPlaybackUrl({ id: asset.id }) }}
-      originalPanorama={{ source: getAssetMediaUrl({ id: asset.id, size: AssetMediaSize.Original }) }}
+      originalPanorama={{ source: getAssetUrl({ asset, forceOriginal: true })! }}
       plugins={[videoPlugin]}
       {adapter}
       navbar

--- a/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getAssetPlaybackUrl, getAssetUrl } from '$lib/utils';
-  import type { AssetResponseDto } from '@immich/sdk';
+  import { getAssetPlaybackUrl, getAssetMediaUrl } from '$lib/utils';
+  import { AssetMediaSize, type AssetResponseDto } from '@immich/sdk';
   import { LoadingSpinner } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
@@ -25,7 +25,7 @@
   {:then [PhotoSphereViewer, adapter, videoPlugin]}
     <PhotoSphereViewer
       panorama={{ source: getAssetPlaybackUrl({ id: asset.id }) }}
-      originalPanorama={{ source: getAssetUrl({ asset, forceOriginal: true })! }}
+      originalPanorama={{ source: getAssetMediaUrl({ id: asset.id, size: AssetMediaSize.Original }) }}
       plugins={[videoPlugin]}
       {adapter}
       navbar

--- a/web/src/lib/utils.spec.ts
+++ b/web/src/lib/utils.spec.ts
@@ -74,6 +74,32 @@ describe('utils', () => {
       expect(url).toContain(asset.id);
     });
 
+    it('should return original URL for video assets with forceOriginal', () => {
+      const asset = assetFactory.build({
+        originalPath: 'video.mp4',
+        originalMimeType: 'video/mp4',
+        type: AssetTypeEnum.Video,
+      });
+
+      const url = getAssetUrl({ asset, forceOriginal: true });
+
+      expect(url).toContain('/original');
+      expect(url).toContain(asset.id);
+    });
+
+    it('should return thumbnail URL for video assets without forceOriginal', () => {
+      const asset = assetFactory.build({
+        originalPath: 'video.mp4',
+        originalMimeType: 'video/mp4',
+        type: AssetTypeEnum.Video,
+      });
+
+      const url = getAssetUrl({ asset });
+
+      expect(url).toContain('/thumbnail');
+      expect(url).toContain(asset.id);
+    });
+
     it('should return thumbnail URL for static images in shared link even with download and showMetadata permissions', () => {
       const asset = assetFactory.build({
         originalPath: 'image.gif',

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -220,7 +220,9 @@ const forceUseOriginal = (asset: AssetResponseDto) => {
 
 export const targetImageSize = (asset: AssetResponseDto, forceOriginal: boolean) => {
   if (forceOriginal || get(alwaysLoadOriginalFile) || forceUseOriginal(asset)) {
-    return isWebCompatibleImage(asset) ? AssetMediaSize.Original : AssetMediaSize.Fullsize;
+    return asset.type === AssetTypeEnum.Video || isWebCompatibleImage(asset)
+      ? AssetMediaSize.Original
+      : AssetMediaSize.Fullsize;
   }
   return AssetMediaSize.Preview;
 };


### PR DESCRIPTION
## Description

360° panorama video playback fails at "Original" quality starting in v2.5.0. The error in the UI is **"The panorama cannot be loaded."** Default (preview) quality works fine.

**Root cause:** PR #25436 changed `video-panorama-viewer.svelte` from using `getAssetOriginalUrl(assetId)` to `getAssetUrl({ asset, forceOriginal: true })`. The new `getAssetUrl` function calls `targetImageSize()`, which returns `AssetMediaSize.Fullsize` instead of `AssetMediaSize.Original` for video assets (since `isWebCompatibleImage()` returns `false` for videos). This causes `getAssetMediaUrl` to use `getAssetThumbnailPath` instead of `getAssetOriginalPath`, serving a thumbnail instead of the original video file to the photo-sphere-viewer.

**Fix:** Use `getAssetMediaUrl` directly with `AssetMediaSize.Original` to always serve the original video file for the panorama viewer, matching the pre-v2.5.0 behavior.

**Browser console errors before fix:**
```
THREE.WARNING: Multiple instances of Three.js being imported.
Uncaught (in promise) Event
```

## How Has This Been Tested?

Tested by deploying custom-built Docker images with this fix applied against a live Immich instance with GoPro Max 360° HEVC videos imported via external library.

**Version testing performed:**

| Version | Original Quality | Default Quality |
|---------|-----------------|-----------------|
| v2.3.1 | ✅ Works | ✅ Works |
| v2.4.1 | ✅ Works | ✅ Works |
| v2.5.0 | ❌ Broken | ✅ Works |
| v2.5.6 | ❌ Broken | ✅ Works |
| v2.5.6 + this fix | ✅ Works | ✅ Works |

- [x] Verified 360° video plays at original quality after fix
- [x] Verified 360° video plays at default quality (unchanged)
- [x] Verified resolution auto-upgrade at 75% zoom still works
- [x] Verified non-panorama assets are not affected

**Reproduction steps:**
1. Upload or import a 360° equirectangular video (e.g., GoPro Max HEVC .mp4)
2. Open the video in the asset viewer
3. Use the settings/quality menu to switch to "Original" quality
4. Panorama viewer fails with "The panorama cannot be loaded"

**Environment:**
- Docker Compose deployment, Ubuntu 22.04, Linux 6.8.0
- GoPro Max2 360° HEVC videos via external library
- Tested on Chrome

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This bug was identified, root-cause analyzed, and the fix was developed with the assistance of **Claude Opus 4.6** (Anthropic's Claude Code CLI). The entire debugging process — including version bisecting (v2.3.1 → v2.4.1 → v2.5.0 → v2.5.6), tracing the code path through `getAssetUrl` → `targetImageSize` → `isWebCompatibleImage` → `getAssetMediaUrl`, identifying the regression introduced by PR #25436, building and testing the fix via custom Docker images — was done collaboratively with Claude. The actual code change is 3 lines (2 import changes + 1 function call change).