### PR TITLE
fix(mobile): cronet image cache clearing on android

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -23,10 +23,18 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import org.chromium.net.CronetEngine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.net.Authenticator
 import java.net.CookieHandler
 import java.net.PasswordAuthentication
@@ -277,8 +285,13 @@ object HttpClientManager {
     return result
   }
 
-  fun rebuildCronetEngine() {
-    cronetEngine = buildCronetEngine()
+  suspend fun rebuildCronetEngine(): Result<Long> {
+    return runCatching {
+      cronetEngine?.shutdown()
+      val deletionResult = deleteFolderAndGetSize(cronetStoragePath.toPath())
+      cronetEngine = buildCronetEngine()
+      deletionResult
+    }
   }
 
   val cronetStoragePath: File get() = cronetStorageDir
@@ -308,6 +321,27 @@ object HttpClientManager {
       .setUserAgent(USER_AGENT)
       .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, MEDIA_CACHE_SIZE_BYTES)
       .build()
+  }
+
+  private suspend fun deleteFolderAndGetSize(root: Path): Long = withContext(Dispatchers.IO) {
+    var totalSize = 0L
+
+    Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+      override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+        totalSize += attrs.size()
+        Files.delete(file)
+        return FileVisitResult.CONTINUE
+      }
+
+      override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+        if (dir != root) {
+          Files.delete(dir)
+        }
+        return FileVisitResult.CONTINUE
+      }
+    })
+
+    totalSize
   }
 
   private fun build(cacheDir: File): OkHttpClient {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -277,10 +277,8 @@ object HttpClientManager {
     return result
   }
 
-  fun rebuildCronetEngine(): CronetEngine {
-    val old = cronetEngine!!
+  fun rebuildCronetEngine() {
     cronetEngine = buildCronetEngine()
-    return old
   }
 
   val cronetStoragePath: File get() = cronetStorageDir
@@ -301,7 +299,7 @@ object HttpClientManager {
     }
   }
 
-  private fun buildCronetEngine(): CronetEngine {
+  fun buildCronetEngine(): CronetEngine {
     return CronetEngine.Builder(appContext)
       .enableHttp2(true)
       .enableQuic(true)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -205,18 +205,20 @@ private class CronetImageFetcher : ImageFetcher {
 
   private fun onDrained() {
     val onCacheCleared = synchronized(stateLock) {
-      val onCacheCleared = onCacheCleared
+      val onCacheCleared = this.onCacheCleared
       this.onCacheCleared = null
       onCacheCleared
-    }
-    if (onCacheCleared != null) {
-      val oldEngine = HttpClientManager.rebuildCronetEngine()
-      oldEngine.shutdown()
-      CoroutineScope(Dispatchers.IO).launch {
-        val result = runCatching { deleteFolderAndGetSize(HttpClientManager.cronetStoragePath.toPath()) }
-        synchronized(stateLock) { draining = false }
-        onCacheCleared(result)
+    } ?: return
+
+    CoroutineScope(Dispatchers.IO).launch {
+      val result = runCatching {
+        HttpClientManager.cronetEngine?.shutdown()
+        val deletionResult = deleteFolderAndGetSize(HttpClientManager.cronetStoragePath.toPath())
+        HttpClientManager.rebuildCronetEngine()
+        deletionResult
       }
+      synchronized(stateLock) { draining = false }
+      onCacheCleared(result)
     }
   }
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -21,11 +21,6 @@ import java.io.EOFException
 import java.io.File
 import java.io.IOException
 import java.nio.ByteBuffer
-import java.nio.file.FileVisitResult
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.SimpleFileVisitor
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.ConcurrentHashMap
 
 private class RemoteRequest(val cancellationSignal: CancellationSignal)
@@ -211,12 +206,7 @@ private class CronetImageFetcher : ImageFetcher {
     } ?: return
 
     CoroutineScope(Dispatchers.IO).launch {
-      val result = runCatching {
-        HttpClientManager.cronetEngine?.shutdown()
-        val deletionResult = deleteFolderAndGetSize(HttpClientManager.cronetStoragePath.toPath())
-        HttpClientManager.rebuildCronetEngine()
-        deletionResult
-      }
+      val result = HttpClientManager.rebuildCronetEngine()
       synchronized(stateLock) { draining = false }
       onCacheCleared(result)
     }
@@ -308,26 +298,6 @@ private class CronetImageFetcher : ImageFetcher {
     }
   }
 
-  suspend fun deleteFolderAndGetSize(root: Path): Long = withContext(Dispatchers.IO) {
-    var totalSize = 0L
-
-    Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
-      override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-        totalSize += attrs.size()
-        Files.delete(file)
-        return FileVisitResult.CONTINUE
-      }
-
-      override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
-        if (dir != root) {
-          Files.delete(dir)
-        }
-        return FileVisitResult.CONTINUE
-      }
-    })
-
-    totalSize
-  }
 }
 
 private class OkHttpImageFetcher private constructor(


### PR DESCRIPTION
## Description

Clearing the image cache on android seems to not work reliably.
From my testing, it seems its not possible to initialise a new CronetEngine with the same cache path, as long as the current one isn't shutdown.

Also as the [docs](https://developer.android.com/develop/connectivity/cronet/reference/org/chromium/net/CronetEngine.html#public-abstract-void-shutdown) mention that calling `CronetEngine.shutdown` can be blocking, and I am not exactly sure on which thread onDrained get called, so I moved the shutdown/recreation also into the coroutine. 


So this PR/solution switches between two cronet directories for caching...


In my emulator I get this error:

```
W/RemoteImagesImpl(25471): java.lang.IllegalStateException: Disk cache storage path already in use
W/RemoteImagesImpl(25471): 	at org.chromium.net.impl.CronetUrlRequestContext.<init>(:com.google.android.gms.dynamite_cronetdynamite@260931035@26.09.31 (260400-0):16)
W/RemoteImagesImpl(25471): 	at org.chromium.net.impl.NativeCronetEngineBuilderImpl.build(:com.google.android.gms.dynamite_cronetdynamite@260931035@26.09.31 (260400-0):18)
W/RemoteImagesImpl(25471): 	at org.chromium.net.CronetEngine$Builder.buildExperimental(CronetEngine.java:557)
W/RemoteImagesImpl(25471): 	at org.chromium.net.CronetEngine$Builder.build(CronetEngine.java:576)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.core.HttpClientManager.buildCronetEngine(HttpClientManager.kt:313)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.core.HttpClientManager.rebuildCronetEngine(HttpClientManager.kt:282)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.images.CronetImageFetcher.onDrained(RemoteImagesImpl.kt:218)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.images.CronetImageFetcher.drain(RemoteImagesImpl.kt:205)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.images.CronetImageFetcher.clearCache(RemoteImagesImpl.kt:245)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.images.ImageFetcherManager.clearCache(RemoteImagesImpl.kt:124)
W/RemoteImagesImpl(25471): 	at app.alextran.immich.images.RemoteImagesImpl$clearCache$1.invokeSuspend(RemoteImagesImpl.kt:90)
W/RemoteImagesImpl(25471): 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
W/RemoteImagesImpl(25471): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Previously I just got an error when cleaning the cache. Now it shows me the actual size of the cleared cache.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
used claude to implement the copilot suggestions. AI inception  

