### PR TITLE
fix: SMTP over TLS

### DIFF
--- a/server/src/repositories/email.repository.ts
+++ b/server/src/repositories/email.repository.ts
@@ -162,6 +162,7 @@ export class EmailRepository {
       host: options.host,
       port: options.port,
       tls: { rejectUnauthorized: !options.ignoreCert },
+      secure: options.secure,
       auth:
         options.username || options.password
           ? {


### PR DESCRIPTION
## Description

PReq #22833 is about adding support for SMTP-over-TLS rather than just STARTTLS when sending emails. That PReq adds almost everything; it just forgot to actually pass the flag to Nodemailer at the end.

This adds that last line of code =)

## How Has This Been Tested?

I deployed it on my server and saw that sending emails now works, where it didn't before.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
