### PR TITLE
fix(mobile): option padding on search dropdowns

### DIFF
--- a/mobile/lib/widgets/search/search_filter/common/dropdown.dart
+++ b/mobile/lib/widgets/search/search_filter/common/dropdown.dart
@@ -16,6 +16,10 @@ class SearchDropdown<T> extends StatelessWidget {
   final Widget? label;
   final Widget? leadingIcon;
 
+  static const WidgetStatePropertyAll<EdgeInsetsGeometry> _optionPadding = WidgetStatePropertyAll<EdgeInsetsGeometry>(
+    EdgeInsetsDirectional.fromSTEB(16, 0, 16, 0),
+  );
+
   @override
   Widget build(BuildContext context) {
     final menuStyle = const MenuStyle(
@@ -26,11 +30,25 @@ class SearchDropdown<T> extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        final styledEntries = dropdownMenuEntries
+            .map(
+              (entry) => DropdownMenuEntry<T>(
+                value: entry.value,
+                label: entry.label,
+                labelWidget: entry.labelWidget,
+                enabled: entry.enabled,
+                leadingIcon: entry.leadingIcon,
+                trailingIcon: entry.trailingIcon,
+                style: (entry.style ?? const ButtonStyle()).copyWith(padding: _optionPadding),
+              ),
+            )
+            .toList(growable: false);
+
         return DropdownMenu(
           controller: controller,
           leadingIcon: leadingIcon,
           width: constraints.maxWidth,
-          dropdownMenuEntries: dropdownMenuEntries,
+          dropdownMenuEntries: styledEntries,
           label: label,
           menuStyle: menuStyle,
           trailingIcon: const Icon(Icons.arrow_drop_down_rounded),

--- a/mobile/lib/widgets/search/search_filter/common/dropdown.dart
+++ b/mobile/lib/widgets/search/search_filter/common/dropdown.dart
@@ -22,7 +22,9 @@ class SearchDropdown<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final menuStyle = const MenuStyle(
+    final mediaQuery = MediaQuery.of(context);
+    final maxMenuHeight = mediaQuery.size.height * 0.5 - mediaQuery.viewPadding.bottom;
+    const menuStyle = MenuStyle(
       shape: WidgetStatePropertyAll<OutlinedBorder>(
         RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15))),
       ),
@@ -48,6 +50,7 @@ class SearchDropdown<T> extends StatelessWidget {
           controller: controller,
           leadingIcon: leadingIcon,
           width: constraints.maxWidth,
+          menuHeight: maxMenuHeight,
           dropdownMenuEntries: styledEntries,
           label: label,
           menuStyle: menuStyle,


### PR DESCRIPTION
## Description

Fixes #27135

<details><summary><h2>Screenshots</h2></summary>

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img height="450" alt="Screenshot_1774129745" src="https://github.com/user-attachments/assets/a9956c70-57ae-400f-878f-7825c632f69e" />
 <td><img height="450" alt="Screenshot_1774129701" src="https://github.com/user-attachments/assets/798c7663-f712-49d0-bc47-65ac5682c186" />
</table>

</details>