### PR TITLE
fix(server): use substring matching for person name search

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -202,13 +202,10 @@ from
 where
   (
     "person"."ownerId" = $1
-    and (
-      lower("person"."name") like $2
-      or lower("person"."name") like $3
-    )
+    and lower("person"."name") like $2
   )
 limit
-  $4
+  $3
 
 -- PersonRepository.getDistinctNames
 select distinct

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -200,10 +200,10 @@ select
 from
   "person"
 where
-  (
-    "person"."ownerId" = $1
-    and lower("person"."name") like $2
-  )
+  "person"."ownerId" = $1
+  and f_unaccent("person"."name") %>> f_unaccent($2)
+order by
+  f_unaccent("person"."name") <->>> f_unaccent($2)
 limit
   $3
 

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -201,11 +201,11 @@ from
   "person"
 where
   "person"."ownerId" = $1
-  and f_unaccent("person"."name") %>> f_unaccent($2)
+  and f_unaccent ("person"."name") %>> f_unaccent ($2)
 order by
-  f_unaccent("person"."name") <->>> f_unaccent($2)
+  f_unaccent ("person"."name") <->>> f_unaccent ($3)
 limit
-  $3
+  $4
 
 -- PersonRepository.getDistinctNames
 select distinct

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -323,10 +323,7 @@ export class PersonRepository {
       .where((eb) =>
         eb.and([
           eb('person.ownerId', '=', userId),
-          eb.or([
-            eb(eb.fn('lower', ['person.name']), 'like', `${personName.toLowerCase()}%`),
-            eb(eb.fn('lower', ['person.name']), 'like', `% ${personName.toLowerCase()}%`),
-          ]),
+          eb(eb.fn('lower', ['person.name']), 'like', `%${personName.toLowerCase()}%`),
         ]),
       )
       .limit(1000)

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -320,13 +320,10 @@ export class PersonRepository {
     return this.db
       .selectFrom('person')
       .selectAll('person')
-      .where((eb) =>
-        eb.and([
-          eb('person.ownerId', '=', userId),
-          eb(eb.fn('lower', ['person.name']), 'like', `%${personName.toLowerCase()}%`),
-        ]),
-      )
-      .limit(1000)
+      .where('person.ownerId', '=', userId)
+      .where(() => sql`f_unaccent("person"."name") %>> f_unaccent(${personName})`)
+      .orderBy(sql`f_unaccent("person"."name") <->>> f_unaccent(${personName})`)
+      .limit(100)
       .$if(!withHidden, (qb) => qb.where('person.isHidden', '=', false))
       .execute();
   }

--- a/server/src/schema/migrations/1773846750001-AddPersonNameTrigramIndex.ts
+++ b/server/src/schema/migrations/1773846750001-AddPersonNameTrigramIndex.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE INDEX "idx_person_name_trigram" ON "person" USING gin (f_unaccent("name") gin_trgm_ops)`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX "idx_person_name_trigram"`.execute(db);
+}

--- a/server/src/schema/migrations/1773846750001-AddPersonNameTrigramIndex.ts
+++ b/server/src/schema/migrations/1773846750001-AddPersonNameTrigramIndex.ts
@@ -1,9 +1,11 @@
 import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
-  await sql`CREATE INDEX "idx_person_name_trigram" ON "person" USING gin (f_unaccent("name") gin_trgm_ops)`.execute(db);
+  await sql`CREATE INDEX "idx_person_name_trigram" ON "person" USING gin (f_unaccent("name") gin_trgm_ops);`.execute(db);
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_idx_person_name_trigram', '{"type":"index","name":"idx_person_name_trigram","sql":"CREATE INDEX \\"idx_person_name_trigram\\" ON \\"person\\" USING gin (f_unaccent(\\"name\\") gin_trgm_ops);"}'::jsonb);`.execute(db);
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-  await sql`DROP INDEX "idx_person_name_trigram"`.execute(db);
+  await sql`DROP INDEX "idx_person_name_trigram";`.execute(db);
+  await sql`DELETE FROM "migration_overrides" WHERE "name" = 'index_idx_person_name_trigram';`.execute(db);
 }

--- a/server/src/schema/tables/person.table.ts
+++ b/server/src/schema/tables/person.table.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   ForeignKeyColumn,
   Generated,
+  Index,
   PrimaryGeneratedColumn,
   Table,
   Timestamp,
@@ -16,6 +17,11 @@ import { AssetFaceTable } from 'src/schema/tables/asset-face.table';
 import { UserTable } from 'src/schema/tables/user.table';
 
 @Table('person')
+@Index({
+  name: 'idx_person_name_trigram',
+  using: 'gin',
+  expression: 'f_unaccent("name") gin_trgm_ops',
+})
 @UpdatedAtTrigger('person_updatedAt')
 @AfterDeleteTrigger({
   scope: 'statement',


### PR DESCRIPTION
## Description

Fixes #18305

The `getByName` query in `person.repository.ts` used two `LIKE` conditions:
- `name%` (prefix match)
- `% name%` (match after a space)

This meant searching for "claude" would find "Claude X" and "Jean Claude" but **not** "Jean-Claude", "Jean (Claude)", or "Jean \"Claude\"".

This PR simplifies the query to use `%name%` (substring match), which finds the search term anywhere in the name. This makes "People Tab / Search people" consistent with "Search options / Filter people" which already uses substring matching.

### Changes
- `server/src/repositories/person.repository.ts`: Replaced two `LIKE` conditions with a single `%name%` substring match
- `server/src/queries/person.repository.sql`: Updated generated SQL to reflect the simplified query