### PR TITLE
fix(web): ESC key closes face/person editor instead of entire asset-viewer

### DIFF
--- a/e2e/src/ui/mock-network/face-editor-network.ts
+++ b/e2e/src/ui/mock-network/face-editor-network.ts
@@ -1,3 +1,4 @@
+import type { AssetFaceResponseDto, AssetResponseDto, PersonWithFacesResponseDto, SourceType } from '@immich/sdk';
 import { BrowserContext } from '@playwright/test';
 import { randomThumbnail } from 'src/ui/generators/timeline';
 
@@ -122,6 +123,89 @@ export const setupFaceEditorMockApiRoutes = async (
       status: 200,
       headers: { 'content-type': 'image/jpeg' },
       body: await randomThumbnail('person-thumb', 1),
+    });
+  });
+};
+
+export type MockFaceSpec = {
+  personId: string;
+  personName: string;
+  faceId: string;
+  boundingBoxX1: number;
+  boundingBoxY1: number;
+  boundingBoxX2: number;
+  boundingBoxY2: number;
+};
+
+const toPersonResponseDto = (spec: MockFaceSpec) => ({
+  id: spec.personId,
+  name: spec.personName,
+  birthDate: null,
+  isHidden: false,
+  thumbnailPath: `/upload/thumbs/${spec.personId}.jpeg`,
+  updatedAt: '2025-01-01T00:00:00.000Z',
+});
+
+const toBoundingBox = (spec: MockFaceSpec, imageWidth: number, imageHeight: number) => ({
+  id: spec.faceId,
+  imageWidth,
+  imageHeight,
+  boundingBoxX1: spec.boundingBoxX1,
+  boundingBoxY1: spec.boundingBoxY1,
+  boundingBoxX2: spec.boundingBoxX2,
+  boundingBoxY2: spec.boundingBoxY2,
+});
+
+export const createMockFacePeople = (
+  specs: MockFaceSpec[],
+  imageWidth: number,
+  imageHeight: number,
+): PersonWithFacesResponseDto[] => {
+  return specs.map((spec) => ({
+    ...toPersonResponseDto(spec),
+    faces: [toBoundingBox(spec, imageWidth, imageHeight)],
+  }));
+};
+
+export const createMockAssetFaces = (
+  specs: MockFaceSpec[],
+  imageWidth: number,
+  imageHeight: number,
+): AssetFaceResponseDto[] => {
+  return specs.map((spec) => ({
+    ...toBoundingBox(spec, imageWidth, imageHeight),
+    person: toPersonResponseDto(spec),
+    sourceType: 'machine-learning' as SourceType,
+  }));
+};
+
+export const setupGetFacesMockApiRoute = async (context: BrowserContext, faces: AssetFaceResponseDto[]) => {
+  await context.route('**/api/faces?*', async (route, request) => {
+    if (request.method() !== 'GET') {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      json: faces,
+    });
+  });
+};
+
+export const setupAssetWithPeopleMockRoute = async (context: BrowserContext, assetDto: AssetResponseDto) => {
+  await context.route('**/api/assets/*', async (route, request) => {
+    if (request.method() !== 'GET') {
+      return route.fallback();
+    }
+    const url = new URL(request.url());
+    const assetId = url.pathname.split('/').at(-1);
+    if (assetId !== assetDto.id) {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      json: assetDto,
     });
   });
 };

--- a/e2e/src/ui/specs/asset-viewer/face-editor.e2e-spec.ts
+++ b/e2e/src/ui/specs/asset-viewer/face-editor.e2e-spec.ts
@@ -282,4 +282,31 @@ test.describe('face-editor', () => {
     expect(afterDrag.left).toBeGreaterThan(beforeDrag.left + 50);
     expect(afterDrag.top).toBeGreaterThan(beforeDrag.top + 20);
   });
+
+  test('Escape closes face editor with focus inside selector', async ({ page }) => {
+    const asset = selectRandom(fixture.assets, rng);
+    await openFaceEditor(page, asset);
+
+    await page
+      .locator('#face-selector')
+      .getByRole('button', { name: /cancel/i })
+      .focus();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('#face-selector')).toBeHidden();
+    await expect(page.locator('#face-editor')).toBeHidden();
+  });
+
+  test('Escape closes face editor with focus outside selector', async ({ page }) => {
+    const asset = selectRandom(fixture.assets, rng);
+    await openFaceEditor(page, asset);
+
+    await page.locator('#immich-asset-viewer').click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('#face-selector')).toBeHidden();
+    await expect(page.locator('#face-editor')).toBeHidden();
+  });
 });

--- a/e2e/src/ui/specs/asset-viewer/person-side-panel.e2e-spec.ts
+++ b/e2e/src/ui/specs/asset-viewer/person-side-panel.e2e-spec.ts
@@ -1,0 +1,131 @@
+import { expect, Page, test } from '@playwright/test';
+import {
+  createMockAssetFaces,
+  createMockFacePeople,
+  createMockPeople,
+  type MockFaceSpec,
+  setupAssetWithPeopleMockRoute,
+  setupFaceEditorMockApiRoutes,
+  setupGetFacesMockApiRoute,
+} from 'src/ui/mock-network/face-editor-network';
+import { assetViewerUtils } from '../timeline/utils';
+import { ensureDetailPanelVisible, setupAssetViewerFixture } from './utils';
+
+const FACE_SPECS: MockFaceSpec[] = [
+  {
+    personId: 'person-alice',
+    personName: 'Alice Johnson',
+    faceId: 'face-alice',
+    boundingBoxX1: 1000,
+    boundingBoxY1: 500,
+    boundingBoxX2: 1500,
+    boundingBoxY2: 1200,
+  },
+  {
+    personId: 'person-bob',
+    personName: 'Bob Smith',
+    faceId: 'face-bob',
+    boundingBoxX1: 2000,
+    boundingBoxY1: 800,
+    boundingBoxX2: 2400,
+    boundingBoxY2: 1600,
+  },
+];
+
+const openPersonSidePanel = async (page: Page) => {
+  await ensureDetailPanelVisible(page);
+  await page.getByLabel('Edit people').click();
+  await page.getByText('Edit faces').waitFor({ state: 'visible' });
+};
+
+test.describe.configure({ mode: 'parallel' });
+test.describe('person-side-panel escape shortcuts', () => {
+  const fixture = setupAssetViewerFixture(850);
+
+  test.beforeEach(async ({ context }) => {
+    const imageWidth = fixture.primaryAssetDto.width ?? 4000;
+    const imageHeight = fixture.primaryAssetDto.height ?? 3000;
+
+    const people = createMockFacePeople(FACE_SPECS, imageWidth, imageHeight);
+    const assetDtoWithPeople = {
+      ...fixture.primaryAssetDto,
+      people,
+      unassignedFaces: [],
+    };
+
+    const assetFaces = createMockAssetFaces(FACE_SPECS, imageWidth, imageHeight);
+
+    await setupAssetWithPeopleMockRoute(context, assetDtoWithPeople);
+    await setupGetFacesMockApiRoute(context, assetFaces);
+    await setupFaceEditorMockApiRoutes(context, createMockPeople(4), { requests: [] });
+  });
+
+  test('Escape closes person side panel with focus inside panel', async ({ page }) => {
+    await page.goto(`/photos/${fixture.primaryAsset.id}`);
+    await assetViewerUtils.waitForViewerLoad(page, fixture.primaryAsset);
+
+    await openPersonSidePanel(page);
+
+    const doneButton = page.getByText('Done');
+    await doneButton.focus();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByText('Edit faces')).toBeHidden();
+  });
+
+  test('Escape closes person side panel with focus outside panel', async ({ page }) => {
+    await page.goto(`/photos/${fixture.primaryAsset.id}`);
+    await assetViewerUtils.waitForViewerLoad(page, fixture.primaryAsset);
+
+    await openPersonSidePanel(page);
+
+    await page.locator('#immich-asset-viewer').click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByText('Edit faces')).toBeHidden();
+  });
+
+  test('Escape closes assign-face panel before person side panel', async ({ page }) => {
+    await page.goto(`/photos/${fixture.primaryAsset.id}`);
+    await assetViewerUtils.waitForViewerLoad(page, fixture.primaryAsset);
+
+    await openPersonSidePanel(page);
+
+    const editButtons = page.getByLabel('Select new face');
+    await editButtons.first().click();
+
+    const assignPanel = page.getByText('All people');
+    await expect(assignPanel).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(assignPanel).toBeHidden();
+    await expect(page.getByText('Edit faces')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByText('Edit faces')).toBeHidden();
+  });
+
+  test('Escape closes assign-face panel with focus outside panels', async ({ page }) => {
+    await page.goto(`/photos/${fixture.primaryAsset.id}`);
+    await assetViewerUtils.waitForViewerLoad(page, fixture.primaryAsset);
+
+    await openPersonSidePanel(page);
+
+    const editButtons = page.getByLabel('Select new face');
+    await editButtons.first().click();
+
+    const assignPanel = page.getByText('All people');
+    await expect(assignPanel).toBeVisible();
+
+    await page.locator('#immich-asset-viewer').click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press('Escape');
+
+    await expect(assignPanel).toBeHidden();
+    await expect(page.getByText('Edit faces')).toBeVisible();
+  });
+});

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -15,14 +15,15 @@
   import SetStackPrimaryAsset from '$lib/components/asset-viewer/actions/set-stack-primary-asset.svelte';
   import SetVisibilityAction from '$lib/components/asset-viewer/actions/set-visibility-action.svelte';
   import UnstackAction from '$lib/components/asset-viewer/actions/unstack-action.svelte';
