### PR TITLE
feat(web): extend admin server stats with queue status and ETA

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsPanel.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsPanel.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import StatsCard from '$lib/components/server-statistics/ServerStatisticsCard.svelte';
+  import { asQueueItem } from '$lib/services/queue.service';
   import { locale } from '$lib/stores/preferences.store';
   import { getBytesWithUnit } from '$lib/utils/byte-units';
-  import type { ServerStatsResponseDto } from '@immich/sdk';
+  import { QueueName, type QueueResponseDto, type ServerStatsResponseDto } from '@immich/sdk';
   import {
     Code,
     FormatBytes,
@@ -20,9 +21,11 @@
 
   type Props = {
     stats: ServerStatsResponseDto;
+    queues: QueueResponseDto[];
+    queueEtaSeconds: Record<string, number | null>;
   };
 
-  const { stats }: Props = $props();
+  const { stats, queues, queueEtaSeconds }: Props = $props();
 
   const zeros = (value: number, maxLength = 13) => {
     const valueLength = value.toString().length;
@@ -31,15 +34,57 @@
     return '0'.repeat(zeroLength);
   };
 
+  const formatEta = (seconds: number | null | undefined) => {
+    if (seconds === null || seconds === undefined) {
+      return '—';
+    }
+
+    if (seconds < 60) {
+      return '<1m';
+    }
+
+    const minutes = Math.ceil(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes.toLocaleString($locale)}m`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+
+    if (remainingMinutes === 0) {
+      return `${hours.toLocaleString($locale)}h`;
+    }
+
+    return `${hours.toLocaleString($locale)}h ${remainingMinutes.toLocaleString($locale)}m`;
+  };
+
+  const queueOrder = [
+    QueueName.MetadataExtraction,
+    QueueName.ThumbnailGeneration,
+    QueueName.Library,
+    QueueName.VideoConversion,
+    QueueName.FaceDetection,
+    QueueName.FacialRecognition,
+    QueueName.SmartSearch,
+    QueueName.Ocr,
+  ];
+
   const TiB = 1024 ** 4;
   let [statsUsage, statsUsageUnit] = $derived(getBytesWithUnit(stats.usage, stats.usage > TiB ? 2 : 0));
+
+  let workerQueues = $derived(
+    queueOrder.flatMap((queueName) => {
+      const queue = queues.find((item) => item.name === queueName);
+      return queue ? [queue] : [];
+    }),
+  );
 </script>
 
-<div class="flex flex-col gap-5 my-4">
+<div class="my-4 flex flex-col gap-5">
   <div>
     <Text class="mb-2" fontWeight="medium">{$t('total_usage')}</Text>
 
-    <div class="hidden justify-between lg:flex gap-4">
+    <div class="hidden justify-between gap-4 lg:flex">
       <StatsCard icon={mdiCameraIris} title={$t('photos')} value={stats.photos} />
       <StatsCard icon={mdiPlayCircle} title={$t('videos')} value={stats.videos} />
       <StatsCard icon={mdiChartPie} title={$t('storage')} value={statsUsage} unit={statsUsageUnit} />
@@ -77,7 +122,7 @@
             <span class="text-light-300">{zeros(statsUsage)}</span><span class="text-primary">{statsUsage}</span>
 
             <div class="absolute -end-1.5 -bottom-4">
-              <Code color="muted" class="text-xs font-light font-mono">{statsUsageUnit}</Code>
+              <Code color="muted" class="font-mono text-xs font-light">{statsUsageUnit}</Code>
             </div>
           </div>
         </div>
@@ -120,6 +165,32 @@
                 {/if}
               </span>
             </TableCell>
+          </TableRow>
+        {/each}
+      </TableBody>
+    </Table>
+  </div>
+
+  <div>
+    <Text class="mb-2 mt-4" fontWeight="medium">{$t('jobs')}</Text>
+    <Table striped size="small" class="table-fixed">
+      <TableHeader>
+        <TableHeading class="w-1/2 text-left">{$t('jobs')}</TableHeading>
+        <TableHeading class="w-1/10">{$t('waiting')}</TableHeading>
+        <TableHeading class="w-1/10">{$t('active')}</TableHeading>
+        <TableHeading class="w-1/10">{$t('failed')}</TableHeading>
+        <TableHeading class="w-1/10">{$t('status')}</TableHeading>
+        <TableHeading class="w-1/10">ETA</TableHeading>
+      </TableHeader>
+      <TableBody>
+        {#each workerQueues as queue (queue.name)}
+          <TableRow>
+            <TableCell class="w-1/2 text-left">{asQueueItem($t, queue).title}</TableCell>
+            <TableCell class="w-1/10">{queue.statistics.waiting.toLocaleString($locale)}</TableCell>
+            <TableCell class="w-1/10">{queue.statistics.active.toLocaleString($locale)}</TableCell>
+            <TableCell class="w-1/10">{queue.statistics.failed.toLocaleString($locale)}</TableCell>
+            <TableCell class="w-1/10">{queue.isPaused ? $t('paused') : $t('active')}</TableCell>
+            <TableCell class="w-1/10">{formatEta(queueEtaSeconds[queue.name])}</TableCell>
           </TableRow>
         {/each}
       </TableBody>

--- a/web/src/routes/admin/server-status/+page.svelte
+++ b/web/src/routes/admin/server-status/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AdminPageLayout from '$lib/components/layouts/AdminPageLayout.svelte';
   import ServerStatisticsPanel from '$lib/components/server-statistics/ServerStatisticsPanel.svelte';
-  import { getServerStatistics } from '@immich/sdk';
+  import { getQueues, getServerStatistics, type QueueResponseDto } from '@immich/sdk';
   import { Container } from '@immich/ui';
   import { onMount } from 'svelte';
   import type { PageData } from './$types';
@@ -10,12 +10,81 @@
     data: PageData;
   };
 
+  type QueueBacklogSnapshot = {
+    backlog: number;
+    timestampMs: number;
+  };
+
   const { data }: Props = $props();
 
+  const initialTimestampMs = Date.now();
   let stats = $state(data.stats);
+  let queues = $state<QueueResponseDto[]>(data.queues);
+  let queueBacklogSnapshots = $state<Record<string, QueueBacklogSnapshot>>(
+    Object.fromEntries(
+      data.queues.map((queue) => [
+        queue.name,
+        {
+          backlog: queue.statistics.waiting + queue.statistics.active,
+          timestampMs: initialTimestampMs,
+        },
+      ]),
+    ),
+  );
+  let queueEtaSeconds = $state<Record<string, number | null>>({});
+
+  const calculateEtaSeconds = (
+    queue: QueueResponseDto,
+    previous: QueueBacklogSnapshot | undefined,
+    timestampMs: number,
+  ): number | null => {
+    const backlog = queue.statistics.waiting + queue.statistics.active;
+
+    if (backlog === 0) {
+      return 0;
+    }
+
+    if (!previous) {
+      return null;
+    }
+
+    const elapsedSeconds = (timestampMs - previous.timestampMs) / 1000;
+    if (elapsedSeconds <= 0) {
+      return null;
+    }
+
+    const processed = previous.backlog - backlog;
+    if (processed <= 0) {
+      return null;
+    }
+
+    const processingRate = processed / elapsedSeconds;
+    if (processingRate <= 0) {
+      return null;
+    }
+
+    return Math.ceil(backlog / processingRate);
+  };
 
   const updateStatistics = async () => {
-    stats = await getServerStatistics();
+    const [nextStats, nextQueues] = await Promise.all([getServerStatistics(), getQueues()]);
+    const timestampMs = Date.now();
+    const nextQueueBacklogSnapshots = { ...queueBacklogSnapshots };
+    const nextQueueEtaSeconds = { ...queueEtaSeconds };
+
+    for (const queue of nextQueues) {
+      const previous = queueBacklogSnapshots[queue.name];
+      nextQueueEtaSeconds[queue.name] = calculateEtaSeconds(queue, previous, timestampMs);
+      nextQueueBacklogSnapshots[queue.name] = {
+        backlog: queue.statistics.waiting + queue.statistics.active,
+        timestampMs,
+      };
+    }
+
+    queueBacklogSnapshots = nextQueueBacklogSnapshots;
+    queueEtaSeconds = nextQueueEtaSeconds;
+    stats = nextStats;
+    queues = nextQueues;
   };
 
   onMount(() => {
@@ -27,6 +96,6 @@
 
 <AdminPageLayout breadcrumbs={[{ title: data.meta.title }]}>
   <Container size="large" center>
-    <ServerStatisticsPanel {stats} />
+    <ServerStatisticsPanel {stats} {queues} {queueEtaSeconds} />
   </Container>
 </AdminPageLayout>

--- a/web/src/routes/admin/server-status/+page.ts
+++ b/web/src/routes/admin/server-status/+page.ts
@@ -1,15 +1,16 @@
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
-import { getServerStatistics } from '@immich/sdk';
+import { getQueues, getServerStatistics } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ url }) => {
   await authenticate(url, { admin: true });
-  const stats = await getServerStatistics();
+  const [stats, queues] = await Promise.all([getServerStatistics(), getQueues()]);
   const $t = await getFormatter();
 
   return {
     stats,
+    queues,
     meta: {
       title: $t('server_stats'),
     },


### PR DESCRIPTION
 ## Description

  Adds an Admin Server Stats UI enhancement that shows worker queue health and estimated completion time (ETA).

  Why:

  Instead of only showing storage/user usage, Server Stats now also makes background queue progress visible.
  This helps new users and admins understand expected “not ready yet” states after adding new libraries (for example missing thumbnails, incomplete face detection, or OCR/search not appearing yet) without needing extra troubleshooting steps.

  What changed:

  - Extended admin server status load to fetch both getServerStatistics() and getQueues()
  - Added queue polling alongside stats polling (every 5 seconds)
  - Added ETA calculation on the client from backlog delta over time
  - Added a new Jobs table to the Server Stats panel with:
  - Queue name
  - Waiting count
  - Active count
  - Failed count
  - Queue status (active/paused)
  - ETA display
  - Added ETA formatting for unknown/short/long durations (—, <1m, Xm, Xh Ym)
  - Added a stable display order for relevant worker queues

  Fixes # (issue)

  ## How Has This Been Tested?

  - [x] Manual: verified new Jobs table appears in Admin > Server Status
  - [x] Manual: verified queue metrics (waiting, active, failed, status) render correctly
  - [x] Manual: verified values refresh continuously with the 5s polling loop
  - [x] Manual: verified ETA behavior (— when rate unknown, <1m, Xm, Xh Ym)
  - [x] Manual: verified existing stats sections (total usage, user usage detail) still work unchanged
  <details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="945" height="803" alt="image" src="https://github.com/user-attachments/assets/23a1dd2c-dd93-419c-9ec1-83640cede55a" />

  Admin > Server Status with Jobs table and ETA column.
  </details>

  ## Checklist:

  - [x] I have carefully read CONTRIBUTING.md
  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR.
  - [x] I have confirmed that any new dependencies are strictly necessary.
  - [ ] I have written tests for new code (if applicable)
  - [x] I have followed naming conventions/patterns in the surrounding code
  - [ ] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
  - [ ] All code in src/repositories/ is pretty basic/simple and does not have any immich specific logic (that belongs in src/services/)

  ## Please describe to which degree, if any, an LLM was used in creating this pull request.

  Codex was used as a development aid for drafting, refactoring suggestions, and review.