### PR TITLE
fix(server): keep properties locked when cleared to blank

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1816,6 +1816,22 @@ describe(MetadataService.name, () => {
       expect(mocks.metadata.writeTags).toHaveBeenCalledWith(asset.files[0].path, { Rating: 0 });
       expect(mocks.asset.unlockProperties).toHaveBeenCalledWith(asset.id, ['rating']);
     });
+
+    it('should not unlock properties with empty values that exiftool cannot persist', async () => {
+      const asset = factory.jobAssets.sidecarWrite();
+      asset.exifInfo.description = '';
+
+      mocks.assetJob.getLockedPropertiesForMetadataExtraction.mockResolvedValue(['description']);
+      mocks.assetJob.getForSidecarWriteJob.mockResolvedValue(asset);
+
+      await expect(sut.handleSidecarWrite({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.metadata.writeTags).toHaveBeenCalledWith(asset.files[0].path, {
+        Description: '',
+        ImageDescription: '',
+      });
+      expect(mocks.asset.unlockProperties).not.toHaveBeenCalled();
+    });
   });
 
   describe('firstDateTime', () => {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -481,7 +481,17 @@ export class MetadataService extends BaseService {
       await this.assetRepository.upsertFile({ assetId: id, type: AssetFileType.Sidecar, path: sidecarPath });
     }
 
-    await this.assetRepository.unlockProperties(asset.id, lockedProperties);
+    // ExifTool treats empty strings as "delete tag", so empty/null values won't be
+    // persisted in the sidecar file. Keep those properties locked to prevent metadata
+    // re-extraction from overwriting them with the original embedded values.
+    const propertiesToUnlock = lockedProperties.filter((property) => {
+      const value = { description, dateTimeOriginal, latitude, longitude, rating, tags, timeZone }[property];
+      return value !== '' && value !== null;
+    });
+
+    if (propertiesToUnlock.length > 0) {
+      await this.assetRepository.unlockProperties(asset.id, propertiesToUnlock);
+    }
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
## Description

When a user clears an image description to blank, the empty value is not persisted in the sidecar file because ExifTool treats empty strings as "delete tag". On the next metadata extraction, the original embedded EXIF value overwrites the user's change, effectively reverting the description.

This fix keeps properties with empty/null values locked after a sidecar write, preventing metadata re-extraction from restoring the original embedded values.

Fixes #19168

## How Has This Been Tested?

- Added unit test verifying that properties with empty values are not unlocked after sidecar write
- All existing metadata service tests pass (2079 tests)

## Checklist

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [ ] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code was used to explore the codebase structure and assist with writing the implementation. The approach was informed by a prior PR (#26504) that addressed the same issue but was closed due to an incomplete PR template. All code was reviewed and understood before submission.