### PR TITLE
fix(mobile): mismatch between system and app color when using low-chroma system color scheme

### DIFF
--- a/mobile/lib/theme/dynamic_theme.dart
+++ b/mobile/lib/theme/dynamic_theme.dart
@@ -19,8 +19,16 @@ abstract final class DynamicTheme {
         // Some palettes do not generate surface container colors accurately,
         // so we regenerate all colors using the primary color
         _theme = ImmichTheme(
-          light: ColorScheme.fromSeed(seedColor: primaryColor, brightness: Brightness.light),
-          dark: ColorScheme.fromSeed(seedColor: primaryColor, brightness: Brightness.dark),
+          light: ColorScheme.fromSeed(
+            seedColor: primaryColor,
+            brightness: Brightness.light,
+            dynamicSchemeVariant: DynamicSchemeVariant.fidelity,
+          ),
+          dark: ColorScheme.fromSeed(
+            seedColor: primaryColor,
+            brightness: Brightness.dark,
+            dynamicSchemeVariant: DynamicSchemeVariant.fidelity,
+          ),
         );
       }
     } catch (error) {


### PR DESCRIPTION
## Description

Fixes #24819 

When "Use system color" = true and the android device is using low-chroma system color scheme (i.e. black/gray), the resulting app color is teal, which is completely different than the system color.

The reason for this behavior is due to `DynamicSchemeVariant.tonalSpot` being used by default by the `ColorScheme.fromSeed` function to get the correct app color scheme matching the system color scheme. The tonalSpot algorithm only preserves the hue level of the source seed color and forces a hardcoded chroma level when constructing the base palettes.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/35552763-41da-461f-94bf-e3afe84b45ee" />

Let's say for example we use gray (`rgb(94, 94, 94)`) as the seed color. When passing this seed color into the `ColorScheme.fromSeed` function, it is first converted to HCT (hue, chroma, tone) color space with value of `hct(209, 2, 40)`.  And since it is using tonalSpot algorithm by default, it ignores the low chroma value of 2 and instead use the hardcoded ones above. So for the primary palette, based on the snippet code above, it results in a TonalPalette with Hue = 209 and Chroma = 36. Hue level of 209 is, well, teal. Combined with Chroma level of 36, it exposes the underlying teal hue. Hence matching with the final color scheme used by the app 🙂.

<img height="150" alt="image" src="https://github.com/user-attachments/assets/6ad70850-91fa-412a-bdfa-25227348d61b" />

The fix is by using `DynamicSchemeVariant.fidelity`, which takes the source seed color's chroma level into the equation.

<img height="350" alt="image" src="https://github.com/user-attachments/assets/6127e96c-9fe2-4b0b-9c31-8de0b25c68e2" />

However, do note that using `.fidelity` changes the primaryContainer color tone a little bit as you can see in the test result below, which might not be preferable. But let me know your thoughts!

## How Has This Been Tested?

Tested on Android 16 simulator with different Material You system color schemes. Also tested both on dark and light mode.

<details><summary><h2>Screenshots</h2></summary>

Light Mode:

<img width="5761" height="4459" alt="Immich Test Light Mode" src="https://github.com/user-attachments/assets/86e75e25-6688-4223-9596-e3e82c9c7868" />

Dark Mode:

<img width="5770" height="4466" alt="Immich Test Dark Mode" src="https://github.com/user-attachments/assets/c3f19993-8a0e-4cc9-a7e9-659768ff5d1e" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used LLM to get a high level explanation for each `DynamicSchemeVariant` enumerations. The code changes are my own.
