### PR TITLE
fix(web): use translation key for square crop aspect ratio label

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -866,6 +866,7 @@
   "crop_aspect_ratio_fixed": "Fixed",
   "crop_aspect_ratio_free": "Free",
   "crop_aspect_ratio_original": "Original",
+  "crop_aspect_ratio_square": "Square",
   "curated_object_page_title": "Things",
   "current_device": "Current device",
   "current_pin_code": "Current PIN code",

--- a/web/src/lib/components/asset-viewer/editor/transform-tool/transform-tool.svelte
+++ b/web/src/lib/components/asset-viewer/editor/transform-tool/transform-tool.svelte
@@ -23,7 +23,7 @@
     { label: '2:3', value: '2:3', width: 16, height: 24 },
     { label: '16:9', value: '16:9', width: 24, height: 14 },
     { label: '9:16', value: '9:16', width: 14, height: 24 },
-    { label: 'Square', value: '1:1', width: 20, height: 20 },
+    { label: $t('crop_aspect_ratio_square'), value: '1:1', width: 20, height: 20 },
   ];
 
   let isRotated = $derived(transformManager.normalizedRotation % 180 !== 0);


### PR DESCRIPTION
## Description

added translation key for the "square" size in the aspect ratio editor.

Fixes # [27256](https://github.com/immich-app/immich/issues/27256)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="204" height="138" alt="grafik" src="https://github.com/user-attachments/assets/4ab7c749-5001-4913-a0c1-12c44d061277" />

</details>


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

find the files in the codebase
