### PR TITLE
fix(mobile): add cookie for auxiliary url

### DIFF
--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -67,6 +67,9 @@ class AuthService {
     bool isValid = false;
 
     try {
+      final urls = ApiService.getServerUrls();
+      urls.add(url);
+      await NetworkRepository.setHeaders(ApiService.getRequestHeaders(), urls);
       final uri = Uri.parse('$url/users/me');
       final response = await NetworkRepository.client.get(uri);
       if (response.statusCode == 200) {


### PR DESCRIPTION
## Description

There is a cookie syncing mechanism to ensure that all URLs have the same cookies. To add an external URL, the app first checks if it gets a 200 response on an authenticated endpoint. However, until the external URL is actually added, there is no cookie for it and auth fails. This PR adds the cookie for the prospective URL first before attempting the validation request.

Fix #27174