### PR TITLE
fix(mobile): reset video controls hide timer when showing controls ch…

### DIFF
--- a/mobile/lib/widgets/asset_viewer/video_controls.dart
+++ b/mobile/lib/widgets/asset_viewer/video_controls.dart
@@ -60,6 +60,9 @@ class VideoControls extends HookConsumerWidget {
       }
     });
 
+    ref.listen(assetViewerProvider.select((v) => v.showingControls), (prev, showing) {
+      if (showing && prev != showing) hideTimer.reset();
+    });
     ref.listen(provider.select((v) => v.status), (_, __) => hideTimer.reset());
 
     final notifier = ref.read(provider.notifier);


### PR DESCRIPTION
## Description

…anges

The hide timer currently only resets when the status of the video changes, but does not account for when the controls change. This means that two things happen:

 1. The hide timer does not reset when the controls become visible again, the controls will stay visible forever or until the playback status changes.
 2. The hide timer will fire too quickly, and will hide the controls much sooner than 5 seconds if the controls are hidden and then shown again before the hide timer fires.

## How Has This Been Tested?

Pixel 8a.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A