### PR TITLE
fix(mobile): remove stop indicator from storage progress bar

### DIFF
--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -167,6 +167,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
               minHeight: 10.0,
               value: percentage,
               borderRadius: const BorderRadius.all(Radius.circular(10.0)),
+              stopIndicatorRadius: 0,
             ),
             Text(
               'backup_controller_page_storage_format',


### PR DESCRIPTION
## Description

When server storage usage is very low (e.g. 0.32%), the Material 3 `LinearProgressIndicator`'s stop indicator (a small circle at the boundary between the filled and unfilled portions) appears before the bar's visual start, creating a confusing UI where the "delimiter" is placed before the slider itself.

This sets `stopIndicatorRadius: 0` to remove the stop indicator from the storage progress bar.

Fixes #23344

## How Has This Been Tested?

- [x] Verified that `stopIndicatorRadius: 0` is a valid property of Flutter's `LinearProgressIndicator` in Material 3 (Flutter 3.35)
- [x] The change removes the stop indicator dot that appears at very low usage percentages

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A - The fix removes the misplaced stop indicator dot from the storage usage progress bar. See issue #23344 for before/after screenshots of the expected behavior.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used to identify the root cause (Material 3's `LinearProgressIndicator` stop indicator) and suggest the one-line fix. The fix itself is a single property addition.