### PR TITLE
fix(web): exclude emoji from translation string

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1072,7 +1072,7 @@
     "failed_to_update_notification_status": "Failed to update notification status",
     "incorrect_email_or_password": "Incorrect email or password",
     "library_folder_already_exists": "This import path already exists.",
-    "page_not_found": "Page not found :/",
+    "page_not_found": "Page not found",
     "paths_validation_failed": "{paths, plural, one {# path} other {# paths}} failed validation",
     "profile_picture_transparent_pixels": "Profile pictures cannot have transparent pixels. Please zoom in and/or move the image.",
     "quota_higher_than_disk_size": "You set a quota higher than the disk size",

--- a/web/src/lib/components/pages/SharedLinkErrorPage.svelte
+++ b/web/src/lib/components/pages/SharedLinkErrorPage.svelte
@@ -8,7 +8,7 @@
 </svelte:head>
 
 <section class="flex flex-col px-4 h-dvh w-dvw place-content-center place-items-center">
-  <h1 class="py-10 text-4xl text-primary">{$t('errors.page_not_found')}</h1>
+  <h1 class="py-10 text-4xl text-primary"><span>{$t('errors.page_not_found')}</span><span class="ps-3">:/</span></h1>
   {#if page.error?.message}
     <h2 class="text-xl text-immich-fg dark:text-immich-dark-fg">{page.error.message}</h2>
   {/if}


### PR DESCRIPTION
re: https://github.com/immich-app/immich/pull/26517#discussion_r2854422843

I'm in favor of keeping the emoji as it adds a light note to the error page.
