### PR TITLE
fix(mobile): low upload timeout on android

### DIFF
--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -22,7 +22,14 @@ class NetworkRepository {
       final session = URLSession.fromRawPointer(clientPointer.cast());
       _client = CupertinoClient.fromSharedSession(session);
     } else {
-      _client = OkHttpClient.fromJniGlobalRef(clientPointer);
+      _client = OkHttpClient.fromJniGlobalRef(
+        clientPointer,
+        configuration: const OkHttpClientConfiguration(
+          connectTimeout: Duration(seconds: 30),
+          readTimeout: Duration(seconds: 60),
+          writeTimeout: Duration(seconds: 60),
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Notably, this is a per-chunk timeout, not a total request timeout. The default is 10 seconds, which might not be enough for slow servers or slow connections. This PR brings it up to match the 60s timeout on iOS.

Fixes #27144