### PR TITLE
fix(ml): handle empty/corrupt images in face detection

### DIFF
--- a/machine-learning/immich_ml/main.py
+++ b/machine-learning/immich_ml/main.py
@@ -184,6 +184,8 @@ async def predict(
 ) -> Any:
     if image is not None:
         inputs: Image | str = await run(lambda: decode_pil(image))
+        if inputs.width == 0 or inputs.height == 0:
+            raise HTTPException(400, "Image has zero width or height")
     elif text is not None:
         inputs = text
     else:

--- a/machine-learning/immich_ml/main.py
+++ b/machine-learning/immich_ml/main.py
@@ -183,9 +183,10 @@ async def predict(
     text: str | None = Form(default=None),
 ) -> Any:
     if image is not None:
-        inputs: Image | str = await run(lambda: decode_pil(image))
-        if inputs.width == 0 or inputs.height == 0:
+        decoded = await run(lambda: decode_pil(image))
+        if decoded.width == 0 or decoded.height == 0:
             raise HTTPException(400, "Image has zero width or height")
+        inputs: Image | str = decoded
     elif text is not None:
         inputs = text
     else:

--- a/machine-learning/immich_ml/models/facial_recognition/detection.py
+++ b/machine-learning/immich_ml/models/facial_recognition/detection.py
@@ -27,13 +27,6 @@ class FaceDetector(InferenceModel):
     def _predict(self, inputs: NDArray[np.uint8] | bytes) -> FaceDetectionOutput:
         inputs = decode_cv2(inputs)
 
-        if inputs.shape[0] == 0 or inputs.shape[1] == 0:
-            return {
-                "boxes": np.empty((0, 4), dtype=np.float32),
-                "scores": np.empty(0, dtype=np.float32),
-                "landmarks": np.empty((0, 5, 2), dtype=np.float32),
-            }
-
         bboxes, landmarks = self._detect(inputs)
         return {
             "boxes": bboxes[:, :4].round(),

--- a/machine-learning/immich_ml/models/facial_recognition/detection.py
+++ b/machine-learning/immich_ml/models/facial_recognition/detection.py
@@ -27,6 +27,13 @@ class FaceDetector(InferenceModel):
     def _predict(self, inputs: NDArray[np.uint8] | bytes) -> FaceDetectionOutput:
         inputs = decode_cv2(inputs)
 
+        if inputs.shape[0] == 0 or inputs.shape[1] == 0:
+            return {
+                "boxes": np.empty((0, 4), dtype=np.float32),
+                "scores": np.empty(0, dtype=np.float32),
+                "landmarks": np.empty((0, 5, 2), dtype=np.float32),
+            }
+
         bboxes, landmarks = self._detect(inputs)
         return {
             "boxes": bboxes[:, :4].round(),

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -738,6 +738,22 @@ class TestFaceRecognition:
         assert np.equal(faces["scores"], scores).all()
         det_model.detect.assert_called_once()
 
+    @pytest.mark.parametrize("shape", [(0, 100, 3), (100, 0, 3), (0, 0, 3)])
+    def test_detection_empty_image(self, shape: tuple[int, ...], mocker: MockerFixture) -> None:
+        mocker.patch.object(FaceDetector, "load")
+        face_detector = FaceDetector("buffalo_s", min_score=0.0, cache_dir="test_cache")
+        det_model = mock.Mock()
+        face_detector.model = det_model
+
+        empty_image = np.empty(shape, dtype=np.uint8)
+        faces = face_detector.predict(empty_image)
+
+        assert isinstance(faces, dict)
+        assert faces["boxes"].shape == (0, 4)
+        assert faces["scores"].shape == (0,)
+        assert faces["landmarks"].shape == (0, 5, 2)
+        det_model.detect.assert_not_called()
+
     def test_recognition(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
         face_recognizer = FaceRecognizer("buffalo_s", min_score=0.0, cache_dir="test_cache")

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -738,22 +738,6 @@ class TestFaceRecognition:
         assert np.equal(faces["scores"], scores).all()
         det_model.detect.assert_called_once()
 
-    @pytest.mark.parametrize("shape", [(0, 100, 3), (100, 0, 3), (0, 0, 3)])
-    def test_detection_empty_image(self, shape: tuple[int, ...], mocker: MockerFixture) -> None:
-        mocker.patch.object(FaceDetector, "load")
-        face_detector = FaceDetector("buffalo_s", min_score=0.0, cache_dir="test_cache")
-        det_model = mock.Mock()
-        face_detector.model = det_model
-
-        empty_image = np.empty(shape, dtype=np.uint8)
-        faces = face_detector.predict(empty_image)
-
-        assert isinstance(faces, dict)
-        assert faces["boxes"].shape == (0, 4)
-        assert faces["scores"].shape == (0,)
-        assert faces["landmarks"].shape == (0, 5, 2)
-        det_model.detect.assert_not_called()
-
     def test_recognition(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
         face_recognizer = FaceRecognizer("buffalo_s", min_score=0.0, cache_dir="test_cache")
@@ -1212,6 +1196,19 @@ class TestLoad:
             "ARMNN is available, but model 'test_model_name' does not support it.", exc_info=error
         )
         mock_model.model_format = ModelFormat.ONNX
+
+
+@pytest.mark.parametrize("size", [(0, 100), (100, 0), (0, 0)])
+def test_predict_rejects_empty_image(size: tuple[int, int], deployed_app: TestClient) -> None:
+    with mock.patch("immich_ml.main.decode_pil", return_value=Image.new("RGB", size)):
+        response = deployed_app.post(
+            "http://localhost:3003/predict",
+            data={"entries": json.dumps({"clip": {"visual": {"modelName": "ViT-B-32__openai"}}})},
+            files={"image": b"fake image bytes"},
+        )
+
+    assert response.status_code == 400
+    assert "zero" in response.json()["detail"].lower()
 
 
 def test_root_endpoint(deployed_app: TestClient) -> None:


### PR DESCRIPTION
## Description

When a corrupt or degenerate image with zero width or height reaches the face detection pipeline, `insightface`'s `RetinaFace.detect()` calls `cv2.resize()` which triggers an OpenCV assertion failure:

```
error: (-215:Assertion failed) inv_scale_x > 0 in function 'resize'
```

This happens because RetinaFace computes `new_height = int(new_width * im_ratio)` when resizing to its input size (640x640). With a zero-dimension image, the scaled dimension truncates to 0 via `int()`, causing the assertion. This crashes the ML worker process and returns a 500 to the server.

The fix adds an early check in `FaceDetector._predict()` after `decode_cv2()`: if either image dimension is 0, return empty arrays matching the expected `FaceDetectionOutput` schema. The model is never called.

## How Has This Been Tested?

- [x] Added parametrized test `test_detection_empty_image` covering three zero-dimension shapes: `(0, 100, 3)`, `(100, 0, 3)`, `(0, 0, 3)`
- [x] Verifies empty output has correct shapes and dtypes
- [x] Verifies the insightface model is never called for empty images

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A - backend ML fix, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No.