### PR TITLE
fix(web): escape handling for tagging and adding a face in asset viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -35,7 +35,7 @@
     type PersonResponseDto,
     type StackResponseDto,
   } from '@immich/sdk';
-  import { ActionButton, CommandPaletteDefaultProvider, Tooltip, isModalOpen, type ActionItem } from '@immich/ui';
+  import { ActionButton, CommandPaletteDefaultProvider, Tooltip, type ActionItem } from '@immich/ui';
   import LoadingDots from '$lib/components/LoadingDots.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import {
@@ -91,7 +91,7 @@
     icon: languageManager.rtl ? mdiArrowRight : mdiArrowLeft,
     $if: () => !!onClose,
     onAction: () => onClose?.(),
-    shortcuts: isModalOpen() || isFaceEditMode.value ? [] : [{ key: 'Escape' }],
+    shortcuts: isFaceEditMode.value ? [] : [{ key: 'Escape' }],
   });
 
   const Actions = $derived(getAssetActions($t, asset));

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -22,6 +22,7 @@
   import { Route } from '$lib/route';
   import { getGlobalActions } from '$lib/services/app.service';
   import { getAssetActions } from '$lib/services/asset.service';
+  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { user } from '$lib/stores/user.store';
   import { getSharedLink, withoutIcons } from '$lib/utils';
   import type { OnUndoDelete } from '$lib/utils/actions';
@@ -34,7 +35,7 @@
     type PersonResponseDto,
     type StackResponseDto,
   } from '@immich/sdk';
-  import { ActionButton, CommandPaletteDefaultProvider, Tooltip, type ActionItem } from '@immich/ui';
+  import { ActionButton, CommandPaletteDefaultProvider, Tooltip, isModalOpen, type ActionItem } from '@immich/ui';
   import LoadingDots from '$lib/components/LoadingDots.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import {
@@ -90,7 +91,7 @@
     icon: languageManager.rtl ? mdiArrowRight : mdiArrowLeft,
     $if: () => !!onClose,
     onAction: () => onClose?.(),
-    shortcuts: [{ key: 'Escape' }],
+    shortcuts: isModalOpen() || isFaceEditMode.value ? [] : [{ key: 'Escape' }],
   });
 
   const Actions = $derived(getAssetActions($t, asset));

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -89,9 +89,9 @@
     title: $t('go_back'),
     type: $t('assets'),
     icon: languageManager.rtl ? mdiArrowRight : mdiArrowLeft,
-    $if: () => !!onClose,
+    $if: () => !!onClose && !isFaceEditMode.value,
     onAction: () => onClose?.(),
-    shortcuts: isFaceEditMode.value ? [] : [{ key: 'Escape' }],
+    shortcuts: [{ key: 'Escape' }],
   });
 
   const Actions = $derived(getAssetActions($t, asset));

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -272,6 +272,14 @@
   };
 </script>
 
+<svelte:document
+  onkeydown={(e) => {
+    if (e.key === 'Escape') {
+      cancel();
+    }
+  }}
+/>
+
 <div
   id="face-editor-data"
   class="absolute start-0 top-0 z-5 h-full w-full overflow-hidden"

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -6,6 +6,7 @@
   import { getNaturalSize, scaleToFit } from '$lib/utils/container-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { createFace, getAllPeople, type PersonResponseDto } from '@immich/sdk';
+  import { shortcut } from '$lib/actions/shortcut';
   import { Button, Input, modalManager, toastManager } from '@immich/ui';
   import { Canvas, InteractiveFabricObject, Rect } from 'fabric';
   import { clamp } from 'lodash-es';
@@ -272,13 +273,7 @@
   };
 </script>
 
-<svelte:document
-  onkeydown={(e) => {
-    if (e.key === 'Escape') {
-      cancel();
-    }
-  }}
-/>
+<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: cancel }} />
 
 <div
   id="face-editor-data"

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -345,8 +345,10 @@
         {
           shortcut: { key: 'Escape' },
           onShortcut: (event) => {
-            event.stopPropagation();
-            closeDropdown();
+            if (isOpen) {
+              event.stopPropagation();
+              closeDropdown();
+            }
           },
         },
       ]}


### PR DESCRIPTION
## Description
In #25627 there was already a fix for esc-key handling, but also a comment that it does not work for all modals in asset viewer.
For my currently only adding to an album can be closed by pressing escape and I'm back on the asset. For all other modals (adding face, adding/changing tag(s), adding/changing location, changing date, sharing) brings me back to the timeline, which is very frustrating.

Basically everything was there just added an escape handler for the add-face dialogue, and disabled the asset viewer esc handling if a modal is open or if face editor is. Modal dialogues already have an "close" handler. Navigation bar also got esc-handler so sharing can be closed by esc.

## How Has This Been Tested?

- [X] Open "Tag dialogue", press esc -> asset viewer
- [X] Open "Location dialogue", press esc -> asset viewer
- [X] Open "Date dialogue", press esc -> asset viewer
- [X] Open "Share dialogue", press esc -> asset viewer
- [X] Open "Add Face dialogue", press esc -> asset viewer
- [X] Open "Album dialogue", press esc -> asset viewer

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Checked my assumption that handling is already there for album handling, but not used for other dialogues. Changing behavior then was straight forward.
