### PR TITLE
chore(mobile): persist video controls visibility when swiping

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -65,13 +65,15 @@ class AssetViewer extends ConsumerStatefulWidget {
 
   static void setAsset(WidgetRef ref, BaseAsset asset) {
     ref.read(assetViewerProvider.notifier).reset();
+
+    // Hide controls by default for videos
+    if (asset.isVideo) ref.read(assetViewerProvider.notifier).setControls(false);
+
     _setAsset(ref, asset);
   }
 
   static void _setAsset(WidgetRef ref, BaseAsset asset) {
     ref.read(assetViewerProvider.notifier).setAsset(asset);
-    // Hide controls by default for videos
-    if (asset.isVideo) ref.read(assetViewerProvider.notifier).setControls(false);
   }
 }
 


### PR DESCRIPTION
## Description

At current, the controls for videos are always hidden when opening an asset from the timeline, and when swiping between assets. The latter is actually quite annoying, so it would be better UX if video controls were hidden when opening from the timeline like before, but visibility of the controls was retained when swiping between assets.

## How Has This Been Tested?

Pixel 8a.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
