### PR TITLE
fix(server): refresh unedited asset dimensions on metadata extraction

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -345,6 +345,7 @@ export const columns = {
     'asset.type',
     'asset.width',
     'asset.height',
+    'asset.isEdited',
   ],
   assetFiles: ['asset_file.id', 'asset_file.path', 'asset_file.type', 'asset_file.isEdited'],
   assetFilesForThumbnail: [

--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -264,6 +264,7 @@ select
   "asset"."type",
   "asset"."width",
   "asset"."height",
+  "asset"."isEdited",
   (
     select
       coalesce(json_agg(agg), '[]')

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1641,12 +1641,32 @@ describe(MetadataService.name, () => {
       );
     });
 
-    it('should not overwrite existing width/height if they already exist', async () => {
-      const asset = AssetFactory.create({ width: 1920, height: 1080 });
+    it('should overwrite existing width/height for unedited assets', async () => {
+      const asset = AssetFactory.create({ width: 1920, height: 1080, isEdited: false });
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
       mockReadTags({ ImageWidth: 1280, ImageHeight: 720 });
 
       await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: 1280,
+          height: 720,
+        }),
+      );
+    });
+
+    it('should not overwrite existing width/height for edited assets', async () => {
+      const asset = AssetFactory.create({ width: 1920, height: 1080, isEdited: true });
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ ImageWidth: 1280, ImageHeight: 720 });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: undefined,
+          height: undefined,
+        }),
+      );
       expect(mocks.asset.update).not.toHaveBeenCalledWith(
         expect.objectContaining({
           width: 1280,

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -327,10 +327,9 @@ export class MetadataService extends BaseService {
           fileCreatedAt: dates.dateTimeOriginal ?? undefined,
           fileModifiedAt: stats.mtime,
 
-          // only update the dimensions if they don't already exist
-          // we don't want to overwrite width/height that are modified by edits
-          width: asset.width == null ? assetWidth : undefined,
-          height: asset.height == null ? assetHeight : undefined,
+          // Keep unedited assets in sync with the file on disk, but don't overwrite edited dimensions.
+          width: !asset.isEdited || asset.width == null ? assetWidth : undefined,
+          height: !asset.isEdited || asset.height == null ? assetHeight : undefined,
         }),
       async () => {
         await this.assetRepository.upsertExif(exifData, { lockedPropertiesBehavior: 'skip' });

--- a/server/test/mappers.ts
+++ b/server/test/mappers.ts
@@ -138,6 +138,7 @@ export const getForMetadataExtraction = (asset: ReturnType<AssetFactory['build']
   originalPath: asset.originalPath,
   ownerId: asset.ownerId,
   type: asset.type,
+  isEdited: asset.isEdited,
   width: asset.width,
   height: asset.height,
   faces: asset.faces.map((face) => getDehydrated(face)),


### PR DESCRIPTION
When an external library asset changes on disk, its stored width/height can become stale and cause aspect ratio issues. This PR updates metadata extraction to refresh width/height for unedited assets, while preserving existing dimensions for edited assets.

Fixes #27085 and likely fixes #27212 as well
