### PR TITLE
feat(ml): per-model CPU execution override

### DIFF
--- a/machine-learning/immich_ml/sessions/ort.py
+++ b/machine-learning/immich_ml/sessions/ort.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,16 @@ from immich_ml.models.constants import SUPPORTED_PROVIDERS
 from immich_ml.schemas import ModelPrecision, SessionNode
 
 from ..config import log, settings
+
+# Models that should be forced to CPU-only execution.
+# Set via MACHINE_LEARNING_CPU_MODELS env var (comma-separated model names).
+# Useful when GPU acceleration crashes for specific models (e.g. face detection
+# on AMD iGPUs with MIGraphX) while working fine for others (e.g. CLIP).
+_CPU_ONLY_MODELS: set[str] = set(
+    name.strip()
+    for name in os.environ.get("MACHINE_LEARNING_CPU_MODELS", "").split(",")
+    if name.strip()
+)
 
 
 class OrtSession:
@@ -24,7 +35,13 @@ class OrtSession:
         sess_options: ort.SessionOptions | None = None,
     ):
         self.model_path = Path(model_path)
-        self.providers = providers if providers is not None else self._providers_default
+        if providers is not None:
+            self.providers = providers
+        elif self._should_force_cpu():
+            log.info(f"Forcing CPU execution for '{self.model_path}' (matched MACHINE_LEARNING_CPU_MODELS)")
+            self.providers = ["CPUExecutionProvider"]
+        else:
+            self.providers = self._providers_default
         self.provider_options = provider_options if provider_options is not None else self._provider_options_default
         self.sess_options = sess_options if sess_options is not None else self._sess_options_default
         self.session = ort.InferenceSession(
@@ -59,6 +76,15 @@ class OrtSession:
     def providers(self, providers: list[str]) -> None:
         log.info(f"Setting execution providers to {providers}, in descending order of preference")
         self._providers = providers
+
+    def _should_force_cpu(self) -> bool:
+        if not _CPU_ONLY_MODELS:
+            return False
+        model_path_str = self.model_path.as_posix().lower()
+        for model_name in _CPU_ONLY_MODELS:
+            if model_name.lower() in model_path_str:
+                return True
+        return False
 
     @property
     def _providers_default(self) -> list[str]:


### PR DESCRIPTION
## Description

Adds `MACHINE_LEARNING_CPU_MODELS` environment variable to force specific ML models to use `CPUExecutionProvider`, bypassing GPU acceleration on a per-model basis.

On AMD integrated GPUs (e.g. Raphael iGPU with MIGraphX), CLIP models compile and run fine on the GPU, but face detection models (antelopev2, buffalo_l) crash with SIGSEGV during MIGraphX compilation. OCR models compile but hit HIP memory errors during inference. Without this change, users must choose between full GPU (with crashes) or full CPU (losing acceleration for models that work fine).

This adds a simple opt-in mechanism: set `MACHINE_LEARNING_CPU_MODELS=antelopev2,buffalo_l,PP-OCRv5` to force those models to CPU while keeping CLIP on GPU.

## How Has This Been Tested?

- [x] AMD Ryzen 9 7950X with Raphael RDNA2 iGPU (2 CUs), ROCm 7.2.0, MIGraphXExecutionProvider
- [x] CLIP (ViT-H-14-378) on MIGraphX: working, fast search confirmed
- [x] Face detection (antelopev2) forced to CPU via env var: stable, no crashes
- [x] Face recognition (antelopev2) forced to CPU via env var: stable, no crashes
- [x] OCR (PP-OCRv5_server) forced to CPU via env var: stable, processing 156K assets
- [x] Empty/unset env var: no behavior change, all models use GPU as before
- [x] Env var with non-matching names: no effect, models use GPU as before

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Logs showing per-model override in action:
```
INFO  Loading detection model 'antelopev2' to memory
INFO  Forcing CPU execution for '/cache/facial-recognition/antelopev2/detection/model.onnx' (matched MACHINE_LEARNING_CPU_MODELS)
INFO  Setting execution providers to ['CPUExecutionProvider'], in descending order of preference

INFO  Loading textual model 'ViT-H-14-378-quickgelu__dfn5b' to memory
INFO  Setting execution providers to ['MIGraphXExecutionProvider', 'CPUExecutionProvider'], in descending order of preference
```

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code was used to develop and test this patch on a live Immich v2.6.2 deployment. The change was iteratively tested on real hardware (AMD Raphael iGPU) to confirm CLIP works on GPU while face detection correctly falls back to CPU.