### PR TITLE
fix(web): prevent horizontal scroll bar in asset viewer side panel

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -587,13 +587,9 @@
       translate="yes"
     >
       {#if showDetailPanel}
-        <div class="h-full">
-          <DetailPanel {asset} currentAlbum={album} />
-        </div>
+        <DetailPanel {asset} currentAlbum={album} />
       {:else if assetViewerManager.isShowEditor}
-        <div class="h-full">
-          <EditorPanel {asset} onClose={closeEditor} />
-        </div>
+        <EditorPanel {asset} onClose={closeEditor} />
       {/if}
     </div>
   {/if}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -580,15 +580,18 @@
     <div
       transition:fly={{ duration: 150 }}
       id="detail-panel"
-      class="row-start-1 row-span-4 overflow-y-auto transition-all dark:border-l dark:border-s-immich-dark-gray bg-light"
+      class={[
+        'row-start-1 row-span-4 overflow-y-auto transition-all dark:border-l dark:border-s-immich-dark-gray bg-light',
+        showDetailPanel ? 'w-90' : 'w-100',
+      ]}
       translate="yes"
     >
       {#if showDetailPanel}
-        <div class="w-90 h-full">
+        <div class="h-full">
           <DetailPanel {asset} currentAlbum={album} />
         </div>
       {:else if assetViewerManager.isShowEditor}
-        <div class="w-100 h-full">
+        <div class="h-full">
           <EditorPanel {asset} onClose={closeEditor} />
         </div>
       {/if}


### PR DESCRIPTION
Fixes #27263 by applying width styles to the scrollable element to prevent a horizontal scrollbar from showing up in some cases