### PR TITLE
fix(web): add drop shadow to asset viewer nav bar and prevent button shrinking

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -104,13 +104,16 @@
 <CommandPaletteDefaultProvider name={$t('assets')} actions={withoutIcons([Close, Cast, ...Object.values(Actions)])} />
 
 <div
-  class="flex h-16 place-items-center justify-between bg-linear-to-b from-black/40 px-3 transition-transform duration-200"
+  class="flex h-16 place-items-center justify-between bg-linear-to-b from-black/40 px-3 transition-transform duration-200 drop-shadow-[0_0_1px_rgba(0,0,0,0.4)]"
 >
   <div class="dark">
     <ActionButton action={Close} />
   </div>
 
-  <div class="flex items-center gap-2 overflow-x-auto dark" data-testid="asset-viewer-navbar-actions">
+  <div
+    class="flex p-1 -m-1 items-center gap-2 overflow-x-auto *:shrink-0 dark"
+    data-testid="asset-viewer-navbar-actions"
+  >
     {#if assetViewerManager.isImageLoading}
       <Tooltip text={$t('loading')}>
         {#snippet child({ props })}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -564,7 +564,7 @@
     {/if}
 
     {#if showOcrButton}
-      <div class="absolute bottom-0 end-0 mb-6 me-6">
+      <div class="absolute bottom-0 end-0 mb-6 me-6 drop-shadow-[0_0_1px_rgba(0,0,0,0.4)]">
         <OcrButton />
       </div>
     {/if}


### PR DESCRIPTION

before: 
<img width="695" height="468" alt="image" src="https://github.com/user-attachments/assets/72ecb548-c06f-406b-8581-c9d568b92cb3" />
after: 
<img width="698" height="469" alt="image" src="https://github.com/user-attachments/assets/6bbf6840-e368-48a5-9fa6-05aa699fc3f4" />

before: 
<img width="694" height="462" alt="image" src="https://github.com/user-attachments/assets/49a98992-b40d-4f33-aa73-1d5b5d8385cd" />
after:
<img width="699" height="465" alt="image" src="https://github.com/user-attachments/assets/f6d478e7-fe82-49c6-9681-d8b128d4ce35" />


before:
<img width="552" height="480" alt="image" src="https://github.com/user-attachments/assets/b9e70331-376a-41ca-8520-8e348e66df64" />
after: 
<img width="547" height="481" alt="image" src="https://github.com/user-attachments/assets/79487e4d-9001-4b7a-bb72-8967099fef69" />


- Add subtle drop shadow to the asset viewer nav bar, and OCR button for better visual separation from the image behind it
- Add margins so the focus outline doesn't clip the button
- Prevent nav bar action buttons from shrinking to nothing by adding *:shrink-0 to the flex container, with p-1/-m-1 to avoid clipping focus outlines

