### PR TITLE
fix(web): allow pasting PIN code from clipboard or password manager

### DIFF
--- a/web/src/lib/components/user-settings-page/PinCodeInput.svelte
+++ b/web/src/lib/components/user-settings-page/PinCodeInput.svelte
@@ -49,22 +49,21 @@
 
   const handleInput = (event: Event, index: number) => {
     const target = event.target as HTMLInputElement;
-    const digits = target.value.replaceAll(/\D/g, '');
+    const digits = target.value.replaceAll(/\D/g, '').slice(0, pinLength - index);
 
     if (digits.length === 0) {
       pinValues[index] = '';
-      target.value = '';
       value = pinValues.join('').trim();
       return;
     }
 
-    for (let i = 0; i < digits.length && index + i < pinLength; i++) {
+    for (let i = 0; i < digits.length; i++) {
       pinValues[index + i] = digits[i];
     }
 
     value = pinValues.join('').trim();
 
-    const lastFilledIndex = Math.min(index + digits.length, pinLength) - 1;
+    const lastFilledIndex = Math.min(index + digits.length, pinLength - 1);
     pinCodeInputElements[lastFilledIndex]?.focus();
 
     if (value.length === pinLength) {

--- a/web/src/lib/components/user-settings-page/PinCodeInput.svelte
+++ b/web/src/lib/components/user-settings-page/PinCodeInput.svelte
@@ -74,6 +74,27 @@
     }
   };
 
+  const handlePaste = (event: ClipboardEvent, index: number) => {
+    event.preventDefault();
+    const pasted = (event.clipboardData?.getData('text') ?? '').replaceAll(/\D/g, '');
+    if (pasted.length === 0) {
+      return;
+    }
+
+    for (let i = 0; i < pasted.length && index + i < pinLength; i++) {
+      pinValues[index + i] = pasted[i];
+    }
+
+    value = pinValues.join('').trim();
+
+    const lastFilledIndex = Math.min(index + pasted.length, pinLength) - 1;
+    pinCodeInputElements[lastFilledIndex]?.focus();
+
+    if (value.length === pinLength) {
+      onFilled?.(value);
+    }
+  };
+
   function handleKeydown(event: KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement }) {
     const target = event.currentTarget as HTMLInputElement;
     const index = pinCodeInputElements.indexOf(target);
@@ -105,6 +126,9 @@
         return;
       }
       default: {
+        if (event.ctrlKey || event.metaKey || event.altKey) {
+          return;
+        }
         if (Number.isNaN(Number(event.key))) {
           event.preventDefault();
         }
@@ -132,6 +156,7 @@
         bind:value={pinValues[index]}
         onkeydown={handleKeydown}
         oninput={(event) => handleInput(event, index)}
+        onpaste={(event) => handlePaste(event, index)}
         aria-label={`PIN digit ${index + 1} of ${pinLength}${label ? ` for ${label}` : ''}`}
       />
     {/each}

--- a/web/src/lib/components/user-settings-page/PinCodeInput.svelte
+++ b/web/src/lib/components/user-settings-page/PinCodeInput.svelte
@@ -49,45 +49,22 @@
 
   const handleInput = (event: Event, index: number) => {
     const target = event.target as HTMLInputElement;
-    let currentPinValue = target.value;
+    const digits = target.value.replaceAll(/\D/g, '');
 
-    if (target.value.length > 1) {
-      currentPinValue = value.slice(0, 1);
-    }
-
-    if (Number.isNaN(Number(value))) {
+    if (digits.length === 0) {
       pinValues[index] = '';
       target.value = '';
+      value = pinValues.join('').trim();
       return;
     }
 
-    pinValues[index] = currentPinValue;
-
-    value = pinValues.join('').trim();
-
-    if (value && index < pinLength - 1) {
-      focusNext(index);
-    }
-
-    if (value.length === pinLength) {
-      onFilled?.(value);
-    }
-  };
-
-  const handlePaste = (event: ClipboardEvent, index: number) => {
-    event.preventDefault();
-    const pasted = (event.clipboardData?.getData('text') ?? '').replaceAll(/\D/g, '');
-    if (pasted.length === 0) {
-      return;
-    }
-
-    for (let i = 0; i < pasted.length && index + i < pinLength; i++) {
-      pinValues[index + i] = pasted[i];
+    for (let i = 0; i < digits.length && index + i < pinLength; i++) {
+      pinValues[index + i] = digits[i];
     }
 
     value = pinValues.join('').trim();
 
-    const lastFilledIndex = Math.min(index + pasted.length, pinLength) - 1;
+    const lastFilledIndex = Math.min(index + digits.length, pinLength) - 1;
     pinCodeInputElements[lastFilledIndex]?.focus();
 
     if (value.length === pinLength) {
@@ -125,15 +102,6 @@
         }
         return;
       }
-      default: {
-        if (event.ctrlKey || event.metaKey || event.altKey) {
-          return;
-        }
-        if (Number.isNaN(Number(event.key))) {
-          event.preventDefault();
-        }
-        break;
-      }
     }
   }
 </script>
@@ -149,14 +117,12 @@
         {type}
         inputmode="numeric"
         pattern="[0-9]*"
-        maxlength="1"
         bind:this={pinCodeInputElements[index]}
         id="pin-code-{index}"
         class="h-12 w-10 rounded-xl border-2 border-suble dark:border-gray-700 text-center text-lg font-medium focus:border-immich-primary focus:ring-primary dark:focus:border-primary font-mono bg-white dark:bg-light"
         bind:value={pinValues[index]}
         onkeydown={handleKeydown}
         oninput={(event) => handleInput(event, index)}
-        onpaste={(event) => handlePaste(event, index)}
         aria-label={`PIN digit ${index + 1} of ${pinLength}${label ? ` for ${label}` : ''}`}
       />
     {/each}


### PR DESCRIPTION
## Description

The `handleKeydown` in `PinCodeInput.svelte` calls `preventDefault()` on all non-numeric keys, which blocks Ctrl+V / Cmd+V. Password managers that simulate keypresses are affected the same way. There is also no `onpaste` handler to distribute a multi-digit string across the individual inputs.

This PR allows modifier key combinations through in `handleKeydown` and adds an `onpaste` handler that extracts digits from clipboard text and fills them across the pin inputs.

Fixes #19613

## How Has This Been Tested?

- [x] Copy a 6-digit PIN and paste into the locked folder prompt with Cmd+V
- [x] Paste a partial PIN (3 digits) starting from the first input — remaining fields stay empty
- [x] Paste text containing non-numeric characters — only digits are used
- [x] Right-click context menu paste works
- [x] Normal digit-by-digit input still works as before

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — no visual changes, only input behavior fix.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.