### PR TITLE
fix(mobile): transparent system navbar when trash bottom bar is visible

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
@@ -12,8 +12,9 @@ class TrashBottomBar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Align(
       alignment: Alignment.bottomCenter,
-      child: ColoredBox(
+      child: Container(
         color: context.themeData.canvasColor,
+        padding: const EdgeInsets.symmetric(vertical: 8),
         child: const SafeArea(
           top: false,
           child: Row(

--- a/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
@@ -10,13 +10,16 @@ class TrashBottomBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final systemUiBottomPadding = MediaQuery.of(context).viewPadding.bottom;
     return SafeArea(
+      bottom: false,
       child: Align(
         alignment: Alignment.bottomCenter,
         child: SizedBox(
-          height: 64,
+          height: 64 + systemUiBottomPadding,
           child: Container(
             color: context.themeData.canvasColor,
+            padding: EdgeInsets.only(bottom: systemUiBottomPadding),
             child: const Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [

--- a/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart
@@ -10,23 +10,18 @@ class TrashBottomBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final systemUiBottomPadding = MediaQuery.of(context).viewPadding.bottom;
-    return SafeArea(
-      bottom: false,
-      child: Align(
-        alignment: Alignment.bottomCenter,
-        child: SizedBox(
-          height: 64 + systemUiBottomPadding,
-          child: Container(
-            color: context.themeData.canvasColor,
-            padding: EdgeInsets.only(bottom: systemUiBottomPadding),
-            child: const Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                DeleteTrashActionButton(source: ActionSource.timeline),
-                RestoreTrashActionButton(source: ActionSource.timeline),
-              ],
-            ),
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: ColoredBox(
+        color: context.themeData.canvasColor,
+        child: const SafeArea(
+          top: false,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              DeleteTrashActionButton(source: ActionSource.timeline),
+              RestoreTrashActionButton(source: ActionSource.timeline),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## Description

When user selects one or more items in the Trash page, the bottom action bar to Delete/Restore the item is shown as expected. However, I can see the trash timeline through the system navigation bar (both on android and ios) which does not look good. Normally when there is a bottom bar or a bottom sheet, user cannot see the main page content underneath the system nav bar.

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-20 at 19 23 59" src="https://github.com/user-attachments/assets/c594bb5d-f0fa-48b7-a3ef-7663cf3189a3" />

The fix is by disabling the SafeArea bottom inset, so that the TrashBottomBar widget is rendered underneath the system navigation bar, and then I extended the bottom bar height and padding to include viewPadding.bottom, filling the area behind the system nav bar and thus avoid the Delete/Restore buttons from overlapping with the nav bar.

## How Has This Been Tested?

Tested on both Android real device and iOS simulator by going to the Trash page and then selecting one or more items. You should no longer be able to see the trash timeline underneath the system nav bar while the trash bottom bar is visible. See the test result below.

<details><summary><h2>Screenshots</h2></summary>

<img width="692" height="710" alt="image" src="https://github.com/user-attachments/assets/8337ba28-c274-4410-9789-f5ea5dded0e8" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM is used in creating this pull request
