### PR TITLE
fix(mobile/web): album cover buttons consistency

### DIFF
--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -143,8 +143,7 @@ enum ActionButtonType {
             !context.isInLockedView && //
             context.currentAlbum != null,
       ActionButtonType.setAlbumCover =>
-        context.isOwner && //
-            !context.isInLockedView && //
+        !context.isInLockedView && //
             context.currentAlbum != null && //
             context.selectedCount == 1,
       ActionButtonType.unstack =>

--- a/mobile/test/utils/action_button_utils_test.dart
+++ b/mobile/test/utils/action_button_utils_test.dart
@@ -727,7 +727,7 @@ void main() {
         expect(ActionButtonType.setAlbumCover.shouldShow(context), isTrue);
       });
 
-      test('should not show when not owner', () {
+      test('should show when not owner', () {
         final album = createRemoteAlbum();
         final context = ActionButtonContext(
           asset: mergedAsset,
@@ -742,7 +742,7 @@ void main() {
           selectedCount: 1,
         );
 
-        expect(ActionButtonType.setAlbumCover.shouldShow(context), isFalse);
+        expect(ActionButtonType.setAlbumCover.shouldShow(context), isTrue);
       });
 
       test('should not show when in locked view', () {

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -476,19 +476,19 @@
             <ChangeDate menuItem />
             <ChangeDescription menuItem />
             <ChangeLocation menuItem />
-            {#if assetInteraction.selectedAssets.length === 1}
-              <MenuOption
-                text={$t('set_as_album_cover')}
-                icon={mdiImageOutline}
-                onClick={() => updateThumbnailUsingCurrentSelection()}
-              />
-            {/if}
             <ArchiveAction
               menuItem
               unarchive={assetInteraction.isAllArchived}
               onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
             />
             <SetVisibilityAction menuItem onVisibilitySet={handleSetVisibility} />
+          {/if}
+          {#if assetInteraction.selectedAssets.length === 1}
+            <MenuOption
+              text={$t('set_as_album_cover')}
+              icon={mdiImageOutline}
+              onClick={() => updateThumbnailUsingCurrentSelection()}
+            />
           {/if}
 
           {#if $preferences.tags.enabled && assetInteraction.isAllUserOwned}


### PR DESCRIPTION
## Description

Fixes #27130

Aligns behavior of the "set album cover" action between web and mobile
 Users may use any photo in the album (including the ones uploaded by other people) to use as the album cover.