### PR TITLE
fix(deps): ML container expects volumes mounted in /usr/src

### DIFF
--- a/docker/docker-compose.rootless.yml
+++ b/docker/docker-compose.rootless.yml
@@ -51,8 +51,8 @@ services:
       - NET_RAW
     volumes:
       - ./ml-model-cache:/cache
-      - ./ml-dotcache:/.cache
-      - ./ml-config:/.config
+      - ./ml-dotcache:/usr/src/.cache
+      - ./ml-config:/usr/src/.config
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
immich-machine-learning service expects R/W .cache and .config folders be mounted in /usr/src, not /

## Description

Hi. I had trouble starting immich-machine-learning today as it was complaining it expected R/W access in /usr/src:

```
[03/26/26 19:52:36] ERROR    Control server error: [Errno 13] Permission denied 
[03/26/26 19:52:38] WARNING  mkdir -p failed for path                           
                             /usr/src/.cache/matplotlib: [Errno 13] Permission  
                             denied: '/usr/src/.cache'     
```

```
[03/26/26 19:48:27] ERROR    Control server error: [Errno 13] Permission denied 
[03/26/26 19:48:29] WARNING  mkdir -p failed for path                           
                             /usr/src/.config/matplotlib: [Errno 13] Permission 
                             denied: '/usr/src/.config'       
```

This fixes it by mounting the ml-config and ml-dotcache volumes in where the service expects them. That having said, I assume those folders should not be expected in /usr/src in the first place and this might be an error in the container image itself.

I also believe the regular (rootful) compose file is also affected, since it doesn't make any effort to map those folders to R/W volumes at all with its:
```
    volumes:
      - model-cache:/cache
```

## How Has This Been Tested?

- updated the volume declarations and the service now works as intended

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None. 
...
