### PR TITLE
fix(server): render storage template date/time tokens in UTC (#24350)

### DIFF
--- a/docs/docs/partials/_storage-template.md
+++ b/docs/docs/partials/_storage-template.md
@@ -6,6 +6,8 @@ You can read more about the differences between storage template engine on and o
 
 The admin user can set the template by using the template builder in the `Administration -> Settings -> Storage Template`. Immich provides a set of variables that you can use in constructing the template, along with additional custom text. If the template produces [multiple files with the same filename, they won't be overwritten](https://github.com/immich-app/immich/discussions/3324) as a sequence number is appended to the filename.
 
+Date and time variables in storage templates are rendered in UTC.
+
 ```bash title="Default template"
 Year/Year-Month-Day/Filename.Extension
 ```

--- a/docs/docs/partials/_storage-template.md
+++ b/docs/docs/partials/_storage-template.md
@@ -6,7 +6,7 @@ You can read more about the differences between storage template engine on and o
 
 The admin user can set the template by using the template builder in the `Administration -> Settings -> Storage Template`. Immich provides a set of variables that you can use in constructing the template, along with additional custom text. If the template produces [multiple files with the same filename, they won't be overwritten](https://github.com/immich-app/immich/discussions/3324) as a sequence number is appended to the filename.
 
-Date and time variables in storage templates are rendered in UTC.
+Date and time variables in storage templates are rendered in the server's local timezone.
 
 ```bash title="Default template"
 Year/Year-Month-Day/Filename.Extension

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -230,7 +230,7 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${album.albumName}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${album.albumName}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -249,11 +249,11 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/other/${month}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/other/${month}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -287,11 +287,11 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${month} - ${album.albumName}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${month} - ${album.albumName}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -312,13 +312,56 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
-        newPath: `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${month}/${asset.originalFileName}`,
+        newPath: `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${month}/${asset.originalFileName}`,
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
       });
+    });
+
+    it('should render storage datetime tokens in UTC to preserve chronological filename ordering across time zones', async () => {
+      const user = UserFactory.create();
+      const assetBerlin = AssetFactory.from({
+        fileCreatedAt: new Date('2025-12-02T14:00:00.000Z'),
+        originalFileName: 'A.jpg',
+      })
+        .owner(user)
+        .exif({ timeZone: 'Europe/Berlin' })
+        .build();
+      const assetLondon = AssetFactory.from({
+        fileCreatedAt: new Date('2025-12-02T14:55:00.000Z'),
+        originalFileName: 'B.jpg',
+      })
+        .owner(user)
+        .exif({ timeZone: 'Europe/London' })
+        .build();
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{y}}{{MM}}{{dd}}_{{HH}}{{mm}}{{ss}}/{{filename}}';
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(assetBerlin));
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(assetLondon));
+
+      await expect(sut.handleMigrationSingle({ id: assetBerlin.id })).resolves.toBe(JobStatus.Success);
+      await expect(sut.handleMigrationSingle({ id: assetLondon.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.move.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          entityId: assetBerlin.id,
+          newPath: `/data/library/${user.id}/20251202_140000/A.jpg`,
+        }),
+      );
+      expect(mocks.move.create).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          entityId: assetLondon.id,
+          newPath: `/data/library/${user.id}/20251202_145500/B.jpg`,
+        }),
+      );
     });
 
     it('should migrate previously failed move from original path when it still exists', async () => {

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -230,7 +230,7 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${album.albumName}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${album.albumName}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -249,11 +249,11 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/other/${month}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/other/${month}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -287,11 +287,11 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
         newPath: expect.stringContaining(
-          `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${month} - ${album.albumName}/${asset.originalFileName}`,
+          `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${month} - ${album.albumName}/${asset.originalFileName}`,
         ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
@@ -312,16 +312,16 @@ describe(StorageTemplateService.name, () => {
 
       expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
 
-      const month = (asset.fileCreatedAt.getUTCMonth() + 1).toString().padStart(2, '0');
+      const month = (asset.fileCreatedAt.getMonth() + 1).toString().padStart(2, '0');
       expect(mocks.move.create).toHaveBeenCalledWith({
         entityId: asset.id,
-        newPath: `/data/library/${user.id}/${asset.fileCreatedAt.getUTCFullYear()}/${month}/${asset.originalFileName}`,
+        newPath: `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${month}/${asset.originalFileName}`,
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
       });
     });
 
-    it('should render storage datetime tokens in UTC to preserve chronological filename ordering across time zones', async () => {
+    it('should render storage datetime tokens in server timezone to preserve chronological filename ordering across time zones', async () => {
       const user = UserFactory.create();
       const assetBerlin = AssetFactory.from({
         fileCreatedAt: new Date('2025-12-02T14:00:00.000Z'),
@@ -348,18 +348,28 @@ describe(StorageTemplateService.name, () => {
       await expect(sut.handleMigrationSingle({ id: assetBerlin.id })).resolves.toBe(JobStatus.Success);
       await expect(sut.handleMigrationSingle({ id: assetLondon.id })).resolves.toBe(JobStatus.Success);
 
+      const formatStorageDateTime = (date: Date) => {
+        const year = date.getFullYear().toString();
+        const month = (date.getMonth() + 1).toString().padStart(2, '0');
+        const day = date.getDate().toString().padStart(2, '0');
+        const hour = date.getHours().toString().padStart(2, '0');
+        const minute = date.getMinutes().toString().padStart(2, '0');
+        const second = date.getSeconds().toString().padStart(2, '0');
+        return `${year}${month}${day}_${hour}${minute}${second}`;
+      };
+
       expect(mocks.move.create).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
           entityId: assetBerlin.id,
-          newPath: `/data/library/${user.id}/20251202_140000/A.jpg`,
+          newPath: `/data/library/${user.id}/${formatStorageDateTime(assetBerlin.fileCreatedAt)}/A.jpg`,
         }),
       );
       expect(mocks.move.create).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
           entityId: assetLondon.id,
-          newPath: `/data/library/${user.id}/20251202_145500/B.jpg`,
+          newPath: `/data/library/${user.id}/${formatStorageDateTime(assetLondon.fileCreatedAt)}/B.jpg`,
         }),
       );
     });

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -32,6 +32,8 @@ const storageTokens = {
   monthOptions: ['M', 'MM', 'MMM', 'MMMM'],
 };
 
+const storageTemplateTimeZone = 'UTC';
+
 const storagePresets = [
   '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}',
   '{{y}}/{{MM}}-{{dd}}/{{filename}}',
@@ -413,19 +415,17 @@ export class StorageTemplateService extends BaseService {
       lensModel: lensModel ?? '',
     };
 
-    const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const zone = asset.timeZone || systemTimeZone;
-    const dt = DateTime.fromJSDate(asset.fileCreatedAt, { zone });
+    const dt = DateTime.fromJSDate(asset.fileCreatedAt, { zone: storageTemplateTimeZone });
 
     for (const token of Object.values(storageTokens).flat()) {
       substitutions[token] = dt.toFormat(token);
       if (albumName) {
-        // Use system time zone for album dates to ensure all assets get the exact same date.
+        // Album date tokens are rendered in UTC to match storage template datetime behavior.
         substitutions['album-startDate-' + token] = albumStartDate
-          ? DateTime.fromJSDate(albumStartDate, { zone: systemTimeZone }).toFormat(token)
+          ? DateTime.fromJSDate(albumStartDate, { zone: storageTemplateTimeZone }).toFormat(token)
           : '';
         substitutions['album-endDate-' + token] = albumEndDate
-          ? DateTime.fromJSDate(albumEndDate, { zone: systemTimeZone }).toFormat(token)
+          ? DateTime.fromJSDate(albumEndDate, { zone: storageTemplateTimeZone }).toFormat(token)
           : '';
       }
     }

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -32,7 +32,7 @@ const storageTokens = {
   monthOptions: ['M', 'MM', 'MMM', 'MMMM'],
 };
 
-const storageTemplateTimeZone = 'UTC';
+const storageTemplateTimeZone = DateTime.local().zoneName;
 
 const storagePresets = [
   '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}',
@@ -420,7 +420,7 @@ export class StorageTemplateService extends BaseService {
     for (const token of Object.values(storageTokens).flat()) {
       substitutions[token] = dt.toFormat(token);
       if (albumName) {
-        // Album date tokens are rendered in UTC to match storage template datetime behavior.
+        // Album date tokens are rendered in the server time zone to match storage template datetime behavior.
         substitutions['album-startDate-' + token] = albumStartDate
           ? DateTime.fromJSDate(albumStartDate, { zone: storageTemplateTimeZone }).toFormat(token)
           : '';

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -32,8 +32,6 @@ const storageTokens = {
   monthOptions: ['M', 'MM', 'MMM', 'MMMM'],
 };
 
-const storageTemplateTimeZone = DateTime.local().zoneName;
-
 const storagePresets = [
   '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}',
   '{{y}}/{{MM}}-{{dd}}/{{filename}}',
@@ -415,18 +413,16 @@ export class StorageTemplateService extends BaseService {
       lensModel: lensModel ?? '',
     };
 
-    const dt = DateTime.fromJSDate(asset.fileCreatedAt, { zone: storageTemplateTimeZone });
+    const dt = DateTime.fromJSDate(asset.fileCreatedAt);
 
     for (const token of Object.values(storageTokens).flat()) {
       substitutions[token] = dt.toFormat(token);
       if (albumName) {
         // Album date tokens are rendered in the server time zone to match storage template datetime behavior.
         substitutions['album-startDate-' + token] = albumStartDate
-          ? DateTime.fromJSDate(albumStartDate, { zone: storageTemplateTimeZone }).toFormat(token)
+          ? DateTime.fromJSDate(albumStartDate).toFormat(token)
           : '';
-        substitutions['album-endDate-' + token] = albumEndDate
-          ? DateTime.fromJSDate(albumEndDate, { zone: storageTemplateTimeZone }).toFormat(token)
-          : '';
+        substitutions['album-endDate-' + token] = albumEndDate ? DateTime.fromJSDate(albumEndDate).toFormat(token) : '';
       }
     }
 


### PR DESCRIPTION
## Description

Storage template dates and time were previously rendered using a local server system timezone context, which could produce non-chronological filenames when assets were taken across time zones for example Berlin to London travel like the example given on the issue. This pr changes the behavior so it always renders storage-template standard by using UTC. As asked by the maintainers on the discord [Storage Template dates/times not adjusted for timezone](https://discord.com/channels/979116623879368755/1478445555750273095) it can be easely changed to different default time zone.

Fixes #24350

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Update existing unit tests to use UTC and not an hard coded local time zone.
- [x] Add new tests that verifies that assets get the correct chronological filename ordering, it is preserverd even if the images were taken in different time zones.
    - Asset A: `2025-12-02T14:00:00.000Z` (Berlin metadata)
    - Asset A: `2025-12-02T14:00:00.000Z` (Berlin metadata)
    - Storage Template: `{{y}}{{MM}}{{dd}}_{{HH}}{{mm}}{{ss}}/{{filename}}`
    - Confirms chronological filename ordering is preserved across time zones.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Github Copilot was used to have an overall understading of the codebase and to explain how the tests were made. Chatgpt was used to correct my grammer on the text of this PR.
...
