### PR TITLE
feat: support external machine learning adapters

### DIFF
--- a/docs/docs/guides/external-ml-database-mode.md
+++ b/docs/docs/guides/external-ml-database-mode.md
@@ -1,0 +1,209 @@
+# External ML Database Mode
+
+:::warning
+This guide documents the custom behavior in this fork. It is not part of upstream Immich by default.
+:::
+
+This fork adds a split machine learning mode:
+
+- CLIP can use dimension-based model names and send only `assetId` to the external machine learning HTTP service.
+- OCR can use `modelName: other` and become passive. Immich stops running OCR jobs and only displays/searches OCR rows that already exist in PostgreSQL.
+- Facial recognition can use `modelName: other` and become passive. Immich stops running face detection, face clustering, and recognition jobs and only displays people/faces that already exist in PostgreSQL.
+
+Use this mode when you want your own service to do the machine learning work and write results directly to the Immich database, while Immich only handles UI and API display.
+
+## Behavior Summary
+
+| Feature | Config value | What Immich does | Who writes the result |
+| --- | --- | --- | --- |
+| CLIP / Smart Search | `clip.modelName` set to a numeric dimension such as `"256"`, `"512"`, `"768"`, `"1024"`, `"1536"`, `"2048"`, or `"2560"` | Calls the machine learning HTTP endpoint, but sends `assetId` instead of image bytes | Immich writes `smart_search` |
+| OCR | `ocr.modelName: "other"` | Skips OCR jobs entirely | Your external service |
+| Faces / People | `facialRecognition.modelName: "other"` | Skips face detection and face recognition jobs entirely | Your external service |
+
+## Configuration
+
+You can configure this in the UI or in the [config file](/install/config-file).
+
+Example:
+
+```json title="immich.json"
+{
+  "machineLearning": {
+    "enabled": true,
+    "urls": ["http://your-ml-service:3003"],
+    "clip": {
+      "enabled": true,
+      "modelName": "768"
+    },
+    "ocr": {
+      "enabled": true,
+      "modelName": "other",
+      "maxResolution": 736,
+      "minDetectionScore": 0.5,
+      "minRecognitionScore": 0.8
+    },
+    "facialRecognition": {
+      "enabled": true,
+      "modelName": "other",
+      "minScore": 0.7,
+      "minFaces": 3,
+      "maxDistance": 0.5
+    }
+  }
+}
+```
+
+## CLIP Usage
+
+CLIP stays active in this fork. The main change is transport and vector size:
+
+- Set `machineLearning.clip.modelName` to the embedding dimension as a plain numeric string, for example `768`, `1536`, `2048`, `3072`, or `4096`.
+- This is generic. Any positive integer dimension is accepted. Common values are `256`, `512`, `768`, `1024`, `1536`, `2048`, and `2560` for your default external model.
+- Immich still queues Smart Search jobs.
+- For these numeric model names, the request sent to the external machine learning HTTP service contains `assetId` instead of an uploaded preview image.
+- Immich still writes the final embedding to `smart_search`.
+
+This is different from OCR and faces. CLIP is not passive.
+
+### CLIP database notes
+
+- Table: `smart_search`
+- Primary key: `assetId`
+- Vector column: `embedding`
+- Actual vector dimension must match the configured model name
+
+The source schema still declares `smart_search.embedding` as `vector(512)`, but this fork resizes the real database column and index at runtime to match the configured dimension.
+
+## OCR Usage
+
+Set `machineLearning.ocr.modelName` to `other` when OCR results will be written by your own service.
+
+In this mode:
+
+- Immich does not call the machine learning HTTP OCR endpoint.
+- Immich does not write `asset_ocr` or `ocr_search`.
+- Immich reads OCR rows from the database for display and OCR search.
+
+Your service is responsible for insert, update, delete, and reprocessing behavior.
+
+### OCR tables
+
+`asset_ocr` stores the visible OCR boxes:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | OCR row id |
+| `assetId` | Asset id |
+| `x1` `y1` `x2` `y2` `x3` `y3` `x4` `y4` | Normalized quadrilateral coordinates in the range `0..1` |
+| `boxScore` | Detection confidence |
+| `textScore` | Recognition confidence |
+| `text` | OCR text |
+| `isVisible` | Whether the text box is visible and should contribute to search |
+
+`ocr_search` stores one aggregated searchable text row per asset:
+
+| Column | Meaning |
+| --- | --- |
+| `assetId` | Asset id |
+| `text` | Aggregated searchable OCR text |
+
+`asset_job_status.ocrAt` is not required for UI rendering, but you should update it if you want the admin queue page to treat the asset as already processed.
+
+```sql title="Mark OCR as completed"
+INSERT INTO "asset_job_status" ("assetId", "ocrAt")
+VALUES ('<asset-id>', NOW())
+ON CONFLICT ("assetId") DO UPDATE
+SET "ocrAt" = EXCLUDED."ocrAt";
+```
+
+## Facial Recognition Usage
+
+Set `machineLearning.facialRecognition.modelName` to `other` when your own service owns the full face pipeline.
+
+In this mode:
+
+- Immich does not call the machine learning HTTP face endpoint.
+- Immich does not create faces, embeddings, people, or clusters.
+- Immich does not run the normal facial recognition aggregation flow.
+- Immich only displays faces and people that already exist in the database.
+
+Your service becomes responsible for detection, clustering, person creation, feature-face selection, thumbnail generation, and lifecycle updates.
+
+### Face and person tables
+
+`asset_face` stores detected faces:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Face id |
+| `assetId` | Asset id |
+| `personId` | Linked person id, nullable |
+| `imageWidth` `imageHeight` | Size of the image space used for the face box |
+| `boundingBoxX1` `boundingBoxY1` `boundingBoxX2` `boundingBoxY2` | Face box coordinates in pixels |
+| `sourceType` | Recommended value: `machine-learning` |
+| `deletedAt` | Soft delete marker |
+| `isVisible` | Whether the face is shown in UI |
+
+`person` stores people:
+
+| Column | Meaning |
+| --- | --- |
+| `id` | Person id |
+| `ownerId` | Must match the asset owner for access control and Explore page visibility |
+| `name` | Person name |
+| `thumbnailPath` | Filesystem path used by the person thumbnail endpoint |
+| `isHidden` | Hidden state |
+| `birthDate` | Optional birth date |
+| `faceAssetId` | Representative face id, references `asset_face.id` |
+| `isFavorite` | Favorite state |
+| `color` | Optional UI color |
+
+`face_search` stores face embeddings:
+
+| Column | Meaning |
+| --- | --- |
+| `faceId` | Face id |
+| `embedding` | Face vector |
+
+`face_search` is not required for basic display of people/faces, but it is the place to persist face embeddings if your external service also needs similarity search or wants to keep the vectors next to Immich data.
+
+`asset_job_status.facesRecognizedAt` is not required for UI rendering, but you should update it if you want the admin queue page to treat the asset as already processed.
+
+```sql title="Mark face processing as completed"
+INSERT INTO "asset_job_status" ("assetId", "facesRecognizedAt")
+VALUES ('<asset-id>', NOW())
+ON CONFLICT ("assetId") DO UPDATE
+SET "facesRecognizedAt" = EXCLUDED."facesRecognizedAt";
+```
+
+## Minimal Contract for External Services
+
+For OCR passive mode, your service should maintain:
+
+- `asset_ocr`
+- `ocr_search`
+- `asset_job_status.ocrAt`
+
+For face passive mode, your service should maintain:
+
+- `asset_face`
+- `person`
+- `person.faceAssetId`
+- `person.thumbnailPath` and the thumbnail file itself
+- `asset_job_status.facesRecognizedAt`
+
+For CLIP dimension mode, your service should provide an HTTP endpoint that can resolve `assetId` and compute the embedding, but Immich still owns:
+
+- Smart Search job queueing
+- `smart_search` writes
+- CLIP vector dimension management
+
+## Operational Notes
+
+- Immich will still enforce normal foreign keys and cascade deletes in PostgreSQL.
+- If your external service rewrites OCR or face results, it should also handle replacement of old rows.
+- Person thumbnails are file-backed. `person.thumbnailPath` must point to a file readable by the Immich server container, or the person thumbnail endpoint will return `404`.
+- For face display, rows with `deletedAt IS NOT NULL` or `isVisible = false` will not appear normally.
+- For OCR search, only the text stored in `ocr_search.text` is used by the OCR search filter.
+
+If you need to inspect or debug the database directly, the [Database Queries guide](/guides/database-queries) is a good companion reference.

