### PR TITLE
fix(mobile): video icon not showing on memories

### DIFF
--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -207,6 +207,11 @@ class DriftMemoryPage extends HookConsumerWidget {
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   DriftMemoryPage.setMemory(ref, memories[pageNumber]);
                 });
+
+                // Update currentAsset to the first asset of the new memory
+                if (memories[pageNumber].assets.isNotEmpty) {
+                  currentAsset.value = memories[pageNumber].assets.first;
+                }
               }
 
               currentAssetPage.value = 0;


### PR DESCRIPTION
## Description

Fixes #26181

## How Has This Been Tested?

- [x] Go to memories
- [x] Navigate between "years" until the first asset in the list is a video
- [x] Video icon shows up correctly, without needing to navigate back and forth 