### PR TITLE
fix(server): use frsize instead of bsize for disk usage on FUSE mounts

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import archiver from 'archiver';
 import chokidar, { ChokidarOptions } from 'chokidar';
 import { escapePath, glob, globStream } from 'fast-glob';
+import { execFileSync } from 'node:child_process';
 import { constants, createReadStream, createWriteStream, existsSync, mkdirSync, ReadOptionsWithBuffer } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -191,10 +192,27 @@ export class StorageRepository {
 
   async checkDiskUsage(folder: string): Promise<DiskUsage> {
     const stats = await fs.statfs(folder);
+
+    // Node.js statfs() exposes bsize (optimal I/O block size) but not frsize
+    // (fundamental filesystem block size). Per POSIX, block counts (blocks, bfree,
+    // bavail) are in units of frsize. On most native filesystems bsize == frsize,
+    // but on FUSE mounts (Docker Desktop on macOS using VirtioFS/gRPC FUSE) they
+    // can differ by orders of magnitude, causing wildly inflated storage reports.
+    // Fall back to bsize if frsize cannot be determined.
+    let blockSize = stats.bsize;
+    try {
+      const frsize = Number(execFileSync('stat', ['-f', '-c', '%S', folder], { encoding: 'utf8' }).trim());
+      if (frsize > 0) {
+        blockSize = frsize;
+      }
+    } catch {
+      // stat format may differ on non-GNU systems; bsize is still a reasonable fallback
+    }
+
     return {
-      available: stats.bavail * stats.bsize,
-      free: stats.bfree * stats.bsize,
-      total: stats.blocks * stats.bsize,
+      available: stats.bavail * blockSize,
+      free: stats.bfree * blockSize,
+      total: stats.blocks * blockSize,
     };
   }
 


### PR DESCRIPTION
## Description

Fixes incorrect storage space reporting on macOS Docker (VirtioFS, gRPC FUSE, OrbStack).

Node.js `fs.statfs()` exposes `bsize` (optimal I/O block size) but not `frsize` (fundamental filesystem block size). Per POSIX, block counts (`blocks`, `bfree`, `bavail`) are in units of `frsize`. On native Linux filesystems `bsize == frsize`, so multiplying by either gives the correct result. However, on **FUSE mounts** (Docker Desktop on macOS with VirtioFS or gRPC FUSE), they diverge dramatically:

| Field | Value | Total via this field |
|-------|-------|---------------------|
| `bsize` | 2,097,152 (2 MiB) | **1.82 PiB** ❌ |
| `frsize` | 16,384 (16 KiB) | **14.9 TiB** ✅ |

This causes the dashboard to report storage like **"602 TiB of 1.8 PiB"** on a 15 TB disk.

Uses `stat -f -c '%S'` (GNU coreutils, available in the Immich container) to obtain the real fundamental block size, falling back to `bsize` when the command is unavailable (e.g. non-GNU systems where this doesn't affect correctness anyway).

Fixes #4318

## How Has This Been Tested?

- [x] Verified `stat -f -c '%S'` returns correct `frsize` (16384) inside the `immich_server` container on OrbStack VirtioFS
- [x] Verified `bsize * blocks` produces the inflated result (1.82 PiB), `frsize * blocks` produces the correct one (14.9 TiB)
- [x] Confirmed on native Linux: `bsize == frsize`, behavior unchanged
- [x] Existing `server.service.spec.ts` tests unaffected (they mock `checkDiskUsage` at the service level)

## Screenshots

**Before (OrbStack VirtioFS):**
```
Storage: 602.3 TiB of 1.8 PiB used
```

**Container statfs values:**
```
Block size: 2097152    Fundamental block size: 16384
Blocks: Total: 976670664  Free: 660904662  Available: 660904662
```

**After:** Reports correct ~4.7 TiB of ~14.9 TiB used (matches `df -h /Volumes/OWCM2RAID2` on host).

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was authored with assistance from Claude Code (Claude Opus 4.6). The root cause analysis (POSIX frsize vs bsize semantics on FUSE mounts), fix approach, and verification were done collaboratively. The code change is minimal and straightforward.