### PR TITLE
fix(mobile): video auth

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -112,6 +112,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
+  implementation "androidx.media3:media3-datasource-okhttp:1.8.0"
   implementation 'org.chromium.net:cronet-embedded:143.7445.0'
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
   implementation "androidx.work:work-runtime-ktx:$work_version"

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
@@ -12,6 +12,8 @@ import app.alextran.immich.connectivity.ConnectivityApiImpl
 import app.alextran.immich.core.HttpClientManager
 import app.alextran.immich.core.ImmichPlugin
 import app.alextran.immich.core.NetworkApiPlugin
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import me.albemala.native_video_player.NativeVideoPlayerPlugin
 import app.alextran.immich.images.LocalImageApi
 import app.alextran.immich.images.LocalImagesImpl
 import app.alextran.immich.images.RemoteImageApi
@@ -31,6 +33,7 @@ class MainActivity : FlutterFragmentActivity() {
   companion object {
     fun registerPlugins(ctx: Context, flutterEngine: FlutterEngine) {
       HttpClientManager.initialize(ctx)
+      NativeVideoPlayerPlugin.dataSourceFactory = { OkHttpDataSource.Factory(HttpClientManager.getClient()) }
       flutterEngine.plugins.add(NetworkApiPlugin())
 
       val messenger = flutterEngine.dartExecutor.binaryMessenger

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -67,6 +67,9 @@ class URLSessionManager: NSObject {
     delegate = URLSessionManagerDelegate()
     session = Self.buildSession(delegate: delegate)
     super.init()
+    if #available(iOS 15, *) {
+      VideoProxyServer.shared.session = session
+    }
     Self.serverUrls = UserDefaults.group.stringArray(forKey: SERVER_URLS_KEY) ?? []
     NotificationCenter.default.addObserver(
       Self.self,
@@ -78,6 +81,9 @@ class URLSessionManager: NSObject {
 
   func recreateSession() {
     session = Self.buildSession(delegate: delegate)
+    if #available(iOS 15, *) {
+      VideoProxyServer.shared.session = session
+    }
   }
 
   static func setServerUrls(_ urls: [String]) {


### PR DESCRIPTION

## Description

It looks like recent changes to auth did not include videos, and so no auth was being sent when loading them.
