### PR TITLE
fix(mobile): server url migration

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -6,6 +6,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+import 'package:immich_mobile/models/auth/auxilary_endpoint.model.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:logging/logging.dart';
@@ -184,8 +185,8 @@ class ApiService {
     if (externalJson != null) {
       final List<dynamic> list = jsonDecode(externalJson);
       for (final entry in list) {
-        final url = entry['url'] as String?;
-        if (url != null && url.isNotEmpty) urls.add(url);
+        final url = AuxilaryEndpoint.fromJson(entry).url;
+        if (url.isNotEmpty) urls.add(url);
       }
     }
     return urls;


### PR DESCRIPTION
## Description

The external endpoints are stored as double-encoded JSON, so decoding it produces a list of strings where each string needs to be decoded. This is silly and should be fixed, but for now this PR just makes it handle this correctly.

## How Has This Been Tested?

To reproduce, add an external URL for network switching on 2.5.6 and then upgrade to 2.6.0

Fixes #27049