### PR TITLE
fix(mobile): add keys to people list

### DIFF
--- a/mobile/lib/presentation/pages/drift_people_collection.page.dart
+++ b/mobile/lib/presentation/pages/drift_people_collection.page.dart
@@ -79,6 +79,7 @@ class _DriftPeopleCollectionPageState extends ConsumerState<DriftPeopleCollectio
                     final person = people[index];
 
                     return Column(
+                      key: ValueKey(person.id),
                       children: [
                         GestureDetector(
                           onTap: () {
@@ -88,6 +89,7 @@ class _DriftPeopleCollectionPageState extends ConsumerState<DriftPeopleCollectio
                             shape: const CircleBorder(side: BorderSide.none),
                             elevation: 3,
                             child: CircleAvatar(
+                              key: ValueKey('avatar-${person.id}'),
                               maxRadius: isTablet ? 100 / 2 : 96 / 2,
                               backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
                             ),


### PR DESCRIPTION
## Description

Fixes an issue where avatars wouldn't show up when searching people that weren't visible when the page loaded.

## How Has This Been Tested?

- [x] Go to the people page
- [x] Search for someone that's down in the list
- [x] Photo appears correctly

<details><summary><h2>Screenshots</h2></summary>

<table>
<tr>
 <td>BEFORE
 <td>AFTER
<tr>
 <td> <img height="200" alt="image" src="https://github.com/user-attachments/assets/d012b609-ebdd-45d6-9a3b-4fd00a940ad5" />
 <td> <img height="200" alt="image" src="https://github.com/user-attachments/assets/ded16bea-cbd2-444d-bc61-80bdbdc1e069" />

</table>

</details>