### PR TITLE
chore: whitelist server deploy files

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,10 @@
   "author": "",
   "private": true,
   "license": "GNU Affero General Public License version 3",
+  "files": [
+    "bin",
+    "dist"
+  ],
   "scripts": {
     "build": "nest build",
     "format": "prettier --cache --check .",


### PR DESCRIPTION
Prevent a bunch of random files from being included in the production build:
- .prettierignore
- .prettierrc
- Dockerfile
- Dockerfile.dev
- mise.toml
- nest-cli.json
- resources/