### PR TITLE
feat(ml): per-model CPU execution override via MACHINE_LEARNING_CPU_MODELS

### DIFF
--- a/machine-learning/immich_ml/sessions/ort.py
+++ b/machine-learning/immich_ml/sessions/ort.py
@@ -18,9 +18,7 @@ from ..config import log, settings
 # Useful when GPU acceleration crashes for specific models (e.g. face detection
 # on AMD iGPUs with MIGraphX) while working fine for others (e.g. CLIP).
 _CPU_ONLY_MODELS: set[str] = set(
-    name.strip()
-    for name in os.environ.get("MACHINE_LEARNING_CPU_MODELS", "").split(",")
-    if name.strip()
+    name.strip() for name in os.environ.get("MACHINE_LEARNING_CPU_MODELS", "").split(",") if name.strip()
 )
 
 

--- a/machine-learning/immich_ml/sessions/ort.py
+++ b/machine-learning/immich_ml/sessions/ort.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,16 @@ from immich_ml.models.constants import SUPPORTED_PROVIDERS
 from immich_ml.schemas import ModelPrecision, SessionNode
 
 from ..config import log, settings
+
+# Models that should be forced to CPU-only execution.
+# Set via MACHINE_LEARNING_CPU_MODELS env var (comma-separated model names).
+# Useful when GPU acceleration crashes for specific models (e.g. face detection
+# on AMD iGPUs with MIGraphX) while working fine for others (e.g. CLIP).
+_CPU_ONLY_MODELS: set[str] = set(
+    name.strip()
+    for name in os.environ.get("MACHINE_LEARNING_CPU_MODELS", "").split(",")
+    if name.strip()
+)
 
 
 class OrtSession:
@@ -24,7 +35,13 @@ class OrtSession:
         sess_options: ort.SessionOptions | None = None,
     ):
         self.model_path = Path(model_path)
-        self.providers = providers if providers is not None else self._providers_default
+        if providers is not None:
+            self.providers = providers
+        elif self._should_force_cpu():
+            log.info(f"Forcing CPU execution for '{self.model_path}' (matched MACHINE_LEARNING_CPU_MODELS)")
+            self.providers = ["CPUExecutionProvider"]
+        else:
+            self.providers = self._providers_default
         self.provider_options = provider_options if provider_options is not None else self._provider_options_default
         self.sess_options = sess_options if sess_options is not None else self._sess_options_default
         self.session = ort.InferenceSession(
@@ -59,6 +76,15 @@ class OrtSession:
     def providers(self, providers: list[str]) -> None:
         log.info(f"Setting execution providers to {providers}, in descending order of preference")
         self._providers = providers
+
+    def _should_force_cpu(self) -> bool:
+        if not _CPU_ONLY_MODELS:
+            return False
+        model_path_str = self.model_path.as_posix().lower()
+        for model_name in _CPU_ONLY_MODELS:
+            if model_name.lower() in model_path_str:
+                return True
+        return False
 
     @property
     def _providers_default(self) -> list[str]:


### PR DESCRIPTION
## Description

Adds a `MACHINE_LEARNING_CPU_MODELS` environment variable that forces specific ML models to use `CPUExecutionProvider`, bypassing GPU acceleration on a per-model basis.

**Problem:** On AMD integrated GPUs (e.g. Raphael iGPU with MIGraphX), CLIP models compile and run fine on the GPU, but face detection models (antelopev2, buffalo_l) crash with SIGSEGV during MIGraphX compilation. OCR models compile but hit HIP memory errors during inference. Currently there is no way to selectively fall back individual models to CPU - it's all GPU or all CPU.

**Solution:** Set `MACHINE_LEARNING_CPU_MODELS=antelopev2,buffalo_l,PP-OCRv5` to force those models to CPU while keeping CLIP on GPU. When unset or empty, behavior is unchanged.

The change is in `OrtSession.__init__` - before falling back to the default providers, it checks if the model path matches any entry in the env var. If so, it overrides to `CPUExecutionProvider`. ~30 lines total.

## How Has This Been Tested?

- [x] Tested on AMD Ryzen 9 7950X with Raphael RDNA2 iGPU (2 CUs), ROCm 7.2.0, MIGraphXExecutionProvider
- [x] CLIP (ViT-H-14-378) on MIGraphX: working, noticeably faster smart search
- [x] Face detection (antelopev2) forced to CPU via env var: stable, no SIGSEGV crashes
- [x] Face recognition (buffalo_l) forced to CPU via env var: stable
- [x] OCR (PP-OCRv5_server) forced to CPU via env var: stable, processing 156K assets without HIP memory errors
- [x] Empty/unset env var: no behavior change, all models use default GPU providers
- [x] Env var with non-matching model names: no effect, models use GPU as expected
- [x] Verified logging output shows which models are forced to CPU on startup

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A - env var configuration, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.