+  import LoadingDots from '$lib/components/LoadingDots.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
+  import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { languageManager } from '$lib/managers/language-manager.svelte';
   import { Route } from '$lib/route';
   import { getGlobalActions } from '$lib/services/app.service';
   import { getAssetActions } from '$lib/services/asset.service';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { user } from '$lib/stores/user.store';
   import { getSharedLink, withoutIcons } from '$lib/utils';
   import type { OnUndoDelete } from '$lib/utils/actions';
@@ -36,8 +37,6 @@
     type StackResponseDto,
   } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider, Tooltip, type ActionItem } from '@immich/ui';
-  import LoadingDots from '$lib/components/LoadingDots.svelte';
-  import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import {
     mdiArrowLeft,
     mdiArrowRight,
@@ -89,7 +88,7 @@
     title: $t('go_back'),
     type: $t('assets'),
     icon: languageManager.rtl ? mdiArrowRight : mdiArrowLeft,
-    $if: () => !!onClose && !isFaceEditMode.value,
+    $if: () => !!onClose && !assetViewerManager.isFaceEditMode && !assetViewerManager.isEditFacesPanelOpen,
     onAction: () => onClose?.(),
     shortcuts: [{ key: 'Escape' }],
   });
@@ -101,13 +100,16 @@
 <CommandPaletteDefaultProvider name={$t('assets')} actions={withoutIcons([Close, Cast, ...Object.values(Actions)])} />
 
 <div
-  class="flex h-16 place-items-center justify-between bg-linear-to-b from-black/40 px-3 transition-transform duration-200"
+  class="flex h-16 place-items-center justify-between bg-linear-to-b from-black/40 px-3 transition-transform duration-200 drop-shadow-[0_0_1px_rgba(0,0,0,0.4)]"
 >
   <div class="dark">
     <ActionButton action={Close} />
   </div>
 
