### PR TITLE
fix(mobile): ignore pointer events on toasts

### DIFF
--- a/mobile/lib/widgets/common/immich_toast.dart
+++ b/mobile/lib/widgets/common/immich_toast.dart
@@ -55,7 +55,7 @@ class ImmichToast {
           bottom: gravity == ToastGravity.BOTTOM ? 150 : null,
           left: MediaQuery.of(context).size.width / 2 - 150,
           right: MediaQuery.of(context).size.width / 2 - 150,
-          child: child,
+          child: IgnorePointer(child: child),
         );
       },
       gravity: gravity,


### PR DESCRIPTION
## Description

These toasts can sometimes cover UI elements and make them impossible to interact with until they are dismissed. Specifically, deleting an asset will show a toast over the video controls and prevent seeking.

## How Has This Been Tested?

Pixel 8a.