--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -3,6 +3,10 @@
 To alleviate [performance issues on low-memory systems](/FAQ.mdx#why-is-immich-slow-on-low-memory-systems-like-the-raspberry-pi) like the Raspberry Pi, you may also host Immich's machine learning container on a more powerful system, such as your laptop or desktop computer. The server container will send requests containing the image preview to the remote machine learning container for processing. The machine learning container does not persist this data or associate it with a particular user.
 
 :::info
+If you are using this fork's custom passive external ML flow, where OCR and facial recognition are written directly to PostgreSQL by your own service, see [External ML Database Mode](/guides/external-ml-database-mode). That mode is different from the standard remote ML container setup documented on this page.
+:::
+
+:::info
 Smart Search and Face Detection will use this feature, but Facial Recognition will not. This is because Facial Recognition uses the _outputs_ of these models that have already been saved to the database. As such, its processing is between the server container and the database.
 :::
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -64,8 +64,9 @@ export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico
 export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
-export const CUSTOM_CLIP_DIMENSIONS = [512, 640, 768, 1024, 1152, 1536] as const;
+export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
+  512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },
   RN101__yfcc15m: { dimSize: 512 },
   'ViT-B-16__laion400m_e31': { dimSize: 512 },
@@ -78,10 +79,12 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-B-32__openai': { dimSize: 512 },
   'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': { dimSize: 512 },
   'XLM-Roberta-Large-Vit-B-32': { dimSize: 512 },
+  640: { dimSize: 640 },
   RN50x4__openai: { dimSize: 640 },
   'ViT-B-16-plus-240__laion400m_e31': { dimSize: 640 },
   'ViT-B-16-plus-240__laion400m_e32': { dimSize: 640 },
   'XLM-Roberta-Large-Vit-B-16Plus': { dimSize: 640 },
+  768: { dimSize: 768 },
   'LABSE-Vit-L-14': { dimSize: 768 },
   RN50x16__openai: { dimSize: 768 },
   'ViT-B-16-SigLIP-256__webli': { dimSize: 768 },
@@ -98,6 +101,7 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'XLM-Roberta-Large-Vit-L-14': { dimSize: 768 },
   'nllb-clip-base-siglip__mrl': { dimSize: 768 },
   'nllb-clip-base-siglip__v1': { dimSize: 768 },
+  1024: { dimSize: 1024 },
   RN50__cc12m: { dimSize: 1024 },
   RN50__openai: { dimSize: 1024 },
   RN50__yfcc15m: { dimSize: 1024 },
@@ -109,6 +113,7 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-L-16-SigLIP-384__webli': { dimSize: 1024 },
   'ViT-g-14__laion2b-s12b-b42k': { dimSize: 1024 },
   'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': { dimSize: 1024 },
+  1152: { dimSize: 1152 },
   'ViT-SO400M-14-SigLIP-384__webli': { dimSize: 1152 },
   'nllb-clip-large-siglip__mrl': { dimSize: 1152 },
   'nllb-clip-large-siglip__v1': { dimSize: 1152 },
@@ -122,6 +127,7 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-SO400M-16-SigLIP2-256__webli': { dimSize: 1152 },
   'ViT-SO400M-16-SigLIP2-384__webli': { dimSize: 1152 },
   'ViT-SO400M-16-SigLIP2-512__webli': { dimSize: 1152 },
+  1536: { dimSize: 1536 },
   'ViT-gopt-16-SigLIP2-256__webli': { dimSize: 1536 },
   'ViT-gopt-16-SigLIP2-384__webli': { dimSize: 1536 },
 };

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -65,6 +65,8 @@ export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
 export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
+export const ASSET_ID_ONLY_FACE_MODELS = ['buffalo_l__asset_id'] as const;
+export const ASSET_ID_ONLY_OCR_MODELS = ['PP-OCRv5_mobile__asset_id', 'PP-OCRv5_server__asset_id'] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -65,7 +65,6 @@ export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
 export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
-export const IMAGE_UPLOAD_FACE_MODELS = ['buffalo_l'] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -64,12 +64,10 @@ export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico
 export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
-export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
 export const EXTERNAL_MODEL_NAME = 'other';
 export const ASSET_ID_ONLY_FACE_MODELS = [EXTERNAL_MODEL_NAME] as const;
 export const ASSET_ID_ONLY_OCR_MODELS = [EXTERNAL_MODEL_NAME] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
-  512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },
   RN101__yfcc15m: { dimSize: 512 },
   'ViT-B-16__laion400m_e31': { dimSize: 512 },
@@ -82,12 +80,10 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-B-32__openai': { dimSize: 512 },
   'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': { dimSize: 512 },
   'XLM-Roberta-Large-Vit-B-32': { dimSize: 512 },
-  640: { dimSize: 640 },
   RN50x4__openai: { dimSize: 640 },
   'ViT-B-16-plus-240__laion400m_e31': { dimSize: 640 },
   'ViT-B-16-plus-240__laion400m_e32': { dimSize: 640 },
   'XLM-Roberta-Large-Vit-B-16Plus': { dimSize: 640 },
-  768: { dimSize: 768 },
   'LABSE-Vit-L-14': { dimSize: 768 },
   RN50x16__openai: { dimSize: 768 },
   'ViT-B-16-SigLIP-256__webli': { dimSize: 768 },
@@ -104,7 +100,6 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'XLM-Roberta-Large-Vit-L-14': { dimSize: 768 },
   'nllb-clip-base-siglip__mrl': { dimSize: 768 },
   'nllb-clip-base-siglip__v1': { dimSize: 768 },
-  1024: { dimSize: 1024 },
   RN50__cc12m: { dimSize: 1024 },
   RN50__openai: { dimSize: 1024 },
   RN50__yfcc15m: { dimSize: 1024 },
@@ -116,7 +111,6 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-L-16-SigLIP-384__webli': { dimSize: 1024 },
   'ViT-g-14__laion2b-s12b-b42k': { dimSize: 1024 },
   'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': { dimSize: 1024 },
-  1152: { dimSize: 1152 },
   'ViT-SO400M-14-SigLIP-384__webli': { dimSize: 1152 },
   'nllb-clip-large-siglip__mrl': { dimSize: 1152 },
   'nllb-clip-large-siglip__v1': { dimSize: 1152 },
@@ -130,7 +124,6 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-SO400M-16-SigLIP2-256__webli': { dimSize: 1152 },
   'ViT-SO400M-16-SigLIP2-384__webli': { dimSize: 1152 },
   'ViT-SO400M-16-SigLIP2-512__webli': { dimSize: 1152 },
-  1536: { dimSize: 1536 },
   'ViT-gopt-16-SigLIP2-256__webli': { dimSize: 1536 },
   'ViT-gopt-16-SigLIP2-384__webli': { dimSize: 1536 },
 };

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -64,8 +64,7 @@ export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico
 export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
-export const QWEN_CLIP_BASE_MODEL = 'qwen3-vl-embedding';
-export const QWEN_CLIP_DIMENSIONS = [512, 640, 768, 1024, 1152, 1536] as const;
+export const CUSTOM_CLIP_DIMENSIONS = [512, 640, 768, 1024, 1152, 1536] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   RN101__openai: { dimSize: 512 },
   RN101__yfcc15m: { dimSize: 512 },

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -64,6 +64,8 @@ export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico
 export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
+export const QWEN_CLIP_BASE_MODEL = 'qwen3-vl-embedding';
+export const QWEN_CLIP_DIMENSIONS = [512, 640, 768, 1024, 1152, 1536] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   RN101__openai: { dimSize: 512 },
   RN101__yfcc15m: { dimSize: 512 },

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -65,8 +65,9 @@ export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
 export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
-export const ASSET_ID_ONLY_FACE_MODELS = ['buffalo_l__asset_id'] as const;
-export const ASSET_ID_ONLY_OCR_MODELS = ['PP-OCRv5_mobile__asset_id', 'PP-OCRv5_server__asset_id'] as const;
+export const EXTERNAL_MODEL_NAME = 'other';
+export const ASSET_ID_ONLY_FACE_MODELS = [EXTERNAL_MODEL_NAME] as const;
+export const ASSET_ID_ONLY_OCR_MODELS = [EXTERNAL_MODEL_NAME] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -65,6 +65,7 @@ export const FACE_THUMBNAIL_SIZE = 250;
 
 type ModelInfo = { dimSize: number };
 export const ASSET_ID_ONLY_CLIP_MODELS = ['512', '640', '768', '1024', '1152', '1536'] as const;
+export const IMAGE_UPLOAD_FACE_MODELS = ['buffalo_l'] as const;
 export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   512: { dimSize: 512 },
   RN101__openai: { dimSize: 512 },

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { MachineLearningConfig } from 'src/config';
 import { CLIPConfig } from 'src/dtos/model-config.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
+import { isAssetIdOnlyClipModel } from 'src/utils/misc';
 
 export interface BoundingBox {
   x1: number;
@@ -27,7 +28,7 @@ export enum ModelType {
   OCR = 'ocr',
 }
 
-export type ModelPayload = { imagePath: string } | { text: string };
+export type ModelPayload = { imagePath: string; assetId?: string } | { text: string };
 
 type ModelOptions = { modelName: string };
 
@@ -206,9 +207,10 @@ export class MachineLearningRepository {
     };
   }
 
