### PR TITLE
feat(mobile): add double-tap seek for videos

### DIFF
--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -28,6 +28,7 @@ import 'package:immich_mobile/widgets/asset_viewer/advanced_bottom_sheet.dart';
 import 'package:immich_mobile/widgets/asset_viewer/bottom_gallery_bar.dart';
 import 'package:immich_mobile/widgets/asset_viewer/detail_panel/detail_panel.dart';
 import 'package:immich_mobile/widgets/asset_viewer/gallery_app_bar.dart';
+import 'package:immich_mobile/widgets/asset_viewer/video_double_tap_seek.dart';
 import 'package:immich_mobile/widgets/common/immich_image.dart';
 import 'package:immich_mobile/widgets/common/immich_thumbnail.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view_gallery.dart';
@@ -271,6 +272,14 @@ class GalleryViewerPage extends HookConsumerWidget {
       return PhotoViewGalleryPageOptions.customChild(
         onDragStart: (_, details, __, ___) => localPosition.value = details.localPosition,
         onDragUpdate: (_, details, __) => handleSwipeUpDown(details),
+        onDoubleTap: (_, details, __) {
+          triggerVideoDoubleTapSeek(
+            ref,
+            playerId: asset.id.toString(),
+            tapX: details.localPosition.dx,
+            viewportWidth: context.width,
+          );
+        },
         heroAttributes: _getHeroAttributes(asset),
         filterQuality: FilterQuality.high,
         initialScale: PhotoViewComputedScale.contained * 0.99,

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -17,6 +17,7 @@ import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/asset.service.dart';
 import 'package:immich_mobile/widgets/asset_viewer/custom_video_player_controls.dart';
+import 'package:immich_mobile/widgets/asset_viewer/video_double_tap_seek.dart';
 import 'package:logging/logging.dart';
 import 'package:native_video_player/native_video_player.dart';
 
@@ -275,6 +276,7 @@ class NativeVideoViewerPage extends HookConsumerWidget {
               ),
             ),
           ),
+        Positioned.fill(child: VideoDoubleTapSeekOverlay(playerId: videoId)),
         if (showControls) Center(child: CustomVideoPlayerControls(videoId: videoId)),
       ],
     );

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -21,6 +21,7 @@ import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/is_motion_video_playing.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/widgets/asset_viewer/video_double_tap_seek.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
 
@@ -238,6 +239,24 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     }
   }
 
+  void _onVideoDoubleTap(
+    BuildContext context,
+    TapDownDetails details,
+    PhotoViewControllerValue controllerValue,
+    BaseAsset asset,
+  ) {
+    if (_showingDetails || _dragStart != null) {
+      return;
+    }
+
+    triggerVideoDoubleTapSeek(
+      ref,
+      playerId: asset.heroTag,
+      tapX: details.localPosition.dx,
+      viewportWidth: context.width,
+    );
+  }
+
   void _onLongPress(BuildContext context, LongPressStartDetails details, PhotoViewControllerValue controllerValue) =>
       ref.read(isPlayingMotionVideoProvider.notifier).playing = true;
 
@@ -327,6 +346,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
       onDragEnd: _onDragEnd,
       onDragCancel: _onDragCancel,
       onTapUp: _onTapUp,
+      onDoubleTap: (context, details, controllerValue) => _onVideoDoubleTap(context, details, controllerValue, asset),
       scaleStateChangedCallback: _onScaleStateChanged,
       heroAttributes: heroAttributes,
       filterQuality: FilterQuality.high,

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/widgets/asset_viewer/video_double_tap_seek.dart';
 import 'package:logging/logging.dart';
 import 'package:native_video_player/native_video_player.dart';
 
@@ -220,6 +221,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
               visible: _isVideoReady,
               child: NativeVideoPlayerView(onViewReady: _initController),
             ),
