### PR TITLE
fix(mobile): duplicate server urls returned

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -176,10 +176,6 @@ class ApiService {
     if (serverEndpoint != null && serverEndpoint.isNotEmpty) {
       urls.add(serverEndpoint);
     }
-    final serverUrl = Store.tryGet(StoreKey.serverUrl);
-    if (serverUrl != null && serverUrl.isNotEmpty) {
-      urls.add(serverUrl);
-    }
     final localEndpoint = Store.tryGet(StoreKey.localEndpoint);
     if (localEndpoint != null && localEndpoint.isNotEmpty) {
       urls.add(localEndpoint);


### PR DESCRIPTION
## Description

getServerUrls returns the same URL twice because serverUrl and serverEndpoint are actually the same thing in practice.