### PR TITLE
fix(web): disable send button

### DIFF
--- a/web/src/lib/components/admin-settings/NotificationSettings.svelte
+++ b/web/src/lib/components/admin-settings/NotificationSettings.svelte
@@ -11,7 +11,7 @@
   import { user } from '$lib/stores/user.store';
   import { handleError } from '$lib/utils/handle-error';
   import { sendTestEmailAdmin } from '@immich/sdk';
-  import { Button, LoadingSpinner, toastManager } from '@immich/ui';
+  import { Button, toastManager } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
 
@@ -142,6 +142,7 @@
               <Button
                 size="small"
                 shape="round"
+                loading={isSending}
                 disabled={!configToEdit.notifications.smtp.enabled}
                 onclick={handleSendTestEmail}
               >
@@ -151,9 +152,6 @@
                   {$t('admin.notification_email_sent_test_email_button')}
                 {/if}
               </Button>
-              {#if isSending}
-                <LoadingSpinner />
-              {/if}
             </div>
           </div>
         </SettingAccordion>


### PR DESCRIPTION
The send test email button now uses the build in spinner while sending. You used to be able to click it multiple times, even though it wouldn't do anything if it was currently sending, which can be a bit confusing.