### PR TITLE
fix(mobile): star rating always defaults to 0

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/rating_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/rating_bar.widget.dart
@@ -39,6 +39,16 @@ class _RatingBarState extends State<RatingBar> {
     _currentRating = widget.initialRating;
   }
 
+  @override
+  void didUpdateWidget(covariant RatingBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialRating != widget.initialRating && _currentRating != widget.initialRating) {
+      setState(() {
+        _currentRating = widget.initialRating;
+      });
+    }
+  }
+
   void _updateRating(Offset localPosition, bool isRTL, {bool isTap = false}) {
     final totalWidth = widget.itemCount * widget.itemSize + (widget.itemCount - 1) * widget.starPadding;
     double dx = localPosition.dx;


### PR DESCRIPTION
## Description

Fixes an issue where the star rating bar in the asset details would always be 0, even if the asset was rated.

## How Has This Been Tested?

- [x] Go to an asset with star rating
- [x] Swipe up to reveal the asset details
- [x] Star rating shows correctly
