### PR TITLE
perf(server): optimize people page query

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -228,12 +228,12 @@ select
 from
   "asset_face"
   left join "asset" on "asset"."id" = "asset_face"."assetId"
-  and "asset_face"."personId" = $1
   and "asset"."visibility" = 'timeline'
   and "asset"."deletedAt" is null
 where
   "asset_face"."deletedAt" is null
   and "asset_face"."isVisible" is true
+  and "asset_face"."personId" = $1
 
 -- PersonRepository.getNumberOfPeople
 select

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -352,13 +352,13 @@ export class PersonRepository {
       .leftJoin('asset', (join) =>
         join
           .onRef('asset.id', '=', 'asset_face.assetId')
-          .on('asset_face.personId', '=', personId)
           .on('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
           .on('asset.deletedAt', 'is', null),
       )
       .select((eb) => eb.fn.count(eb.fn('distinct', ['asset.id'])).as('count'))
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
+      .where('asset_face.personId', '=', personId)
       .executeTakeFirst();
 
     return {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Change the "asset_face"."personId" = $1 from Join Sql to Where Sql section.
Let the database apply index.
<!--- Why is this change required? What problem does it solve? -->
The original Sql didn't use index and the modify Sql using index.
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

Before : 
```
explain (analyze , buffers ) select count(distinct("asset"."id")) as "count"                                     
from "asset_face"                                                                                                         
left join "asset" 
on "asset"."id" = "asset_face"."assetId" 
  and "asset_face"."personId" = '982bf83e-9b66-42d7-9bd6-d327841fed43' 
  and "asset"."visibility" = 'timeline' 
  and "asset"."deletedAt" is null                                               
where "asset_face"."deletedAt" is null 
  and "asset_face"."isVisible" is true;       
```                                       
```

                                                            QUERY PLAN                                                    
                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------
---------                                                                                                                 
 Aggregate  (cost=98777.54..98777.55 rows=1 width=8) (actual time=1477.959..1477.962 rows=1 loops=1)                      
   Buffers: shared hit=60813                                                                                              
   ->  Hash Left Join  (cost=63113.69..96109.13 rows=1067362 width=16) (actual time=671.093..1398.740 rows=1061314 loops=1
)                                                                                                                         
         Hash Cond: (asset_face."assetId" = asset.id)                                                                     
         Join Filter: (asset_face."personId" = '982bf83e-9b66-42d7-9bd6-d327841fed43'::uuid)                              
         Rows Removed by Join Filter: 1051049                                                                             
         Buffers: shared hit=60813                                                                                        
         ->  Seq Scan on asset_face  (cost=0.00..30193.62 rows=1067362 width=32) (actual time=0.011..319.056 rows=1061314 
loops=1)                                                                                                                  
               Filter: (("deletedAt" IS NULL) AND ("isVisible" IS TRUE))                                                  
               Rows Removed by Filter: 24                                                                                 
               Buffers: shared hit=19520                                                                                  
         ->  Hash  (cost=52866.94..52866.94 rows=819740 width=16) (actual time=668.364..668.365 rows=818451 loops=1)      
               Buckets: 1048576  Batches: 1  Memory Usage: 46557kB                                                        
               Buffers: shared hit=41293                                                                                  
               ->  Seq Scan on asset  (cost=0.00..52866.94 rows=819740 width=16) (actual time=0.020..433.253 rows=818451 l
oops=1)                                                                                                                   
                     Filter: (("deletedAt" IS NULL) AND (visibility = 'timeline'::asset_visibility_enum))                 
                     Rows Removed by Filter: 107464                                                                       
                     Buffers: shared hit=41293                                                                            
 Planning:                                                                                                                
   Buffers: shared hit=17                                                                                                 
 Planning Time: 0.437 ms                                                                                                  
 Execution Time: 1479.872 ms                                                                                              
(22 rows)     
```                                             

After : 
```
explain analyze select count(distinct("asset"."id")) as "count"                                                  
from "asset_face"                                                                                                         
left join "asset"                                                                                                         
on "asset"."id" = "asset_face"."assetId"                                                                                  
  and "asset"."visibility" = 'timeline'                                                                                     
  and "asset"."deletedAt" is null                                                                                           
where "asset_face"."deletedAt" is null 
  and "asset_face"."isVisible" is true 
  and "asset_face"."personId" = '982bf83e-9b66-42d7-9bd6-d327841fed43' ;  

```

```
                                                                                 QUERY PLAN                          
                                                                                                                          
--------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------                                                             
 Aggregate  (cost=139.72..139.73 rows=1 width=8) (actual time=0.069..0.070 rows=1 loops=1)                                
   ->  Nested Loop Left Join  (cost=0.85..139.64 rows=34 width=16) (actual time=0.028..0.031 rows=1 loops=1)              
         ->  Index Only Scan using "asset_face_personId_assetId_notDeleted_isVisible_idx" on asset_face  (cost=0.43..42.99
 rows=34 width=16) (actual time=0.016..0.017 rows=1 loops=1)                                                              
               Index Cond: ("personId" = '982bf83e-9b66-42d7-9bd6-d327841fed43'::uuid)                                    
               Heap Fetches: 1                                                                                            
         ->  Index Only Scan using "asset_id_timeline_notDeleted_idx" on asset  (cost=0.42..2.84 rows=1 width=16) (actual 
time=0.010..0.010 rows=1 loops=1)                                                                                         
               Index Cond: (id = asset_face."assetId")                                                                    
               Heap Fetches: 1                                                                                            
 Planning Time: 0.479 ms                                                                                                  
 Execution Time: 0.113 ms                                                                                                 
(10 rows)         
```              

## How Has This Been Tested?

At Immich Web : 

http://[immich server]/people/982bf83e-9b66-42d7-9bd6-d327841fed43'?previousRoute=%2Fpeople

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x ] I have carefully read CONTRIBUTING.md
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation if applicable
- [ x] I have no unrelated changes in the PR.
- [ x] I have confirmed that any new dependencies are strictly necessary.
- [ x] I have written tests for new code (if applicable)
- [ x] I have followed naming conventions/patterns in the surrounding code
- [ x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
