### PR TITLE
fix(web): jump to primary stacked asset from memory

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -63,8 +63,9 @@
   let playerInitialized = $state(false);
   let paused = $state(false);
   let current = $state<MemoryAsset | undefined>(undefined);
-  let currentMemoryAssetFull = $derived.by(async () =>
-    current?.asset ? await getAssetInfo({ ...authManager.params, id: current.asset.id }) : undefined,
+  const currentAssetId = $derived(current?.asset.id);
+  const currentMemoryAssetFull = $derived.by(async () =>
+    currentAssetId ? await getAssetInfo({ ...authManager.params, id: currentAssetId }) : undefined,
   );
   let currentTimelineAssets = $derived(current?.memory.assets ?? []);
   let viewerAssets = $derived([
@@ -550,14 +551,18 @@
               </div>
 
               <div>
-                <IconButton
-                  href={Route.photos({ at: current.asset.id })}
-                  icon={mdiImageSearch}
-                  aria-label={$t('view_in_timeline')}
-                  color="secondary"
-                  variant="ghost"
-                  shape="round"
-                />
+                {#await currentMemoryAssetFull then asset}
+                  {#if asset}
+                    <IconButton
+                      href={Route.photos({ at: asset.stack?.primaryAssetId ?? asset.id })}
+                      icon={mdiImageSearch}
+                      aria-label={$t('view_in_timeline')}
+                      color="secondary"
+                      variant="ghost"
+                      shape="round"
+                    />
+                  {/if}
+                {/await}
               </div>
             </div>
             <!-- CONTROL BUTTONS -->


### PR DESCRIPTION
Fixes #24144 where clicking "View in timeline" on a memory navigates to a non-primary stacked asset, causing navigation to fail. Fixed by navigating to the primary asset of a stack.