### PR TITLE
feat: add preview button when selecting images

### DIFF
--- a/e2e/src/ui/specs/timeline/utils.ts
+++ b/e2e/src/ui/specs/timeline/utils.ts
@@ -62,7 +62,7 @@ export const thumbnailUtils = {
     return page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"]`);
   },
   selectButton(page: Page, assetId: string) {
-    return page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"] button`);
+    return page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"] button[role="checkbox"]`);
   },
   selectedAsset(page: Page) {
     return page.locator('[data-thumbnail-focus-container][data-selected]');

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -21,6 +21,7 @@
     mdiHeart,
     mdiMotionPauseOutline,
     mdiMotionPlayOutline,
+    mdiMagnifyPlusOutline,
     mdiRotate360,
   } from '@mdi/js';
   import { onMount } from 'svelte';
@@ -46,6 +47,7 @@
     dimmed?: boolean;
     albumUsers?: UserResponseDto[];
     onClick?: (asset: TimelineAsset) => void;
+    onPreview?: (asset: TimelineAsset) => void;
     onSelect?: (asset: TimelineAsset) => void;
     onMouseEvent?: (event: { isMouseOver: boolean; selectedGroupIndex: number }) => void;
   }
@@ -65,6 +67,7 @@
     showStackedIcon = true,
     albumUsers = [],
     onClick = undefined,
+    onPreview = undefined,
     onSelect = undefined,
     onMouseEvent = undefined,
     imageClass = '',
@@ -427,6 +430,23 @@
         {:else}
           <Icon data-icon-select icon={mdiCheckCircle} size="24" class="text-white/80 hover:text-white" />
         {/if}
+      </button>
+    {/if}
+
+    <!-- Preview asset button (visible on hover when any asset is selected) -->
+    {#if mouseOver && onPreview}
+      <button
+        type="button"
+        onclick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onPreview?.($state.snapshot(asset));
+        }}
+        class="absolute z-2 bottom-1 end-1 rounded-full bg-black/50 p-1.5 hover:bg-black/70 focus:outline-none transition-colors"
+        tabindex={-1}
+        aria-label="Preview asset"
+      >
+        <Icon icon={mdiMagnifyPlusOutline} size="20" class="text-white" />
       </button>
     {/if}
 

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -19,9 +19,9 @@
     mdiCheckCircle,
     mdiFileGifBox,
     mdiHeart,
+    mdiMagnifyPlusOutline,
     mdiMotionPauseOutline,
     mdiMotionPlayOutline,
-    mdiMagnifyPlusOutline,
     mdiRotate360,
   } from '@mdi/js';
   import { onMount } from 'svelte';
@@ -442,7 +442,8 @@
           e.preventDefault();
           onPreview?.($state.snapshot(asset));
         }}
-        class="absolute z-2 bottom-1 end-1 rounded-full bg-black/50 p-1.5 hover:bg-black/70 focus:outline-none transition-colors"
+        class="absolute z-2 bottom-1 end-1 rounded-full bg-black/25 p-1.5 hover:bg-black/50 focus:outline-none transition-colors"
+        in:fade={{ duration: 100 }}
         tabindex={-1}
         aria-label="Preview asset"
       >

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -386,6 +386,7 @@
               void navigateToAsset(asset);
             }}
             onSelect={() => handleSelectAssets(currentAsset)}
+            onPreview={assetInteraction.selectionActive ? () => void navigateToAsset(asset) : undefined}
             onMouseEvent={() => assetMouseEventHandler(currentAsset)}
             {showArchiveIcon}
             asset={currentAsset}

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -696,6 +696,7 @@
                   void onSelectAssets(asset);
                 }}
                 onMouseEvent={() => handleSelectAssetCandidates(asset)}
+                onPreview={(isSelectionMode || assetInteraction.selectionActive) ? (asset) => void navigate({ targetRoute: 'current', assetId: asset.id }) : undefined}
                 selected={isAssetSelected}
                 selectionCandidate={isAssetSelectionCandidate}
                 disabled={isAssetDisabled}

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -696,7 +696,9 @@
                   void onSelectAssets(asset);
                 }}
                 onMouseEvent={() => handleSelectAssetCandidates(asset)}
-                onPreview={(isSelectionMode || assetInteraction.selectionActive) ? (asset) => void navigate({ targetRoute: 'current', assetId: asset.id }) : undefined}
+                onPreview={isSelectionMode || assetInteraction.selectionActive
+                  ? (asset) => void navigate({ targetRoute: 'current', assetId: asset.id })
+                  : undefined}
                 selected={isAssetSelected}
                 selectionCandidate={isAssetSelectionCandidate}
                 disabled={isAssetDisabled}


### PR DESCRIPTION
## Description

When multi-selecting images in Google Photos, a "full screen preview" button appears in the bottom right corner of the image thumbnails when hovering over them. If you click it, you can view the image full screen without losing your selections. This is very helpful when reviewing multiple similar images to choose which to keep/delete/organize (culling.)

## How Has This Been Tested?


- [x] Preview icon does not appear when multi-selection is not active
- [x] Preview icon appears when you multi-select
- [x] Clicking preview icon opens the image full screen without losing selections

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

<img width="1140" height="456" alt="image" src="https://github.com/user-attachments/assets/8280a8cd-af6b-4564-b532-d2ed75f61021" />
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Research and prototyping. The code in this PR is simple, targeted, and matches the surrounding code.