### PR TITLE
fix: ignore errors deleting untitled album

### DIFF
--- a/web/src/lib/services/album.service.ts
+++ b/web/src/lib/services/album.service.ts
@@ -273,7 +273,7 @@ export const handleDeleteAlbum = async (album: AlbumResponseDto, options?: { pro
     }
     return true;
   } catch (error) {
-    handleError(error, $t('errors.unable_to_delete_album'));
+    handleError(error, $t('errors.unable_to_delete_album'), { notify });
     return false;
   }
 };

--- a/web/src/lib/utils/handle-error.ts
+++ b/web/src/lib/utils/handle-error.ts
@@ -23,7 +23,8 @@ export function standardizeError(error: unknown) {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-export function handleError(error: unknown, localizedMessage: string) {
+export function handleError(error: unknown, localizedMessage: string, options?: { notify?: boolean }) {
+  const { notify = true } = options ?? {};
   const standardizedError = standardizeError(error);
   if (standardizedError.name === 'AbortError') {
     return;
@@ -39,7 +40,9 @@ export function handleError(error: unknown, localizedMessage: string) {
 
     const errorMessage = serverMessage || localizedMessage;
 
-    toastManager.danger(errorMessage);
+    if (notify) {
+      toastManager.danger(errorMessage);
+    }
 
     return errorMessage;
   } catch (error) {


### PR DESCRIPTION
Don't notify when the untitled album fails to delete.

Fixes #24572