### PR TITLE
fix(mobile): isolate auth to app instance

### DIFF
--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -88,8 +88,8 @@ class NetworkApiImpl: NetworkApi {
       }
     }
 
-    if headers != UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] {
-      UserDefaults.group.set(headers, forKey: HEADERS_KEY)
+    if headers != UserDefaults.standard.dictionary(forKey: HEADERS_KEY) as? [String: String] {
+      UserDefaults.standard.set(headers, forKey: HEADERS_KEY)
       URLSessionManager.shared.recreateSession()
     }
   }

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -4,7 +4,6 @@ import native_video_player
 let CLIENT_CERT_LABEL = "app.alextran.immich.client_identity"
 let HEADERS_KEY = "immich.request_headers"
 let SERVER_URLS_KEY = "immich.server_urls"
-let APP_GROUP = "group.app.immich.share"
 let COOKIE_EXPIRY_DAYS: TimeInterval = 400
 
 enum AuthCookie: CaseIterable {
@@ -26,10 +25,6 @@ enum AuthCookie: CaseIterable {
   }
 
   static let names: Set<String> = Set(allCases.map(\.name))
-}
-
-extension UserDefaults {
-  static let group = UserDefaults(suiteName: APP_GROUP)!
 }
 
 /// Manages a shared URLSession with SSL configuration support.
@@ -55,7 +50,7 @@ class URLSessionManager: NSObject {
     let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     return "Immich_iOS_\(version)"
   }()
-  static let cookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: APP_GROUP)
+  static let cookieStorage = HTTPCookieStorage.shared
   private static var serverUrls: [String] = []
   private static var isSyncing = false
 
@@ -67,7 +62,7 @@ class URLSessionManager: NSObject {
     delegate = URLSessionManagerDelegate()
     session = Self.buildSession(delegate: delegate)
     super.init()
-    Self.serverUrls = UserDefaults.group.stringArray(forKey: SERVER_URLS_KEY) ?? []
+    Self.serverUrls = UserDefaults.standard.stringArray(forKey: SERVER_URLS_KEY) ?? []
     NotificationCenter.default.addObserver(
       Self.self,
       selector: #selector(Self.cookiesDidChange),
@@ -83,7 +78,7 @@ class URLSessionManager: NSObject {
   static func setServerUrls(_ urls: [String]) {
     guard urls != serverUrls else { return }
     serverUrls = urls
-    UserDefaults.group.set(urls, forKey: SERVER_URLS_KEY)
+    UserDefaults.standard.set(urls, forKey: SERVER_URLS_KEY)
     syncAuthCookies()
   }
 
@@ -151,7 +146,7 @@ class URLSessionManager: NSObject {
     config.httpMaximumConnectionsPerHost = 64
     config.timeoutIntervalForRequest = 60
 
-    var headers = UserDefaults.group.dictionary(forKey: HEADERS_KEY) as? [String: String] ?? [:]
+    var headers = UserDefaults.standard.dictionary(forKey: HEADERS_KEY) as? [String: String] ?? [:]
     headers["User-Agent"] = headers["User-Agent"] ?? userAgent
     config.httpAdditionalHeaders = headers
 


### PR DESCRIPTION
## Description

Credentials are currently shared for the whole app group, which causes debug, test flight and release versions to conflict with each other. This results in really weird behaviour like one instance of the app acknowledging syncs which the other instances aren't aware of.

## How Has This Been Tested?

Not tested.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
