### PR TITLE
fix(mobile): refresh viewer state after favorite/unfavorite toggle

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/favorite_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/favorite_action_button.widget.dart
@@ -23,7 +23,7 @@ class FavoriteActionButton extends ConsumerWidget {
     final result = await ref.read(actionProvider.notifier).favorite(source);
 
     if (source == ActionSource.viewer) {
-      return;
+      return; // Viewer state is updated by actionProvider; no toast needed
     }
 
     ref.read(multiSelectProvider.notifier).reset();

--- a/mobile/lib/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart
@@ -23,7 +23,7 @@ class UnFavoriteActionButton extends ConsumerWidget {
     final result = await ref.read(actionProvider.notifier).unFavorite(source);
 
     if (source == ActionSource.viewer) {
-      return;
+      return; // Viewer state is updated by actionProvider; no toast needed
     }
 
     ref.read(multiSelectProvider.notifier).reset();

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -150,25 +150,37 @@ class ActionNotifier extends Notifier<void> {
     }
   }
 
-  Future<ActionResult> favorite(ActionSource source) async {
+  Future<ActionResult> favorite(ActionSource source) => _toggleFavorite(source, isFavorite: true);
+
+  Future<ActionResult> unFavorite(ActionSource source) => _toggleFavorite(source, isFavorite: false);
+
+  Future<ActionResult> _toggleFavorite(ActionSource source, {required bool isFavorite}) async {
     final ids = _getOwnedRemoteIdsForSource(source);
     try {
-      await _service.favorite(ids);
+      if (isFavorite) {
+        await _service.favorite(ids);
+      } else {
+        await _service.unFavorite(ids);
+      }
+      if (source == ActionSource.viewer) {
+        await _refreshViewerAsset();
+      }
       return ActionResult(count: ids.length, success: true);
     } catch (error, stack) {
-      _logger.severe('Failed to favorite assets', error, stack);
+      _logger.severe('Failed to ${isFavorite ? '' : 'un'}favorite assets', error, stack);
       return ActionResult(count: ids.length, success: false, error: error.toString());
     }
   }
 
-  Future<ActionResult> unFavorite(ActionSource source) async {
-    final ids = _getOwnedRemoteIdsForSource(source);
-    try {
-      await _service.unFavorite(ids);
-      return ActionResult(count: ids.length, success: true);
-    } catch (error, stack) {
-      _logger.severe('Failed to unfavorite assets', error, stack);
-      return ActionResult(count: ids.length, success: false, error: error.toString());
+  Future<void> _refreshViewerAsset() async {
+    final currentAsset = ref.read(assetViewerProvider).currentAsset;
+    if (currentAsset is RemoteAsset) {
+      final updated = await _assetService.getRemoteAsset(currentAsset.id);
+      if (updated != null) {
+        ref.read(assetViewerProvider.notifier).setAsset(updated);
+      } else {
+        _logger.warning('Failed to refresh viewer asset: getRemoteAsset returned null for ${currentAsset.id}');
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Fixes the favorite/unfavorite toggle not updating the heart icon when used from the asset viewer. The action succeeds server-side but the viewer keeps showing the stale state until the user navigates away and back.

**Root cause:** `ActionNotifier.favorite` and `unFavorite` updated the multiselect timeline state but never pushed a refreshed asset back into `assetViewerProvider`. The viewer icon is driven by `currentAsset.isFavorite`, which was never updated.

Fixes #(none — no open issue, but this is a clear regression from the new action provider architecture)

**`action.provider.dart`**
- After a successful toggle from `ActionSource.viewer`, fetches the updated asset via `_assetService.getRemoteAsset` and calls `assetViewerProvider.notifier.setAsset` — the same pattern already used by `unStack`
- Extracted `_refreshViewerAsset` helper to avoid duplication
- Merged `favorite` and `unFavorite` into a shared `_toggleFavorite` private method (they were structurally identical except for the service call)
- Added `_logger.warning` when `getRemoteAsset` returns null (was previously silent)

**`favorite_action_button.widget.dart` / `unfavorite_action_button.widget.dart`**
- Early-return for `ActionSource.viewer` suppresses the toast — the icon update is the feedback in that context

## How Has This Been Tested?

- [x] Tap heart on a remote asset in the viewer → icon toggles immediately without navigating away
- [x] Tap heart in timeline multiselect → toast still appears as before (no regression)
- [x] Unfavorite is symmetric
- [x] Full unit test suite (701 tests) passes with no regressions

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Screenshots to be added — heart icon toggling in viewer -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (claude-sonnet-4-6) was used to assist with root cause analysis, code review, and drafting the PR description. All code changes were reviewed and tested manually on device.