### PR TITLE
fix: bounding box return type

### DIFF
--- a/server/src/utils/transform.spec.ts
+++ b/server/src/utils/transform.spec.ts
@@ -155,6 +155,33 @@ describe('transformFaceBoundingBox', () => {
       expect(result.boundingBoxX2).toBe(50);
       expect(result.boundingBoxY2).toBe(50);
     });
+
+    it('should always return whole numbers', () => {
+      const edits: AssetEditActionItem[] = [
+        { action: AssetEditAction.Crop, parameters: { x: 50, y: 50, width: 250, height: 250 } },
+      ];
+
+      expect(transformFaceBoundingBox(baseFace, edits, { width: 1000, height: 400 })).toMatchObject({
+        boundingBoxX1: 50,
+        boundingBoxY1: 0,
+        boundingBoxX2: 150,
+        boundingBoxY2: 50,
+      });
+
+      expect(transformFaceBoundingBox(baseFace, edits, { width: 1001, height: 401 })).toMatchObject({
+        boundingBoxX1: 50,
+        boundingBoxY1: 0,
+        boundingBoxX2: 150,
+        boundingBoxY2: 50,
+      });
+
+      expect(transformFaceBoundingBox(baseFace, edits, { width: 999, height: 399 })).toMatchObject({
+        boundingBoxX1: 49,
+        boundingBoxY1: -0,
+        boundingBoxX2: 149,
+        boundingBoxY2: 49,
+      });
+    });
   });
 });
 

--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -179,10 +179,10 @@ export const transformFaceBoundingBox = (
   // Ensure x1,y1 is top-left and x2,y2 is bottom-right
   const [p1, p2] = transformedPoints;
   return {
-    boundingBoxX1: Math.min(p1.x, p2.x),
-    boundingBoxY1: Math.min(p1.y, p2.y),
-    boundingBoxX2: Math.max(p1.x, p2.x),
-    boundingBoxY2: Math.max(p1.y, p2.y),
+    boundingBoxX1: Math.trunc(Math.min(p1.x, p2.x)),
+    boundingBoxY1: Math.trunc(Math.min(p1.y, p2.y)),
+    boundingBoxX2: Math.trunc(Math.max(p1.x, p2.x)),
+    boundingBoxY2: Math.trunc(Math.max(p1.y, p2.y)),
     imageWidth: currentWidth,
     imageHeight: currentHeight,
   };

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -591,10 +591,10 @@ describe(PersonService.name, () => {
         expect.arrayContaining([
           expect.objectContaining({
             person: expect.objectContaining({ id: person.id }),
-            boundingBoxX1: expect.closeTo(25, 1),
-            boundingBoxY1: expect.closeTo(50, 1),
-            boundingBoxX2: expect.closeTo(100, 1),
-            boundingBoxY2: expect.closeTo(100, 1),
+            boundingBoxX1: 25,
+            boundingBoxY1: 49,
+            boundingBoxX2: 99,
+            boundingBoxY2: 100,
           }),
         ]),
       );


### PR DESCRIPTION
Always return the bounding box coordinates as integers.

Fixes #26563