### PR TITLE
fix(server): memory fragmentation

### DIFF
--- a/server/bin/start.sh
+++ b/server/bin/start.sh
@@ -15,13 +15,12 @@ log_message() {
 
 log_message "Initializing Immich $IMMICH_SOURCE_REF"
 
-# TODO: Update to mimalloc v3 when verified memory isn't released issue is fixed
-# lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
-# if [ -f "$lib_path" ]; then
-#   export LD_PRELOAD="$lib_path"
-# else
-#   echo "skipping libmimalloc - path not found $lib_path"
-# fi
+lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
+if [ -f "$lib_path" ]; then
+  export LD_PRELOAD="$lib_path"
+else
+  echo "skipping libmimalloc - path not found $lib_path"
+fi
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
 SERVER_HOME="$(readlink -f "$(dirname "$0")/..")"
 


### PR DESCRIPTION
## Description

We commented out libmimalloc3 due to a memory leak issue, but this has been fixed. It is a superior allocator that is able to use less memory over time compared to the default glibc allocator and does not suffer from memory bloat in the same way. It is also generally higher performance; while not tested here, ML sees a 10% overall throughput increase with this allocator. This PR re-enables it for prod builds. The dev image apparently has the old (alpha) version of libmimalloc3 installed, so it will need a base image update before it can be enabled for dev.

## How Has This Been Tested?

I imported 10k assets, deleted them all and repeated several times with a container limit of 2GiB. The default allocator used less memory at the very start, but kept creeping upward and eventually led to several server crashes. The server did not crash when using mimalloc and it idled at 1GiB at the end of it.