### PR TITLE
fix(web): keep map view open after closing asset viewer

### DIFF
--- a/e2e/src/specs/web/album.e2e-spec.ts
+++ b/e2e/src/specs/web/album.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { LoginResponseDto } from '@immich/sdk';
-import { test } from '@playwright/test';
-import { utils } from 'src/utils';
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { testAssetDir, utils } from 'src/utils';
 
 test.describe('Album', () => {
   let admin: LoginResponseDto;
@@ -21,5 +22,42 @@ test.describe('Album', () => {
 
     await page.reload();
     await page.getByRole('button', { name: 'Select photos' }).waitFor();
+  });
+
+  test('should keep map view open after viewing an asset from the map and going back', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+
+    const imagePath = `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`;
+    const mapAsset = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(imagePath),
+        filename: 'thompson-springs.jpg',
+      },
+    });
+
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
+
+    const mapAlbum = await utils.createAlbum(admin.accessToken, {
+      albumName: 'Map Test Album',
+      assetIds: [mapAsset.id],
+    });
+
+    await page.goto(`/albums/${mapAlbum.id}`);
+    const mapButton = page.getByRole('button', { name: 'Map' });
+    await expect(mapButton).toBeVisible();
+    await mapButton.click();
+
+    const mapModal = page.getByRole('dialog');
+    await expect(mapModal).toBeVisible();
+
+    const mapMarker = mapModal.getByRole('img', { name: /Map marker/i }).first();
+    await expect(mapMarker).toBeVisible();
+    await mapMarker.click();
+
+    await page.waitForSelector('#immich-asset-viewer');
+    await page.getByRole('button', { name: 'Go back' }).click();
+
+    await expect(page.locator('#immich-asset-viewer')).not.toBeVisible();
+    await expect(mapModal).toBeVisible();
   });
 });

--- a/web/src/lib/components/album-page/album-map.svelte
+++ b/web/src/lib/components/album-page/album-map.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import MapModal from '$lib/modals/MapModal.svelte';
-  import { Route } from '$lib/route';
-  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { navigate } from '$lib/utils/navigation';
   import { getAlbumInfo, type AlbumResponseDto, type MapMarkerResponseDto } from '@immich/sdk';
   import { IconButton, modalManager } from '@immich/ui';
   import { mdiMapOutline } from '@mdi/js';
@@ -17,7 +15,6 @@
 
   let { album }: Props = $props();
   let abortController: AbortController;
-  let { isViewing } = assetViewingStore;
 
   let returnToMap = $state(false);
   let mapMarkers: MapMarkerResponseDto[] = $state([]);
@@ -32,9 +29,9 @@
   });
 
   $effect(() => {
-    if (!$isViewing && returnToMap) {
+    if (!assetViewerManager.isViewing && returnToMap) {
       returnToMap = false;
-      void openMap();
+      void onClick();
     }
   });
 
@@ -66,7 +63,7 @@
   const onClick = async () => {
     const assetIds = await modalManager.show(MapModal, { mapMarkers });
     if (assetIds) {
-      await goto(Route.viewAlbumAsset({ albumId: album.id, assetId: assetIds[0] }));
+      await navigate({ targetRoute: 'current', assetId: assetIds[0] });
       returnToMap = true;
     } else {
       returnToMap = false;

--- a/web/src/lib/components/album-page/album-map.svelte
+++ b/web/src/lib/components/album-page/album-map.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import MapModal from '$lib/modals/MapModal.svelte';
+  import { Route } from '$lib/route';
+  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { getAlbumInfo, type AlbumResponseDto, type MapMarkerResponseDto } from '@immich/sdk';
   import { IconButton, modalManager } from '@immich/ui';
   import { mdiMapOutline } from '@mdi/js';
@@ -14,7 +17,9 @@
 
   let { album }: Props = $props();
   let abortController: AbortController;
+  let { isViewing } = assetViewingStore;
 
+  let returnToMap = $state(false);
   let mapMarkers: MapMarkerResponseDto[] = $state([]);
 
   onMount(async () => {
@@ -24,6 +29,13 @@
   onDestroy(() => {
     abortController?.abort();
     assetViewerManager.showAssetViewer(false);
+  });
+
+  $effect(() => {
+    if (!$isViewing && returnToMap) {
+      returnToMap = false;
+      void openMap();
+    }
   });
 
   async function loadMapMarkers() {
@@ -54,7 +66,10 @@
   const onClick = async () => {
     const assetIds = await modalManager.show(MapModal, { mapMarkers });
     if (assetIds) {
-      await assetViewerManager.setAssetId(assetIds[0]);
+      await goto(Route.viewAlbumAsset({ albumId: album.id, assetId: assetIds[0] }));
+      returnToMap = true;
+    } else {
+      returnToMap = false;
     }
   };
 </script>


### PR DESCRIPTION
## Description

This PR fixes the issue where the album map modal would close when a user navigated back from viewing an asset.

**The Bugged Flow:**
Album -> Map Viewer -> Open a Photo -> Back Arrow -> Album
**The Correct Flow:**
Album -> Map Viewer -> Open a Photo -> Back Arrow -> Map Viewer 

This problem was solved by adding a state variable that controls whether the map should be open or not, activating the openMap function when necessary.
The asset viewer was being opened in this flow in a way that did not update the URL, which interrupted the navigation history and caused the "go back" action to fail during this flow. By changing it to use the pattern used in other files in the project, the problem was completely solved.

Fixes #26642 (issue)

## How Has This Been Tested?

- [X] Manually tested the UI flow
- [X] Added a E2E test that verifies this flow 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
N/A
</details>

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Revising spelling errors in my PR text.
Reviewing my code logic. 