### PR TITLE
fix(web): preserve timezone when changing timestamp (Closes #25354)

### DIFF
--- a/web/src/lib/modals/AssetChangeDateModal.spec.ts
+++ b/web/src/lib/modals/AssetChangeDateModal.spec.ts
@@ -1,0 +1,67 @@
+import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { DateTime } from 'luxon';
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import AssetChangeDateModal from './AssetChangeDateModal.svelte';
+
+describe('AssetChangeDateModal component', () => {
+  const initialDate = DateTime.fromISO('2026-03-19T23:31:30.112');
+  const initialTimeZone = 'Europe/Lisbon';
+  const onClose = vi.fn();
+
+  const getDateInput = async () => (await screen.findByDisplayValue('2026-03-19T23:31:30.112')) as HTMLInputElement;
+  const getTimeZoneInput = () => screen.getByRole('combobox', { name: /timezone/i }) as HTMLInputElement;
+
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
+    vi.resetAllMocks();
+    Element.prototype.animate = getAnimateMock();
+  });
+
+  afterAll(async () => {
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
+  });
+
+  test('preserves the selected timezone when changing the datetime', async () => {
+    render(AssetChangeDateModal, {
+      props: {
+        initialDate,
+        initialTimeZone,
+        timezoneInput: true,
+        asset: { id: 'asset-id' } as never,
+        onClose,
+      },
+    });
+
+    const timezoneInput = getTimeZoneInput();
+    const datetimeInput = await getDateInput();
+
+    const initialTimezoneValue = timezoneInput.value;
+
+    await fireEvent.focus(timezoneInput);
+    await fireEvent.input(timezoneInput, { target: { value: 'Pacific/Pitcairn' } });
+
+    const option = await screen.findByText(/Pacific\/Pitcairn/i);
+    await fireEvent.click(option);
+
+    expect(timezoneInput.value).toBe('Pacific/Pitcairn (-08:00)');
+    expect(timezoneInput.value).not.toBe(initialTimezoneValue);
+
+    const beforeDatetime = datetimeInput.value;
+
+    await fireEvent.input(datetimeInput, {
+      target: { value: '2026-03-19T23:31:31.113' },
+    });
+    await fireEvent.change(datetimeInput, {
+      target: { value: '2026-03-19T23:31:31.113' },
+    });
+
+    expect(datetimeInput.value).not.toBe(beforeDatetime);
+    expect(timezoneInput.value).toBe('Pacific/Pitcairn (-08:00)');
+  });
+});

--- a/web/src/lib/modals/AssetChangeDateModal.svelte
+++ b/web/src/lib/modals/AssetChangeDateModal.svelte
@@ -23,10 +23,7 @@
   let selectedDate = $state(initialDate.toFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"));
   const timezones = $derived(getTimezones(selectedDate));
 
-  // svelte-ignore state_referenced_locally
-  let lastSelectedTimezone = $state(getPreferredTimeZone(initialDate, initialTimeZone, timezones));
-  // the offsets (and validity) for time zones may change if the date is changed, which is why we recompute the list
-  let selectedOption = $derived(getPreferredTimeZone(initialDate, initialTimeZone, timezones, lastSelectedTimezone));
+  let selectedOption = $state(getPreferredTimeZone(initialDate, initialTimeZone, getTimezones(selectedDate)));
 
   const onSubmit = async () => {
     if (!date.isValid || !selectedOption) {
@@ -45,12 +42,11 @@
     }
   };
 
-  // Store the user's timezone choice in lastSelectedTimezone so selectedOption can be recomputed from it (getPreferredTimeZone)
-  $effect(() => {
-    if (selectedOption) {
-      lastSelectedTimezone = selectedOption;
-    }
-  });
+  const updateSelectedDate = (value: string) => {
+    selectedDate = value;
+
+    selectedOption = getPreferredTimeZone(initialDate, initialTimeZone, getTimezones(value), selectedOption);
+  };
 
   // when changing the time zone, assume the configured date/time is meant for that time zone (instead of updating it)
   const date = $derived(DateTime.fromISO(selectedDate, { zone: selectedOption?.value, setZone: true }));
@@ -66,7 +62,12 @@
   size="small"
 >
   <Label for="datetime" class="block mb-1">{$t('date_and_time')}</Label>
-  <DateInput class="immich-form-input w-full mb-2" id="datetime" type="datetime-local" bind:value={selectedDate} />
+  <DateInput
+    class="immich-form-input w-full mb-2"
+    id="datetime"
+    type="datetime-local"
+    bind:value={() => selectedDate, updateSelectedDate}
+  />
   {#if timezoneInput}
     <div class="w-full">
       <Combobox bind:selectedOption label={$t('timezone')} options={timezones} placeholder={$t('search_timezone')} />

--- a/web/src/lib/modals/AssetChangeDateModal.svelte
+++ b/web/src/lib/modals/AssetChangeDateModal.svelte
@@ -45,6 +45,13 @@
     }
   };
 
+  // Store the user's timezone choice in lastSelectedTimezone so selectedOption can be recomputed from it (getPreferredTimeZone)
+  $effect(() => {
+    if (selectedOption) {
+      lastSelectedTimezone = selectedOption;
+    }
+  });
+
   // when changing the time zone, assume the configured date/time is meant for that time zone (instead of updating it)
   const date = $derived(DateTime.fromISO(selectedDate, { zone: selectedOption?.value, setZone: true }));
 </script>


### PR DESCRIPTION
Changing the timestamp no longer resets the selected timezone.

## Description

I started by reproducing the issue to confirm it was consistent. 
I then identified the cause: lastSelectedTimezone was initialized once when the modal opened, but it was never updated afterward. 
Meanwhile, selectedOption was recomputed every time the user changed the date or time. Since selectedOption was resolved through getPreferredTimeZone(), and that function used lastSelectedTimezone as the preferred fallback, the selection kept reverting to the original timezone instead of preserving the user’s latest choice. 
I fixed this by ensuring that when the user updates the timezone or timestamp, the current selection is propagated to lastSelectedTimezone. That preserved value is then used when selectedOption is recomputed, so the modal now keeps the user-selected timezone instead of resetting it if it is valid. 
I made sure the change fixed the issue and made a test for it.

Fixes #25354

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I tested it manually using the development container (make dev), I changed the timezone of an image and then changed the timestamp and the timezone chosen persisted.
- [x] I made a test that tests if a chosen valid timezone and timestamp is picked, the chosen timezone persists.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used an LLM for spelling and grammar checking and also as a tool to verify my logic.
...