+            Positioned.fill(child: VideoDoubleTapSeekOverlay(playerId: widget.asset.heroTag)),
             Center(
               child: AnimatedOpacity(
                 opacity: status == VideoPlaybackStatus.buffering ? 1.0 : 0.0,

--- a/mobile/lib/widgets/asset_viewer/video_double_tap_seek.dart
+++ b/mobile/lib/widgets/asset_viewer/video_double_tap_seek.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/asset_viewer/video_player_provider.dart';
+import 'package:immich_mobile/providers/cast.provider.dart';
+
+enum VideoDoubleTapSeekDirection { backward, forward }
+
+const videoDoubleTapSeekStep = Duration(seconds: 10);
+const _videoDoubleTapCenterDeadZoneWidth = 128.0;
+const _videoDoubleTapOverlayDuration = Duration(milliseconds: 900);
+const _videoDoubleTapRippleDuration = Duration(milliseconds: 550);
+
+VideoDoubleTapSeekDirection? resolveVideoDoubleTapSeekDirection({
+  required double tapX,
+  required double viewportWidth,
+  double centerDeadZoneWidth = _videoDoubleTapCenterDeadZoneWidth,
+}) {
+  if (viewportWidth <= 0) {
+    return null;
+  }
+
+  final halfDeadZone = math.min(centerDeadZoneWidth / 2, viewportWidth / 4);
+  final centerX = viewportWidth / 2;
+
+  if (tapX < centerX - halfDeadZone) {
+    return VideoDoubleTapSeekDirection.backward;
+  }
+
+  if (tapX > centerX + halfDeadZone) {
+    return VideoDoubleTapSeekDirection.forward;
+  }
+
+  return null;
+}
+
+Duration _clampDuration(Duration value, Duration max) {
+  if (value < Duration.zero) {
+    return Duration.zero;
+  }
+
+  if (max > Duration.zero && value > max) {
+    return max;
+  }
+
+  return value;
+}
+
+void triggerVideoDoubleTapSeek(
+  WidgetRef ref, {
+  required String playerId,
+  required double tapX,
+  required double viewportWidth,
+  Duration step = videoDoubleTapSeekStep,
+}) {
+  final direction = resolveVideoDoubleTapSeekDirection(tapX: tapX, viewportWidth: viewportWidth);
+  if (direction == null) {
+    return;
+  }
+
+  final isForward = direction == VideoDoubleTapSeekDirection.forward;
+  final signedStep = isForward ? step : -step;
+
+  final cast = ref.read(castProvider);
+  if (cast.isCasting) {
+    if (cast.duration <= Duration.zero) {
+      return;
+    }
+
+    final target = _clampDuration(cast.currentTime + signedStep, cast.duration);
+    if (target == cast.currentTime) {
+      return;
+    }
+
+    ref.read(castProvider.notifier).seekTo(target);
+    ref.read(videoDoubleTapSeekIndicatorProvider(playerId).notifier).show(direction, step);
+    return;
+  }
+
+  final state = ref.read(videoPlayerProvider(playerId));
+  if (state.duration <= Duration.zero) {
+    return;
+  }
+
+  final target = _clampDuration(state.position + signedStep, state.duration);
+  if (target == state.position) {
+    return;
+  }
+
+  ref.read(videoPlayerProvider(playerId).notifier).seekTo(target);
+  ref.read(videoDoubleTapSeekIndicatorProvider(playerId).notifier).show(direction, step);
+}
+
+@immutable
+class VideoDoubleTapSeekIndicatorState {
+  final VideoDoubleTapSeekDirection direction;
+  final Duration total;
+  final int sequence;
+
+  const VideoDoubleTapSeekIndicatorState({required this.direction, required this.total, required this.sequence});
+}
+
+class VideoDoubleTapSeekIndicatorNotifier extends StateNotifier<VideoDoubleTapSeekIndicatorState?> {
+  VideoDoubleTapSeekIndicatorNotifier() : super(null);
+
+  Timer? _hideTimer;
+  int _sequence = 0;
+
+  @override
+  void dispose() {
+    _hideTimer?.cancel();
+    super.dispose();
+  }
+
+  void show(VideoDoubleTapSeekDirection direction, Duration amount) {
+    final current = state;
+    final total = current != null && current.direction == direction ? current.total + amount : amount;
+
+    state = VideoDoubleTapSeekIndicatorState(direction: direction, total: total, sequence: ++_sequence);
+
+    _hideTimer?.cancel();
+    _hideTimer = Timer(_videoDoubleTapOverlayDuration, () => state = null);
+  }
+}
+
+final videoDoubleTapSeekIndicatorProvider = StateNotifierProvider.autoDispose
+    .family<VideoDoubleTapSeekIndicatorNotifier, VideoDoubleTapSeekIndicatorState?, String>((ref, _) {
+      return VideoDoubleTapSeekIndicatorNotifier();
+    });
+
+class VideoDoubleTapSeekOverlay extends ConsumerWidget {
+  final String playerId;
+
+  const VideoDoubleTapSeekOverlay({super.key, required this.playerId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(videoDoubleTapSeekIndicatorProvider(playerId));
+    if (state == null) {
+      return const SizedBox.shrink();
+    }
+
+    final isForward = state.direction == VideoDoubleTapSeekDirection.forward;
+    final alignment = isForward ? Alignment.centerRight : Alignment.centerLeft;
+    final icon = isForward ? Icons.fast_forward_rounded : Icons.fast_rewind_rounded;
+    final label = '${isForward ? '+' : '-'}${state.total.inSeconds.abs()}s';
+
+    return IgnorePointer(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final halfWidth = constraints.maxWidth / 2;
+          final diameter = math.max(halfWidth * 1.9, constraints.maxHeight * 1.2);
+
+          return Stack(
+            children: [
+              Align(
+                alignment: alignment,
+                child: FractionallySizedBox(
+                  widthFactor: 0.5,
+                  heightFactor: 1,
+                  child: ClipRect(
+                    child: TweenAnimationBuilder<double>(
+                      key: ValueKey(state.sequence),
+                      tween: Tween(begin: 0, end: 1),
+                      duration: _videoDoubleTapRippleDuration,
+                      curve: Curves.easeOutCubic,
+                      builder: (context, progress, _) {
+                        final fade = 1 - Curves.easeIn.transform(progress);
+                        final scale = 0.3 + progress;
+
+                        return Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            Positioned(
+                              left: isForward ? null : -diameter * 0.45,
+                              right: isForward ? -diameter * 0.45 : null,
+                              top: (constraints.maxHeight - diameter) / 2,
+                              child: Opacity(
+                                opacity: 0.24 * fade,
+                                child: Transform.scale(
+                                  scale: scale,
+                                  child: Container(
+                                    width: diameter,
+                                    height: diameter,
+                                    decoration: BoxDecoration(
+                                      shape: BoxShape.circle,
+                                      gradient: RadialGradient(
+                                        colors: [
+                                          Colors.white.withValues(alpha: 0.8),
+                                          Colors.white.withValues(alpha: 0.24),
+                                          Colors.transparent,
+                                        ],
+                                        stops: const [0.0, 0.45, 1.0],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment(isForward ? 0.52 : -0.52, 0),
+                child: TweenAnimationBuilder<double>(
+                  key: ValueKey('content-${state.sequence}'),
+                  tween: Tween(begin: 0, end: 1),
+                  duration: _videoDoubleTapRippleDuration,
+                  curve: Curves.easeOutCubic,
+                  builder: (context, progress, child) {
+                    final fade = 1 - Curves.easeIn.transform(progress);
+                    return Opacity(
+                      opacity: fade,
+                      child: Transform.scale(scale: 0.92 + (progress * 0.08), child: child),
+                    );
+                  },
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.34),
+                      borderRadius: BorderRadius.circular(999),
+                      border: Border.all(color: Colors.white.withValues(alpha: 0.14)),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(icon, color: Colors.white, size: 32),
+                          const SizedBox(height: 4),
+                          Text(
+                            label,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                              shadows: [Shadow(color: Colors.black87, blurRadius: 8)],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/photo_view/photo_view.dart
+++ b/mobile/lib/widgets/photo_view/photo_view.dart
@@ -254,6 +254,7 @@ class PhotoView extends StatefulWidget {
     this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -297,6 +298,7 @@ class PhotoView extends StatefulWidget {
     this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -406,6 +408,9 @@ class PhotoView extends StatefulWidget {
   /// A pointer that might cause a tap has contacted the screen at a particular
   /// location.
   final PhotoViewImageTapDownCallback? onTapDown;
+
+  /// A pointer that completed a double tap in the PhotoView region.
+  final PhotoViewImageDoubleTapCallback? onDoubleTap;
 
   /// A pointer that might cause a tap has contacted the screen at a particular
   /// location.
@@ -566,6 +571,7 @@ class _PhotoViewState extends State<PhotoView> with AutomaticKeepAliveClientMixi
                 scaleStateCycle: widget.scaleStateCycle,
                 onTapUp: widget.onTapUp,
                 onTapDown: widget.onTapDown,
+                onDoubleTap: widget.onDoubleTap,
                 onDragStart: widget.onDragStart,
                 onDragEnd: widget.onDragEnd,
                 onDragUpdate: widget.onDragUpdate,
@@ -599,6 +605,7 @@ class _PhotoViewState extends State<PhotoView> with AutomaticKeepAliveClientMixi
                 scaleStateCycle: widget.scaleStateCycle,
                 onTapUp: widget.onTapUp,
                 onTapDown: widget.onTapDown,
+                onDoubleTap: widget.onDoubleTap,
                 onDragStart: widget.onDragStart,
                 onDragEnd: widget.onDragEnd,
                 onDragUpdate: widget.onDragUpdate,
@@ -642,6 +649,10 @@ typedef PhotoViewImageTapUpCallback =
 
 /// A type definition for a callback when the user taps down the photoview region
 typedef PhotoViewImageTapDownCallback =
+    Function(BuildContext context, TapDownDetails details, PhotoViewControllerValue controllerValue);
+
+/// A type definition for a callback when the user completes a double tap in the photoview region.
+typedef PhotoViewImageDoubleTapCallback =
     Function(BuildContext context, TapDownDetails details, PhotoViewControllerValue controllerValue);
 
 /// A type definition for a callback when the user drags up

--- a/mobile/lib/widgets/photo_view/photo_view_gallery.dart
+++ b/mobile/lib/widgets/photo_view/photo_view_gallery.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/widgets/photo_view/photo_view.dart'
         PhotoViewImageDragEndCallback,
         PhotoViewImageDragStartCallback,
         PhotoViewImageDragUpdateCallback,
+        PhotoViewImageDoubleTapCallback,
         PhotoViewImageLongPressStartCallback,
         PhotoViewImageScaleEndCallback,
         PhotoViewImageTapDownCallback,
@@ -281,6 +282,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             scaleStateCycle: pageOption.scaleStateCycle,
             onTapUp: pageOption.onTapUp,
             onTapDown: pageOption.onTapDown,
+            onDoubleTap: pageOption.onDoubleTap,
             onDragStart: pageOption.onDragStart,
             onDragEnd: pageOption.onDragEnd,
             onDragUpdate: pageOption.onDragUpdate,
@@ -319,6 +321,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             scaleStateCycle: pageOption.scaleStateCycle,
             onTapUp: pageOption.onTapUp,
             onTapDown: pageOption.onTapDown,
+            onDoubleTap: pageOption.onDoubleTap,
             onDragStart: pageOption.onDragStart,
             onDragEnd: pageOption.onDragEnd,
             onDragUpdate: pageOption.onDragUpdate,
@@ -366,6 +369,7 @@ class PhotoViewGalleryPageOptions {
     this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -397,6 +401,7 @@ class PhotoViewGalleryPageOptions {
     this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -466,6 +471,9 @@ class PhotoViewGalleryPageOptions {
 
   /// Mirror to [PhotoView.onTapDown]
   final PhotoViewImageTapDownCallback? onTapDown;
+
+  /// Mirror to [PhotoView.onDoubleTap]
+  final PhotoViewImageDoubleTapCallback? onDoubleTap;
 
   /// Mirror to [PhotoView.onScaleEnd]
   final PhotoViewImageScaleEndCallback? onScaleEnd;

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view.dart'
     show
+        PhotoViewImageDoubleTapCallback,
         PhotoViewScaleState,
         PhotoViewHeroAttributes,
         PhotoViewImageTapDownCallback,
@@ -33,6 +34,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.enableRotation,
     required this.onTapUp,
     required this.onTapDown,
+    required this.onDoubleTap,
     required this.onDragStart,
     required this.onDragEnd,
     required this.onDragUpdate,
@@ -60,6 +62,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.enableRotation,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -97,6 +100,7 @@ class PhotoViewCore extends StatefulWidget {
 
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
+  final PhotoViewImageDoubleTapCallback? onDoubleTap;
   final PhotoViewImageScaleEndCallback? onScaleEnd;
 
   final PhotoViewImageDragStartCallback? onDragStart;
@@ -126,6 +130,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     with TickerProviderStateMixin, PhotoViewControllerDelegate, HitCornersDetector {
   double? _scaleBefore;
   double? _rotationBefore;
+  TapDownDetails? _lastDoubleTapDownDetails;
 
   late final AnimationController _scaleAnimationController;
   Animation<double>? _scaleAnimation;
@@ -233,7 +238,19 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     }
   }
 
+  void onDoubleTapDown(TapDownDetails details) {
+    _lastDoubleTapDownDetails = details;
+  }
+
   void onDoubleTap() {
+    final details = _lastDoubleTapDownDetails;
+    _lastDoubleTapDownDetails = null;
+
+    if (widget.onDoubleTap != null && details != null) {
+      widget.onDoubleTap!(context, details, controller.value);
+      return;
+    }
+
     nextScaleState();
   }
 
@@ -376,6 +393,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
           return PhotoViewGestureDetector(
             disableScaleGestures: widget.disableScaleGestures,
+            onDoubleTapDown: onDoubleTapDown,
             onDoubleTap: widget.disableScaleGestures ? null : onDoubleTap,
             onScaleStart: widget.disableScaleGestures ? null : onScaleStart,
             onScaleUpdate: widget.disableScaleGestures ? null : onScaleUpdate,

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
@@ -11,6 +11,7 @@ class PhotoViewGestureDetector extends StatelessWidget {
     this.onScaleStart,
     this.onScaleUpdate,
     this.onScaleEnd,
+    this.onDoubleTapDown,
     this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
@@ -24,6 +25,7 @@ class PhotoViewGestureDetector extends StatelessWidget {
     this.disableScaleGestures = false,
   });
 
+  final GestureTapDownCallback? onDoubleTapDown;
   final GestureDoubleTapCallback? onDoubleTap;
   final HitCornersDetector? hitDetector;
 
@@ -83,7 +85,9 @@ class PhotoViewGestureDetector extends StatelessWidget {
     gestures[DoubleTapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
       () => DoubleTapGestureRecognizer(debugOwner: this),
       (DoubleTapGestureRecognizer instance) {
-        instance.onDoubleTap = onDoubleTap;
+        instance
+          ..onDoubleTapDown = onDoubleTapDown
+          ..onDoubleTap = onDoubleTap;
       },
     );
 

--- a/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
+++ b/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
@@ -24,6 +24,7 @@ class ImageWrapper extends StatefulWidget {
     required this.scaleStateCycle,
     required this.onTapUp,
     required this.onTapDown,
+    required this.onDoubleTap,
     required this.onDragStart,
     required this.onDragEnd,
     required this.onDragUpdate,
@@ -59,6 +60,7 @@ class ImageWrapper extends StatefulWidget {
   final ScaleStateCycle? scaleStateCycle;
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
+  final PhotoViewImageDoubleTapCallback? onDoubleTap;
   final PhotoViewImageDragStartCallback? onDragStart;
   final PhotoViewImageDragEndCallback? onDragEnd;
   final PhotoViewImageDragUpdateCallback? onDragUpdate;
@@ -201,6 +203,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
         scaleStateCycle: widget.scaleStateCycle,
         onTapUp: widget.onTapUp,
         onTapDown: widget.onTapDown,
+        onDoubleTap: widget.onDoubleTap,
         onDragStart: widget.onDragStart,
         onDragEnd: widget.onDragEnd,
         onDragUpdate: widget.onDragUpdate,
@@ -232,6 +235,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       scaleBoundaries: scaleBoundaries,
       onTapUp: widget.onTapUp,
       onTapDown: widget.onTapDown,
+      onDoubleTap: widget.onDoubleTap,
       onDragStart: widget.onDragStart,
       onDragEnd: widget.onDragEnd,
       onDragUpdate: widget.onDragUpdate,
@@ -281,6 +285,7 @@ class CustomChildWrapper extends StatelessWidget {
     required this.scaleStateCycle,
     this.onTapUp,
     this.onTapDown,
+    this.onDoubleTap,
     this.onDragStart,
     this.onDragEnd,
     this.onDragUpdate,
@@ -314,6 +319,7 @@ class CustomChildWrapper extends StatelessWidget {
   final ScaleStateCycle? scaleStateCycle;
   final PhotoViewImageTapUpCallback? onTapUp;
   final PhotoViewImageTapDownCallback? onTapDown;
+  final PhotoViewImageDoubleTapCallback? onDoubleTap;
   final PhotoViewImageDragStartCallback? onDragStart;
   final PhotoViewImageDragEndCallback? onDragEnd;
   final PhotoViewImageDragUpdateCallback? onDragUpdate;
@@ -350,6 +356,7 @@ class CustomChildWrapper extends StatelessWidget {
       scaleBoundaries: scaleBoundaries,
       onTapUp: onTapUp,
       onTapDown: onTapDown,
+      onDoubleTap: onDoubleTap,
       onDragStart: onDragStart,
       onDragEnd: onDragEnd,
       onDragUpdate: onDragUpdate,

--- a/mobile/test/modules/asset_viewer/video_double_tap_seek_test.dart
+++ b/mobile/test/modules/asset_viewer/video_double_tap_seek_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/widgets/asset_viewer/video_double_tap_seek.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  TestUtils.init();
+
+  group('resolveVideoDoubleTapSeekDirection', () {
+    test('returns backward for taps on the left side', () {
+      final direction = resolveVideoDoubleTapSeekDirection(tapX: 40, viewportWidth: 400);
+      expect(direction, VideoDoubleTapSeekDirection.backward);
+    });
+
+    test('returns forward for taps on the right side', () {
+      final direction = resolveVideoDoubleTapSeekDirection(tapX: 360, viewportWidth: 400);
+      expect(direction, VideoDoubleTapSeekDirection.forward);
+    });
+
+    test('returns null for taps inside the center dead zone', () {
+      final direction = resolveVideoDoubleTapSeekDirection(tapX: 200, viewportWidth: 400);
+      expect(direction, isNull);
+    });
+  });
+
+  group('videoDoubleTapSeekIndicatorProvider', () {
+    const playerId = 'video-1';
+
+    test('accumulates repeated taps in the same direction', () {
+      final container = TestUtils.createContainer();
+      final notifier = container.read(videoDoubleTapSeekIndicatorProvider(playerId).notifier);
+
+      notifier.show(VideoDoubleTapSeekDirection.forward, const Duration(seconds: 10));
+      notifier.show(VideoDoubleTapSeekDirection.forward, const Duration(seconds: 10));
+
+      final state = container.read(videoDoubleTapSeekIndicatorProvider(playerId));
+      expect(state?.direction, VideoDoubleTapSeekDirection.forward);
+      expect(state?.total, const Duration(seconds: 20));
+    });
+
+    test('resets the total when direction changes', () {
+      final container = TestUtils.createContainer();
+      final notifier = container.read(videoDoubleTapSeekIndicatorProvider(playerId).notifier);
+
+      notifier.show(VideoDoubleTapSeekDirection.forward, const Duration(seconds: 10));
+      notifier.show(VideoDoubleTapSeekDirection.backward, const Duration(seconds: 10));
+
+      final state = container.read(videoDoubleTapSeekIndicatorProvider(playerId));
+      expect(state?.direction, VideoDoubleTapSeekDirection.backward);
+      expect(state?.total, const Duration(seconds: 10));
+    });
+
+    test('clears the indicator after the overlay timeout', () async {
+      final container = TestUtils.createContainer();
+      final notifier = container.read(videoDoubleTapSeekIndicatorProvider(playerId).notifier);
+
+      notifier.show(VideoDoubleTapSeekDirection.forward, const Duration(seconds: 10));
+      expect(container.read(videoDoubleTapSeekIndicatorProvider(playerId)), isNotNull);
+
+      await Future.delayed(const Duration(milliseconds: 950));
+
+      expect(container.read(videoDoubleTapSeekIndicatorProvider(playerId)), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds Google Photos / YouTube style double-tap seeking for videos in the mobile viewers.

- wires a custom double-tap callback through Immich's in-repo `PhotoView` stack so video surfaces can react to the second tap location
- adds left/right seek zones with a center dead zone and a shared helper for resolving direction and applying `10s` seeks
- shows a side-specific ripple/overlay with accumulated `+10s` / `-10s` feedback for repeated taps
- applies the interaction in both mobile video viewer paths used by the gallery and the presentation asset viewer
- adds focused tests for seek-zone resolution and overlay accumulation/reset behavior

Related to #17411 and #18137.

Note: this PR is intentionally scoped to mobile. The web app still uses the native video controls path, so web parity would need a separate custom-controls follow-up.

## How Has This Been Tested?

- [x] `dart analyze lib/pages/common/gallery_viewer.page.dart lib/presentation/widgets/asset_viewer/asset_page.widget.dart lib/pages/common/native_video_viewer.page.dart lib/presentation/widgets/asset_viewer/video_viewer.widget.dart lib/widgets/asset_viewer/video_double_tap_seek.dart lib/widgets/photo_view/photo_view.dart lib/widgets/photo_view/photo_view_gallery.dart lib/widgets/photo_view/src/core/photo_view_core.dart lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart lib/widgets/photo_view/src/photo_view_wrappers.dart test/modules/asset_viewer/video_double_tap_seek_test.dart`
- [x] `flutter test test/modules/asset_viewer/video_double_tap_seek_test.dart`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not captured in this run.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (N/A, mobile-only change)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) (N/A, mobile-only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to assist with implementation drafting and local verification, and the resulting code and behavior were reviewed in-repo before opening this PR.
