### PR TITLE
fix(mobile): view similar photos from search

### DIFF
--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -107,6 +107,8 @@ class DriftSearchPage extends HookConsumerWidget {
     searchPreFilter() {
       if (preFilter != null) {
         Future.delayed(Duration.zero, () {
+          filter.value = preFilter;
+          textSearchController.clear();
           searchFilter(preFilter);
 
           if (preFilter.location.city != null) {

--- a/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
@@ -24,20 +24,22 @@ class SimilarPhotosActionButton extends ConsumerWidget {
     }
 
     ref.invalidate(assetViewerProvider);
-    ref
-        .read(searchPreFilterProvider.notifier)
-        .setFilter(
-          SearchFilter(
-            assetId: assetId,
-            people: {},
-            location: SearchLocationFilter(),
-            camera: SearchCameraFilter(),
-            date: SearchDateFilter(),
-            display: SearchDisplayFilters(isNotInAlbum: false, isArchive: false, isFavorite: false),
-            rating: SearchRatingFilter(),
-            mediaType: AssetType.image,
-          ),
-        );
+    ref.invalidate(paginatedSearchProvider);
+
+    final preFilterNotifier = ref.read(searchPreFilterProvider.notifier);
+    preFilterNotifier.clear();
+    preFilterNotifier.setFilter(
+      SearchFilter(
+        assetId: assetId,
+        people: {},
+        location: SearchLocationFilter(),
+        camera: SearchCameraFilter(),
+        date: SearchDateFilter(),
+        display: SearchDisplayFilters(isNotInAlbum: false, isArchive: false, isFavorite: false),
+        rating: SearchRatingFilter(),
+        mediaType: AssetType.image,
+      ),
+    );
 
     unawaited(context.navigateTo(const DriftSearchRoute()));
   }

--- a/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
@@ -26,20 +26,20 @@ class SimilarPhotosActionButton extends ConsumerWidget {
     ref.invalidate(assetViewerProvider);
     ref.invalidate(paginatedSearchProvider);
 
-    final preFilterNotifier = ref.read(searchPreFilterProvider.notifier);
-    preFilterNotifier.clear();
-    preFilterNotifier.setFilter(
-      SearchFilter(
-        assetId: assetId,
-        people: {},
-        location: SearchLocationFilter(),
-        camera: SearchCameraFilter(),
-        date: SearchDateFilter(),
-        display: SearchDisplayFilters(isNotInAlbum: false, isArchive: false, isFavorite: false),
-        rating: SearchRatingFilter(),
-        mediaType: AssetType.image,
-      ),
-    );
+    ref.read(searchPreFilterProvider.notifier)
+      ..clear()
+      ..setFilter(
+        SearchFilter(
+          assetId: assetId,
+          people: {},
+          location: SearchLocationFilter(),
+          camera: SearchCameraFilter(),
+          date: SearchDateFilter(),
+          display: SearchDisplayFilters(isNotInAlbum: false, isArchive: false, isFavorite: false),
+          rating: SearchRatingFilter(),
+          mediaType: AssetType.image,
+        ),
+      );
 
     unawaited(context.navigateTo(const DriftSearchRoute()));
   }


### PR DESCRIPTION
## Description

Fixes #27115

## How Has This Been Tested?

- [x] Search for something using context search
- [x] Click on a result & click "view similar photos"
- [x] Successfully searches for similar assets