### PR TITLE
feat(web): add remove from album button in asset viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/action.ts
+++ b/web/src/lib/components/asset-viewer/actions/action.ts
@@ -12,6 +12,7 @@ type ActionMap = {
   [AssetAction.UNSTACK]: { assets: TimelineAsset[] };
   [AssetAction.SET_STACK_PRIMARY_ASSET]: { stack: StackResponseDto };
   [AssetAction.REMOVE_ASSET_FROM_STACK]: { stack: StackResponseDto | null; asset: AssetResponseDto };
+  [AssetAction.REMOVE_FROM_ALBUM]: { asset: TimelineAsset };
   [AssetAction.SET_VISIBILITY_LOCKED]: { asset: TimelineAsset };
   [AssetAction.SET_VISIBILITY_TIMELINE]: { asset: TimelineAsset };
   [AssetAction.SET_PERSON_FEATURED_PHOTO]: { asset: AssetResponseDto; person: PersonResponseDto };

--- a/web/src/lib/components/asset-viewer/actions/remove-from-album-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/remove-from-album-action.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
+  import { AssetAction } from '$lib/constants';
+  import { handleError } from '$lib/utils/handle-error';
+  import { toTimelineAsset } from '$lib/utils/timeline-util';
+  import { removeAssetFromAlbum, type AlbumResponseDto, type AssetResponseDto } from '@immich/sdk';
+  import { modalManager, toastManager } from '@immich/ui';
+  import { mdiImageRemoveOutline } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+  import type { OnAction } from './action';
+
+  interface Props {
+    asset: AssetResponseDto;
+    album: AlbumResponseDto;
+    onAction: OnAction;
+  }
+
+  let { asset, album, onAction }: Props = $props();
+
+  const handleRemove = async () => {
+    const isConfirmed = await modalManager.showDialog({
+      prompt: $t('remove_assets_album_confirmation', { values: { count: 1 } }),
+    });
+    if (!isConfirmed) return;
+
+    try {
+      await removeAssetFromAlbum({ id: album.id, bulkIdsDto: { ids: [asset.id] } });
+      toastManager.success($t('assets_removed_count', { values: { count: 1 } }));
+      onAction({ type: AssetAction.REMOVE_FROM_ALBUM, asset: toTimelineAsset(asset) });
+    } catch (error) {
+      handleError(error, $t('errors.error_removing_assets_from_album'));
+    }
+  };
+</script>
+
+<MenuOption text={$t('remove_from_album')} icon={mdiImageRemoveOutline} onClick={handleRemove} />

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -8,6 +8,7 @@
   import KeepThisDeleteOthersAction from '$lib/components/asset-viewer/actions/keep-this-delete-others.svelte';
   import RatingAction from '$lib/components/asset-viewer/actions/rating-action.svelte';
   import RemoveAssetFromStack from '$lib/components/asset-viewer/actions/remove-asset-from-stack.svelte';
+  import RemoveFromAlbumAction from '$lib/components/asset-viewer/actions/remove-from-album-action.svelte';
   import RestoreAction from '$lib/components/asset-viewer/actions/restore-action.svelte';
   import SetAlbumCoverAction from '$lib/components/asset-viewer/actions/set-album-cover-action.svelte';
   import SetFeaturedPhotoAction from '$lib/components/asset-viewer/actions/set-person-featured-action.svelte';
@@ -168,6 +169,7 @@
           {/if}
         {/if}
         {#if album}
+          <RemoveFromAlbumAction {asset} {album} {onAction} />
           <SetAlbumCoverAction {asset} {album} />
         {/if}
         {#if person}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -330,7 +330,8 @@
         };
         break;
       }
-      case AssetAction.UNSTACK: {
+      case AssetAction.UNSTACK:
+      case AssetAction.REMOVE_FROM_ALBUM: {
         closeViewer();
         break;
       }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -10,6 +10,7 @@ export enum AssetAction {
   UNSTACK = 'unstack',
   SET_STACK_PRIMARY_ASSET = 'set-stack-primary-asset',
   REMOVE_ASSET_FROM_STACK = 'remove-asset-from-stack',
+  REMOVE_FROM_ALBUM = 'remove-from-album',
   SET_VISIBILITY_LOCKED = 'set-visibility-locked',
   SET_VISIBILITY_TIMELINE = 'set-visibility-timeline',
   SET_PERSON_FEATURED_PHOTO = 'set-person-featured-photo',


### PR DESCRIPTION
## Description

vibe coded on claude code
Tested in local development environment
I can attach screenshots if needed.
All of below is AI generated

Adds a **Remove from album** option to the asset viewer's overflow (⋮) menu, visible only when viewing an asset in the context of an album.

Previously, users had to leave the asset viewer and use multi-select to remove a photo from an album. This change lets them do it in one step without losing their place.

## Changes

- New `RemoveFromAlbumAction` component (`asset-viewer/actions/remove-from-album-action.svelte`) — shows a confirmation dialog, calls the existing `removeAssetFromAlbum` SDK method, displays a success toast, then fires `onAction`
- Added `REMOVE_FROM_ALBUM` to `AssetAction` enum and `ActionMap`
- Asset viewer closes on `REMOVE_FROM_ALBUM` (same behaviour as `UNSTACK`)
- Menu item appears inside the existing `{#if album}` block, above "Set as album cover"

## Testing

Tested against a production Immich instance:
- Opens album → clicks photo → ⋮ menu → "Remove from album" is present
- Confirms → asset is removed from album, viewer closes, photo is gone from album
- Option does not appear when viewing photos outside of an album context
- Cancel on confirmation dialog does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)