### PR TITLE
fix(mobile): deep link navigation stuck at first photo

### DIFF
--- a/mobile/lib/routing/asset_viewer_guard.dart
+++ b/mobile/lib/routing/asset_viewer_guard.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:auto_route/auto_route.dart';
+import 'package:immich_mobile/routing/router.dart';
+
+/// Handles duplicate navigation to the AssetViewerRoute (primarily for deep linking).
+/// When a deep link navigates to a new asset while an AssetViewerRoute is already
+/// on top of the stack, this guard replaces the current route instead of blocking
+/// the navigation, ensuring the new asset is displayed.
+class AssetViewerGuard extends AutoRouteGuard {
+  const AssetViewerGuard();
+  @override
+  void onNavigation(NavigationResolver resolver, StackRouter router) async {
+    final newRouteName = resolver.route.name;
+    final currentTopRouteName =
+        router.stack.isNotEmpty ? router.stack.last.name : null;
+
+    if (currentTopRouteName == newRouteName) {
+      // Replace instead of pushing duplicate
+      final args = resolver.route.args as AssetViewerRouteArgs;
+
+      unawaited(
+        router.replace(
+          AssetViewerRoute(
+            initialIndex: args.initialIndex,
+            timelineService: args.timelineService,
+            heroOffset: args.heroOffset,
+            currentAlbum: args.currentAlbum,
+          ),
+        ),
+      );
+      // Prevent further navigation since we replaced the route
+      resolver.next(false);
+      return;
+    }
+    resolver.next(true);
+  }
+}

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -114,6 +114,7 @@ import 'package:immich_mobile/presentation/pages/search/drift_search.page.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/routing/asset_viewer_guard.dart';
 import 'package:immich_mobile/routing/auth_guard.dart';
 import 'package:immich_mobile/routing/backup_permission_guard.dart';
 import 'package:immich_mobile/routing/custom_transition_builders.dart';
@@ -144,6 +145,7 @@ class AppRouter extends RootStackRouter {
   late final BackupPermissionGuard _backupPermissionGuard;
   late final LockedGuard _lockedGuard;
   late final GalleryGuard _galleryGuard;
+  late final AssetViewerGuard _assetViewerGuard;
 
   AppRouter(
     ApiService apiService,
@@ -156,6 +158,7 @@ class AppRouter extends RootStackRouter {
     _lockedGuard = LockedGuard(apiService, secureStorageService, localAuthService);
     _backupPermissionGuard = BackupPermissionGuard(galleryPermissionNotifier);
     _galleryGuard = const GalleryGuard();
+    _assetViewerGuard = const AssetViewerGuard();
   }
 
   @override
@@ -297,7 +300,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: RemoteAlbumRoute.page, guards: [_authGuard]),
     AutoRoute(
       page: AssetViewerRoute.page,
-      guards: [_authGuard, _duplicateGuard],
+      guards: [_authGuard, _assetViewerGuard],
       type: RouteType.custom(
         customRouteBuilder: <T>(context, child, page) => PageRouteBuilder<T>(
           fullscreenDialog: page.fullscreenDialog,


### PR DESCRIPTION
Fixes #25689. Added AssetViewerGuard that replaces the current AssetViewerRoute on duplicate deep link navigation instead of blocking it, following the existing GalleryGuard pattern.