### PR TITLE
fix(server): use UTC for database backup filename timestamps

### DIFF
--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -108,7 +108,7 @@ describe(DatabaseBackupService.name, () => {
 
     it('should remove failed backup files', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.backupEnabled);
-      //`immich-db-backup-${DateTime.now().toFormat("yyyyLLdd'T'HHmmss")}-v${serverVersion.toString()}-pg${databaseVersion.split(' ')[0]}.sql.gz.tmp`,
+      //`immich-db-backup-${DateTime.now().toUTC().toFormat("yyyyLLdd'T'HHmmss")}-v${serverVersion.toString()}-pg${databaseVersion.split(' ')[0]}.sql.gz.tmp`,
       mocks.storage.readdir.mockResolvedValue([
         'immich-db-backup-123.sql.gz.tmp',
         `immich-db-backup-${DateTime.fromISO('2025-07-25T11:02:16Z').toFormat("yyyyLLdd'T'HHmmss")}-v1.234.5-pg14.5.sql.gz.tmp`,

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -223,7 +223,7 @@ export class DatabaseBackupService {
 
     this.logger.log(`Database Backup Starting. Database Version: ${databaseMajorVersion}`);
 
-    const filename = `${filenamePrefix}immich-db-backup-${DateTime.now().toFormat("yyyyLLdd'T'HHmmss")}-v${serverVersion.toString()}-pg${databaseVersion.split(' ')[0]}.sql.gz`;
+    const filename = `${filenamePrefix}immich-db-backup-${DateTime.now().toUTC().toFormat("yyyyLLdd'T'HHmmss")}-v${serverVersion.toString()}-pg${databaseVersion.split(' ')[0]}.sql.gz`;
     const backupFilePath = path.join(StorageCore.getBaseFolder(StorageFolder.Backups), filename);
     const temporaryFilePath = `${backupFilePath}.tmp`;
 


### PR DESCRIPTION
## Summary

Fixes #26502

The database backup filename timestamp is generated using `DateTime.now().toFormat()`, which uses the server's local timezone (e.g., `Europe/Berlin`). However, the web frontend in `MaintenanceBackupEntry.svelte` parses this timestamp assuming UTC (`{ zone: 'utc' }`). This mismatch causes incorrect relative time display -- for example, a backup created moments ago may show as "in 59 minutes" if the server is in CET (UTC+1).

The fix adds `.toUTC()` before `.toFormat()` in the backup filename generation, so the timestamp is always in UTC. This aligns the server output with the frontend's existing UTC-based parsing logic.

### Changes

- `server/src/services/database-backup.service.ts`: `DateTime.now().toFormat(...)` -> `DateTime.now().toUTC().toFormat(...)`
- `server/src/services/database-backup.service.spec.ts`: Updated matching comment

### Notes

- Existing backups with local-timezone timestamps will continue to display with the same (slight) offset they always had -- this only affects newly created backups going forward.
- The frontend code (`MaintenanceBackupEntry.svelte`) needs no changes since it already correctly parses timestamps as UTC.

## Test plan

- [x] Verified that existing unit tests in `database-backup.service.spec.ts` are unaffected (they already use UTC ISO strings)
- [ ] Create a database backup on a server with `TZ` set to a non-UTC timezone and verify the Web UI shows the correct relative time