### PR TITLE
fix(server): extract make/model from sony video files

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -72,6 +72,8 @@ export interface ImmichTags extends Omit<Tags, TagsWithWrongTypes> {
 
   AndroidMake?: string;
   AndroidModel?: string;
+  DeviceManufacturer?: string;
+  DeviceModelName?: string;
 }
 
 @Injectable()

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1569,6 +1569,10 @@ describe(MetadataService.name, () => {
       },
       { exif: { AndroidMake: '1', AndroidModel: '2' }, expected: { make: '1', model: '2' } },
       { exif: { DeviceManufacturer: '1', DeviceModelName: '2' }, expected: { make: '1', model: '2' } },
+      {
+        exif: { Make: '1', Model: '2', DeviceManufacturer: '3', DeviceModelName: '4' },
+        expected: { make: '1', model: '2' },
+      },
     ])('should read camera make and model $exif -> $expected', async ({ exif, expected }) => {
       const asset = AssetFactory.create();
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset);

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1568,6 +1568,7 @@ describe(MetadataService.name, () => {
         expected: { make: '1', model: '2' },
       },
       { exif: { AndroidMake: '1', AndroidModel: '2' }, expected: { make: '1', model: '2' } },
+      { exif: { DeviceManufacturer: '1', DeviceModelName: '2' }, expected: { make: '1', model: '2' } },
     ])('should read camera make and model $exif -> $expected', async ({ exif, expected }) => {
       const asset = AssetFactory.create();
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -289,8 +289,8 @@ export class MetadataService extends BaseService {
       colorspace: exifTags.ColorSpace === undefined ? null : String(exifTags.ColorSpace),
 
       // camera
-      make: exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? exifTags.DeviceManufacturer ?? null,
-      model: exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? exifTags.DeviceModelName ?? null,
+      make: exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? (exifTags.DeviceManufacturer || null),
+      model: exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? (exifTags.DeviceModelName || null),
       fps: validate(Number.parseFloat(exifTags.VideoFrameRate!)),
       iso: validate(exifTags.ISO) as number,
       exposureTime: exifTags.ExposureTime ?? null,

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -289,8 +289,8 @@ export class MetadataService extends BaseService {
       colorspace: exifTags.ColorSpace === undefined ? null : String(exifTags.ColorSpace),
 
       // camera
-      make: exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? null,
-      model: exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? null,
+      make: exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? exifTags.DeviceManufacturer ?? null,
+      model: exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? exifTags.DeviceModelName ?? null,
       fps: validate(Number.parseFloat(exifTags.VideoFrameRate!)),
       iso: validate(exifTags.ISO) as number,
       exposureTime: exifTags.ExposureTime ?? null,

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -289,8 +289,10 @@ export class MetadataService extends BaseService {
       colorspace: exifTags.ColorSpace === undefined ? null : String(exifTags.ColorSpace),
 
       // camera
-      make: exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? (exifTags.DeviceManufacturer || null),
-      model: exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? (exifTags.DeviceModelName || null),
+      make:
+        exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? (exifTags.DeviceManufacturer || null),
+      model:
+        exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? (exifTags.DeviceModelName || null),
       fps: validate(Number.parseFloat(exifTags.VideoFrameRate!)),
       iso: validate(exifTags.ISO) as number,
       exposureTime: exifTags.ExposureTime ?? null,


### PR DESCRIPTION
## Description

Sony XAVC .mp4 video files (recorded by Sony cameras such as the ILCE-7CM2, and other A7 series cameras) store camera manufacturer and model information in non standard `DeviceManufacturer` and `DeviceModelName` tags rather than the standard EXIF `Make` and `Model` tags. As a result, Immich is unable to extract camera make and model from these files during its metadata extraction.

This change adds `DeviceManufacturer` and `DeviceModelName` as additional fallbacks in the make/model extraction chain, consistent with the existing pattern of falling back to `Device.Manufacturer`, `Device.ModelName`, `AndroidMake`, and `AndroidModel`.

## How Has This Been Tested?
- [x] Confirmed that the `DeviceManufacturer` and `DeviceModelName` tags are present in Sony XAVC video files via ExifTool (see screenshot)
- [x] Verified that Sony XAVC .MP4 files recorded on an ILCE-7CM2 now correctly show Sony and ILCE-7CM2 as make and model in Immich after metadata refresh
- [x] Confirmed no regression for files that already have standard Make/Model tags (this includes other mirrorless cameras inc. Fujifilm X-T4, X-T5, X100V), as the new fallbacks are last in the chain

## Screenshots (if appropriate)
How exiftool typically (and successfully) extracts Make and Model from a file
<img width="1343" height="104" alt="Screenshot 2026-03-11 at 2 54 14 am" src="https://github.com/user-attachments/assets/9a52dbd8-c1d0-4297-ac02-8f0e9c73116a" />

The same flags failing on Sony video files, and how alternative flags can provide this info instead
<img width="1976" height="176" alt="Screenshot 2026-03-11 at 2 40 21 am" src="https://github.com/user-attachments/assets/cb627fd8-8d06-4136-bb30-db3c9180463e" />

How Sony video files are appear currently
<img width="413" height="436" alt="Screenshot 2026-03-11 at 2 37 27 am" src="https://github.com/user-attachments/assets/897fa518-e0ec-404a-8d57-c3d98d151c4e" />

How Sony video files appear after this fix
<img width="411" height="475" alt="Screenshot 2026-03-11 at 3 01 57 am" src="https://github.com/user-attachments/assets/bc86ae3a-3630-4c11-88b1-a464e1af305f" />
