### PR TITLE
fix(web): fix zoom touch event handling 

### DIFF
--- a/web/src/lib/actions/zoom-image.ts
+++ b/web/src/lib/actions/zoom-image.ts
@@ -23,7 +23,25 @@ export const zoomImageAction = (node: HTMLElement, options?: { disabled?: boolea
   node.addEventListener('wheel', onInteractionStart, { capture: true });
   node.addEventListener('pointerdown', onInteractionStart, { capture: true });
 
+  // Suppress Safari's synthetic dblclick on double-tap. Without this, zoom-image's touchstart
+  // handler zooms to maxZoom (10x), then Safari's synthetic dblclick triggers photo-viewer's
+  // handler which conflicts. Chrome does not fire synthetic dblclick on touch.
+  let lastPointerWasTouch = false;
+  const trackPointerType = (event: PointerEvent) => {
+    lastPointerWasTouch = event.pointerType === 'touch';
+  };
+  const suppressTouchDblClick = (event: MouseEvent) => {
+    if (lastPointerWasTouch) {
+      event.stopImmediatePropagation();
+    }
+  };
+  node.addEventListener('pointerdown', trackPointerType, { capture: true });
+  node.addEventListener('dblclick', suppressTouchDblClick, { capture: true });
+
+  // Allow zoomed content to render outside the container bounds
   node.style.overflow = 'visible';
+  // Prevent browser handling of touch gestures so zoom-image can manage them
+  node.style.touchAction = 'none';
   return {
     update(newOptions?: { disabled?: boolean }) {
       options = newOptions;
@@ -34,6 +52,8 @@ export const zoomImageAction = (node: HTMLElement, options?: { disabled?: boolea
       }
       node.removeEventListener('wheel', onInteractionStart, { capture: true });
       node.removeEventListener('pointerdown', onInteractionStart, { capture: true });
+      node.removeEventListener('pointerdown', trackPointerType, { capture: true });
+      node.removeEventListener('dblclick', suppressTouchDblClick, { capture: true });
       zoomInstance.cleanup();
     },
   };

--- a/web/src/lib/components/AdaptiveImage.svelte
+++ b/web/src/lib/components/AdaptiveImage.svelte
@@ -162,8 +162,9 @@
 <div class="relative h-full w-full overflow-hidden will-change-transform" bind:this={ref}>
   {@render backdrop?.()}
 
+  <!-- pointer-events-none so events pass through to the container where zoom-image listens -->
   <div
-    class="absolute inset-0"
+    class="absolute inset-0 pointer-events-none"
     style:transform={zoomTransform}
     style:transform-origin={zoomTransform ? '0 0' : undefined}
   >


### PR DESCRIPTION
Three fixes for zoom behavior:

`pointer-events-none` on the zoom transform wrapper — The div that applies the zoom transform was intercepting pointer events, preventing them from reaching the container where zoom-image's listeners live. Making it transparent to events lets clicks, touches, and gestures pass through correctly. 

`touchAction = 'none'` — Without this, the browser tries to handle touch gestures itself (scroll, pinch-to-zoom, etc.) which fights with zoom-image's own touch handling. Disabling it gives zoom-image full control.  introduced by #26636

`stopImmediatePropagation` on touch dblclick — On double-tap, zoom-image detects it via `touchstart` timing and zooms to maxZoom (10x). But Safari also fires a synthetic `dblclick` event, which triggers photo-viewer's double-click handler and conflicts with the zoom already in progress (you'd see it start zooming in then snap back). This suppresses that synthetic `dblclick` on touch devices. Chrome doesn't have this issue since it doesn't fire synthetic `dblclick` on touch. 


related #26636 #26732