### PR TITLE
feat(web): focus on face-editor search input

### DIFF
--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -27,7 +27,7 @@
   let faceRect: Rect | undefined = $state();
   let faceSelectorEl: HTMLDivElement | undefined = $state();
   let scrollableListEl: HTMLDivElement | undefined = $state();
-  let searchContainerEl: HTMLDivElement | undefined = $state();
+  let searchInputEl: HTMLInputElement | null = $state(null);
   let page = $state(1);
   let candidates = $state<PersonResponseDto[]>([]);
 
@@ -79,15 +79,11 @@
     setDefaultFaceRectanglePosition(faceRect);
   };
 
-  const focusSearchInput = () => {
-    searchContainerEl?.querySelector('input')?.focus();
-  };
-
   onMount(async () => {
     setupCanvas();
     await getPeople();
     await tick();
-    focusSearchInput();
+    searchInputEl?.focus();
   });
 
   const imageContentMetrics = $derived.by(() => {
@@ -232,11 +228,11 @@
     if (rect && cvs) {
       rect.on('moving', positionFaceSelector);
       rect.on('scaling', positionFaceSelector);
-      cvs.on('object:modified', focusSearchInput);
+      cvs.on('object:modified', () => searchInputEl?.focus());
       return () => {
         rect.off('moving', positionFaceSelector);
         rect.off('scaling', positionFaceSelector);
-        cvs.off('object:modified', focusSearchInput);
+        cvs.off('object:modified', () => searchInputEl?.focus());
       };
     }
   });
@@ -319,8 +315,8 @@
   >
     <p class="text-center text-sm">{$t('select_person_to_tag')}</p>
 
-    <div class="my-3 relative" bind:this={searchContainerEl}>
-      <Input placeholder={$t('search_people')} bind:value={searchTerm} size="tiny" />
+    <div class="my-3 relative">
+      <Input placeholder={$t('search_people')} bind:value={searchTerm} bind:ref={searchInputEl} size="tiny" />
     </div>
 
     <div bind:this={scrollableListEl} class="h-62.5 overflow-y-auto mt-2">

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -300,7 +300,7 @@
   };
 </script>
 
-<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: cancel }} />
+<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: cancel, ignoreInputFields: false }} />
 
 <div
   id="face-editor-data"

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -229,7 +229,7 @@
   $effect(() => {
     const rect = faceRect;
     const cvs = canvas;
-    if (rect) {
+    if (rect && cvs) {
       rect.on('moving', positionFaceSelector);
       rect.on('scaling', positionFaceSelector);
       cvs.on('object:modified', focusSearchInput);

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -10,7 +10,7 @@
   import { Button, Input, modalManager, toastManager } from '@immich/ui';
   import { Canvas, InteractiveFabricObject, Rect } from 'fabric';
   import { clamp } from 'lodash-es';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -27,6 +27,7 @@
   let faceRect: Rect | undefined = $state();
   let faceSelectorEl: HTMLDivElement | undefined = $state();
   let scrollableListEl: HTMLDivElement | undefined = $state();
+  let searchContainerEl: HTMLDivElement | undefined = $state();
   let page = $state(1);
   let candidates = $state<PersonResponseDto[]>([]);
 
@@ -78,9 +79,15 @@
     setDefaultFaceRectanglePosition(faceRect);
   };
 
+  const focusSearchInput = () => {
+    searchContainerEl?.querySelector('input')?.focus();
+  };
+
   onMount(async () => {
     setupCanvas();
     await getPeople();
+    await tick();
+    focusSearchInput();
   });
 
   const imageContentMetrics = $derived.by(() => {
@@ -221,12 +228,15 @@
 
   $effect(() => {
     const rect = faceRect;
+    const cvs = canvas;
     if (rect) {
       rect.on('moving', positionFaceSelector);
       rect.on('scaling', positionFaceSelector);
+      cvs.on('object:modified', focusSearchInput);
       return () => {
         rect.off('moving', positionFaceSelector);
         rect.off('scaling', positionFaceSelector);
+        cvs.off('object:modified', focusSearchInput);
       };
     }
   });
@@ -309,7 +319,7 @@
   >
     <p class="text-center text-sm">{$t('select_person_to_tag')}</p>
 
-    <div class="my-3 relative">
+    <div class="my-3 relative" bind:this={searchContainerEl}>
       <Input placeholder={$t('search_people')} bind:value={searchTerm} size="tiny" />
     </div>
 


### PR DESCRIPTION
## Description
To further optimize #26826 the face-search input now is focused when opened. Also ensured to keep the focus on the search if the face-box is moved or resized (which most likely will always happen). Escape-key handling is also kept, so one can still close the face-editor.

## How Has This Been Tested?
- [X] Open face-editor with shortcut 'p' or by clicking on the +-button.
- [X] Check if focus is on the search input.
- [X] Move or resize face-editor and check if focus stays/returns to search input.
- [X] Press escape and check that face-editor closes and returns to photo-viewer.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
AI was used to check codebase, if there are other ways to do focus-related things. As per my understanding the approach with svelte-tick is used in similar cases.