### PR TITLE
feat(web): add shortcuts to rotate images

### DIFF
--- a/web/src/lib/components/asset-viewer/editor/editor-panel.svelte
+++ b/web/src/lib/components/asset-viewer/editor/editor-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { shortcut } from '$lib/actions/shortcut';
+  import { shortcuts } from '$lib/actions/shortcut';
   import { editManager, EditToolType } from '$lib/managers/edit/edit-manager.svelte';
   import { websocketEvents } from '$lib/stores/websocket';
   import { getAssetEdits, type AssetResponseDto } from '@immich/sdk';
@@ -47,7 +47,12 @@
   let { asset = $bindable(), onClose }: Props = $props();
 </script>
 
-<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: onClose }} />
+<svelte:document
+  use:shortcuts={[
+    { shortcut: { key: 'Escape' }, onShortcut: onClose },
+    { shortcut: { key: 'Enter' }, onShortcut: applyEdits },
+  ]}
+/>
 
 <section class="relative flex flex-col h-full p-2 dark:bg-immich-dark-bg dark:text-immich-dark-fg dark pt-3">
   <HStack class="justify-between me-4">

--- a/web/src/lib/components/asset-viewer/editor/transform-tool/transform-tool.svelte
+++ b/web/src/lib/components/asset-viewer/editor/transform-tool/transform-tool.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcuts } from '$lib/actions/shortcut';
   import { transformManager } from '$lib/managers/edit/transform-manager.svelte';
   import { Button, HStack, IconButton } from '@immich/ui';
   import { mdiFlipHorizontal, mdiFlipVertical, mdiRotateLeft, mdiRotateRight } from '@mdi/js';
@@ -67,6 +68,13 @@
     transformManager.mirror(axis);
   }
 </script>
+
+<svelte:document
+  use:shortcuts={[
+    { shortcut: { key: ']' }, onShortcut: () => rotateImage(90) },
+    { shortcut: { key: '[' }, onShortcut: () => rotateImage(-90) },
+  ]}
+/>
 
 <div class="mt-3 px-4">
   <div class="flex h-10 w-full items-center justify-between text-sm mt-2">

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -249,6 +249,7 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
       !asset.originalPath.toLowerCase().endsWith('.gif') &&
       !asset.originalPath.toLowerCase().endsWith('.svg'),
     onAction: () => assetViewerManager.openEditor(),
+    shortcuts: [{ key: 'e' }],
   };
 
   const RefreshFacesJob: ActionItem = {


### PR DESCRIPTION
## Description

This PR adds a few shortcuts:

- 'e' to open image editor
- '[' and ']' to rotate images
- 'enter' to accept edits

I am currently sorting though a lot of images, and have to rotate many of them. Having a keyboard-based workflow would help tremendously with this work.

## How Has This Been Tested?

Pressing the 'e' key on the asset viewer page, then using '[' and ']' to rotate the image. Then using 'enter' or 'escape' to accept / reject the changes.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Changes were made with my own meatspace fingies. LLM was used to get an overview of the code and help me set up a local dev environment.

...
