### PR TITLE
feat(mobile): add configurable timeline dynamic layout threshold

### DIFF
--- a/mobile/lib/domain/models/setting.model.dart
+++ b/mobile/lib/domain/models/setting.model.dart
@@ -2,6 +2,7 @@ import 'package:immich_mobile/domain/models/store.model.dart';
 
 enum Setting<T> {
   tilesPerRow<int>(StoreKey.tilesPerRow, 4),
+  dynamicLayout<bool>(StoreKey.dynamicLayout, false),
   groupAssetsBy<int>(StoreKey.groupAssetsBy, 0),
   showStorageIndicator<bool>(StoreKey.storageIndicator, true),
   loadOriginal<bool>(StoreKey.loadOriginal, false),

--- a/mobile/lib/domain/models/store.model.dart
+++ b/mobile/lib/domain/models/store.model.dart
@@ -94,7 +94,8 @@ enum StoreKey<T> {
   cleanupCutoffDaysAgo<int>._(1011),
   cleanupDefaultsInitialized<bool>._(1012),
 
-  syncMigrationStatus<String>._(1013);
+  syncMigrationStatus<String>._(1013),
+  timelineDynamicLayoutThreshold<int>._(1014);
 
   const StoreKey._(this.id);
   final int id;

--- a/mobile/lib/presentation/widgets/timeline/dynamic_layout_threshold.dart
+++ b/mobile/lib/presentation/widgets/timeline/dynamic_layout_threshold.dart
@@ -1,0 +1,14 @@
+const int kTimelineDynamicLayoutMinThreshold = 2;
+const int kTimelineDynamicLayoutMaxThreshold = 6;
+const int kTimelineMobileDefaultDynamicLayoutThreshold = 2;
+const int kTimelineTabletDefaultDynamicLayoutThreshold = 3;
+
+int resolveTimelineDynamicLayoutThreshold({required bool isMobile, int? configuredThreshold}) {
+  return configuredThreshold ??
+      (isMobile ? kTimelineMobileDefaultDynamicLayoutThreshold : kTimelineTabletDefaultDynamicLayoutThreshold);
+}
+
+bool shouldUseDynamicLayout({required int columnCount, required bool isMobile, int? configuredThreshold}) {
+  return columnCount <=
+      resolveTimelineDynamicLayoutThreshold(isMobile: isMobile, configuredThreshold: configuredThreshold);
+}

--- a/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail_tile.widget.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/dynamic_layout_threshold.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/row.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/header.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
@@ -20,6 +21,7 @@ import 'package:immich_mobile/providers/asset_viewer/is_motion_video_playing.pro
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -104,7 +106,12 @@ class _FixedSegmentRow extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isScrubbing = ref.watch(timelineStateProvider.select((s) => s.isScrubbing));
     final timelineService = ref.read(timelineServiceProvider);
-    final isDynamicLayout = columnCount <= (context.isMobile ? 2 : 3);
+    final configuredThreshold = ref.watch(timelineDynamicLayoutThresholdProvider).value;
+    final isDynamicLayout = shouldUseDynamicLayout(
+      columnCount: columnCount,
+      isMobile: context.isMobile,
+      configuredThreshold: configuredThreshold,
+    );
 
     if (isScrubbing) {
       return _buildPlaceholder(context);

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -143,6 +143,7 @@ class _SliverTimeline extends ConsumerStatefulWidget {
 class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
   late final ScrollController _scrollController;
   StreamSubscription? _eventSubscription;
+  ProviderSubscription<int>? _tilesPerRowSubscription;
 
   // Drag selection state
   bool _dragging = false;
@@ -154,6 +155,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
   double _scaleFactor = 3.0;
   double _baseScaleFactor = 3.0;
   int? _restoreAssetIndex;
+  int? _pendingTilesPerRowWrite;
 
   @override
   void initState() {
@@ -167,6 +169,10 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     _baseScaleFactor = _scaleFactor;
 
     ref.listenManual(multiSelectProvider.select((s) => s.isEnabled), _onMultiSelectionToggled);
+    _tilesPerRowSubscription = ref.listenManual<int>(
+      settingsProvider.select((s) => s.get(Setting.tilesPerRow)),
+      _onTilesPerRowChanged,
+    );
   }
 
   @override
@@ -226,6 +232,32 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     EventStream.shared.emit(MultiSelectToggleEvent(isEnabled));
   }
 
+  void _onTilesPerRowChanged(int? previous, int next) {
+    if (next == _pendingTilesPerRowWrite) {
+      _pendingTilesPerRowWrite = null;
+      return;
+    }
+
+    if (next == _perRow || !mounted) {
+      return;
+    }
+
+    final asyncSegments = ref.read(timelineSegmentProvider);
+    asyncSegments.whenData((segments) {
+      if (!mounted || next == _perRow) {
+        return;
+      }
+
+      final targetAssetIndex = _getCurrentAssetIndex(segments);
+      setState(() {
+        _perRow = next;
+        _scaleFactor = 7.0 - _perRow;
+        _baseScaleFactor = _scaleFactor;
+        _restoreAssetIndex = targetAssetIndex;
+      });
+    });
+  }
+
   int? _getCurrentAssetIndex(List<Segment> segments) {
     final currentOffset = _scrollController.offset.clamp(0.0, _scrollController.position.maxScrollExtent);
     final segment = segments.findByOffset(currentOffset) ?? segments.lastOrNull;
@@ -248,6 +280,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
   void dispose() {
     _scrollController.dispose();
     _eventSubscription?.cancel();
+    _tilesPerRowSubscription?.close();
     super.dispose();
   }
 
@@ -359,12 +392,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
   @override
   Widget build(BuildContext _) {
-    final configuredTilesPerRow = ref.watch(settingsProvider.select((s) => s.get(Setting.tilesPerRow)));
-    if (configuredTilesPerRow != _perRow) {
-      _perRow = configuredTilesPerRow;
-      _scaleFactor = 7.0 - _perRow;
-      _baseScaleFactor = _scaleFactor;
-    }
+    ref.watch(settingsProvider.select((s) => s.get(Setting.tilesPerRow)));
 
     final asyncSegments = ref.watch(timelineSegmentProvider);
     final maxHeight = ref.watch(timelineArgsProvider.select((args) => args.maxHeight));
@@ -460,6 +488,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
                           _restoreAssetIndex = targetAssetIndex;
                         });
 
+                        _pendingTilesPerRowWrite = _perRow;
                         ref.read(settingsProvider.notifier).set(Setting.tilesPerRow, _perRow);
                       }
                     };

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -359,6 +359,13 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
   @override
   Widget build(BuildContext _) {
+    final configuredTilesPerRow = ref.watch(settingsProvider.select((s) => s.get(Setting.tilesPerRow)));
+    if (configuredTilesPerRow != _perRow) {
+      _perRow = configuredTilesPerRow;
+      _scaleFactor = 7.0 - _perRow;
+      _baseScaleFactor = _scaleFactor;
+    }
+
     final asyncSegments = ref.watch(timelineSegmentProvider);
     final maxHeight = ref.watch(timelineArgsProvider.select((args) => args.maxHeight));
     final isSelectionMode = ref.watch(multiSelectProvider.select((s) => s.forceEnable));

--- a/mobile/lib/providers/infrastructure/setting.provider.dart
+++ b/mobile/lib/providers/infrastructure/setting.provider.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/services/setting.service.dart';
 import 'package:immich_mobile/providers/infrastructure/store.provider.dart';
 
@@ -18,3 +19,8 @@ class SettingsNotifier extends Notifier<SettingsService> {
 }
 
 final settingsProvider = NotifierProvider<SettingsNotifier, SettingsService>(SettingsNotifier.new);
+
+final timelineDynamicLayoutThresholdProvider = StreamProvider<int?>((ref) {
+  final store = ref.watch(storeServiceProvider);
+  return store.watch(StoreKey.timelineDynamicLayoutThreshold);
+}, dependencies: [storeServiceProvider]);

--- a/mobile/lib/providers/infrastructure/setting.provider.dart
+++ b/mobile/lib/providers/infrastructure/setting.provider.dart
@@ -20,6 +20,26 @@ class SettingsNotifier extends Notifier<SettingsService> {
 
 final settingsProvider = NotifierProvider<SettingsNotifier, SettingsService>(SettingsNotifier.new);
 
+final tilesPerRowSettingProvider = StreamProvider<int>((ref) {
+  final store = ref.watch(storeServiceProvider);
+  return store.watch(StoreKey.tilesPerRow).map((value) => value ?? Setting.tilesPerRow.defaultValue);
+}, dependencies: [storeServiceProvider]);
+
+final groupAssetsBySettingProvider = StreamProvider<int>((ref) {
+  final store = ref.watch(storeServiceProvider);
+  return store.watch(StoreKey.groupAssetsBy).map((value) => value ?? Setting.groupAssetsBy.defaultValue);
+}, dependencies: [storeServiceProvider]);
+
+final storageIndicatorSettingProvider = StreamProvider<bool>((ref) {
+  final store = ref.watch(storeServiceProvider);
+  return store.watch(StoreKey.storageIndicator).map((value) => value ?? Setting.showStorageIndicator.defaultValue);
+}, dependencies: [storeServiceProvider]);
+
+final dynamicLayoutSettingProvider = StreamProvider<bool>((ref) {
+  final store = ref.watch(storeServiceProvider);
+  return store.watch(StoreKey.dynamicLayout).map((value) => value ?? Setting.dynamicLayout.defaultValue);
+}, dependencies: [storeServiceProvider]);
+
 final timelineDynamicLayoutThresholdProvider = StreamProvider<int?>((ref) {
   final store = ref.watch(storeServiceProvider);
   return store.watch(StoreKey.timelineDynamicLayoutThreshold);

--- a/mobile/lib/widgets/asset_grid/group_divider_title.dart
+++ b/mobile/lib/widgets/asset_grid/group_divider_title.dart
@@ -1,15 +1,13 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
-import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
+import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 
-class GroupDividerTitle extends HookConsumerWidget {
+class GroupDividerTitle extends ConsumerWidget {
   const GroupDividerTitle({
     super.key,
     required this.text,
@@ -27,13 +25,8 @@ class GroupDividerTitle extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final appSettingService = ref.watch(appSettingsServiceProvider);
-    final groupBy = useState(GroupAssetsBy.day);
-
-    useEffect(() {
-      groupBy.value = GroupAssetsBy.values[appSettingService.getSetting<int>(AppSettingsEnum.groupAssetsBy)];
-      return null;
-    }, []);
+    final groupByIndex = ref.watch(groupAssetsBySettingProvider).valueOrNull ?? GroupAssetsBy.day.index;
+    final groupBy = GroupAssetsBy.values[groupByIndex];
 
     void handleTitleIconClick() {
       ref.read(hapticFeedbackProvider.notifier).heavyImpact();
@@ -46,7 +39,7 @@ class GroupDividerTitle extends HookConsumerWidget {
 
     return Padding(
       padding: EdgeInsets.only(
-        top: groupBy.value == GroupAssetsBy.month ? 32.0 : 16.0,
+        top: groupBy == GroupAssetsBy.month ? 32.0 : 16.0,
         bottom: 16.0,
         left: 12.0,
         right: 12.0,
@@ -55,7 +48,7 @@ class GroupDividerTitle extends HookConsumerWidget {
         children: [
           Text(
             text,
-            style: groupBy.value == GroupAssetsBy.month
+            style: groupBy == GroupAssetsBy.month
                 ? context.textTheme.bodyLarge?.copyWith(fontSize: 24.0)
                 : context.textTheme.labelLarge?.copyWith(
                     color: context.textTheme.labelLarge?.color?.withAlpha(250),

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
@@ -5,13 +5,13 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline.provider.dart';
 import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/widgets/asset_grid/immich_asset_grid_view.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
-import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ImmichAssetGrid extends HookConsumerWidget {
@@ -58,11 +58,25 @@ class ImmichAssetGrid extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var settings = ref.watch(appSettingsServiceProvider);
+    final configuredPerRow = ref.watch(tilesPerRowSettingProvider).valueOrNull ?? Setting.tilesPerRow.defaultValue;
+    final configuredDynamicLayout = ref.watch(dynamicLayoutSettingProvider).valueOrNull ?? false;
+    final configuredStorageIndicator =
+        ref.watch(storageIndicatorSettingProvider).valueOrNull ?? Setting.showStorageIndicator.defaultValue;
 
-    final perRow = useState(assetsPerRow ?? settings.getSetting(AppSettingsEnum.tilesPerRow)!);
+    final perRow = useState(assetsPerRow ?? configuredPerRow);
     final scaleFactor = useState(7.0 - perRow.value);
     final baseScaleFactor = useState(7.0 - perRow.value);
+
+    useEffect(() {
+      if (assetsPerRow != null || perRow.value == configuredPerRow) {
+        return null;
+      }
+
+      perRow.value = configuredPerRow;
+      scaleFactor.value = 7.0 - configuredPerRow;
+      baseScaleFactor.value = 7.0 - configuredPerRow;
+      return null;
+    }, [assetsPerRow, configuredPerRow]);
 
     /// assets need different hero tags across tabs / modals
     /// otherwise, hero animations are performed across tabs (looks buggy!)
@@ -90,7 +104,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
                 scaleFactor.value = max(min(5.0, baseScaleFactor.value * details.scale), 1.0);
                 if (7 - scaleFactor.value.toInt() != perRow.value) {
                   perRow.value = 7 - scaleFactor.value.toInt();
-                  settings.setSetting(AppSettingsEnum.tilesPerRow, perRow.value);
+                  ref.read(settingsProvider.notifier).set(Setting.tilesPerRow, perRow.value);
                 }
               };
             },
@@ -100,13 +114,13 @@ class ImmichAssetGrid extends HookConsumerWidget {
           onRefresh: onRefresh,
           assetsPerRow: perRow.value,
           listener: listener,
-          showStorageIndicator: showStorageIndicator ?? settings.getSetting(AppSettingsEnum.storageIndicator),
+          showStorageIndicator: showStorageIndicator ?? configuredStorageIndicator,
           renderList: renderList,
           margin: margin,
           selectionActive: selectionActive,
           preselectedAssets: preselectedAssets,
           canDeselect: canDeselect,
-          dynamicLayout: dynamicLayout ?? settings.getSetting(AppSettingsEnum.dynamicLayout),
+          dynamicLayout: dynamicLayout ?? configuredDynamicLayout,
           showMultiSelectIndicator: showMultiSelectIndicator,
           visibleItemsListener: visibleItemsListener,
           topWidget: topWidget,

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -1,11 +1,8 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
-import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
 import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
@@ -15,18 +12,12 @@ class GroupSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final groupByIndex = useAppSettingsState(AppSettingsEnum.groupAssetsBy);
-    final groupBy = GroupAssetsBy.values[groupByIndex.value];
-
-    Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
-      await ref.watch(appSettingsServiceProvider).setSetting(AppSettingsEnum.groupAssetsBy, groupBy.index);
-      ref.invalidate(appSettingsServiceProvider);
-    }
+    final groupByIndex = ref.watch(groupAssetsBySettingProvider).valueOrNull ?? GroupAssetsBy.day.index;
+    final groupBy = GroupAssetsBy.values[groupByIndex];
 
     void changeGroupValue(GroupAssetsBy? value) {
       if (value != null) {
-        groupByIndex.value = value.index;
-        unawaited(updateAppSettings(groupBy));
+        ref.read(settingsProvider.notifier).set(Setting.groupAssetsBy, value.index);
       }
     }
 

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
@@ -1,8 +1,13 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/dynamic_layout_threshold.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
@@ -17,6 +22,18 @@ class LayoutSettings extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final useDynamicLayout = useAppSettingsState(AppSettingsEnum.dynamicLayout);
     final tilesPerRow = useAppSettingsState(AppSettingsEnum.tilesPerRow);
+    final configuredThreshold = ref.watch(timelineDynamicLayoutThresholdProvider).value;
+    final dynamicLayoutThreshold = useState(
+      resolveTimelineDynamicLayoutThreshold(isMobile: context.isMobile, configuredThreshold: configuredThreshold),
+    );
+
+    useEffect(() {
+      dynamicLayoutThreshold.value = resolveTimelineDynamicLayoutThreshold(
+        isMobile: context.isMobile,
+        configuredThreshold: configuredThreshold,
+      );
+      return null;
+    }, [configuredThreshold, context.isMobile]);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -31,6 +48,20 @@ class LayoutSettings extends HookConsumerWidget {
             title: "asset_list_layout_settings_dynamic_layout_title".t(context: context),
             onChanged: (_) => ref.invalidate(appSettingsServiceProvider),
           ),
+        if (Store.isBetaTimelineEnabled)
+          SettingsSliderListTile(
+            valueNotifier: dynamicLayoutThreshold,
+            text: 'Dynamic layout threshold (${dynamicLayoutThreshold.value} columns)',
+            label: "${dynamicLayoutThreshold.value}",
+            maxValue: kTimelineDynamicLayoutMaxThreshold.toDouble(),
+            minValue: kTimelineDynamicLayoutMinThreshold.toDouble(),
+            noDivisons: kTimelineDynamicLayoutMaxThreshold - kTimelineDynamicLayoutMinThreshold,
+            onChangeEnd: (value) async {
+              await Store.put(StoreKey.timelineDynamicLayoutThreshold, value);
+              ref.invalidate(appSettingsServiceProvider);
+              ref.invalidate(settingsProvider);
+            },
+          ),
         SettingsSliderListTile(
           valueNotifier: tilesPerRow,
           text: 'theme_setting_asset_list_tiles_per_row_title'.tr(namedArgs: {'count': "${tilesPerRow.value}"}),
@@ -38,7 +69,10 @@ class LayoutSettings extends HookConsumerWidget {
           maxValue: 6,
           minValue: 2,
           noDivisons: 4,
-          onChangeEnd: (_) => ref.invalidate(appSettingsServiceProvider),
+          onChangeEnd: (_) {
+            ref.invalidate(appSettingsServiceProvider);
+            ref.invalidate(settingsProvider);
+          },
         ),
       ],
     );

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
@@ -2,15 +2,13 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
-import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/dynamic_layout_threshold.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
-import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
 import 'package:immich_mobile/widgets/settings/settings_slider_list_tile.dart';
 import 'package:immich_mobile/widgets/settings/settings_switch_list_tile.dart';
@@ -20,8 +18,10 @@ class LayoutSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final useDynamicLayout = useAppSettingsState(AppSettingsEnum.dynamicLayout);
-    final tilesPerRow = useAppSettingsState(AppSettingsEnum.tilesPerRow);
+    final useDynamicLayoutValue = ref.watch(dynamicLayoutSettingProvider).valueOrNull ?? false;
+    final tilesPerRowValue = ref.watch(tilesPerRowSettingProvider).valueOrNull ?? Setting.tilesPerRow.defaultValue;
+    final useDynamicLayout = useState(useDynamicLayoutValue);
+    final tilesPerRow = useState(tilesPerRowValue);
     final configuredThreshold = ref.watch(timelineDynamicLayoutThresholdProvider).value;
     final dynamicLayoutThreshold = useState(
       resolveTimelineDynamicLayoutThreshold(isMobile: context.isMobile, configuredThreshold: configuredThreshold),
@@ -35,6 +35,16 @@ class LayoutSettings extends HookConsumerWidget {
       return null;
     }, [configuredThreshold, context.isMobile]);
 
+    useEffect(() {
+      useDynamicLayout.value = useDynamicLayoutValue;
+      return null;
+    }, [useDynamicLayoutValue]);
+
+    useEffect(() {
+      tilesPerRow.value = tilesPerRowValue;
+      return null;
+    }, [tilesPerRowValue]);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -46,7 +56,7 @@ class LayoutSettings extends HookConsumerWidget {
           SettingsSwitchListTile(
             valueNotifier: useDynamicLayout,
             title: "asset_list_layout_settings_dynamic_layout_title".t(context: context),
-            onChanged: (_) => ref.invalidate(appSettingsServiceProvider),
+            onChanged: (value) => ref.read(settingsProvider.notifier).set(Setting.dynamicLayout, value),
           ),
         if (Store.isBetaTimelineEnabled)
           SettingsSliderListTile(
@@ -58,8 +68,6 @@ class LayoutSettings extends HookConsumerWidget {
             noDivisons: kTimelineDynamicLayoutMaxThreshold - kTimelineDynamicLayoutMinThreshold,
             onChangeEnd: (value) async {
               await Store.put(StoreKey.timelineDynamicLayoutThreshold, value);
-              ref.invalidate(appSettingsServiceProvider);
-              ref.invalidate(settingsProvider);
             },
           ),
         SettingsSliderListTile(
@@ -69,10 +77,7 @@ class LayoutSettings extends HookConsumerWidget {
           maxValue: 6,
           minValue: 2,
           noDivisons: 4,
-          onChangeEnd: (_) {
-            ref.invalidate(appSettingsServiceProvider);
-            ref.invalidate(settingsProvider);
-          },
+          onChangeEnd: (value) => ref.read(settingsProvider.notifier).set(Setting.tilesPerRow, value),
         ),
       ],
     );

--- a/mobile/test/modules/settings/live_photo_grid_settings_test.dart
+++ b/mobile/test/modules/settings/live_photo_grid_settings_test.dart
@@ -1,0 +1,203 @@
+@Tags(['widget'])
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart' show IStoreRepository;
+import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
+import 'package:immich_mobile/widgets/asset_grid/group_divider_title.dart';
+import 'package:immich_mobile/widgets/asset_grid/immich_asset_grid.dart';
+import 'package:immich_mobile/widgets/asset_grid/immich_asset_grid_view.dart';
+import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
+import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_layout_settings.dart';
+
+import '../../test_utils.dart';
+import '../../widget_tester_extensions.dart';
+
+void main() {
+  late _InMemoryStoreRepository repository;
+
+  final renderList = RenderList(
+    [
+      RenderAssetGridElement(
+        RenderAssetGridElementType.assets,
+        date: DateTime(2024, 1, 1),
+        count: 1,
+        totalCount: 1,
+        offset: 0,
+      ),
+    ],
+    null,
+    [
+      Asset(
+        checksum: 'checksum',
+        localId: '1',
+        ownerId: 1,
+        fileCreatedAt: DateTime(2024, 1, 1),
+        fileModifiedAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        durationInSeconds: 0,
+        type: AssetType.image,
+        fileName: 'asset.jpg',
+        isFavorite: false,
+        isArchived: false,
+        isTrashed: false,
+      ),
+    ],
+  );
+
+  setUpAll(() async {
+    TestUtils.init();
+    repository = _InMemoryStoreRepository();
+    await StoreService.init(storeRepository: repository);
+  });
+
+  setUp(() async {
+    await Store.clear();
+    await Store.put(StoreKey.tilesPerRow, 4);
+    await Store.put(StoreKey.dynamicLayout, false);
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.day.index);
+    await Store.put(StoreKey.betaTimeline, false);
+  });
+
+  testWidgets('ImmichAssetGrid reacts to live tiles-per-row and layout changes', (tester) async {
+    await tester.pumpConsumerWidget(ImmichAssetGrid(renderList: renderList));
+    await tester.pumpAndSettle();
+
+    var gridView = tester.widget<ImmichAssetGridView>(find.byType(ImmichAssetGridView));
+    expect(gridView.assetsPerRow, 4);
+    expect(gridView.dynamicLayout, isFalse);
+
+    await Store.put(StoreKey.tilesPerRow, 5);
+    await Store.put(StoreKey.dynamicLayout, true);
+    await tester.pumpAndSettle();
+
+    gridView = tester.widget<ImmichAssetGridView>(find.byType(ImmichAssetGridView));
+    expect(gridView.assetsPerRow, 5);
+    expect(gridView.dynamicLayout, isTrue);
+  });
+
+  testWidgets('GroupDividerTitle reacts to live group setting changes', (tester) async {
+    await tester.pumpConsumerWidget(
+      const GroupDividerTitle(
+        text: 'January',
+        multiselectEnabled: false,
+        onSelect: _noop,
+        onDeselect: _noop,
+        selected: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    var padding = tester.widget<Padding>(
+      find.descendant(of: find.byType(GroupDividerTitle), matching: find.byType(Padding)).first,
+    );
+    expect((padding.padding as EdgeInsets).top, 16.0);
+
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.month.index);
+    await tester.pumpAndSettle();
+
+    padding = tester.widget<Padding>(
+      find.descendant(of: find.byType(GroupDividerTitle), matching: find.byType(Padding)).first,
+    );
+    expect((padding.padding as EdgeInsets).top, 32.0);
+  });
+
+  testWidgets('GroupSettings writes the selected group value', (tester) async {
+    await tester.pumpConsumerWidget(const GroupSettings());
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byWidgetPredicate((widget) => widget is RadioListTile<GroupAssetsBy> && widget.value == GroupAssetsBy.month),
+    );
+    await tester.pumpAndSettle();
+
+    expect(Store.get(StoreKey.groupAssetsBy, GroupAssetsBy.day.index), GroupAssetsBy.month.index);
+  });
+
+  testWidgets('LayoutSettings writes dynamic layout and tiles per row', (tester) async {
+    await tester.pumpConsumerWidget(const LayoutSettings());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+    expect(Store.get(StoreKey.dynamicLayout, false), isTrue);
+
+    final slider = tester.widget<Slider>(find.byType(Slider));
+    slider.onChanged?.call(5.0);
+    slider.onChangeEnd?.call(5.0);
+    await tester.pumpAndSettle();
+
+    expect(Store.get(StoreKey.tilesPerRow, 4), 5);
+  });
+}
+
+void _noop() {}
+
+class _InMemoryStoreRepository implements IStoreRepository {
+  final Map<StoreKey<Object?>, Object?> _values = {};
+  final StreamController<List<StoreDto<Object>>> _allController = StreamController.broadcast();
+  final Map<StoreKey<Object?>, StreamController<Object?>> _controllers = {};
+
+  @override
+  Future<bool> deleteAll() async {
+    _values.clear();
+    for (final controller in _controllers.values) {
+      controller.add(null);
+    }
+    _emitAll();
+    return true;
+  }
+
+  @override
+  Future<void> delete<T>(StoreKey<T> key) async {
+    _values.remove(key as StoreKey<Object?>);
+    _controllerFor(key).add(null);
+    _emitAll();
+  }
+
+  @override
+  Future<List<StoreDto<Object>>> getAll() async => _snapshot();
+
+  @override
+  Future<T?> tryGet<T>(StoreKey<T> key) async => _values[key as StoreKey<Object?>] as T?;
+
+  @override
+  Future<bool> upsert<T>(StoreKey<T> key, T value) async {
+    _values[key as StoreKey<Object?>] = value;
+    _controllerFor(key).add(value);
+    _emitAll();
+    return true;
+  }
+
+  @override
+  Stream<T?> watch<T>(StoreKey<T> key) async* {
+    yield _values[key as StoreKey<Object?>] as T?;
+    yield* _controllerFor(key).stream.cast<T?>();
+  }
+
+  @override
+  Stream<List<StoreDto<Object>>> watchAll() async* {
+    yield _snapshot();
+    yield* _allController.stream;
+  }
+
+  StreamController<Object?> _controllerFor<T>(StoreKey<T> key) {
+    final objectKey = key as StoreKey<Object?>;
+    return _controllers.putIfAbsent(objectKey, () => StreamController<Object?>.broadcast());
+  }
+
+  void _emitAll() {
+    _allController.add(_snapshot());
+  }
+
+  List<StoreDto<Object>> _snapshot() {
+    return _values.entries.map((entry) => StoreDto<Object>(entry.key as StoreKey<Object>, entry.value)).toList();
+  }
+}

--- a/mobile/test/presentation/widgets/timeline/dynamic_layout_threshold_test.dart
+++ b/mobile/test/presentation/widgets/timeline/dynamic_layout_threshold_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/dynamic_layout_threshold.dart';
+
+void main() {
+  group('resolveTimelineDynamicLayoutThreshold', () {
+    test('uses phone fallback when unset', () {
+      expect(resolveTimelineDynamicLayoutThreshold(isMobile: true, configuredThreshold: null), 2);
+    });
+
+    test('uses tablet fallback when unset', () {
+      expect(resolveTimelineDynamicLayoutThreshold(isMobile: false, configuredThreshold: null), 3);
+    });
+
+    test('uses explicit configured threshold', () {
+      for (final threshold in [2, 3, 4, 5, 6]) {
+        expect(resolveTimelineDynamicLayoutThreshold(isMobile: true, configuredThreshold: threshold), threshold);
+        expect(resolveTimelineDynamicLayoutThreshold(isMobile: false, configuredThreshold: threshold), threshold);
+      }
+    });
+  });
+
+  group('shouldUseDynamicLayout', () {
+    test('disables 3-column dynamic layout when threshold is 2', () {
+      expect(shouldUseDynamicLayout(columnCount: 3, isMobile: true, configuredThreshold: 2), isFalse);
+    });
+
+    test('enables 3-column dynamic layout when threshold is 3', () {
+      expect(shouldUseDynamicLayout(columnCount: 3, isMobile: true, configuredThreshold: 3), isTrue);
+    });
+
+    test('enables 6-column dynamic layout when threshold is 6', () {
+      expect(shouldUseDynamicLayout(columnCount: 6, isMobile: true, configuredThreshold: 6), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR adds a user-configurable dynamic layout threshold for the new mobile timeline/photo grid.

Previously, dynamic layout on mobile was effectively limited to lower column counts, so 3-column grids stayed fixed. This change adds a setting that lets users choose the threshold themselves, while preserving the existing defaults when no override is set.

In addition to the new setting, this PR also updates the affected mobile settings/grid/timeline code paths to react to store-backed setting changes live, so changes like tiles-per-row, grouping, and dynamic layout apply immediately without user having to close and re-open the app again.

Related feature request: https://github.com/immich-app/immich/discussions/27229

## How Has This Been Tested?

- [x] `cd mobile && mise x -- flutter test test/presentation/widgets/timeline/dynamic_layout_threshold_test.dart`
- [x] `cd mobile && mise x -- flutter test test/modules/settings/live_photo_grid_settings_test.dart`
- [x] Manual verification on iOS device:
  - confirmed the new `Dynamic layout threshold` slider appears in Photo Grid settings
  - confirmed 3-column grid remains fixed before increasing the threshold
  - confirmed dynamic layout is applied at 3 columns after increasing the threshold
  - confirmed related layout/grouping changes still update correctly

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

### Settings before
<img width="603" height="1311" alt="IMG_3066" src="https://github.com/user-attachments/assets/12c49cba-9a7f-41e7-87fb-4d2942cba459" />

### Settings after
<img width="603" height="1311" alt="IMG_3063" src="https://github.com/user-attachments/assets/ebf40a8c-2b63-4299-88b0-c8d2cf6c60f7" />

### Grid before
<img width="603" height="1311" alt="IMG_3065" src="https://github.com/user-attachments/assets/f9636658-f463-48c3-a0ab-fb55e52c6900" />

### Grid after
<img width="603" height="1311" alt="IMG_3064" src="https://github.com/user-attachments/assets/cc0ec967-2c96-48d7-becd-d44e46a15854" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The initial implementation was largely generated with GPT-5.4 on Codex. I manually reviewed the changes, tested them on my own device, and validated the behavior before opening this PR.
