### PR TITLE
feat(mobile): enable local motion photo playback

### DIFF
--- a/mobile/lib/domain/models/asset/base_asset.model.dart
+++ b/mobile/lib/domain/models/asset/base_asset.model.dart
@@ -45,12 +45,14 @@ sealed class BaseAsset {
   bool get isImage => type == AssetType.image;
   bool get isVideo => type == AssetType.video;
 
-  bool get isMotionPhoto => livePhotoVideoId != null;
+  /// True for remote assets with a paired live-photo video ([livePhotoVideoId] != null)
+  /// and for local assets whose playback style was resolved to [AssetPlaybackStyle.livePhoto].
+  bool get isMotionPhoto => playbackStyle == AssetPlaybackStyle.livePhoto;
   bool get isAnimatedImage => playbackStyle == AssetPlaybackStyle.imageAnimated;
 
   AssetPlaybackStyle get playbackStyle {
     if (isVideo) return AssetPlaybackStyle.video;
-    if (isMotionPhoto) return AssetPlaybackStyle.livePhoto;
+    if (livePhotoVideoId != null) return AssetPlaybackStyle.livePhoto;
     if (isImage && durationInSeconds != null && durationInSeconds! > 0) return AssetPlaybackStyle.imageAnimated;
     if (isImage) return AssetPlaybackStyle.image;
     return AssetPlaybackStyle.unknown;

--- a/mobile/lib/infrastructure/repositories/storage.repository.dart
+++ b/mobile/lib/infrastructure/repositories/storage.repository.dart
@@ -12,7 +12,6 @@ class StorageRepository {
 
   Future<File?> getFileForAsset(String assetId) async {
     File? file;
-    final log = Logger('StorageRepository');
 
     try {
       final entity = await AssetEntity.fromId(assetId);
@@ -34,37 +33,32 @@ class StorageRepository {
   }
 
   Future<File?> getMotionFileForAsset(LocalAsset asset) async {
+    return getMotionFileById(asset.id);
+  }
+
+  Future<File?> getMotionFileById(String assetId) async {
     File? file;
-    final log = Logger('StorageRepository');
 
     try {
-      final entity = await AssetEntity.fromId(asset.id);
+      final entity = await AssetEntity.fromId(assetId);
       file = await entity?.originFileWithSubtype;
       if (file == null) {
-        log.warning(
-          "Cannot get motion file for asset ${asset.id}, name: ${asset.name}, created on: ${asset.createdAt}",
-        );
+        log.warning("Cannot get motion file for asset $assetId");
         return null;
       }
 
       final exists = await file.exists();
       if (!exists) {
-        log.warning("Motion file for asset ${asset.id} does not exist");
+        log.warning("Motion file for asset $assetId does not exist");
         return null;
       }
     } catch (error, stackTrace) {
-      log.warning(
-        "Error getting motion file for asset ${asset.id}, name: ${asset.name}, created on: ${asset.createdAt}",
-        error,
-        stackTrace,
-      );
+      log.warning("Error getting motion file for asset $assetId", error, stackTrace);
     }
     return file;
   }
 
   Future<AssetEntity?> getAssetEntityForAsset(LocalAsset asset) async {
-    final log = Logger('StorageRepository');
-
     AssetEntity? entity;
 
     try {
@@ -130,8 +124,6 @@ class StorageRepository {
   }
 
   Future<void> clearCache() async {
-    final log = Logger('StorageRepository');
-
     try {
       await PhotoManager.clearFileCache();
     } catch (error, stackTrace) {

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -100,9 +101,12 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
     if (!mounted) return null;
 
     try {
-      if (videoAsset.hasLocal && videoAsset.livePhotoVideoId == null) {
+      if (videoAsset.hasLocal) {
         final id = videoAsset is LocalAsset ? videoAsset.id : (videoAsset as RemoteAsset).localId!;
-        final file = await StorageRepository().getFileForAsset(id);
+        File? file = videoAsset.isMotionPhoto
+            ? await StorageRepository().getMotionFileById(id)
+            : await StorageRepository().getFileForAsset(id);
+
         if (!mounted) return null;
 
         if (file == null) {

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -287,8 +287,6 @@ class _AssetTypeIcons extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hasStack = asset is RemoteAsset && (asset as RemoteAsset).stackId != null;
-    final isLivePhoto = asset is RemoteAsset && asset.livePhotoVideoId != null;
-
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
@@ -300,7 +298,7 @@ class _AssetTypeIcons extends StatelessWidget {
             padding: EdgeInsets.only(right: 10.0, top: 6.0),
             child: _TileOverlayIcon(Icons.burst_mode_rounded),
           ),
-        if (isLivePhoto)
+        if (asset.isMotionPhoto)
           const Padding(
             padding: EdgeInsets.only(right: 10.0, top: 6.0),
             child: _TileOverlayIcon(Icons.motion_photos_on_rounded),


### PR DESCRIPTION
## Description

Enables local (on-device) motion photos and live photos to play in the asset viewer. Previously only remote assets triggered the video component — assets with a local copy never animated.

This is a cleaned-up version of the work started by @LeLunZ in draft PR #26784. The prerequisite `playbackStyle` infrastructure from that series (#26541, #26596, #26747) was merged but the motion photo playback follow-up was left as a draft. This PR completes that work, resolves a circular dependency in `base_asset.model.dart` that appeared after the infrastructure landed, and polishes it for submission. All credit for the core approach goes to @LeLunZ.

Fixes #23525

**`video_viewer.widget.dart`**
- Check `videoAsset.isMotionPhoto` to select the right local file: motion assets use `getMotionFileById` (fetches the paired subtype via `originFileWithSubtype`), regular videos use `getFileForAsset`

**`thumbnail_tile.widget.dart`**
- Changed the live-photo badge check from `asset is RemoteAsset && asset.livePhotoVideoId != null` to `asset.isMotionPhoto` — shows the icon for local motion photos too

**`storage.repository.dart`**
- Extracted `getMotionFileById(String assetId)` from `getMotionFileForAsset(LocalAsset asset)` so the viewer can call it with a raw ID (needed when the resolved asset is a `RemoteAsset` with a `localId`)

**`base_asset.model.dart`**
- Fixed circular dependency: `isMotionPhoto` delegates to `playbackStyle`; `playbackStyle` uses `livePhotoVideoId != null` directly
- Added doc comment covering both remote (`livePhotoVideoId`) and local (resolved playback style) paths

Happy to make any changes before merging. @LeLunZ — if there was anything else you had planned for the original PR, please let me know and I'll incorporate it.

## How Has This Been Tested?

- [x] Verified local motion photos animate in the asset viewer on iOS (iPhone 15 Pro, iOS 18)
- [x] Verified live photo badge appears on local-only motion photos in the timeline grid
- [x] Full unit test suite (701 tests) passes with no regressions

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Screenshots to be added -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (claude-sonnet-4-6) was used to assist with code review, refactoring suggestions, and drafting the PR description. All code changes were reviewed and tested manually on device.