-  async encodeImage(imagePath: string, { modelName }: CLIPConfig) {
+  async encodeImage(assetId: string, imagePath: string, { modelName }: CLIPConfig) {
     const request = { [ModelTask.SEARCH]: { [ModelType.VISUAL]: { modelName } } };
-    const response = await this.predict<ClipVisualResponse>({ imagePath }, request);
+    const payload = isAssetIdOnlyClipModel(modelName) ? { imagePath, assetId } : { imagePath };
+    const response = await this.predict<ClipVisualResponse>(payload, request);
     return response[ModelTask.SEARCH];
   }
 
@@ -234,8 +236,12 @@ export class MachineLearningRepository {
     formData.append('entries', JSON.stringify(config));
 
     if ('imagePath' in payload) {
-      const fileBuffer = await readFile(payload.imagePath);
-      formData.append('image', new Blob([new Uint8Array(fileBuffer)]));
+      if (payload.assetId) {
+        formData.append('assetId', payload.assetId);
+      } else {
+        const fileBuffer = await readFile(payload.imagePath);
+        formData.append('image', new Blob([new Uint8Array(fileBuffer)]));
+      }
     } else if ('text' in payload) {
       formData.append('text', payload.text);
     } else {

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { MachineLearningConfig } from 'src/config';
 import { CLIPConfig } from 'src/dtos/model-config.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
-import { isAssetIdOnlyClipModel } from 'src/utils/misc';
+import { isAssetIdOnlyClipModel, isAssetIdOnlyFaceModel, isAssetIdOnlyOcrModel } from 'src/utils/misc';
 
 export interface BoundingBox {
   x1: number;
@@ -192,14 +192,15 @@ export class MachineLearningRepository {
     throw new Error(`Machine learning request '${JSON.stringify(config)}' failed for all URLs`);
   }
 
-  async detectFaces(imagePath: string, { modelName, minScore }: FaceDetectionOptions) {
+  async detectFaces(assetId: string, imagePath: string | null, { modelName, minScore }: FaceDetectionOptions) {
     const request = {
       [ModelTask.FACIAL_RECOGNITION]: {
         [ModelType.DETECTION]: { modelName, options: { minScore } },
         [ModelType.RECOGNITION]: { modelName },
       },
     };
-    const response = await this.predict<FacialRecognitionResponse>({ imagePath }, request);
+    const payload = isAssetIdOnlyFaceModel(modelName) ? { imagePath: imagePath ?? '', assetId } : { imagePath: imagePath ?? '' };
+    const response = await this.predict<FacialRecognitionResponse>(payload, request);
     return {
       imageHeight: response.imageHeight,
       imageWidth: response.imageWidth,
@@ -227,7 +228,8 @@ export class MachineLearningRepository {
         [ModelType.RECOGNITION]: { modelName, options: { minScore: minRecognitionScore } },
       },
     };
-    const response = await this.predict<OcrResponse>({ imagePath: imagePath ?? '', assetId }, request);
+    const payload = isAssetIdOnlyOcrModel(modelName) ? { imagePath: imagePath ?? '', assetId } : { imagePath: imagePath ?? '' };
+    const response = await this.predict<OcrResponse>(payload, request);
     return response[ModelTask.OCR];
   }
 

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { MachineLearningConfig } from 'src/config';
 import { CLIPConfig } from 'src/dtos/model-config.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
-import { isAssetIdOnlyClipModel, isAssetIdOnlyFaceModel } from 'src/utils/misc';
+import { isAssetIdOnlyClipModel } from 'src/utils/misc';
 
 export interface BoundingBox {
   x1: number;
@@ -192,15 +192,14 @@ export class MachineLearningRepository {
     throw new Error(`Machine learning request '${JSON.stringify(config)}' failed for all URLs`);
   }
 
-  async detectFaces(assetId: string, imagePath: string | null, { modelName, minScore }: FaceDetectionOptions) {
+  async detectFaces(imagePath: string, { modelName, minScore }: FaceDetectionOptions) {
     const request = {
       [ModelTask.FACIAL_RECOGNITION]: {
         [ModelType.DETECTION]: { modelName, options: { minScore } },
         [ModelType.RECOGNITION]: { modelName },
       },
     };
-    const payload = isAssetIdOnlyFaceModel(modelName) ? { imagePath: imagePath ?? '', assetId } : { imagePath: imagePath ?? '' };
-    const response = await this.predict<FacialRecognitionResponse>(payload, request);
+    const response = await this.predict<FacialRecognitionResponse>({ imagePath }, request);
     return {
       imageHeight: response.imageHeight,
       imageWidth: response.imageWidth,

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { MachineLearningConfig } from 'src/config';
 import { CLIPConfig } from 'src/dtos/model-config.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
-import { isAssetIdOnlyClipModel } from 'src/utils/misc';
+import { isAssetIdOnlyClipModel, isAssetIdOnlyFaceModel } from 'src/utils/misc';
 
 export interface BoundingBox {
   x1: number;
@@ -192,14 +192,15 @@ export class MachineLearningRepository {
     throw new Error(`Machine learning request '${JSON.stringify(config)}' failed for all URLs`);
   }
 
-  async detectFaces(imagePath: string, { modelName, minScore }: FaceDetectionOptions) {
+  async detectFaces(assetId: string, imagePath: string | null, { modelName, minScore }: FaceDetectionOptions) {
     const request = {
       [ModelTask.FACIAL_RECOGNITION]: {
         [ModelType.DETECTION]: { modelName, options: { minScore } },
         [ModelType.RECOGNITION]: { modelName },
       },
     };
-    const response = await this.predict<FacialRecognitionResponse>({ imagePath }, request);
+    const payload = isAssetIdOnlyFaceModel(modelName) ? { imagePath: imagePath ?? '', assetId } : { imagePath: imagePath ?? '' };
+    const response = await this.predict<FacialRecognitionResponse>(payload, request);
     return {
       imageHeight: response.imageHeight,
       imageWidth: response.imageWidth,

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -220,14 +220,14 @@ export class MachineLearningRepository {
     return response[ModelTask.SEARCH];
   }
 
-  async ocr(imagePath: string, { modelName, minDetectionScore, minRecognitionScore, maxResolution }: OcrOptions) {
+  async ocr(assetId: string, imagePath: string | null, { modelName, minDetectionScore, minRecognitionScore, maxResolution }: OcrOptions) {
     const request = {
       [ModelTask.OCR]: {
         [ModelType.DETECTION]: { modelName, options: { minScore: minDetectionScore, maxResolution } },
         [ModelType.RECOGNITION]: { modelName, options: { minScore: minRecognitionScore } },
       },
     };
-    const response = await this.predict<OcrResponse>({ imagePath }, request);
+    const response = await this.predict<OcrResponse>({ imagePath: imagePath ?? '', assetId }, request);
     return response[ModelTask.OCR];
   }
 

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -59,6 +59,25 @@ describe(OcrService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.Ocr, data: { id: asset.id } }]);
       expect(mocks.assetJob.streamForOcrJob).toHaveBeenCalledWith(true);
     });
+
+    it('should skip for external OCR model', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          ocr: {
+            modelName: 'other',
+            enabled: true,
+            minDetectionScore: 0.5,
+            minRecognitionScore: 0.8,
+            maxResolution: 736,
+          },
+        },
+      });
+
+      await expect(sut.handleQueueOcr({ force: false })).resolves.toBe(JobStatus.Skipped);
+      expect(mocks.assetJob.streamForOcrJob).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleOcr', () => {
@@ -81,7 +100,7 @@ describe(OcrService.name, () => {
       expect(mocks.machineLearning.ocr).not.toHaveBeenCalled();
     });
 
-    it('should process assets without a resize path for asset-id-only OCR models', async () => {
+    it('should skip for external OCR model', async () => {
       const asset = AssetFactory.create();
       mocks.systemMetadata.get.mockResolvedValue({
         machineLearning: {
@@ -96,18 +115,10 @@ describe(OcrService.name, () => {
         },
       });
       mocks.assetJob.getForOcr.mockResolvedValue({ visibility: AssetVisibility.Timeline, previewFile: null });
-      mockOcrResult();
 
-      expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Success);
-
-      expect(mocks.machineLearning.ocr).toHaveBeenCalledWith(
-        asset.id,
-        null,
-        expect.objectContaining({
-          modelName: 'other',
-        }),
-      );
-      expect(mocks.ocr.upsert).toHaveBeenCalledWith(asset.id, [], '');
+      expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Skipped);
+      expect(mocks.machineLearning.ocr).not.toHaveBeenCalled();
+      expect(mocks.ocr.upsert).not.toHaveBeenCalled();
     });
 
     it('should save the returned objects', async () => {

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -87,7 +87,7 @@ describe(OcrService.name, () => {
         machineLearning: {
           enabled: true,
           ocr: {
-            modelName: 'PP-OCRv5_mobile__asset_id',
+            modelName: 'other',
             enabled: true,
             minDetectionScore: 0.5,
             minRecognitionScore: 0.8,
@@ -104,7 +104,7 @@ describe(OcrService.name, () => {
         asset.id,
         null,
         expect.objectContaining({
-          modelName: 'PP-OCRv5_mobile__asset_id',
+          modelName: 'other',
         }),
       );
       expect(mocks.ocr.upsert).toHaveBeenCalledWith(asset.id, [], '');

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -71,8 +71,30 @@ describe(OcrService.name, () => {
       expect(mocks.machineLearning.encodeImage).not.toHaveBeenCalled();
     });
 
-    it('should process assets without a resize path', async () => {
+    it('should fail for original OCR models without a resize path', async () => {
       const asset = AssetFactory.create();
+      mocks.assetJob.getForOcr.mockResolvedValue({ visibility: AssetVisibility.Timeline, previewFile: null });
+
+      expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Failed);
+
+      expect(mocks.ocr.upsert).not.toHaveBeenCalled();
+      expect(mocks.machineLearning.ocr).not.toHaveBeenCalled();
+    });
+
+    it('should process assets without a resize path for asset-id-only OCR models', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          ocr: {
+            modelName: 'PP-OCRv5_mobile__asset_id',
+            enabled: true,
+            minDetectionScore: 0.5,
+            minRecognitionScore: 0.8,
+            maxResolution: 736,
+          },
+        },
+      });
       mocks.assetJob.getForOcr.mockResolvedValue({ visibility: AssetVisibility.Timeline, previewFile: null });
       mockOcrResult();
 
@@ -82,7 +104,7 @@ describe(OcrService.name, () => {
         asset.id,
         null,
         expect.objectContaining({
-          modelName: 'PP-OCRv5_mobile',
+          modelName: 'PP-OCRv5_mobile__asset_id',
         }),
       );
       expect(mocks.ocr.upsert).toHaveBeenCalledWith(asset.id, [], '');

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -71,14 +71,21 @@ describe(OcrService.name, () => {
       expect(mocks.machineLearning.encodeImage).not.toHaveBeenCalled();
     });
 
-    it('should skip assets without a resize path', async () => {
+    it('should process assets without a resize path', async () => {
       const asset = AssetFactory.create();
       mocks.assetJob.getForOcr.mockResolvedValue({ visibility: AssetVisibility.Timeline, previewFile: null });
+      mockOcrResult();
 
-      expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Failed);
+      expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Success);
 
-      expect(mocks.ocr.upsert).not.toHaveBeenCalled();
-      expect(mocks.machineLearning.ocr).not.toHaveBeenCalled();
+      expect(mocks.machineLearning.ocr).toHaveBeenCalledWith(
+        asset.id,
+        null,
+        expect.objectContaining({
+          modelName: 'PP-OCRv5_mobile',
+        }),
+      );
+      expect(mocks.ocr.upsert).toHaveBeenCalledWith(asset.id, [], '');
     });
 
     it('should save the returned objects', async () => {
@@ -93,6 +100,7 @@ describe(OcrService.name, () => {
       expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Success);
 
       expect(mocks.machineLearning.ocr).toHaveBeenCalledWith(
+        asset.id,
         '/uploads/user-id/thumbs/path.jpg',
         expect.objectContaining({
           modelName: 'PP-OCRv5_mobile',
@@ -156,6 +164,7 @@ describe(OcrService.name, () => {
       expect(await sut.handleOcr({ id: asset.id })).toEqual(JobStatus.Success);
 
       expect(mocks.machineLearning.ocr).toHaveBeenCalledWith(
+        asset.id,
         '/uploads/user-id/thumbs/path.jpg',
         expect.objectContaining({
           modelName: 'PP-OCRv5_server',

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -45,7 +45,7 @@ export class OcrService extends BaseService {
     }
 
     const asset = await this.assetJobRepository.getForOcr(id);
-    if (!asset || !asset.previewFile) {
+    if (!asset) {
       return JobStatus.Failed;
     }
 
@@ -53,7 +53,7 @@ export class OcrService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    const ocrResults = await this.machineLearningRepository.ocr(asset.previewFile, machineLearning.ocr);
+    const ocrResults = await this.machineLearningRepository.ocr(id, asset.previewFile, machineLearning.ocr);
     const { ocrDataList, searchText } = this.parseOcrResults(id, ocrResults);
     await this.ocrRepository.upsert(id, ocrDataList, searchText);
 

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -6,7 +6,7 @@ import { OCR } from 'src/repositories/machine-learning.repository';
 import { BaseService } from 'src/services/base.service';
 import { JobItem, JobOf } from 'src/types';
 import { tokenizeForSearch } from 'src/utils/database';
-import { isOcrEnabled } from 'src/utils/misc';
+import { isAssetIdOnlyOcrModel, isOcrEnabled } from 'src/utils/misc';
 
 @Injectable()
 export class OcrService extends BaseService {
@@ -45,7 +45,8 @@ export class OcrService extends BaseService {
     }
 
     const asset = await this.assetJobRepository.getForOcr(id);
-    if (!asset) {
+    const assetIdOnlyModel = isAssetIdOnlyOcrModel(machineLearning.ocr.modelName);
+    if (!asset || (!asset.previewFile && !assetIdOnlyModel)) {
       return JobStatus.Failed;
     }
 

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -17,6 +17,10 @@ export class OcrService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    if (isAssetIdOnlyOcrModel(machineLearning.ocr.modelName)) {
+      return JobStatus.Skipped;
+    }
+
     if (force) {
       await this.ocrRepository.deleteAll();
     }
@@ -44,9 +48,12 @@ export class OcrService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    if (isAssetIdOnlyOcrModel(machineLearning.ocr.modelName)) {
+      return JobStatus.Skipped;
+    }
+
     const asset = await this.assetJobRepository.getForOcr(id);
-    const assetIdOnlyModel = isAssetIdOnlyOcrModel(machineLearning.ocr.modelName);
-    if (!asset || (!asset.previewFile && !assetIdOnlyModel)) {
+    if (!asset || !asset.previewFile) {
       return JobStatus.Failed;
     }
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -520,6 +520,30 @@ describe(PersonService.name, () => {
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.PersonCleanup });
     });
 
+    it('should not cleanup or queue person aggregation for external face model', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          facialRecognition: {
+            enabled: true,
+            modelName: 'other',
+            minScore: 0.7,
+            maxDistance: 0.5,
+            minFaces: 3,
+          },
+        },
+      });
+      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
+
+      await sut.handleQueueDetectFaces({ force: true });
+
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+      expect(mocks.person.vacuum).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetDetectFaces, data: { id: asset.id } }]);
+    });
+
     it('should delete existing people and faces if forced', async () => {
       const asset = AssetFactory.create();
       const face = AssetFaceFactory.from().person().build();
@@ -577,6 +601,25 @@ describe(PersonService.name, () => {
       await expect(sut.handleQueueRecognizeFaces({})).resolves.toBe(JobStatus.Skipped);
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it('should skip for external face model', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          facialRecognition: {
+            enabled: true,
+            modelName: 'other',
+            minScore: 0.7,
+            maxDistance: 0.5,
+            minFaces: 3,
+          },
+        },
+      });
+
+      await expect(sut.handleQueueRecognizeFaces({})).resolves.toBe(JobStatus.Skipped);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
     });
 
     it('should queue missing assets', async () => {
@@ -797,7 +840,7 @@ describe(PersonService.name, () => {
           enabled: true,
           facialRecognition: {
             enabled: true,
-            modelName: 'buffalo_l__asset_id',
+            modelName: 'other',
             minScore: 0.7,
             maxDistance: 0.5,
             minFaces: 3,
@@ -812,8 +855,10 @@ describe(PersonService.name, () => {
       expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
         asset.id,
         null,
-        expect.objectContaining({ minScore: 0.7, modelName: 'buffalo_l__asset_id' }),
+        expect.objectContaining({ minScore: 0.7, modelName: 'other' }),
       );
+      expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should delete an existing face not among the new detected faces', async () => {
@@ -899,6 +944,24 @@ describe(PersonService.name, () => {
   });
 
   describe('handleRecognizeFaces', () => {
+    it('should skip for external face model', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          facialRecognition: {
+            enabled: true,
+            modelName: 'other',
+            minScore: 0.7,
+            maxDistance: 0.5,
+            minFaces: 3,
+          },
+        },
+      });
+
+      expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Skipped);
+      expect(mocks.person.getFaceForFacialRecognitionJob).not.toHaveBeenCalled();
+    });
+
     it('should fail if face does not exist', async () => {
       expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -751,7 +751,6 @@ describe(PersonService.name, () => {
       mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
       await sut.handleDetectFaces({ id: asset.id });
       expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
-        asset.id,
         asset.files[0].path,
         expect.objectContaining({ minScore: 0.7, modelName: 'buffalo_l' }),
       );
@@ -788,32 +787,6 @@ describe(PersonService.name, () => {
       ]);
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-    });
-
-    it('should detect faces by asset id for custom face models without a resize path', async () => {
-      const asset = AssetFactory.from().exif().build();
-      mocks.systemMetadata.get.mockResolvedValue({
-        machineLearning: {
-          enabled: true,
-          facialRecognition: {
-            enabled: true,
-            modelName: 'custom-face-model',
-            minScore: 0.7,
-            maxDistance: 0.5,
-            minFaces: 3,
-          },
-        },
-      });
-      mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
-      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
-
-      await sut.handleDetectFaces({ id: asset.id });
-
-      expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
-        asset.id,
-        null,
-        expect.objectContaining({ minScore: 0.7, modelName: 'custom-face-model' }),
-      );
     });
 
     it('should delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -751,6 +751,7 @@ describe(PersonService.name, () => {
       mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
       await sut.handleDetectFaces({ id: asset.id });
       expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
+        asset.id,
         asset.files[0].path,
         expect.objectContaining({ minScore: 0.7, modelName: 'buffalo_l' }),
       );
@@ -787,6 +788,32 @@ describe(PersonService.name, () => {
       ]);
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    });
+
+    it('should detect faces by asset id for asset-id-only face models without a resize path', async () => {
+      const asset = AssetFactory.from().exif().build();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          facialRecognition: {
+            enabled: true,
+            modelName: 'buffalo_l__asset_id',
+            minScore: 0.7,
+            maxDistance: 0.5,
+            minFaces: 3,
+          },
+        },
+      });
+      mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+
+      await sut.handleDetectFaces({ id: asset.id });
+
+      expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
+        asset.id,
+        null,
+        expect.objectContaining({ minScore: 0.7, modelName: 'buffalo_l__asset_id' }),
+      );
     });
 
     it('should delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -536,12 +536,12 @@ describe(PersonService.name, () => {
       });
       mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
 
-      await sut.handleQueueDetectFaces({ force: true });
+      await expect(sut.handleQueueDetectFaces({ force: true })).resolves.toBe(JobStatus.Skipped);
 
       expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
       expect(mocks.person.vacuum).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalled();
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetDetectFaces, data: { id: asset.id } }]);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should delete existing people and faces if forced', async () => {
@@ -833,7 +833,7 @@ describe(PersonService.name, () => {
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
     });
 
-    it('should detect faces by asset id for asset-id-only face models without a resize path', async () => {
+    it('should skip detect faces for external face model', async () => {
       const asset = AssetFactory.from().exif().build();
       mocks.systemMetadata.get.mockResolvedValue({
         machineLearning: {
@@ -847,16 +847,11 @@ describe(PersonService.name, () => {
           },
         },
       });
-      mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
       mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
 
-      await sut.handleDetectFaces({ id: asset.id });
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Skipped);
 
-      expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
-        asset.id,
-        null,
-        expect.objectContaining({ minScore: 0.7, modelName: 'other' }),
-      );
+      expect(mocks.machineLearning.detectFaces).not.toHaveBeenCalled();
       expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -751,6 +751,7 @@ describe(PersonService.name, () => {
       mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
       await sut.handleDetectFaces({ id: asset.id });
       expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
+        asset.id,
         asset.files[0].path,
         expect.objectContaining({ minScore: 0.7, modelName: 'buffalo_l' }),
       );
@@ -787,6 +788,32 @@ describe(PersonService.name, () => {
       ]);
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    });
+
+    it('should detect faces by asset id for custom face models without a resize path', async () => {
+      const asset = AssetFactory.from().exif().build();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: {
+          enabled: true,
+          facialRecognition: {
+            enabled: true,
+            modelName: 'custom-face-model',
+            minScore: 0.7,
+            maxDistance: 0.5,
+            minFaces: 3,
+          },
+        },
+      });
+      mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+
+      await sut.handleDetectFaces({ id: asset.id });
+
+      expect(mocks.machineLearning.detectFaces).toHaveBeenCalledWith(
+        asset.id,
+        null,
+        expect.objectContaining({ minScore: 0.7, modelName: 'custom-face-model' }),
+      );
     });
 
     it('should delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -274,8 +274,11 @@ export class PersonService extends BaseService {
     }
 
     const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
+    if (assetIdOnlyModel) {
+      return JobStatus.Skipped;
+    }
 
-    if (force && !assetIdOnlyModel) {
+    if (force) {
       await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
       await this.handlePersonCleanup();
       await this.personRepository.vacuum({ reindexVectors: true });
@@ -294,7 +297,7 @@ export class PersonService extends BaseService {
 
     await this.jobRepository.queueAll(jobs);
 
-    if (force === undefined && !assetIdOnlyModel) {
+    if (force === undefined) {
       await this.jobRepository.queue({ name: JobName.PersonCleanup });
     }
 
@@ -308,10 +311,14 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
+    if (assetIdOnlyModel) {
+      return JobStatus.Skipped;
+    }
+
     const asset = await this.assetJobRepository.getForDetectFacesJob(id);
     const previewFile = asset?.files[0];
-    const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
-    if (!asset || (!assetIdOnlyModel && (asset.files.length !== 1 || !previewFile))) {
+    if (!asset || asset.files.length !== 1 || !previewFile) {
       return JobStatus.Failed;
     }
 
@@ -325,11 +332,6 @@ export class PersonService extends BaseService {
       machineLearning.facialRecognition,
     );
     this.logger.debug(`${faces.length} faces detected in ${previewFile?.path ?? asset.id}`);
-
-    if (assetIdOnlyModel) {
-      await this.assetRepository.upsertJobStatus({ assetId: asset.id, facesRecognizedAt: new Date() });
-      return JobStatus.Success;
-    }
 
     const facesToAdd: (Insertable<AssetFaceTable> & { id: string })[] = [];
     const embeddings: FaceSearchTable[] = [];

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -43,7 +43,7 @@ import { JobItem, JobOf } from 'src/types';
 import { getDimensions } from 'src/utils/asset.util';
 import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
-import { isAssetIdOnlyFaceModel, isFacialRecognitionEnabled } from 'src/utils/misc';
+import { isFacialRecognitionEnabled } from 'src/utils/misc';
 import { Point, transformPoints } from 'src/utils/transform';
 
 @Injectable()
@@ -308,8 +308,7 @@ export class PersonService extends BaseService {
 
     const asset = await this.assetJobRepository.getForDetectFacesJob(id);
     const previewFile = asset?.files[0];
-    const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
-    if (!asset || asset.files.length !== 1 || (!previewFile && !assetIdOnlyModel)) {
+    if (!asset || asset.files.length !== 1 || !previewFile) {
       return JobStatus.Failed;
     }
 
@@ -318,11 +317,10 @@ export class PersonService extends BaseService {
     }
 
     const { imageHeight, imageWidth, faces } = await this.machineLearningRepository.detectFaces(
-      asset.id,
-      previewFile?.path ?? null,
+      previewFile.path,
       machineLearning.facialRecognition,
     );
-    this.logger.debug(`${faces.length} faces detected in ${previewFile?.path ?? asset.id}`);
+    this.logger.debug(`${faces.length} faces detected in ${previewFile.path}`);
 
     const facesToAdd: (Insertable<AssetFaceTable> & { id: string })[] = [];
     const embeddings: FaceSearchTable[] = [];

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -43,7 +43,7 @@ import { JobItem, JobOf } from 'src/types';
 import { getDimensions } from 'src/utils/asset.util';
 import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
-import { isFacialRecognitionEnabled } from 'src/utils/misc';
+import { isAssetIdOnlyFaceModel, isFacialRecognitionEnabled } from 'src/utils/misc';
 import { Point, transformPoints } from 'src/utils/transform';
 
 @Injectable()
@@ -308,7 +308,8 @@ export class PersonService extends BaseService {
 
     const asset = await this.assetJobRepository.getForDetectFacesJob(id);
     const previewFile = asset?.files[0];
-    if (!asset || asset.files.length !== 1 || !previewFile) {
+    const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
+    if (!asset || asset.files.length !== 1 || (!previewFile && !assetIdOnlyModel)) {
       return JobStatus.Failed;
     }
 
@@ -317,10 +318,11 @@ export class PersonService extends BaseService {
     }
 
     const { imageHeight, imageWidth, faces } = await this.machineLearningRepository.detectFaces(
-      previewFile.path,
+      asset.id,
+      previewFile?.path ?? null,
       machineLearning.facialRecognition,
     );
-    this.logger.debug(`${faces.length} faces detected in ${previewFile.path}`);
+    this.logger.debug(`${faces.length} faces detected in ${previewFile?.path ?? asset.id}`);
 
     const facesToAdd: (Insertable<AssetFaceTable> & { id: string })[] = [];
     const embeddings: FaceSearchTable[] = [];

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -273,7 +273,9 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    if (force) {
+    const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
+
+    if (force && !assetIdOnlyModel) {
       await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
       await this.handlePersonCleanup();
       await this.personRepository.vacuum({ reindexVectors: true });
@@ -292,7 +294,7 @@ export class PersonService extends BaseService {
 
     await this.jobRepository.queueAll(jobs);
 
-    if (force === undefined) {
+    if (force === undefined && !assetIdOnlyModel) {
       await this.jobRepository.queue({ name: JobName.PersonCleanup });
     }
 
@@ -309,7 +311,7 @@ export class PersonService extends BaseService {
     const asset = await this.assetJobRepository.getForDetectFacesJob(id);
     const previewFile = asset?.files[0];
     const assetIdOnlyModel = isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName);
-    if (!asset || asset.files.length !== 1 || (!previewFile && !assetIdOnlyModel)) {
+    if (!asset || (!assetIdOnlyModel && (asset.files.length !== 1 || !previewFile))) {
       return JobStatus.Failed;
     }
 
@@ -323,6 +325,11 @@ export class PersonService extends BaseService {
       machineLearning.facialRecognition,
     );
     this.logger.debug(`${faces.length} faces detected in ${previewFile?.path ?? asset.id}`);
+
+    if (assetIdOnlyModel) {
+      await this.assetRepository.upsertJobStatus({ assetId: asset.id, facesRecognizedAt: new Date() });
+      return JobStatus.Success;
+    }
 
     const facesToAdd: (Insertable<AssetFaceTable> & { id: string })[] = [];
     const embeddings: FaceSearchTable[] = [];
@@ -409,6 +416,10 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    if (isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName)) {
+      return JobStatus.Skipped;
+    }
+
     await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
 
     if (nightly) {
@@ -464,6 +475,10 @@ export class PersonService extends BaseService {
   async handleRecognizeFaces({ id, deferred }: JobOf<JobName.FacialRecognition>): Promise<JobStatus> {
     const { machineLearning } = await this.getConfig({ withCache: true });
     if (!isFacialRecognitionEnabled(machineLearning)) {
+      return JobStatus.Skipped;
+    }
+
+    if (isAssetIdOnlyFaceModel(machineLearning.facialRecognition.modelName)) {
       return JobStatus.Skipped;
     }
 

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -40,6 +40,15 @@ describe(SmartInfoService.name, () => {
       ).not.toThrow();
     });
 
+    it('should allow Qwen CLIP variants with explicit dimensions', () => {
+      expect(() =>
+        sut.onConfigValidate({
+          newConfig: { machineLearning: { clip: { modelName: 'qwen3-vl-embedding-1024' } } } as SystemConfig,
+          oldConfig: {} as SystemConfig,
+        }),
+      ).not.toThrow();
+    });
+
     it('should fail for an unsupported model', () => {
       expect(() =>
         sut.onConfigValidate({
@@ -205,6 +214,7 @@ describe(SmartInfoService.name, () => {
       expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Success);
 
       expect(mocks.machineLearning.encodeImage).toHaveBeenCalledWith(
+        asset.id,
         asset.files[0].path,
         expect.objectContaining({ modelName: 'ViT-B-32__openai' }),
       );
@@ -242,6 +252,7 @@ describe(SmartInfoService.name, () => {
 
       expect(mocks.database.wait).toHaveBeenCalledWith(512);
       expect(mocks.machineLearning.encodeImage).toHaveBeenCalledWith(
+        asset.id,
         asset.files[0].path,
         expect.objectContaining({ modelName: 'ViT-B-32__openai' }),
       );
@@ -257,6 +268,12 @@ describe(SmartInfoService.name, () => {
 
     it('should clean the model name', () => {
       expect(getCLIPModelInfo('ViT-B-32::openai')).toEqual({ dimSize: 512 });
+    });
+
+    it('should resolve Qwen CLIP dimensions from the model name', () => {
+      expect(getCLIPModelInfo('qwen3-vl-embedding')).toEqual({ dimSize: 1536 });
+      expect(getCLIPModelInfo('qwen3-vl-embedding-768')).toEqual({ dimSize: 768 });
+      expect(getCLIPModelInfo('org/qwen3-vl-embedding:1152')).toEqual({ dimSize: 1152 });
     });
 
     it('should throw an error if the model is not present', () => {

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -1,7 +1,7 @@
 import { SystemConfig } from 'src/config';
 import { AssetFileType, AssetVisibility, ImmichWorker, JobName, JobStatus } from 'src/enum';
 import { SmartInfoService } from 'src/services/smart-info.service';
-import { getCLIPModelInfo } from 'src/utils/misc';
+import { getCLIPModelInfo, isAssetIdOnlyClipModel } from 'src/utils/misc';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { systemConfigStub } from 'test/fixtures/system-config.stub';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
@@ -40,10 +40,10 @@ describe(SmartInfoService.name, () => {
       ).not.toThrow();
     });
 
-    it('should allow Qwen CLIP variants with explicit dimensions', () => {
+    it('should allow custom CLIP variants with explicit dimensions', () => {
       expect(() =>
         sut.onConfigValidate({
-          newConfig: { machineLearning: { clip: { modelName: 'qwen3-vl-embedding-1024' } } } as SystemConfig,
+          newConfig: { machineLearning: { clip: { modelName: 'custom-clip-model-1024' } } } as SystemConfig,
           oldConfig: {} as SystemConfig,
         }),
       ).not.toThrow();
@@ -270,14 +270,26 @@ describe(SmartInfoService.name, () => {
       expect(getCLIPModelInfo('ViT-B-32::openai')).toEqual({ dimSize: 512 });
     });
 
-    it('should resolve Qwen CLIP dimensions from the model name', () => {
-      expect(getCLIPModelInfo('qwen3-vl-embedding')).toEqual({ dimSize: 1536 });
-      expect(getCLIPModelInfo('qwen3-vl-embedding-768')).toEqual({ dimSize: 768 });
-      expect(getCLIPModelInfo('org/qwen3-vl-embedding:1152')).toEqual({ dimSize: 1152 });
+    it('should resolve custom CLIP dimensions from the model name', () => {
+      expect(getCLIPModelInfo('custom-clip-model-768')).toEqual({ dimSize: 768 });
+      expect(getCLIPModelInfo('org/custom-clip-model:1152')).toEqual({ dimSize: 1152 });
+      expect(getCLIPModelInfo('another_model_1536')).toEqual({ dimSize: 1536 });
     });
 
     it('should throw an error if the model is not present', () => {
       expect(() => getCLIPModelInfo('test-model')).toThrow('Unknown CLIP model: test-model');
+    });
+  });
+
+  describe('isAssetIdOnlyClipModel', () => {
+    it('should detect custom dimension variants', () => {
+      expect(isAssetIdOnlyClipModel('custom-clip-model-768')).toBe(true);
+      expect(isAssetIdOnlyClipModel('org/custom-clip-model:1152')).toBe(true);
+    });
+
+    it('should not flag built-in CLIP models', () => {
+      expect(isAssetIdOnlyClipModel('ViT-B-16-SigLIP-512__webli')).toBe(false);
+      expect(isAssetIdOnlyClipModel('ViT-B-32__openai')).toBe(false);
     });
   });
 });

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -271,9 +271,13 @@ describe(SmartInfoService.name, () => {
     });
 
     it('should resolve numeric CLIP model names', () => {
+      expect(getCLIPModelInfo('256')).toEqual({ dimSize: 256 });
       expect(getCLIPModelInfo('768')).toEqual({ dimSize: 768 });
       expect(getCLIPModelInfo('org/1152')).toEqual({ dimSize: 1152 });
       expect(getCLIPModelInfo('1536')).toEqual({ dimSize: 1536 });
+      expect(getCLIPModelInfo('2048')).toEqual({ dimSize: 2048 });
+      expect(getCLIPModelInfo('2560')).toEqual({ dimSize: 2560 });
+      expect(getCLIPModelInfo('org/4096')).toEqual({ dimSize: 4096 });
     });
 
     it('should throw an error if the model is not present', () => {
@@ -283,8 +287,12 @@ describe(SmartInfoService.name, () => {
 
   describe('isAssetIdOnlyClipModel', () => {
     it('should detect numeric asset-id-only models', () => {
+      expect(isAssetIdOnlyClipModel('256')).toBe(true);
       expect(isAssetIdOnlyClipModel('768')).toBe(true);
       expect(isAssetIdOnlyClipModel('org/1152')).toBe(true);
+      expect(isAssetIdOnlyClipModel('2048')).toBe(true);
+      expect(isAssetIdOnlyClipModel('2560')).toBe(true);
+      expect(isAssetIdOnlyClipModel('org/4096')).toBe(true);
     });
 
     it('should not flag built-in CLIP models', () => {

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -43,7 +43,7 @@ describe(SmartInfoService.name, () => {
     it('should allow custom CLIP variants with explicit dimensions', () => {
       expect(() =>
         sut.onConfigValidate({
-          newConfig: { machineLearning: { clip: { modelName: 'custom-clip-model-1024' } } } as SystemConfig,
+          newConfig: { machineLearning: { clip: { modelName: '1024' } } } as SystemConfig,
           oldConfig: {} as SystemConfig,
         }),
       ).not.toThrow();
@@ -270,10 +270,10 @@ describe(SmartInfoService.name, () => {
       expect(getCLIPModelInfo('ViT-B-32::openai')).toEqual({ dimSize: 512 });
     });
 
-    it('should resolve custom CLIP dimensions from the model name', () => {
-      expect(getCLIPModelInfo('custom-clip-model-768')).toEqual({ dimSize: 768 });
-      expect(getCLIPModelInfo('org/custom-clip-model:1152')).toEqual({ dimSize: 1152 });
-      expect(getCLIPModelInfo('another_model_1536')).toEqual({ dimSize: 1536 });
+    it('should resolve numeric CLIP model names', () => {
+      expect(getCLIPModelInfo('768')).toEqual({ dimSize: 768 });
+      expect(getCLIPModelInfo('org/1152')).toEqual({ dimSize: 1152 });
+      expect(getCLIPModelInfo('1536')).toEqual({ dimSize: 1536 });
     });
 
     it('should throw an error if the model is not present', () => {
@@ -282,9 +282,9 @@ describe(SmartInfoService.name, () => {
   });
 
   describe('isAssetIdOnlyClipModel', () => {
-    it('should detect custom dimension variants', () => {
-      expect(isAssetIdOnlyClipModel('custom-clip-model-768')).toBe(true);
-      expect(isAssetIdOnlyClipModel('org/custom-clip-model:1152')).toBe(true);
+    it('should detect numeric asset-id-only models', () => {
+      expect(isAssetIdOnlyClipModel('768')).toBe(true);
+      expect(isAssetIdOnlyClipModel('org/1152')).toBe(true);
     });
 
     it('should not flag built-in CLIP models', () => {

--- a/server/src/services/smart-info.service.ts
+++ b/server/src/services/smart-info.service.ts
@@ -108,7 +108,7 @@ export class SmartInfoService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    const embedding = await this.machineLearningRepository.encodeImage(asset.files[0].path, machineLearning.clip);
+    const embedding = await this.machineLearningRepository.encodeImage(asset.id, asset.files[0].path, machineLearning.clip);
 
     if (this.databaseRepository.isBusy(DatabaseLock.CLIPDimSize)) {
       this.logger.verbose(`Waiting for CLIP dimension size to be updated`);

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -20,7 +20,6 @@ import { SystemConfig } from 'src/config';
 import {
   ASSET_ID_ONLY_CLIP_MODELS,
   CLIP_MODEL_INFO,
-  IMAGE_UPLOAD_FACE_MODELS,
   endpointTags,
   serverVersion,
 } from 'src/constants';
@@ -132,10 +131,6 @@ function cleanModelName(modelName: string): string {
 
 export function isAssetIdOnlyClipModel(modelName: string) {
   return ASSET_ID_ONLY_CLIP_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_CLIP_MODELS)[number]);
-}
-
-export function isAssetIdOnlyFaceModel(modelName: string) {
-  return !IMAGE_UPLOAD_FACE_MODELS.includes(cleanModelName(modelName) as (typeof IMAGE_UPLOAD_FACE_MODELS)[number]);
 }
 
 export function getCLIPModelInfo(modelName: string) {

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -18,7 +18,6 @@ import picomatch from 'picomatch';
 import parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
 import {
-  ASSET_ID_ONLY_CLIP_MODELS,
   ASSET_ID_ONLY_FACE_MODELS,
   ASSET_ID_ONLY_OCR_MODELS,
   CLIP_MODEL_INFO,
@@ -131,8 +130,22 @@ function cleanModelName(modelName: string): string {
   return token.replaceAll(':', '_');
 }
 
+function getNumericClipDimSize(modelName: string): number | undefined {
+  const cleanedModelName = cleanModelName(modelName);
+  if (!/^\d+$/.test(cleanedModelName)) {
+    return undefined;
+  }
+
+  const dimSize = Number.parseInt(cleanedModelName, 10);
+  if (!Number.isSafeInteger(dimSize) || dimSize <= 0) {
+    return undefined;
+  }
+
+  return dimSize;
+}
+
 export function isAssetIdOnlyClipModel(modelName: string) {
-  return ASSET_ID_ONLY_CLIP_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_CLIP_MODELS)[number]);
+  return getNumericClipDimSize(modelName) !== undefined;
 }
 
 export function isAssetIdOnlyFaceModel(modelName: string) {
@@ -144,6 +157,11 @@ export function isAssetIdOnlyOcrModel(modelName: string) {
 }
 
 export function getCLIPModelInfo(modelName: string) {
+  const numericDimSize = getNumericClipDimSize(modelName);
+  if (numericDimSize) {
+    return { dimSize: numericDimSize };
+  }
+
   const modelInfo = CLIP_MODEL_INFO[cleanModelName(modelName)];
   if (modelInfo) {
     return modelInfo;

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -19,6 +19,8 @@ import parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
 import {
   ASSET_ID_ONLY_CLIP_MODELS,
+  ASSET_ID_ONLY_FACE_MODELS,
+  ASSET_ID_ONLY_OCR_MODELS,
   CLIP_MODEL_INFO,
   endpointTags,
   serverVersion,
@@ -131,6 +133,14 @@ function cleanModelName(modelName: string): string {
 
 export function isAssetIdOnlyClipModel(modelName: string) {
   return ASSET_ID_ONLY_CLIP_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_CLIP_MODELS)[number]);
+}
+
+export function isAssetIdOnlyFaceModel(modelName: string) {
+  return ASSET_ID_ONLY_FACE_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_FACE_MODELS)[number]);
+}
+
+export function isAssetIdOnlyOcrModel(modelName: string) {
+  return ASSET_ID_ONLY_OCR_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_OCR_MODELS)[number]);
 }
 
 export function getCLIPModelInfo(modelName: string) {

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -18,8 +18,8 @@ import picomatch from 'picomatch';
 import parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
 import {
+  ASSET_ID_ONLY_CLIP_MODELS,
   CLIP_MODEL_INFO,
-  CUSTOM_CLIP_DIMENSIONS,
   endpointTags,
   serverVersion,
 } from 'src/constants';
@@ -129,38 +129,14 @@ function cleanModelName(modelName: string): string {
   return token.replaceAll(':', '_');
 }
 
-function parseCustomClipModelInfo(modelName: string) {
-  const token = cleanModelName(modelName);
-  const match = token.match(/(?:^|[-_])(\d+)$/);
-  if (!match) {
-    return;
-  }
-
-  const dimSize = Number.parseInt(match[1], 10);
-  if (!CUSTOM_CLIP_DIMENSIONS.some((dimension) => dimension === dimSize)) {
-    return;
-  }
-
-  return { dimSize, assetIdOnly: true };
-}
-
 export function isAssetIdOnlyClipModel(modelName: string) {
-  if (CLIP_MODEL_INFO[cleanModelName(modelName)]) {
-    return false;
-  }
-
-  return parseCustomClipModelInfo(modelName)?.assetIdOnly ?? false;
+  return ASSET_ID_ONLY_CLIP_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_CLIP_MODELS)[number]);
 }
 
 export function getCLIPModelInfo(modelName: string) {
   const modelInfo = CLIP_MODEL_INFO[cleanModelName(modelName)];
   if (modelInfo) {
     return modelInfo;
-  }
-
-  const customModelInfo = parseCustomClipModelInfo(modelName);
-  if (customModelInfo) {
-    return { dimSize: customModelInfo.dimSize };
   }
 
   throw new Error(`Unknown CLIP model: ${modelName}`);

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -20,6 +20,7 @@ import { SystemConfig } from 'src/config';
 import {
   ASSET_ID_ONLY_CLIP_MODELS,
   CLIP_MODEL_INFO,
+  IMAGE_UPLOAD_FACE_MODELS,
   endpointTags,
   serverVersion,
 } from 'src/constants';
@@ -131,6 +132,10 @@ function cleanModelName(modelName: string): string {
 
 export function isAssetIdOnlyClipModel(modelName: string) {
   return ASSET_ID_ONLY_CLIP_MODELS.includes(cleanModelName(modelName) as (typeof ASSET_ID_ONLY_CLIP_MODELS)[number]);
+}
+
+export function isAssetIdOnlyFaceModel(modelName: string) {
+  return !IMAGE_UPLOAD_FACE_MODELS.includes(cleanModelName(modelName) as (typeof IMAGE_UPLOAD_FACE_MODELS)[number]);
 }
 
 export function getCLIPModelInfo(modelName: string) {

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -17,7 +17,13 @@ import path from 'node:path';
 import picomatch from 'picomatch';
 import parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
-import { CLIP_MODEL_INFO, endpointTags, serverVersion } from 'src/constants';
+import {
+  CLIP_MODEL_INFO,
+  QWEN_CLIP_BASE_MODEL,
+  QWEN_CLIP_DIMENSIONS,
+  endpointTags,
+  serverVersion,
+} from 'src/constants';
 import { extraSyncModels } from 'src/dtos/sync.dto';
 import { ApiCustomExtension, ImmichCookie, ImmichHeader, MetadataKey } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -124,7 +130,35 @@ function cleanModelName(modelName: string): string {
   return token.replaceAll(':', '_');
 }
 
+function parseQwenClipModelInfo(modelName: string) {
+  const token = cleanModelName(modelName);
+  if (token === QWEN_CLIP_BASE_MODEL) {
+    return { dimSize: 1536, assetIdOnly: false };
+  }
+
+  const match = token.match(/^qwen3-vl-embedding(?:[-_](\d+))$/);
+  if (!match) {
+    return;
+  }
+
+  const dimSize = Number.parseInt(match[1], 10);
+  if (!QWEN_CLIP_DIMENSIONS.some((dimension) => dimension === dimSize)) {
+    return;
+  }
+
+  return { dimSize, assetIdOnly: true };
+}
+
+export function isAssetIdOnlyClipModel(modelName: string) {
+  return parseQwenClipModelInfo(modelName)?.assetIdOnly ?? false;
+}
+
 export function getCLIPModelInfo(modelName: string) {
+  const qwenModelInfo = parseQwenClipModelInfo(modelName);
+  if (qwenModelInfo) {
+    return { dimSize: qwenModelInfo.dimSize };
+  }
+
   const modelInfo = CLIP_MODEL_INFO[cleanModelName(modelName)];
   if (!modelInfo) {
     throw new Error(`Unknown CLIP model: ${modelName}`);

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -19,8 +19,7 @@ import parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
 import {
   CLIP_MODEL_INFO,
-  QWEN_CLIP_BASE_MODEL,
-  QWEN_CLIP_DIMENSIONS,
+  CUSTOM_CLIP_DIMENSIONS,
   endpointTags,
   serverVersion,
 } from 'src/constants';
@@ -130,19 +129,15 @@ function cleanModelName(modelName: string): string {
   return token.replaceAll(':', '_');
 }
 
-function parseQwenClipModelInfo(modelName: string) {
+function parseCustomClipModelInfo(modelName: string) {
   const token = cleanModelName(modelName);
-  if (token === QWEN_CLIP_BASE_MODEL) {
-    return { dimSize: 1536, assetIdOnly: false };
-  }
-
-  const match = token.match(/^qwen3-vl-embedding(?:[-_](\d+))$/);
+  const match = token.match(/(?:^|[-_])(\d+)$/);
   if (!match) {
     return;
   }
 
   const dimSize = Number.parseInt(match[1], 10);
-  if (!QWEN_CLIP_DIMENSIONS.some((dimension) => dimension === dimSize)) {
+  if (!CUSTOM_CLIP_DIMENSIONS.some((dimension) => dimension === dimSize)) {
     return;
   }
 
@@ -150,21 +145,25 @@ function parseQwenClipModelInfo(modelName: string) {
 }
 
 export function isAssetIdOnlyClipModel(modelName: string) {
-  return parseQwenClipModelInfo(modelName)?.assetIdOnly ?? false;
+  if (CLIP_MODEL_INFO[cleanModelName(modelName)]) {
+    return false;
+  }
+
+  return parseCustomClipModelInfo(modelName)?.assetIdOnly ?? false;
 }
 
 export function getCLIPModelInfo(modelName: string) {
-  const qwenModelInfo = parseQwenClipModelInfo(modelName);
-  if (qwenModelInfo) {
-    return { dimSize: qwenModelInfo.dimSize };
-  }
-
   const modelInfo = CLIP_MODEL_INFO[cleanModelName(modelName)];
-  if (!modelInfo) {
-    throw new Error(`Unknown CLIP model: ${modelName}`);
+  if (modelInfo) {
+    return modelInfo;
   }
 
-  return modelInfo;
+  const customModelInfo = parseCustomClipModelInfo(modelName);
+  if (customModelInfo) {
+    return { dimSize: customModelInfo.dimSize };
+  }
+
+  throw new Error(`Unknown CLIP model: ${modelName}`);
 }
 
 function sortKeys<T>(target: T): T {

--- a/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+++ b/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -17,6 +17,26 @@
   const disabled = $derived(featureFlagsManager.value.configFile);
   const config = $derived(systemConfigManager.value);
   let configToEdit = $state(systemConfigManager.cloneValue());
+
+  const facialRecognitionModelOptions = [
+    { value: 'antelopev2', text: 'antelopev2' },
+    { value: 'buffalo_l', text: 'buffalo_l' },
+    { value: 'buffalo_m', text: 'buffalo_m' },
+    { value: 'buffalo_s', text: 'buffalo_s' },
+    { value: 'other', text: 'other (external service writes database)' },
+  ];
+
+  const ocrModelOptions = [
+    { text: 'PP-OCRv5_server (Chinese, Japanese and English)', value: 'PP-OCRv5_server' },
+    { text: 'PP-OCRv5_mobile (Chinese, Japanese and English)', value: 'PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (English-only)', value: 'EN__PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (Greek and English)', value: 'EL__PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (Korean and English)', value: 'KOREAN__PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (Latin script languages)', value: 'LATIN__PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (Russian, Belarusian, Ukrainian and English)', value: 'ESLAV__PP-OCRv5_mobile' },
+    { text: 'PP-OCRv5_mobile (Thai and English)', value: 'TH__PP-OCRv5_mobile' },
+    { text: 'other (external service writes database)', value: 'other' },
+  ];
 </script>
 
 <div class="mt-2">
@@ -140,6 +160,9 @@
                   {/snippet}
                 </FormatMessage>
               </p>
+              <p class="immich-form-label pb-2 text-sm">
+                This fork supports generic numeric CLIP dimensions, for example `256`, `512`, `768`, `1024`, `1536`, `2048`, and `2560` (default).
+              </p>
             {/snippet}
           </SettingInputField>
         </div>
@@ -195,12 +218,7 @@
             desc={$t('admin.machine_learning_facial_recognition_model_description')}
             name="facial-recognition-model"
             bind:value={configToEdit.machineLearning.facialRecognition.modelName}
-            options={[
-              { value: 'antelopev2', text: 'antelopev2' },
-              { value: 'buffalo_l', text: 'buffalo_l' },
-              { value: 'buffalo_m', text: 'buffalo_m' },
-              { value: 'buffalo_s', text: 'buffalo_s' },
-            ]}
+            options={facialRecognitionModelOptions}
             disabled={disabled ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.facialRecognition.enabled}
@@ -274,16 +292,7 @@
             desc={$t('admin.machine_learning_ocr_model_description')}
             name="ocr-model"
             bind:value={configToEdit.machineLearning.ocr.modelName}
-            options={[
-              { text: 'PP-OCRv5_server (Chinese, Japanese and English)', value: 'PP-OCRv5_server' },
-              { text: 'PP-OCRv5_mobile (Chinese, Japanese and English)', value: 'PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (English-only)', value: 'EN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Greek and English)', value: 'EL__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Korean and English)', value: 'KOREAN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Latin script languages)', value: 'LATIN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Russian, Belarusian, Ukrainian and English)', value: 'ESLAV__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Thai and English)', value: 'TH__PP-OCRv5_mobile' },
-            ]}
+            options={ocrModelOptions}
             disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.ocr.enabled}
             isEdited={configToEdit.machineLearning.ocr.modelName !== config.machineLearning.ocr.modelName}
           />


### PR DESCRIPTION
## Description

This PR adds support for integrating external machine learning adapters while preserving the existing behavior of Immich's built-in models. The goal is to let external services handle ML execution and, for selected workflows, write database results directly, while Immich focuses on configuration and presentation.

The changes in this PR include:

- support for generic numeric CLIP model names so external embedding services can choose their own vector dimensions
- `assetId`-only requests for numeric CLIP visual embeddings
- passive `other` modes for OCR and face workflows so external services can own ML execution and persistence while Immich only displays the resulting data
- admin settings updates to expose the new options
- documentation for the external database-driven integration mode

Fixes # (issue)

## How Has This Been Tested?

- [x] Updated server-side tests for generic numeric CLIP dimensions
- [x] Built the server Docker image locally as `immich-server:codex-20260322`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No screenshots were added for this change.

</details>

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This pull request was primarily developed with the assistance of an LLM-based coding tool, with iterative human direction and review.