### PR TITLE
chore(mobile): reduce spacing on video controls

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -71,16 +71,13 @@ class ViewerBottomBar extends ConsumerWidget {
                 ),
                 child: SafeArea(
                   top: false,
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 16),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (asset.isVideo) VideoControls(videoPlayerName: asset.heroTag),
-                        if (!isReadonlyModeEnabled)
-                          Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: actions),
-                      ],
-                    ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (asset.isVideo) VideoControls(videoPlayerName: asset.heroTag),
+                      if (!isReadonlyModeEnabled)
+                        Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: actions),
+                    ],
                   ),
                 ),
               ),

--- a/mobile/lib/theme/theme_data.dart
+++ b/mobile/lib/theme/theme_data.dart
@@ -62,6 +62,7 @@ ThemeData getThemeData({required ColorScheme colorScheme, required Locale locale
     ),
     chipTheme: const ChipThemeData(side: BorderSide.none),
     sliderTheme: const SliderThemeData(
+      trackHeight: 12,
       // ignore: deprecated_member_use
       year2023: false,
     ),

--- a/mobile/lib/widgets/asset_viewer/video_controls.dart
+++ b/mobile/lib/widgets/asset_viewer/video_controls.dart
@@ -66,9 +66,9 @@ class VideoControls extends HookConsumerWidget {
     final isLoaded = duration != Duration.zero;
 
     return Padding(
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.only(left: 16, right: 16, bottom: 12),
       child: Column(
-        spacing: 16,
+        spacing: 4,
         children: [
           Row(
             children: [
@@ -77,8 +77,8 @@ class VideoControls extends HookConsumerWidget {
                 padding: const EdgeInsets.all(12),
                 constraints: const BoxConstraints(),
                 icon: isFinished
-                    ? const Icon(Icons.replay, color: Colors.white, size: 32, shadows: _controlShadows)
-                    : AnimatedPlayPause(color: Colors.white, size: 32, playing: isPlaying, shadows: _controlShadows),
+                    ? const Icon(Icons.replay, color: Colors.white, shadows: _controlShadows)
+                    : AnimatedPlayPause(color: Colors.white, playing: isPlaying, shadows: _controlShadows),
                 onPressed: () => _toggle(ref, isCasting),
               ),
               const Spacer(),
@@ -91,7 +91,7 @@ class VideoControls extends HookConsumerWidget {
                   shadows: _controlShadows,
                 ),
               ),
-              const SizedBox(width: 16),
+              const SizedBox(width: 12),
             ],
           ),
           Slider(


### PR DESCRIPTION
## Description

The spacing was required for the old slider, but the new one has its own spacing and makes it redundant. There is too much now, and we've received feedback that it should be less sparse. The default track height of 16px is an improvement over the old track height, but it is very thick. A middleground of 12px might be better.

## How Has This Been Tested?

Pixel 8a.

<details><summary><h2>Screenshots (before/after)</h2></summary>

![IMG_20260327_001252](https://github.com/user-attachments/assets/91f77081-a069-4035-9d4b-9ed4f1d00434)

![IMG_20260327_011944](https://github.com/user-attachments/assets/4b32e009-6379-4c36-b9e5-c86945f68824)

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
