### PR TITLE
fix(web): fix person visibility toggle not showing named people

### DIFF
--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -47,8 +47,8 @@
         isHidden = true;
       } else if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
         isHidden = false;
-      } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
-        isHidden = true;
+      } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD) {
+        isHidden = !person.name;
       }
 
       setHiddenOverride(person, isHidden);


### PR DESCRIPTION
## Description

When cycling the visibility toggle from HIDE_ALL to HIDE_UNNAMED, named people remained hidden. The HIDE_UNNAMED branch only set `isHidden = true` for unnamed people but never reset named people to `isHidden = false`.

Fix: changed the condition to `isHidden = !person.name`, so named people are shown and unnamed people are hidden when HIDE_UNNAMED is active.

Fixes #19956

## How Has This Been Tested?

- [ ] Manual test: toggle visibility SHOW_ALL → HIDE_UNNAMED → HIDE_ALL → SHOW_ALL
- [ ] Verify HIDE_UNNAMED shows named people and hides unnamed ones
- [ ] Verify transitioning from HIDE_ALL to HIDE_UNNAMED correctly reveals named people

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — logic-only fix, no visual UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used to assist with locating the relevant component and identifying the logic bug. I reviewed the fix and confirmed the toggle cycle behavior is correct.