### PR TITLE
chore(mobile): remove background from asset viewer back button

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart
@@ -113,17 +113,14 @@ class _AppBarBackButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final showingDetails = ref.watch(assetViewerProvider.select((state) => state.showingDetails));
-    final backgroundColor = showingDetails && !context.isDarkTheme ? Colors.white : Colors.black;
-    final foregroundColor = showingDetails && !context.isDarkTheme ? Colors.black : Colors.white;
-
     return Padding(
       padding: const EdgeInsets.only(left: 12.0),
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          backgroundColor: backgroundColor,
+          backgroundColor: showingDetails ? context.colorScheme.surface : Colors.transparent,
           shape: const CircleBorder(),
           iconSize: 22,
-          iconColor: foregroundColor,
+          iconColor: showingDetails ? context.colorScheme.onSurface : Colors.white,
           padding: EdgeInsets.zero,
           elevation: showingDetails ? 4 : 0,
         ),


### PR DESCRIPTION
## Description

We recently changed the asset viewer to use a gradient. The circle button looks out of place now.

## How Has This Been Tested?

Pixel 8a.

<details><summary><h2>Screenshots (before/after)</h2></summary>

<!-- Images go below this line. -->

<img width="1080" height="2400" alt="Screenshot_20260311-160823" src="https://github.com/user-attachments/assets/81680a7e-de91-4ad4-bcd6-b25e52500281" />

<img width="1080" height="2400" alt="Screenshot_20260311-160804" src="https://github.com/user-attachments/assets/07143049-7dd6-4ded-9b95-7062a1b6b9f0" />


</details>
