### PR TITLE
fix(web): resize long album names (Closes #26533)

### DIFF
--- a/e2e/src/specs/web/album.e2e-spec.ts
+++ b/e2e/src/specs/web/album.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { LoginResponseDto } from '@immich/sdk';
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { utils } from 'src/utils';
 
 test.describe('Album', () => {
@@ -21,5 +21,36 @@ test.describe('Album', () => {
 
     await page.reload();
     await page.getByRole('button', { name: 'Select photos' }).waitFor();
+  });
+
+  test('resizes album title font size based on text and viewport size', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.setViewportSize({ width: 1100, height: 1025 });
+
+    await page.goto('/albums');
+    await page.getByRole('button', { name: 'Create album' }).click();
+
+    const input = page.getByPlaceholder('Add a title');
+    await expect(input).toBeVisible();
+
+    const getFontSize = async () => Number.parseFloat(await input.evaluate((el) => getComputedStyle(el).fontSize));
+
+    await input.pressSequentially('A small title');
+    await page.waitForTimeout(100);
+    const shortTitleFontSize = await getFontSize();
+
+    await input.clear();
+    await input.pressSequentially(
+      'A title that is quite large, maybe too large, stop please! A title that is quite large, maybe too large, stop please!',
+    );
+    await page.waitForTimeout(100);
+    const longTitleFontSize = await getFontSize();
+
+    await page.setViewportSize({ width: 600, height: 1025 });
+    await page.waitForTimeout(100);
+    const smallWindowFontSize = await getFontSize();
+
+    expect(shortTitleFontSize).toBeGreaterThan(longTitleFontSize);
+    expect(longTitleFontSize).toBeGreaterThan(smallWindowFontSize);
   });
 });

--- a/web/src/lib/components/album-page/album-title.svelte
+++ b/web/src/lib/components/album-page/album-title.svelte
@@ -3,6 +3,7 @@
   import { eventManager } from '$lib/managers/event-manager.svelte';
   import { handleError } from '$lib/utils/handle-error';
   import { updateAlbumInfo } from '@immich/sdk';
+  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { tv } from 'tailwind-variants';
 
@@ -16,6 +17,15 @@
   let { id, albumName = $bindable(), isOwned, onUpdate }: Props = $props();
 
   let newAlbumName = $derived(albumName);
+  let inputEl: HTMLInputElement;
+  let sizeIndex = $state(0);
+
+  const sizeClasses = [
+    'text-2xl md:text-4xl lg:text-6xl',
+    'text-xl md:text-2xl lg:text-4xl',
+    'text-lg md:text-xl lg:text-2xl',
+    'text-base md:text-lg lg:text-xl',
+  ];
 
   const handleUpdateName = async () => {
     if (newAlbumName === albumName) {
@@ -39,7 +49,7 @@
   };
 
   const styles = tv({
-    base: 'w-[99%] mb-2 border-b-2 border-transparent text-2xl md:text-4xl lg:text-6xl text-primary outline-none transition-all focus:border-b-2 focus:border-immich-primary focus:outline-none bg-light dark:focus:border-immich-dark-primary dark:focus:bg-immich-dark-gray placeholder:text-primary/90',
+    base: 'w-[99%] mb-2 border-b-2 border-transparent text-primary outline-none transition-all focus:border-b-2 focus:border-immich-primary focus:outline-none bg-light dark:focus:border-immich-dark-primary dark:focus:bg-immich-dark-gray placeholder:text-primary/90',
     variants: {
       isOwned: {
         true: 'hover:border-gray-400',
@@ -47,12 +57,49 @@
       },
     },
   });
+
+  const updateTextSize = () => {
+    if (!inputEl) {
+      return;
+    }
+
+    const availableWidth = inputEl.clientWidth;
+    const style = getComputedStyle(inputEl);
+    const span = document.createElement('span');
+
+    span.textContent = inputEl.value || inputEl.placeholder;
+    span.style.fontFamily = style.fontFamily;
+    span.style.fontWeight = style.fontWeight;
+    span.style.fontStyle = style.fontStyle;
+    span.style.letterSpacing = style.letterSpacing;
+    span.style.textTransform = style.textTransform;
+
+    document.body.append(span);
+    sizeIndex = sizeClasses.length - 1;
+
+    for (let i = 0; i < sizeClasses.length; i += 1) {
+      span.className = `${sizeClasses[i]} absolute invisible whitespace-nowrap pointer-events-none`;
+
+      if (Math.ceil(span.getBoundingClientRect().width) <= availableWidth) {
+        sizeIndex = i;
+        break;
+      }
+    }
+
+    span.remove();
+  };
+
+  onMount(updateTextSize);
 </script>
 
+<svelte:window on:resize={updateTextSize} />
+
 <input
+  bind:this={inputEl}
   use:shortcut={{ shortcut: { key: 'Enter' }, onShortcut: (e) => e.currentTarget.blur() }}
   onblur={handleUpdateName}
-  class={styles({ isOwned })}
+  oninput={updateTextSize}
+  class={`${styles({ isOwned })} ${sizeClasses[sizeIndex]}`}
   type="text"
   bind:value={newAlbumName}
   disabled={!isOwned}


### PR DESCRIPTION
## Description

This PR fixes the issue where long album titles will cause them to overflow from the screen without any attempt to resize it.

I added two things for this fix: size classes for the Album title and a method for calculating the Album title's current size and choosing which size class to pick. 

The size classes' values follow the project's guidelines starting with the largest size, which are the same as the original default values, and reducing the size in tiers. These classes use tailwind css and follow project's specification for different sized viewports. 

To calculate the Album title's text size I found two options: the use of Canvas2D or creating a temporary invisible DOM element. I chose the latter because the project's tooling mentioned lack of support for Canvas2D. After calculating the title's size, the method calculates which size class the title should have to fit in the viewport.

For visibility reasons the size classes don't go any lower than what was set as the smallest size class but if needed it is very easy to add and/or remove size tiers. I verified that my fix worked as intended and created e2e tests for it.

Fixes #26533 (issue)

## How Has This Been Tested?

- [x] Manually tested using the development container in chrome and firefox.
- [x] Added a e2e test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="1455" height="1212" alt="image" src="https://github.com/user-attachments/assets/b6a47f34-2951-46a3-b5c3-84268d378e4f" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used a LLM for grammar and spell checking and also for some questioning about alternative methods of implementation.

...
