### PR TITLE
fix(mobile): correct maximumSizeBytes setter to use maximumSizeBytes property

### DIFF
--- a/mobile/lib/utils/cache/custom_image_cache.dart
+++ b/mobile/lib/utils/cache/custom_image_cache.dart
@@ -20,7 +20,7 @@ final class CustomImageCache implements ImageCache {
   set maximumSize(int value) => _small.maximumSize = value;
 
   @override
-  set maximumSizeBytes(int value) => _small.maximumSize = value;
+  set maximumSizeBytes(int value) => _small.maximumSizeBytes = value;
 
   @override
   void clear() {


### PR DESCRIPTION
## Description

Noticed in my recent searches for image loading issues, that there was a small bug in the custom image cache. Probably copy/paste error. 
I think that actually hadn't had any impact, as we don't call the setter anywhere yet.

## How Has This Been Tested?
-

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/
