### PR TITLE
fix(server): allow clearing asset description to blank

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -8,7 +8,7 @@ import { constants } from 'node:fs/promises';
 import { join, parse } from 'node:path';
 import { JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
-import { Asset, AssetFile } from 'src/database';
+import { Asset, AssetFile, LockableProperty } from 'src/database';
 import { OnEvent, OnJob } from 'src/decorators';
 import {
   AssetFileType,
@@ -459,10 +459,17 @@ export class MetadataService extends BaseService {
       lockedProperties,
     );
 
+    // exiftool treats empty strings as "delete field", which would cause the EXIF-embedded
+    // description to reappear on re-extraction. When the user has explicitly cleared the
+    // description, skip writing it to the sidecar and keep 'description' locked so that
+    // metadata extraction preserves the empty value from the database.
+    const descriptionCleared = description !== undefined && description === '';
+    const sidecarDescription = descriptionCleared ? undefined : description;
+
     const exif = _.omitBy(
       <Tags>{
-        Description: description,
-        ImageDescription: description,
+        Description: sidecarDescription,
+        ImageDescription: sidecarDescription,
         DateTimeOriginal: mergeTimeZone(dateTimeOriginal, timeZone)?.toISO(),
         GPSLatitude: latitude,
         GPSLongitude: longitude,
@@ -472,17 +479,26 @@ export class MetadataService extends BaseService {
       _.isUndefined,
     );
 
-    if (Object.keys(exif).length === 0) {
+    // Properties that should remain locked because they cannot be represented in the sidecar
+    // (e.g. an empty description would be treated as "delete" by exiftool).
+    const keepLocked: LockableProperty[] = descriptionCleared ? ['description'] : [];
+    const propertiesToUnlock = lockedProperties.filter((p) => !keepLocked.includes(p));
+
+    if (Object.keys(exif).length === 0 && keepLocked.length === 0) {
       return JobStatus.Skipped;
     }
 
-    await this.metadataRepository.writeTags(sidecarPath, exif);
+    if (Object.keys(exif).length > 0) {
+      await this.metadataRepository.writeTags(sidecarPath, exif);
 
-    if (asset.files.length === 0) {
-      await this.assetRepository.upsertFile({ assetId: id, type: AssetFileType.Sidecar, path: sidecarPath });
+      if (asset.files.length === 0) {
+        await this.assetRepository.upsertFile({ assetId: id, type: AssetFileType.Sidecar, path: sidecarPath });
+      }
     }
 
-    await this.assetRepository.unlockProperties(asset.id, lockedProperties);
+    if (propertiesToUnlock.length > 0) {
+      await this.assetRepository.unlockProperties(asset.id, propertiesToUnlock);
+    }
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
## Description

When a user clears an asset's description to blank, the description reverts to the EXIF-embedded value on the next metadata extraction.

Root cause: exiftool treats empty strings as "delete field", removing tags from the sidecar. Then `unlockProperties` removes the lock on `description`, allowing the next metadata extraction to overwrite the empty DB value with the original EXIF-embedded description.

Fix:
- Skip writing empty description to sidecar (exiftool would just delete it anyway)
- Keep `description` in `lockedProperties` when explicitly cleared, so subsequent metadata extractions preserve the user's intent

Fixes #19168

## How Has This Been Tested?

- [ ] Set a description on an asset, then clear it to blank — verify it stays empty after refresh
- [ ] Set a non-empty description — verify it still works correctly
- [ ] Run metadata extraction — verify blank description is preserved
- [ ] Bulk update descriptions — verify it works correctly

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — server-side logic fix, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used to assist with understanding the metadata extraction pipeline, identifying the root cause across the sidecar write and unlock flow, and drafting the fix. I reviewed the changes and confirmed the approach handles the edge cases correctly.