### PR TITLE
fix: let renovate update base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,10 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["ghcr.io/immich-app/base-server-*"],
+      "maxMajorIncrement": 0
+    },
+    {
       "matchPackageNames": ["ruby"],
       "groupName": "ruby",
       "matchCurrentVersion": "< 3.4",


### PR DESCRIPTION
It currently sees the tags as one massive major version and nopes out:

```
DEBUG: Skipping ghcr.io/immich-app/base-server-prod@202603101113 because major increment 70001 exceeds maxMajorIncrement 500
DEBUG: Skipping ghcr.io/immich-app/base-server-prod@202603171117 because major increment 140005 exceeds maxMajorIncrement 500
DEBUG: Skipping ghcr.io/immich-app/base-server-prod@202603241118 because major increment 210006 exceeds maxMajorIncrement 500
```
