### PR TITLE
fix(mobile): remove upload timeout

### DIFF
--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -150,7 +150,6 @@ class URLSessionManager: NSObject {
     config.httpCookieStorage = cookieStorage
     config.httpMaximumConnectionsPerHost = 64
     config.timeoutIntervalForRequest = 60
-    config.timeoutIntervalForResource = 300
 
     var headers = UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] ?? [:]
     headers["User-Agent"] = headers["User-Agent"] ?? userAgent


### PR DESCRIPTION
## Description

This sets a 300 second limit on uploads and downloads, which isn't what we want.

Fixes #27222