### PR TITLE
fix(mobile): streamline error handling for live photo saving

### DIFF
--- a/mobile/lib/services/download.service.dart
+++ b/mobile/lib/services/download.service.dart
@@ -109,7 +109,7 @@ class DownloadService {
       return result != null;
     } on PlatformException catch (error, stack) {
       // Handle saving MotionPhotos on iOS
-      if (error.code == 'PHPhotosErrorDomain (-1)') {
+      if (error.code.startsWith('PHPhotosErrorDomain')) {
         final result = await _fileMediaRepository.saveImageWithFile(imageFilePath, title: task.filename);
         return result != null;
       }


### PR DESCRIPTION
## Description

Backed up Android motion photos, currently can't be downloaded onto iOS. The fallback of only downloading the still image currently only runs when the `PHPhotosErrorDomain (-1)` error is thrown. 
I guess there are multiple other error codes such as `PHPhotosErrorDomain (3302)` and probably more which iOS throws incase Live Photos can't be saved. 

In all these cases we should always fallback to static only download. 

Fixes #26124

## How Has This Been Tested?

- Tested in emulator and made sure android motion photos download as static image on iOS 

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/
