### PR TITLE
fix(server): flaky metadata tests

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -330,7 +330,7 @@ describe(MetadataService.name, () => {
         duration: null,
         fileCreatedAt: asset.fileCreatedAt,
         fileModifiedAt: asset.fileModifiedAt,
-        localDateTime: asset.localDateTime,
+        localDateTime: asset.fileCreatedAt,
         width: null,
         height: null,
       });
@@ -360,7 +360,7 @@ describe(MetadataService.name, () => {
         duration: null,
         fileCreatedAt: asset.fileCreatedAt,
         fileModifiedAt: asset.fileModifiedAt,
-        localDateTime: asset.localDateTime,
+        localDateTime: asset.fileCreatedAt,
         width: null,
         height: null,
       });

--- a/server/test/factories/asset.factory.ts
+++ b/server/test/factories/asset.factory.ts
@@ -19,7 +19,7 @@ import {
   UserLike,
 } from 'test/factories/types';
 import { UserFactory } from 'test/factories/user.factory';
-import { newDate, newSha1, newUuid, newUuidV7 } from 'test/small.factory';
+import { newSha1, newUuid, newUuidV7 } from 'test/small.factory';
 
 export class AssetFactory {
   #owner!: UserFactory;
@@ -43,10 +43,12 @@ export class AssetFactory {
 
     const originalFileName = dto.originalFileName ?? (dto.type === AssetType.Video ? `MOV_${id}.mp4` : `IMG_${id}.jpg`);
 
+    let now = Date.now();
+
     return new AssetFactory({
       id,
-      createdAt: newDate(),
-      updatedAt: newDate(),
+      createdAt: new Date(now++),
+      updatedAt: new Date(now++),
       deletedAt: null,
       updateId: newUuidV7(),
       status: AssetStatus.Active,
@@ -55,14 +57,14 @@ export class AssetFactory {
       deviceId: '',
       duplicateId: null,
       duration: null,
-      fileCreatedAt: newDate(),
-      fileModifiedAt: newDate(),
+      fileCreatedAt: new Date(now++),
+      fileModifiedAt: new Date(now++),
       isExternal: false,
       isFavorite: false,
       isOffline: false,
       libraryId: null,
       livePhotoVideoId: null,
-      localDateTime: newDate(),
+      localDateTime: new Date(now),
       originalFileName,
       originalPath: `/data/library/${originalFileName}`,
       ownerId: newUuid(),


### PR DESCRIPTION
## Description

Dates on the asset factory use the current time, and they are usually all the same time, but may occasionally be a millisecond out. This behaviour hid the fact that some tests were asserting against the wrong field, and would flake.

We can resolve this by ensuring that each date on a test asset is unique.

## How Has This Been Tested?

Ran the tests.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
