### PR TITLE
fix: validate accept header before returning html

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -81,7 +81,7 @@ export const connect = async (url: string, key: string) => {
 
   const [error] = await withError(getMyUser());
   if (isHttpError(error)) {
-    logError(error, 'Failed to connect to server');
+    logError(error, `Failed to connect to server ${url}`);
     process.exit(1);
   }
 

--- a/server/src/services/api.service.ts
+++ b/server/src/services/api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotAcceptableException } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import { NextFunction, Request, Response } from 'express';
 import { readFileSync } from 'node:fs';
@@ -72,6 +72,13 @@ export class ApiService {
         return next();
       }
 
+      const responseType = request.accepts('text/html');
+      if (!responseType) {
+        throw new NotAcceptableException(
+          `The route ${request.path} was requested as ${request.header('accept')}, but only returns text/html`,
+        );
+      }
+
       let status = 200;
       let html = index;
 
@@ -105,7 +112,7 @@ export class ApiService {
         html = render(index, meta);
       }
 
-      res.status(status).type('text/html').header('Cache-Control', 'no-store').send(html);
+      res.status(status).type(responseType).header('Cache-Control', 'no-store').send(html);
     };
   }
 }


### PR DESCRIPTION
Throw a 406 Not Acceptable http exception when the index.html page is requested as `application/json`.

Fixes #25193

### Background

The server always responded to requests for the index.html page with a 200 + html content. However, since this is a catch all route, (and many API requests expect `application/json`), it would sometimes respond to requests for `application/json` with `text/html` (bad/incorrect), which is unexpected and would cause issues like #25193. Now, in these situations, it throws an exception instead.