-  <div class="flex items-center gap-2 overflow-x-auto dark" data-testid="asset-viewer-navbar-actions">
+  <div
+    class="flex p-1 -m-1 items-center gap-2 overflow-x-auto *:shrink-0 dark"
+    data-testid="asset-viewer-navbar-actions"
+  >
     {#if assetViewerManager.isImageLoading}
       <Tooltip text={$t('loading')}>
         {#snippet child({ props })}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -15,7 +15,6 @@
   import { eventManager } from '$lib/managers/event-manager.svelte';
   import { getAssetActions } from '$lib/services/asset.service';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { ocrManager } from '$lib/stores/ocr.svelte';
   import { alwaysLoadOriginalVideo } from '$lib/stores/preferences.store';
   import { SlideshowNavigation, SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
@@ -466,7 +465,7 @@
 >
   <!-- Top navigation bar -->
   {#if $slideshowState === SlideshowState.None && !assetViewerManager.isShowEditor}
-    <div class="col-span-4 col-start-1 row-span-1 row-start-1 transition-transform">
+    <div class="z-1 col-span-4 col-start-1 row-span-1 row-start-1 transition-transform">
       <AssetViewerNavBar
         {asset}
         {album}
@@ -497,7 +496,7 @@
     </div>
   {/if}
 
-  {#if $slideshowState === SlideshowState.None && showNavigation && !assetViewerManager.isShowEditor && !isFaceEditMode.value && previousAsset}
+  {#if $slideshowState === SlideshowState.None && showNavigation && !assetViewerManager.isShowEditor && !assetViewerManager.isFaceEditMode && previousAsset}
     <div class="my-auto col-span-1 col-start-1 row-span-full row-start-1 justify-self-start">
       <PreviousAssetAction onPreviousAsset={() => navigateAsset('previous')} />
     </div>
@@ -564,13 +563,13 @@
     {/if}
 
     {#if showOcrButton}
-      <div class="absolute bottom-0 end-0 mb-6 me-6">
+      <div class="absolute bottom-0 end-0 mb-6 me-6 drop-shadow-[0_0_1px_rgba(0,0,0,0.4)]">
         <OcrButton />
       </div>
     {/if}
   </div>
 
-  {#if $slideshowState === SlideshowState.None && showNavigation && !assetViewerManager.isShowEditor && !isFaceEditMode.value && nextAsset}
+  {#if $slideshowState === SlideshowState.None && showNavigation && !assetViewerManager.isShowEditor && !assetViewerManager.isFaceEditMode && nextAsset}
     <div class="my-auto col-span-1 col-start-4 row-span-full row-start-1 justify-self-end">
       <NextAssetAction onNextAsset={() => navigateAsset('next')} />
     </div>

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -7,10 +7,11 @@
   import { timeToLoadTheMap } from '$lib/constants';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { eventManager } from '$lib/managers/event-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
+  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
   import { Route } from '$lib/route';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { locale } from '$lib/stores/preferences.store';
   import { preferences, user } from '$lib/stores/user.store';
@@ -41,6 +42,7 @@
     mdiPlus,
   } from '@mdi/js';
   import { DateTime } from 'luxon';
+  import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
   import { slide } from 'svelte/transition';
   import ImageThumbnail from '../assets/thumbnail/image-thumbnail.svelte';
@@ -57,11 +59,9 @@
   let { asset, currentAlbum = null }: Props = $props();
 
   let showAssetPath = $state(false);
-  let showEditFaces = $state(false);
   let isOwner = $derived($user?.id === asset.ownerId);
   let people = $derived(asset.people || []);
   let unassignedFaces = $derived(asset.unassignedFaces || []);
-  let showingHiddenPeople = $state(false);
   let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
   let dateTime = $derived(
     timeZone && asset.exifInfo?.dateTimeOriginal
@@ -106,7 +106,8 @@
       return;
     }
 
-    showEditFaces = false;
+    assetViewerManager.isEditFacesPanelOpen = false;
+    assetViewerManager.showingHiddenPeople = false;
     previousId = asset.id;
   });
 
@@ -122,7 +123,10 @@
 
   const handleRefreshPeople = async () => {
     asset = await getAssetInfo({ id: asset.id });
-    showEditFaces = false;
+    assetViewingStore.setAsset(asset);
+    eventManager.emit('AssetUpdate', asset);
+    assetViewerManager.isEditFacesPanelOpen = false;
+    assetViewerManager.showingHiddenPeople = false;
   };
 
   const getAssetFolderHref = (asset: AssetResponseDto) => {
@@ -143,438 +147,451 @@
       initialTimeZone: timeZone,
     });
   };
+
+  onDestroy(() => {
+    assetViewerManager.isEditFacesPanelOpen = false;
+    assetViewerManager.showingHiddenPeople = false;
+  });
 </script>
 
 <OnEvents onAlbumAddAssets={() => (albums = refreshAlbums())} />
 
-<section class="relative p-2">
-  <div class="flex place-items-center gap-2">
-    <IconButton
-      icon={mdiClose}
-      aria-label={$t('close')}
-      onclick={() => assetViewerManager.closeDetailPanel()}
-      shape="round"
-      color="secondary"
-      variant="ghost"
-    />
-    <p class="text-lg text-immich-fg dark:text-immich-dark-fg">{$t('info')}</p>
-  </div>
+<section inert={assetViewerManager.isEditFacesPanelOpen}>
+  <section class="relative p-2">
+    <div class="flex place-items-center gap-2">
+      <IconButton
+        icon={mdiClose}
+        aria-label={$t('close')}
+        onclick={() => assetViewerManager.closeDetailPanel()}
+        shape="round"
+        color="secondary"
+        variant="ghost"
+      />
+      <p class="text-lg text-immich-fg dark:text-immich-dark-fg">{$t('info')}</p>
+    </div>
 
-  {#if asset.isOffline}
-    <section class="px-4 py-4">
-      <div role="alert">
-        <div class="rounded-t bg-red-500 px-4 py-2 font-bold text-white">
-          {$t('asset_offline')}
-        </div>
-        <div class="border border-t-0 border-red-400 bg-red-100 px-4 py-3 text-red-700">
-          <p>
-            {#if $user?.isAdmin}
-              {$t('admin.asset_offline_description')}
-            {:else}
-              {$t('asset_offline_description')}
-            {/if}
-          </p>
-        </div>
-        <div class="rounded-b bg-red-500 px-4 py-2 text-white text-sm">
-          <p>{asset.originalPath}</p>
-        </div>
-      </div>
-    </section>
-  {/if}
-
-  <DetailPanelDescription {asset} {isOwner} />
-  <DetailPanelRating {asset} {isOwner} />
-
-  {#if !authManager.isSharedLink && isOwner}
-    <section class="px-4 pt-4 text-sm">
-      <div class="flex h-10 w-full items-center justify-between">
-        <Text size="small" color="muted">{$t('people')}</Text>
-        <div class="flex gap-2 items-center">
-          {#if people.some((person) => person.isHidden)}
-            <IconButton
-              aria-label={$t('show_hidden_people')}
-              icon={showingHiddenPeople ? mdiEyeOff : mdiEye}
-              size="medium"
-              shape="round"
-              color="secondary"
-              variant="ghost"
-              onclick={() => (showingHiddenPeople = !showingHiddenPeople)}
-            />
-          {/if}
-          <IconButton
-            aria-label={$t('tag_people')}
-            icon={mdiPlus}
-            size="medium"
-            shape="round"
-            color="secondary"
-            variant="ghost"
-            onclick={() => (isFaceEditMode.value = !isFaceEditMode.value)}
-          />
-
-          {#if people.length > 0 || unassignedFaces.length > 0}
-            <IconButton
-              aria-label={$t('edit_people')}
-              icon={mdiPencil}
-              size="medium"
-              shape="round"
-              color="secondary"
-              variant="ghost"
-              onclick={() => (showEditFaces = true)}
-            />
-          {/if}
-        </div>
-      </div>
-
-      <div class="mt-2 flex flex-wrap gap-2">
-        {#each people as person, index (person.id)}
-          {#if showingHiddenPeople || !person.isHidden}
-            <a
-              class="w-22"
-              href={Route.viewPerson(person, { previousRoute })}
-              onfocus={() => ($boundingBoxesArray = people[index].faces)}
-              onblur={() => ($boundingBoxesArray = [])}
-              onmouseover={() => ($boundingBoxesArray = people[index].faces)}
-              onmouseleave={() => ($boundingBoxesArray = [])}
-            >
-              <div class="relative">
-                <ImageThumbnail
-                  curve
-                  shadow
-                  url={getPeopleThumbnailUrl(person)}
-                  altText={person.name}
-                  title={person.name}
-                  widthStyle="90px"
-                  heightStyle="90px"
-                  hidden={person.isHidden}
-                />
-              </div>
-              <p class="mt-1 truncate font-medium" title={person.name}>{person.name}</p>
-              {#if person.birthDate}
-                {@const personBirthDate = DateTime.fromISO(person.birthDate)}
-                {@const age = Math.floor(DateTime.fromISO(asset.localDateTime).diff(personBirthDate, 'years').years)}
-                {@const ageInMonths = Math.floor(
-                  DateTime.fromISO(asset.localDateTime).diff(personBirthDate, 'months').months,
-                )}
-                {#if age >= 0}
-                  <p
-                    class="font-light"
-                    title={personBirthDate.toLocaleString(
-                      {
-                        month: 'long',
-                        day: 'numeric',
-                        year: 'numeric',
-                      },
-                      { locale: $locale },
-                    )}
-                  >
-                    {#if ageInMonths <= 11}
-                      {$t('age_months', { values: { months: ageInMonths } })}
-                    {:else if ageInMonths > 12 && ageInMonths <= 23}
-                      {$t('age_year_months', { values: { months: ageInMonths - 12 } })}
-                    {:else}
-                      {$t('age_years', { values: { years: age } })}
-                    {/if}
-                  </p>
-                {/if}
+    {#if asset.isOffline}
+      <section class="px-4 py-4">
+        <div role="alert">
+          <div class="rounded-t bg-red-500 px-4 py-2 font-bold text-white">
+            {$t('asset_offline')}
+          </div>
+          <div class="border border-t-0 border-red-400 bg-red-100 px-4 py-3 text-red-700">
+            <p>
+              {#if $user?.isAdmin}
+                {$t('admin.asset_offline_description')}
+              {:else}
+                {$t('asset_offline_description')}
               {/if}
-            </a>
-          {/if}
-        {/each}
-      </div>
-    </section>
-  {/if}
-
-  <div class="px-4 py-4">
-    {#if asset.exifInfo}
-      <div class="flex h-10 w-full items-center justify-between text-sm">
-        <Text size="small" color="muted">{$t('details')}</Text>
-      </div>
-    {:else}
-      <Text size="small" color="muted">{$t('no_exif_info_available')}</Text>
+            </p>
+          </div>
+          <div class="rounded-b bg-red-500 px-4 py-2 text-white text-sm">
+            <p>{asset.originalPath}</p>
+          </div>
+        </div>
+      </section>
     {/if}
 
-    {#if dateTime}
-      <button
-        type="button"
-        class="flex w-full text-start justify-between place-items-start gap-4 py-4"
-        onclick={handleChangeDate}
-        title={isOwner ? $t('edit_date') : ''}
-        class:hover:text-primary={isOwner}
-      >
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
+    <DetailPanelDescription {asset} {isOwner} />
+    <DetailPanelRating {asset} {isOwner} />
 
-          <div>
-            <p>
-              {dateTime.toLocaleString(
-                {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
-                },
-                { locale: $locale },
-              )}
-            </p>
-            <div class="flex gap-2 text-sm">
+    {#if !authManager.isSharedLink && isOwner}
+      <section class="px-4 pt-4 text-sm">
+        <div class="flex h-10 w-full items-center justify-between">
+          <Text size="small" color="muted">{$t('people')}</Text>
+          <div class="flex gap-2 items-center">
+            {#if people.some((person) => person.isHidden)}
+              <IconButton
+                aria-label={$t('show_hidden_people')}
+                icon={assetViewerManager.showingHiddenPeople ? mdiEyeOff : mdiEye}
+                size="medium"
+                shape="round"
+                color="secondary"
+                variant="ghost"
+                onclick={() => (assetViewerManager.showingHiddenPeople = !assetViewerManager.showingHiddenPeople)}
+              />
+            {/if}
+            <IconButton
+              aria-label={$t('tag_people')}
+              icon={mdiPlus}
+              size="medium"
+              shape="round"
+              color="secondary"
+              variant="ghost"
+              onclick={() => (assetViewerManager.isFaceEditMode = !assetViewerManager.isFaceEditMode)}
+            />
+
+            {#if people.length > 0 || unassignedFaces.length > 0}
+              <IconButton
+                aria-label={$t('edit_people')}
+                icon={mdiPencil}
+                size="medium"
+                shape="round"
+                color="secondary"
+                variant="ghost"
+                onclick={() => (assetViewerManager.isEditFacesPanelOpen = true)}
+              />
+            {/if}
+          </div>
+        </div>
+
+        <div class="mt-2 flex flex-wrap gap-4">
+          {#each people as person, index (person.id)}
+            {#if assetViewerManager.showingHiddenPeople || !person.isHidden}
+              {@const isHighlighted = people[index].faces.some((f) => $boundingBoxesArray.some((b) => b.id === f.id))}
+              <a
+                class={[
+                  'group w-22 outline-none transition-opacity',
+                  $boundingBoxesArray.length > 0 && !isHighlighted && 'opacity-40',
+                ]}
+                href={Route.viewPerson(person, { previousRoute })}
+                onfocus={() => ($boundingBoxesArray = people[index].faces)}
+                onblur={() => ($boundingBoxesArray = [])}
+                onpointerover={() => ($boundingBoxesArray = people[index].faces)}
+                onpointerleave={() => ($boundingBoxesArray = [])}
+              >
+                <div class="relative">
+                  <ImageThumbnail
+                    curve
+                    shadow
+                    url={getPeopleThumbnailUrl(person)}
+                    altText={person.name}
+                    title={person.name}
+                    widthStyle="90px"
+                    heightStyle="90px"
+                    hidden={person.isHidden}
+                    highlighted={isHighlighted}
+                    class="group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary"
+                  />
+                </div>
+                <p class="mt-1 truncate font-medium" title={person.name}>{person.name}</p>
+                {#if person.birthDate}
+                  {@const personBirthDate = DateTime.fromISO(person.birthDate)}
+                  {@const age = Math.floor(DateTime.fromISO(asset.localDateTime).diff(personBirthDate, 'years').years)}
+                  {@const ageInMonths = Math.floor(
+                    DateTime.fromISO(asset.localDateTime).diff(personBirthDate, 'months').months,
+                  )}
+                  {#if age >= 0}
+                    <p
+                      class="font-light"
+                      title={personBirthDate.toLocaleString(
+                        {
+                          month: 'long',
+                          day: 'numeric',
+                          year: 'numeric',
+                        },
+                        { locale: $locale },
+                      )}
+                    >
+                      {#if ageInMonths <= 11}
+                        {$t('age_months', { values: { months: ageInMonths } })}
+                      {:else if ageInMonths > 12 && ageInMonths <= 23}
+                        {$t('age_year_months', { values: { months: ageInMonths - 12 } })}
+                      {:else}
+                        {$t('age_years', { values: { years: age } })}
+                      {/if}
+                    </p>
+                  {/if}
+                {/if}
+              </a>
+            {/if}
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    <div class="px-4 py-4">
+      {#if asset.exifInfo}
+        <div class="flex h-10 w-full items-center justify-between text-sm">
+          <Text size="small" color="muted">{$t('details')}</Text>
+        </div>
+      {:else}
+        <Text size="small" color="muted">{$t('no_exif_info_available')}</Text>
+      {/if}
+
+      {#if dateTime}
+        <button
+          type="button"
+          class="flex w-full text-start justify-between place-items-start gap-4 py-4"
+          onclick={handleChangeDate}
+          title={isOwner ? $t('edit_date') : ''}
+          class:hover:text-primary={isOwner}
+        >
+          <div class="flex gap-4">
+            <div>
+              <Icon icon={mdiCalendar} size="24" />
+            </div>
+
+            <div>
               <p>
                 {dateTime.toLocaleString(
                   {
-                    weekday: 'short',
-                    hour: 'numeric',
-                    minute: '2-digit',
-                    second: '2-digit',
-                    timeZoneName: timeZone ? 'longOffset' : undefined,
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
                   },
                   { locale: $locale },
                 )}
               </p>
-            </div>
-          </div>
-        </div>
-
-        {#if isOwner}
-          <div class="p-1">
-            <Icon icon={mdiPencil} size="20" />
-          </div>
-        {/if}
-      </button>
-    {:else if !dateTime && isOwner}
-      <div class="flex justify-between place-items-start gap-4 py-4">
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
-        </div>
-        <div class="p-1">
-          <Icon icon={mdiPencil} size="20" />
-        </div>
-      </div>
-    {/if}
-
-    <div class="flex gap-4 py-4">
-      <div><Icon icon={mdiImageOutline} size="24" /></div>
-
-      <div>
-        <p class="break-all flex place-items-center gap-2 whitespace-pre-wrap">
-          {asset.originalFileName}
-          {#if isOwner}
-            <IconButton
-              icon={mdiInformationOutline}
-              aria-label={$t('show_file_location')}
-              size="small"
-              shape="round"
-              color="secondary"
-              variant="ghost"
-              onclick={toggleAssetPath}
-            />
-          {/if}
-        </p>
-        {#if showAssetPath}
-          <p class="text-xs opacity-50 break-all pb-2 hover:text-primary" transition:slide={{ duration: 250 }}>
-            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve this is supposed to be treated as an absolute/external link -->
-            <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')} class="whitespace-pre-wrap">
-              {asset.originalPath}
-            </a>
-          </p>
-        {/if}
-        {#if (asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth) || asset.exifInfo?.fileSizeInByte}
-          <div class="flex gap-2 text-sm">
-            {#if asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth}
-              {#if getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)}
+              <div class="flex gap-2 text-sm">
                 <p>
-                  {getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)} MP
+                  {dateTime.toLocaleString(
+                    {
+                      weekday: 'short',
+                      hour: 'numeric',
+                      minute: '2-digit',
+                      second: '2-digit',
+                      timeZoneName: timeZone ? 'longOffset' : undefined,
+                    },
+                    { locale: $locale },
+                  )}
                 </p>
-              {/if}
-              {@const { width, height } = getDimensions(asset.exifInfo)}
-              <p>{width} x {height}</p>
-            {/if}
-            {#if asset.exifInfo?.fileSizeInByte}
-              <p>{getByteUnitString(asset.exifInfo.fileSizeInByte, $locale)}</p>
-            {/if}
-          </div>
-        {/if}
-      </div>
-    </div>
-
-    {#if asset.exifInfo?.make || asset.exifInfo?.model || asset.exifInfo?.exposureTime || asset.exifInfo?.iso}
-      <div class="flex gap-4 py-4">
-        <div><Icon icon={mdiCamera} size="24" /></div>
-
-        <div>
-          {#if asset.exifInfo?.make || asset.exifInfo?.model}
-            <p>
-              <a
-                href={Route.search({
-                  make: asset.exifInfo?.make ?? undefined,
-                  model: asset.exifInfo?.model ?? undefined,
-                })}
-                title="{$t('search_for')} {asset.exifInfo.make || ''} {asset.exifInfo.model || ''}"
-                class="hover:text-primary"
-              >
-                {asset.exifInfo.make || ''}
-                {asset.exifInfo.model || ''}
-              </a>
-            </p>
-          {/if}
-
-          <div class="flex gap-2 text-sm">
-            {#if asset.exifInfo.exposureTime}
-              <p>{`${asset.exifInfo.exposureTime} s`}</p>
-            {/if}
-
-            {#if asset.exifInfo.iso}
-              <p>{`ISO ${asset.exifInfo.iso}`}</p>
-            {/if}
-          </div>
-        </div>
-      </div>
-    {/if}
-
-    {#if asset.exifInfo?.lensModel || asset.exifInfo?.fNumber || asset.exifInfo?.focalLength}
-      <div class="flex gap-4 py-4">
-        <div><Icon icon={mdiCameraIris} size="24" /></div>
-
-        <div>
-          {#if asset.exifInfo?.lensModel}
-            <p>
-              <a
-                href={Route.search({ lensModel: asset.exifInfo.lensModel })}
-                title="{$t('search_for')} {asset.exifInfo.lensModel}"
-                class="hover:text-primary line-clamp-1"
-              >
-                {asset.exifInfo.lensModel}
-              </a>
-            </p>
-          {/if}
-
-          <div class="flex gap-2 text-sm">
-            {#if asset.exifInfo?.fNumber}
-              <p>ƒ/{asset.exifInfo.fNumber.toLocaleString($locale)}</p>
-            {/if}
-
-            {#if asset.exifInfo.focalLength}
-              <p>{`${asset.exifInfo.focalLength.toLocaleString($locale)} mm`}</p>
-            {/if}
-          </div>
-        </div>
-      </div>
-    {/if}
-
-    <DetailPanelLocation {isOwner} {asset} />
-  </div>
-</section>
-
-{#if latlng && featureFlagsManager.value.map}
-  <div class="h-90">
-    {#await import('$lib/components/shared-components/map/map.svelte')}
-      {#await delay(timeToLoadTheMap) then}
-        <!-- show the loading spinner only if loading the map takes too much time -->
-        <div class="flex items-center justify-center h-full w-full">
-          <LoadingSpinner />
-        </div>
-      {/await}
-    {:then { default: Map }}
-      <Map
-        mapMarkers={[
-          {
-            lat: latlng.lat,
-            lon: latlng.lng,
-            id: asset.id,
-            city: asset.exifInfo?.city ?? null,
-            state: asset.exifInfo?.state ?? null,
-            country: asset.exifInfo?.country ?? null,
-          },
-        ]}
-        center={latlng}
-        showSettings={false}
-        zoom={12.5}
-        simplified
-        useLocationPin
-        showSimpleControls={!showEditFaces}
-        onOpenInMapView={() => goto(Route.map({ ...latlng, zoom: 12.5 }))}
-      >
-        {#snippet popup({ marker })}
-          {@const { lat, lon } = marker}
-          <div class="flex flex-col items-center gap-1">
-            <p class="font-bold">{lat.toPrecision(6)}, {lon.toPrecision(6)}</p>
-            <a
-              href="https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=13#map=15/{lat}/{lon}"
-              target="_blank"
-              class="font-medium text-primary underline focus:outline-none"
-            >
-              {$t('open_in_openstreetmap')}
-            </a>
-          </div>
-        {/snippet}
-      </Map>
-    {/await}
-  </div>
-{/if}
-
-{#if currentAlbum && currentAlbum.albumUsers.length > 0 && asset.owner}
-  <section class="px-6 dark:text-immich-dark-fg mt-4">
-    <Text size="small" color="muted">{$t('shared_by')}</Text>
-    <div class="flex gap-4 pt-4">
-      <div>
-        <UserAvatar user={asset.owner} size="md" />
-      </div>
-
-      <div class="mb-auto mt-auto">
-        <p>
-          {asset.owner.name}
-        </p>
-      </div>
-    </div>
-  </section>
-{/if}
-
-{#await albums then albums}
-  {#if albums.length > 0}
-    <section class="px-6 py-6 dark:text-immich-dark-fg">
-      <div class="pb-4">
-        <Text size="small" color="muted">{$t('appears_in')}</Text>
-      </div>
-      {#each albums as album (album.id)}
-        <a href={Route.viewAlbum(album)}>
-          <div class="flex gap-4 pt-2 hover:cursor-pointer items-center">
-            <div>
-              <img
-                alt={album.albumName}
-                class="h-12.5 w-12.5 rounded object-cover"
-                src={album.albumThumbnailAssetId &&
-                  getAssetMediaUrl({ id: album.albumThumbnailAssetId, size: AssetMediaSize.Preview })}
-                draggable="false"
-              />
-            </div>
-
-            <div class="mb-auto mt-auto">
-              <p class="dark:text-immich-dark-primary">{album.albumName}</p>
-              <div class="flex flex-col gap-0 text-sm">
-                <div>
-                  <AlbumListItemDetails {album} />
-                </div>
               </div>
             </div>
           </div>
-        </a>
-      {/each}
+
+          {#if isOwner}
+            <div class="p-1">
+              <Icon icon={mdiPencil} size="20" />
+            </div>
+          {/if}
+        </button>
+      {:else if !dateTime && isOwner}
+        <div class="flex justify-between place-items-start gap-4 py-4">
+          <div class="flex gap-4">
+            <div>
+              <Icon icon={mdiCalendar} size="24" />
+            </div>
+          </div>
+          <div class="p-1">
+            <Icon icon={mdiPencil} size="20" />
+          </div>
+        </div>
+      {/if}
+
+      <div class="flex gap-4 py-4">
+        <div><Icon icon={mdiImageOutline} size="24" /></div>
+
+        <div>
+          <p class="break-all flex place-items-center gap-2 whitespace-pre-wrap">
+            {asset.originalFileName}
+            {#if isOwner}
+              <IconButton
+                icon={mdiInformationOutline}
+                aria-label={$t('show_file_location')}
+                size="small"
+                shape="round"
+                color="secondary"
+                variant="ghost"
+                onclick={toggleAssetPath}
+              />
+            {/if}
+          </p>
+          {#if showAssetPath}
+            <p class="text-xs opacity-50 break-all pb-2 hover:text-primary" transition:slide={{ duration: 250 }}>
+              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve this is supposed to be treated as an absolute/external link -->
+              <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')} class="whitespace-pre-wrap">
+                {asset.originalPath}
+              </a>
+            </p>
+          {/if}
+          {#if (asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth) || asset.exifInfo?.fileSizeInByte}
+            <div class="flex gap-2 text-sm">
+              {#if asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth}
+                {#if getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)}
+                  <p>
+                    {getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)} MP
+                  </p>
+                {/if}
+                {@const { width, height } = getDimensions(asset.exifInfo)}
+                <p>{width} x {height}</p>
+              {/if}
+              {#if asset.exifInfo?.fileSizeInByte}
+                <p>{getByteUnitString(asset.exifInfo.fileSizeInByte, $locale)}</p>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      {#if asset.exifInfo?.make || asset.exifInfo?.model || asset.exifInfo?.exposureTime || asset.exifInfo?.iso}
+        <div class="flex gap-4 py-4">
+          <div><Icon icon={mdiCamera} size="24" /></div>
+
+          <div>
+            {#if asset.exifInfo?.make || asset.exifInfo?.model}
+              <p>
+                <a
+                  href={Route.search({
+                    make: asset.exifInfo?.make ?? undefined,
+                    model: asset.exifInfo?.model ?? undefined,
+                  })}
+                  title="{$t('search_for')} {asset.exifInfo.make || ''} {asset.exifInfo.model || ''}"
+                  class="hover:text-primary"
+                >
+                  {asset.exifInfo.make || ''}
+                  {asset.exifInfo.model || ''}
+                </a>
+              </p>
+            {/if}
+
+            <div class="flex gap-2 text-sm">
+              {#if asset.exifInfo.exposureTime}
+                <p>{`${asset.exifInfo.exposureTime} s`}</p>
+              {/if}
+
+              {#if asset.exifInfo.iso}
+                <p>{`ISO ${asset.exifInfo.iso}`}</p>
+              {/if}
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      {#if asset.exifInfo?.lensModel || asset.exifInfo?.fNumber || asset.exifInfo?.focalLength}
+        <div class="flex gap-4 py-4">
+          <div><Icon icon={mdiCameraIris} size="24" /></div>
+
+          <div>
+            {#if asset.exifInfo?.lensModel}
+              <p>
+                <a
+                  href={Route.search({ lensModel: asset.exifInfo.lensModel })}
+                  title="{$t('search_for')} {asset.exifInfo.lensModel}"
+                  class="hover:text-primary line-clamp-1"
+                >
+                  {asset.exifInfo.lensModel}
+                </a>
+              </p>
+            {/if}
+
+            <div class="flex gap-2 text-sm">
+              {#if asset.exifInfo?.fNumber}
+                <p>ƒ/{asset.exifInfo.fNumber.toLocaleString($locale)}</p>
+              {/if}
+
+              {#if asset.exifInfo.focalLength}
+                <p>{`${asset.exifInfo.focalLength.toLocaleString($locale)} mm`}</p>
+              {/if}
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      <DetailPanelLocation {isOwner} {asset} />
+    </div>
+  </section>
+
+  {#if latlng && featureFlagsManager.value.map}
+    <div class="h-90">
+      {#await import('$lib/components/shared-components/map/map.svelte')}
+        {#await delay(timeToLoadTheMap) then}
+          <!-- show the loading spinner only if loading the map takes too much time -->
+          <div class="flex items-center justify-center h-full w-full">
+            <LoadingSpinner />
+          </div>
+        {/await}
+      {:then { default: Map }}
+        <Map
+          mapMarkers={[
+            {
+              lat: latlng.lat,
+              lon: latlng.lng,
+              id: asset.id,
+              city: asset.exifInfo?.city ?? null,
+              state: asset.exifInfo?.state ?? null,
+              country: asset.exifInfo?.country ?? null,
+            },
+          ]}
+          center={latlng}
+          showSettings={false}
+          zoom={12.5}
+          simplified
+          useLocationPin
+          showSimpleControls={!assetViewerManager.isEditFacesPanelOpen}
+          onOpenInMapView={() => goto(Route.map({ ...latlng, zoom: 12.5 }))}
+        >
+          {#snippet popup({ marker })}
+            {@const { lat, lon } = marker}
+            <div class="flex flex-col items-center gap-1">
+              <p class="font-bold">{lat.toPrecision(6)}, {lon.toPrecision(6)}</p>
+              <a
+                href="https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=13#map=15/{lat}/{lon}"
+                target="_blank"
+                class="font-medium text-primary underline focus:outline-none"
+              >
+                {$t('open_in_openstreetmap')}
+              </a>
+            </div>
+          {/snippet}
+        </Map>
+      {/await}
+    </div>
+  {/if}
+
+  {#if currentAlbum && currentAlbum.albumUsers.length > 0 && asset.owner}
+    <section class="px-6 dark:text-immich-dark-fg mt-4">
+      <Text size="small" color="muted">{$t('shared_by')}</Text>
+      <div class="flex gap-4 pt-4">
+        <div>
+          <UserAvatar user={asset.owner} size="md" />
+        </div>
+
+        <div class="mb-auto mt-auto">
+          <p>
+            {asset.owner.name}
+          </p>
+        </div>
+      </div>
     </section>
   {/if}
-{/await}
 
-{#if $preferences?.tags?.enabled}
-  <section class="relative px-2 pb-12 dark:bg-immich-dark-bg dark:text-immich-dark-fg">
-    <DetailPanelTags {asset} {isOwner} />
-  </section>
-{/if}
+  {#await albums then albums}
+    {#if albums.length > 0}
+      <section class="px-6 py-6 dark:text-immich-dark-fg">
+        <div class="pb-4">
+          <Text size="small" color="muted">{$t('appears_in')}</Text>
+        </div>
+        {#each albums as album (album.id)}
+          <a href={Route.viewAlbum(album)}>
+            <div class="flex gap-4 pt-2 hover:cursor-pointer items-center">
+              <div>
+                <img
+                  alt={album.albumName}
+                  class="h-12.5 w-12.5 rounded object-cover"
+                  src={album.albumThumbnailAssetId &&
+                    getAssetMediaUrl({ id: album.albumThumbnailAssetId, size: AssetMediaSize.Preview })}
+                  draggable="false"
+                />
+              </div>
 
-{#if showEditFaces}
+              <div class="mb-auto mt-auto">
+                <p class="dark:text-immich-dark-primary">{album.albumName}</p>
+                <div class="flex flex-col gap-0 text-sm">
+                  <div>
+                    <AlbumListItemDetails {album} />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        {/each}
+      </section>
+    {/if}
+  {/await}
+
+  {#if $preferences?.tags?.enabled}
+    <section class="relative px-2 pb-12 dark:bg-immich-dark-bg dark:text-immich-dark-fg">
+      <DetailPanelTags {asset} {isOwner} />
+    </section>
+  {/if}
+</section>
+
+{#if assetViewerManager.isEditFacesPanelOpen}
   <PersonSidePanel
     assetId={asset.id}
     assetType={asset.type}
-    onClose={() => (showEditFaces = false)}
+    onClose={() => (assetViewerManager.isEditFacesPanelOpen = false)}
     onRefresh={handleRefreshPeople}
   />
 {/if}

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
+  import { shortcut } from '$lib/actions/shortcut';
   import ImageThumbnail from '$lib/components/assets/thumbnail/image-thumbnail.svelte';
+  import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { getPeopleThumbnailUrl } from '$lib/utils';
   import { getNaturalSize, scaleToFit } from '$lib/utils/container-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { createFace, getAllPeople, type PersonResponseDto } from '@immich/sdk';
-  import { shortcut } from '$lib/actions/shortcut';
   import { Button, Input, modalManager, toastManager } from '@immich/ui';
   import { Canvas, InteractiveFabricObject, Rect } from 'fabric';
   import { clamp } from 'lodash-es';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -137,7 +137,7 @@
   };
 
   const cancel = () => {
-    isFaceEditMode.value = false;
+    assetViewerManager.isFaceEditMode = false;
   };
 
   const getPeople = async () => {
@@ -285,9 +285,13 @@
     } catch (error) {
       handleError(error, 'Error tagging face');
     } finally {
-      isFaceEditMode.value = false;
+      cancel();
     }
   };
+
+  onDestroy(() => {
+    cancel();
+  });
 </script>
 
 <svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: cancel }} />

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -8,7 +8,6 @@
   import AssetViewerEvents from '$lib/components/AssetViewerEvents.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { castManager } from '$lib/managers/cast-manager.svelte';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { ocrManager } from '$lib/stores/ocr.svelte';
   import { boundingBoxesArray, type Faces } from '$lib/stores/people.store';
   import { SlideshowLook, SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
@@ -83,6 +82,18 @@
     };
   });
 
+  const highlightedBoxes = $derived(getBoundingBox($boundingBoxesArray, overlayMetrics));
+  const isHighlighting = $derived(highlightedBoxes.length > 0);
+
+  let visibleBoxes = $state<ReturnType<typeof getBoundingBox>>([]);
+  let visibleBoundingBoxes = $state<Faces[]>([]);
+  $effect(() => {
+    if (isHighlighting) {
+      visibleBoxes = highlightedBoxes;
+      visibleBoundingBoxes = $boundingBoxesArray;
+    }
+  });
+
   const ocrBoxes = $derived(ocrManager.showOverlay ? getOcrBoundingBoxes(ocrManager.data, overlayMetrics) : []);
 
   const onCopy = async () => {
@@ -106,7 +117,7 @@
   const onPlaySlideshow = () => ($slideshowState = SlideshowState.PlaySlideshow);
 
   $effect(() => {
-    if (isFaceEditMode.value && assetViewerManager.zoom > 1) {
+    if (assetViewerManager.isFaceEditMode && assetViewerManager.zoom > 1) {
       onZoom();
     }
   });
@@ -151,22 +162,42 @@
     $slideshowState !== SlideshowState.None && $slideshowLook === SlideshowLook.BlurredBackground && !!asset.thumbhash,
   );
 
-  const faceToNameMap = $derived.by(() => {
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const map = new Map<Faces, string>();
+  const { faceToNameMap, faceToPersonFaces, faces } = $derived.by(() => {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- maps are recreated each derivation, not mutated reactively
+    const faceToNameMap = new Map<Faces, string | undefined>();
     for (const person of asset.people ?? []) {
+      if (person.isHidden && !assetViewerManager.isEditFacesPanelOpen && !assetViewerManager.showingHiddenPeople) {
+        continue;
+      }
       for (const face of person.faces ?? []) {
-        map.set(face, person.name);
+        faceToNameMap.set(face, person.name);
       }
     }
-    return map;
-  });
+    if (assetViewerManager.isEditFacesPanelOpen) {
+      for (const face of asset.unassignedFaces ?? []) {
+        faceToNameMap.set(face, undefined);
+      }
+    }
 
-  const faces = $derived(Array.from(faceToNameMap.keys()));
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- same as above
+    const faceToPersonFaces = new Map<string, Faces[]>();
+    for (const person of asset.people ?? []) {
+      const personFaces = person.faces ?? [];
+      for (const face of personFaces) {
+        faceToPersonFaces.set(face.id, personFaces);
+      }
+    }
+
+    return {
+      faceToNameMap,
+      faceToPersonFaces,
+      faces: Array.from(faceToNameMap.keys()),
+    };
+  });
 
   const handleImageMouseMove = (event: MouseEvent) => {
     $boundingBoxesArray = [];
-    if (!assetViewerManager.imgRef || !element || isFaceEditMode.value || ocrManager.showOverlay) {
+    if (!assetViewerManager.imgRef || !element || assetViewerManager.isFaceEditMode || ocrManager.showOverlay) {
       return;
     }
 
@@ -182,10 +213,19 @@
     const mouseY = (event.clientY - containerRect.top - contentOffsetY * currentZoom - currentPositionY) / currentZoom;
 
     const faceBoxes = getBoundingBox(faces, overlayMetrics);
+    // don't use SvelteSet here since - this is a local variable for deduplication
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const seen = new Set<string>();
 
     for (const [index, box] of faceBoxes.entries()) {
       if (mouseX >= box.left && mouseX <= box.left + box.width && mouseY >= box.top && mouseY <= box.top + box.height) {
-        $boundingBoxesArray.push(faces[index]);
+        const siblingFaces = faceToPersonFaces.get(faces[index].id);
+        for (const face of siblingFaces ?? [faces[index]]) {
+          if (!seen.has(face.id)) {
+            seen.add(face.id);
+            $boundingBoxesArray.push(face);
+          }
+        }
       }
     }
   };
@@ -215,7 +255,7 @@
   ondblclick={onZoom}
   onmousemove={handleImageMouseMove}
   onmouseleave={handleImageMouseLeave}
-  use:zoomImageAction={{ disabled: isFaceEditMode.value || ocrManager.showOverlay }}
+  use:zoomImageAction={{ disabled: assetViewerManager.isFaceEditMode || ocrManager.showOverlay }}
   {...useSwipe((event) => onSwipe?.(event))}
 >
   <AdaptiveImage
@@ -243,21 +283,38 @@
       {/if}
     {/snippet}
     {#snippet overlays()}
-      {#each getBoundingBox($boundingBoxesArray, overlayMetrics) as boundingbox, index (boundingbox.id)}
-        <div
-          class="absolute border-solid border-white border-3 rounded-lg"
-          style="top: {boundingbox.top}px; left: {boundingbox.left}px; height: {boundingbox.height}px; width: {boundingbox.width}px;"
-        ></div>
-        {#if faceToNameMap.get($boundingBoxesArray[index])}
+      <div
+        class="absolute inset-0 pointer-events-none transition-opacity duration-150"
+        style:opacity={isHighlighting ? 1 : 0}
+      >
+        <svg class="absolute inset-0 w-full h-full">
+          <defs>
+            <mask id="face-dim-mask">
+              <rect width="100%" height="100%" fill="white" />
+              {#each visibleBoxes as box (box.id)}
+                <rect x={box.left} y={box.top} width={box.width} height={box.height} fill="black" rx="8" />
+              {/each}
+            </mask>
+          </defs>
+          <rect width="100%" height="100%" fill="rgba(0,0,0,0.4)" mask="url(#face-dim-mask)" />
+        </svg>
+        <!-- visibleBoxes and visibleBoundingBoxes are index-aligned (getBoundingBox preserves order) -->
+        {#each visibleBoxes as boundingbox, index (boundingbox.id)}
           <div
-            class="absolute bg-white/90 text-black px-2 py-1 rounded text-sm font-medium whitespace-nowrap pointer-events-none shadow-lg"
-            style="top: {boundingbox.top + boundingbox.height + 4}px; left: {boundingbox.left +
-              boundingbox.width}px; transform: translateX(-100%);"
-          >
-            {faceToNameMap.get($boundingBoxesArray[index])}
-          </div>
-        {/if}
-      {/each}
+            class="absolute border-solid border-white border-3 rounded-lg"
+            style="top: {boundingbox.top}px; left: {boundingbox.left}px; height: {boundingbox.height}px; width: {boundingbox.width}px;"
+          ></div>
+          {#if faceToNameMap.get(visibleBoundingBoxes[index])}
+            <div
+              class="absolute bg-white/90 text-black px-2 py-1 rounded text-sm font-medium whitespace-nowrap pointer-events-none shadow-lg"
+              style="top: {boundingbox.top + boundingbox.height + 4}px; left: {boundingbox.left +
+                boundingbox.width}px; transform: translateX(-100%);"
+            >
+              {faceToNameMap.get(visibleBoundingBoxes[index])}
+            </div>
+          {/if}
+        {/each}
+      </div>
 
       {#each ocrBoxes as ocrBox (ocrBox.id)}
         <OcrBoundingBox {ocrBox} />
@@ -265,7 +322,7 @@
     {/snippet}
   </AdaptiveImage>
 
-  {#if isFaceEditMode.value && assetViewerManager.imgRef}
+  {#if assetViewerManager.isFaceEditMode && assetViewerManager.imgRef}
     <FaceEditor htmlElement={assetViewerManager.imgRef} {containerWidth} {containerHeight} assetId={asset.id} />
   {/if}
 </div>

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -3,7 +3,7 @@
   import VideoRemoteViewer from '$lib/components/asset-viewer/video-remote-viewer.svelte';
   import { assetViewerFadeDuration } from '$lib/constants';
   import { castManager } from '$lib/managers/cast-manager.svelte';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
+  import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import {
     autoPlayVideo,
     loopVideo as loopVideoPreference,
@@ -115,7 +115,7 @@
   let containerHeight = $state(0);
 
   $effect(() => {
-    if (isFaceEditMode.value) {
+    if (assetViewerManager.isFaceEditMode) {
       videoPlayer?.pause();
     }
   });
@@ -172,7 +172,7 @@
         </div>
       {/if}
 
-      {#if isFaceEditMode.value}
+      {#if assetViewerManager.isFaceEditMode}
         <FaceEditor htmlElement={videoPlayer} {containerWidth} {containerHeight} {assetId} />
       {/if}
     {/if}

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -16,6 +16,7 @@
     circle?: boolean;
     hidden?: boolean;
     border?: boolean;
+    highlighted?: boolean;
     hiddenIconClass?: string;
     class?: ClassValue;
     brokenAssetClass?: ClassValue;
@@ -34,6 +35,7 @@
     circle = false,
     hidden = false,
     border = false,
+    highlighted = false,
     hiddenIconClass = 'text-white',
     onComplete = undefined,
     class: imageClass = '',
@@ -60,6 +62,8 @@
     shadow && 'shadow-lg',
     (circle || !heightStyle) && 'aspect-square',
     border && 'border-3 border-immich-dark-primary/80 hover:border-immich-primary',
+    'transition-shadow duration-150',
+    highlighted && 'ring-4 ring-immich-primary dark:ring-immich-dark-primary',
   ]);
 
   let style = $derived(
@@ -67,25 +71,27 @@
   );
 </script>
 
-{#if errored}
-  <BrokenAsset class={[sharedClasses, brokenAssetClass]} width={widthStyle} height={heightStyle} />
-{:else}
-  <Image
-    src={url}
-    onLoad={setLoaded}
-    onError={setErrored}
-    class={['object-cover bg-gray-300 dark:bg-gray-700', sharedClasses, imageClass]}
-    {style}
-    alt={loaded || errored ? altText : ''}
-    draggable={false}
-    title={title ?? undefined}
-    loading={preload ? 'eager' : 'lazy'}
-  />
-{/if}
+<div class="relative" style:width={widthStyle} style:height={heightStyle}>
+  {#if errored}
+    <BrokenAsset class={[sharedClasses, brokenAssetClass]} width={widthStyle} height={heightStyle} />
+  {:else}
+    <Image
+      src={url}
+      onLoad={setLoaded}
+      onError={setErrored}
+      class={['object-cover bg-gray-300 dark:bg-gray-700', sharedClasses, imageClass]}
+      {style}
+      alt={loaded || errored ? altText : ''}
+      draggable={false}
+      title={title ?? undefined}
+      loading={preload ? 'eager' : 'lazy'}
+    />
+  {/if}
 
-{#if hidden}
-  <div class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
-    <!-- TODO fix `title` type -->
-    <Icon title={title ?? undefined} icon={mdiEyeOffOutline} size="2em" class={hiddenIconClass} />
-  </div>
-{/if}
+  {#if hidden}
+    <div class="pointer-events-none absolute inset-s-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
+      <!-- TODO fix `title` type -->
+      <Icon title={title ?? undefined} icon={mdiEyeOffOutline} size="2em" class={hiddenIconClass} />
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/components/faces-page/assign-face-side-panel.svelte
+++ b/web/src/lib/components/faces-page/assign-face-side-panel.svelte
@@ -5,11 +5,12 @@
   import { getPeopleThumbnailUrl, handlePromiseError } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { zoomImageToBase64 } from '$lib/utils/people-utils';
+  import { boundingBoxesArray } from '$lib/stores/people.store';
   import { getPersonNameWithHiddenValue } from '$lib/utils/person';
   import { AssetTypeEnum, getAllPeople, type AssetFaceResponseDto, type PersonResponseDto } from '@immich/sdk';
   import { IconButton, LoadingSpinner } from '@immich/ui';
   import { mdiArrowLeftThin, mdiClose, mdiMagnify, mdiPlus } from '@mdi/js';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { linear } from 'svelte/easing';
   import { fly } from 'svelte/transition';
@@ -51,19 +52,25 @@
   let searchedPeople: PersonResponseDto[] = $state([]);
   let searchFaces = $state(false);
   let searchName = $state('');
-
+  let hoveredPersonId = $state<string | null>(null);
   let showPeople = $derived(searchName ? searchedPeople : allPeople.filter((person) => !person.isHidden));
 
+  const focusHighlightClass =
+    'group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary';
+
   onMount(() => {
+    $boundingBoxesArray = [editedFace];
     handlePromiseError(loadPeople());
+  });
+
+  onDestroy(() => {
+    $boundingBoxesArray = [];
   });
 
   const handleCreatePerson = async () => {
     const timeout = setTimeout(() => (isShowLoadingNewPerson = true), timeBeforeShowLoadingSpinner);
 
     const newFeaturePhoto = await zoomImageToBase64(editedFace, assetId, assetType, assetViewerManager.imgRef);
-
-    onCreatePerson(newFeaturePhoto);
 
     clearTimeout(timeout);
     isShowLoadingNewPerson = false;
@@ -153,11 +160,17 @@
         <LoadingSpinner />
       </div>
     {:else}
-      <div class="immich-scrollbar mt-4 flex flex-wrap gap-2 overflow-y-auto">
+      <div class="mt-4 flex flex-wrap gap-2">
         {#each showPeople as person (person.id)}
           {#if !editedFace.person || person.id !== editedFace.person.id}
-            <div class="w-fit">
-              <button type="button" class="w-22.5" onclick={() => onReassign(person)}>
+            <div class="h-29 w-24">
+              <button
+                type="button"
+                class="group w-22.5 outline-none"
+                onclick={() => onReassign(person)}
+                onpointerover={() => (hoveredPersonId = person.id)}
+                onpointerleave={() => (hoveredPersonId = null)}
+              >
                 <div class="relative">
                   <ImageThumbnail
                     curve
@@ -168,6 +181,8 @@
                     widthStyle="90px"
                     heightStyle="90px"
                     hidden={person.isHidden}
+                    highlighted={hoveredPersonId === person.id}
+                    class={focusHighlightClass}
                   />
                 </div>
 

--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcut } from '$lib/actions/shortcut';
   import OnEvents from '$lib/components/OnEvents.svelte';
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
@@ -58,6 +59,8 @@
   let automaticRefreshTimeout: ReturnType<typeof setTimeout>;
 
   const thumbnailWidth = '90px';
+  const focusHighlightClass =
+    'group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary';
 
   async function loadPeople() {
     const timeout = setTimeout(() => (isShowLoadingPeople = true), timeBeforeShowLoadingSpinner);
@@ -156,6 +159,7 @@
   };
 
   const handleFacePicker = (face: AssetFaceResponseDto) => {
+    $boundingBoxesArray = [face];
     editedFace = face;
     showSelectedFaces = true;
   };
@@ -188,7 +192,21 @@
 
 <OnEvents {onPersonThumbnailReady} />
 
+<svelte:document
+  use:shortcut={{
+    shortcut: { key: 'Escape' },
+    onShortcut: () => {
+      if (showSelectedFaces) {
+        showSelectedFaces = false;
+      } else {
+        onClose();
+      }
+    },
+  }}
+/>
+
 <section
+  inert={showSelectedFaces}
   transition:fly={{ x: 360, duration: 100, easing: linear }}
   class="absolute top-0 h-full w-90 overflow-x-hidden p-2 dark:text-immich-dark-fg bg-light"
 >
@@ -226,14 +244,23 @@
       {:else}
         {#each peopleWithFaces as face, index (face.id)}
           {@const personName = face.person ? face.person?.name : $t('face_unassigned')}
-          <div class="relative h-29 w-24">
+          {@const isHighlighted = $boundingBoxesArray.some((f) => f.id === face.id)}
+          <div
+            role="group"
+            class={[
+              'relative h-29 w-24 transition-opacity',
+              $boundingBoxesArray.length > 0 && !isHighlighted && 'opacity-40',
+            ]}
+            onpointerover={() => ($boundingBoxesArray = [peopleWithFaces[index]])}
+            onpointerleave={() => !showSelectedFaces && ($boundingBoxesArray = [])}
+          >
             <div
               role="button"
-              tabindex={index}
-              class="absolute start-0 top-0 h-22.5 w-22.5 cursor-default"
+              tabindex={0}
+              data-testid="face-thumbnail"
+              class="group absolute inset-s-0 top-0 h-22.5 w-22.5 cursor-default outline-none"
               onfocus={() => ($boundingBoxesArray = [peopleWithFaces[index]])}
-              onmouseover={() => ($boundingBoxesArray = [peopleWithFaces[index]])}
-              onmouseleave={() => ($boundingBoxesArray = [])}
+              onblur={() => ($boundingBoxesArray = [])}
             >
               <div class="relative">
                 {#if selectedPersonToCreate[face.id]}
@@ -245,6 +272,8 @@
                     title={$t('new_person')}
                     widthStyle={thumbnailWidth}
                     heightStyle={thumbnailWidth}
+                    highlighted={isHighlighted}
+                    class={focusHighlightClass}
                   />
                 {:else if selectedPersonToReassign[face.id]}
                   <ImageThumbnail
@@ -259,6 +288,8 @@
                     widthStyle={thumbnailWidth}
                     heightStyle={thumbnailWidth}
                     hidden={selectedPersonToReassign[face.id].isHidden}
+                    highlighted={isHighlighted}
+                    class={focusHighlightClass}
                   />
                 {:else if face.person}
                   <ImageThumbnail
@@ -270,6 +301,8 @@
                     widthStyle={thumbnailWidth}
                     heightStyle={thumbnailWidth}
                     hidden={face.person.isHidden}
+                    highlighted={isHighlighted}
+                    class={focusHighlightClass}
                   />
                 {:else}
                   {#await zoomImageToBase64(face, assetId, assetType, assetViewerManager.imgRef)}
@@ -281,6 +314,8 @@
                       title={$t('face_unassigned')}
                       widthStyle="90px"
                       heightStyle="90px"
+                      highlighted={isHighlighted}
+                      class={focusHighlightClass}
                     />
                   {:then data}
                     <ImageThumbnail
@@ -291,6 +326,8 @@
                       title={$t('face_unassigned')}
                       widthStyle="90px"
                       heightStyle="90px"
+                      highlighted={isHighlighted}
+                      class={focusHighlightClass}
                     />
                   {/await}
                 {/if}
@@ -310,12 +347,11 @@
                 {#if selectedPersonToCreate[face.id] || selectedPersonToReassign[face.id]}
                   <IconButton
                     shape="round"
-                    variant="ghost"
-                    color="primary"
+                    color="secondary"
                     icon={mdiRestart}
                     aria-label={$t('reset')}
                     size="small"
-                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform"
+                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform hover:bg-dark! hover:brightness-110"
                     onclick={() => handleReset(face.id)}
                   />
                 {:else}
@@ -325,7 +361,7 @@
                     icon={mdiPencil}
                     aria-label={$t('select_new_face')}
                     size="small"
-                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform"
+                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform hover:bg-primary! hover:brightness-110"
                     onclick={() => handleFacePicker(face)}
                   />
                 {/if}
@@ -347,7 +383,7 @@
                     icon={mdiTrashCan}
                     aria-label={$t('delete_face')}
                     size="small"
-                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform"
+                    class="absolute start-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform hover:bg-danger! hover:brightness-125"
                     onclick={() => deleteAssetFace(face)}
                   />
                 </div>

--- a/web/src/lib/managers/asset-viewer-manager.svelte.ts
+++ b/web/src/lib/managers/asset-viewer-manager.svelte.ts
@@ -39,6 +39,9 @@ export class AssetViewerManager extends BaseEventManager<Events> {
   isShowActivityPanel = $state(false);
   isPlayingMotionPhoto = $state(false);
   isShowEditor = $state(false);
+  isFaceEditMode = $state(false);
+  isEditFacesPanelOpen = $state(false);
+  showingHiddenPeople = $state(false);
 
   get isImageLoading() {
     return this.#isImageLoading;

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -5,7 +5,6 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import AssetAddToAlbumModal from '$lib/modals/AssetAddToAlbumModal.svelte';
 import AssetTagModal from '$lib/modals/AssetTagModal.svelte';
 import SharedLinkCreateModal from '$lib/modals/SharedLinkCreateModal.svelte';
-import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
 import { user as authUser, preferences } from '$lib/stores/user.store';
 import type { AssetControlContext } from '$lib/types';
 import { getAssetMediaUrl, getSharedLink, sleep } from '$lib/utils';
@@ -230,7 +229,7 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto) =
     type: $t('assets'),
     $if: () => isOwner && asset.type === AssetTypeEnum.Image && !asset.isTrashed,
     onAction: () => {
-      isFaceEditMode.value = !isFaceEditMode.value;
+      assetViewerManager.isFaceEditMode = !assetViewerManager.isFaceEditMode;
     },
     shortcuts: { key: 'p' },
   };

--- a/web/src/lib/stores/face-edit.svelte.ts
+++ b/web/src/lib/stores/face-edit.svelte.ts
@@ -1,1 +1,0 @@
-export const isFaceEditMode = $state({ value: false });

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { beforeNavigate } from '$app/navigation';
   import ActionMenuItem from '$lib/components/ActionMenuItem.svelte';
   import UserPageLayout from '$lib/components/layouts/user-page-layout.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
@@ -25,7 +24,6 @@
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { memoryStore } from '$lib/stores/memory.store.svelte';
   import { preferences, user } from '$lib/stores/user.store';
   import { getAssetMediaUrl, memoryLaneTitle } from '$lib/utils';
@@ -85,10 +83,6 @@
     timelineManager.removeAssets(assetIds);
     assetInteraction.clearMultiselect();
   };
-
-  beforeNavigate(() => {
-    isFaceEditMode.value = false;
-  });
 
   const items = $derived(
     memoryStore.memories.map((memory) => ({


### PR DESCRIPTION
## Summary

- Fix ESC key closing the entire asset viewer when the face or person editor panel is open — it now correctly closes just the panel
- UI Tweak: add `highlighted` prop to image-thumbnail with bidirectional face highlighting between thumbnails and bounding box overlays
- UI Tweak: `focus-visible` outlines on person/face thumbnails for keyboard navigation
- Refactor: move face edit state into `AssetViewerManager`

---

<img width="956" height="441" alt="Highlights are bidirectional" src="https://github.com/user-attachments/assets/f970cd71-ba21-4f4d-a50f-5d3c88197fda" />

> Highlights are bidirectional - hover over the person in the sidebar, or hover over the face in the photo - the bounding box and the connected thumbnail appear together

<img width="954" height="440" alt="Hovering over unassigned face in asset viewer highlights the face in the Edit faces editor" src="https://github.com/user-attachments/assets/5865b3b2-c574-47e3-90ae-4e56bbfdd791" />

> Hovering over unassigned face in asset viewer will highlight the face in the 'Edit faces' editor (but only in Edit faces editor — not when normally hovering in asset-viewer)

<img width="336" height="153" alt="image" src="https://github.com/user-attachments/assets/83215f20-0a09-4ec1-b861-c35293442fbd" />

> Here this is the typical situation - person thumbnail was hovered

<img width="323" height="148" alt="Person thumbnail hovered and focused by keyboard" src="https://github.com/user-attachments/assets/a106411c-b219-4cea-a441-e4ff1f305c44" />

> Here, this person thumbnail is hovered AND focused by keyboard (tabbing to it)

<img width="334" height="153" alt="First person thumbnail focused, third person hovered" src="https://github.com/user-attachments/assets/ddd94bba-e74a-4534-bd31-f7e584933dff" />

> Here, the first person thumbnail is focused (primary outline), but the 3rd person is hovered (white-outline)

<img width="337" height="269" alt="Focus indicator" src="https://github.com/user-attachments/assets/4ea1acb0-74de-4f9b-a969-d429a22c8809" />

> For reference - the existing 'focused element' treatment: outline-2 offset-2

---

### Styles
Using the existing pattern already in use - i.e. for 

**Focus outline** (`focusHighlightClass`):
`outline-2` (2px), `outline-offset-2` (2px gap), `outline-immich-primary` / `dark:outline-immich-dark-primary` (blue).
Triggered via `group-focus-visible` — appears when tabbing.

**Highlighted overlay** (`image-thumbnail` span):
`border-2 border-white` (2px white border), `absolute inset-0 pointer-events-none` (fills the image exactly).
Matches image rounding (`rounded-xl` / `rounded-full`).
Triggered by hover/pointer on the thumbnail or on the bounding box in the viewer.
