### PR TITLE
fix(web): make link fit album card

### DIFF
--- a/web/src/lib/components/album-page/album-card-group.svelte
+++ b/web/src/lib/components/album-page/album-card-group.svelte
@@ -65,6 +65,7 @@
       {#each albums as album, index (album.id)}
         <a
           href={Route.viewAlbum(album)}
+          class="h-fit"
           animate:flip={{ duration: 400 }}
           oncontextmenu={(event) => oncontextmenu(event, album)}
         >


### PR DESCRIPTION
## Description
Make the link fit around the album card. Currently, clicking on the link but outside the (outlined on hover) album card opens the album, and right-clicking opens the context menu. This is unintuitive because the card is not in its hover state.

## How Has This Been Tested?
Hover & right-click. See the screenshot below for illustration on how cards can be smaller than the link.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="644" height="495" alt="image" src="https://github.com/user-attachments/assets/b1253bb6-c960-4f06-84fb-871619d9245c" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
