### PR TITLE
fix(web): prevent Safari from overwriting live photo image with video

### DIFF
--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -78,7 +78,7 @@ describe('AssetService', () => {
       const asset = assetFactory.build({ originalFileName: 'asset.heic', livePhotoVideoId: '1' });
       await handleDownloadAsset(asset, { edited: false });
       expect($t).toHaveBeenNthCalledWith(1, 'downloading_asset_filename', { values: { filename: 'asset.heic' } });
-      expect($t).toHaveBeenNthCalledWith(2, 'downloading_asset_filename', { values: { filename: 'asset.mov' } });
+      expect($t).toHaveBeenNthCalledWith(2, 'downloading_asset_filename', { values: { filename: 'asset-motion.mov' } });
       expect(toastManager.primary).toHaveBeenCalledWith('formatter');
     });
   });

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -319,8 +319,14 @@ export const handleDownloadAsset = async (asset: AssetResponseDto, { edited }: {
   if (asset.livePhotoVideoId) {
     const motionAsset = await getAssetInfo({ ...authManager.params, id: asset.livePhotoVideoId });
     if (!isAndroidMotionVideo(motionAsset) || get(preferences)?.download.includeEmbeddedVideos) {
+      const motionFilename = motionAsset.originalFileName;
+      const lastDotIndex = motionFilename.lastIndexOf('.');
+      const motionDownloadFilename =
+        lastDotIndex > 0
+          ? `${motionFilename.slice(0, lastDotIndex)}-motion${motionFilename.slice(lastDotIndex)}`
+          : `${motionFilename}-motion`;
       assets.push({
-        filename: motionAsset.originalFileName,
+        filename: motionDownloadFilename,
         id: asset.livePhotoVideoId,
         cacheKey: motionAsset.thumbhash,
       });


### PR DESCRIPTION
## Description

When downloading a live photo from a shared album link in Safari, both the image and motion video share the same base filename. Safari overwrites the first download with the second, leaving only the `.mov` file.

Fix: append `-motion` suffix to the video filename (e.g., `IMG_1234.heic` stays as-is, `IMG_1234.mov` becomes `IMG_1234-motion.mov`).

Fixes #23055

## How Has This Been Tested?

- [x] Updated existing unit test (`asset.service.spec.ts`) to match new motion filename format
- [ ] Manual test: download live photo from shared link in Safari — verify both files saved
- [ ] Manual test: verify download still works in Chrome/Firefox

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — no visual changes, this is a download filename fix.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used to assist with identifying the relevant code and drafting the fix. I reviewed and verified the changes, confirmed the approach matches the maintainer's suggestion in #23055, and validated the test update.