### PR TITLE
fix(web) Incorrect group selection with shift pressed

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -849,7 +849,8 @@ export class AssetRepository {
           .$if(!!options.isTrashed, (qb) => qb.where('asset.status', '!=', AssetStatus.Deleted))
           .$if(!!options.tagId, (qb) => withTagId(qb, options.tagId!))
           .orderBy(sql`(asset."localDateTime" AT TIME ZONE 'UTC')::date`, order)
-          .orderBy('asset.fileCreatedAt', order),
+          .orderBy('asset.fileCreatedAt', order)
+          .orderBy('asset.id', order),
       )
       .with('agg', (qb) =>
         qb

--- a/web/src/lib/managers/timeline-manager/day-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/day-group.svelte.ts
@@ -74,8 +74,16 @@ export class DayGroup {
   }
 
   sortAssets(sortOrder: AssetOrder = AssetOrder.Desc) {
-    const sortFn = plainDateTimeCompare.bind(undefined, sortOrder === AssetOrder.Asc);
-    this.viewerAssets.sort((a, b) => sortFn(a.asset.fileCreatedAt, b.asset.fileCreatedAt));
+    const isAscending = sortOrder === AssetOrder.Asc;
+    this.viewerAssets.sort((a, b) => {
+      const timeComparison = plainDateTimeCompare(isAscending, a.asset.fileCreatedAt, b.asset.fileCreatedAt);
+      if (timeComparison !== 0) {
+        return timeComparison;
+      }
+      if (a.asset.id < b.asset.id) return isAscending ? -1 : 1;
+      if (a.asset.id > b.asset.id) return isAscending ? 1 : -1;
+      return 0;
+    });
   }
 
   getFirstAsset() {

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -119,8 +119,18 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
   if (!endMonthGroup || !endAsset) {
     return [];
   }
+
   const assetOrder: AssetOrder = timelineManager.getAssetOrder();
-  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, startAsset.fileCreatedAt, endAsset.fileCreatedAt) < 0) {
+  const isAscending = assetOrder === AssetOrder.Asc;
+  const timeComparison = plainDateTimeCompare(isAscending, startAsset.fileCreatedAt, endAsset.fileCreatedAt);
+  // If we have a number of incorrectly timestamped assets, lets make sure that
+  // they are still sorted in a stable way:
+  const idComparison = isAscending
+    ? startAsset.id > endAsset.id
+    : startAsset.id < endAsset.id;
+  const needsSwap = timeComparison < 0 || (timeComparison === 0 && idComparison);
+
+  if (needsSwap) {
     [startAsset, endAsset] = [endAsset, startAsset];
     // eslint-disable-next-line no-useless-assignment
     [startMonthGroup, endMonthGroup] = [endMonthGroup, startMonthGroup];

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -120,7 +120,7 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
     return [];
   }
   const assetOrder: AssetOrder = timelineManager.getAssetOrder();
-  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, startAsset.localDateTime, endAsset.localDateTime) < 0) {
+  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, startAsset.fileCreatedAt, endAsset.fileCreatedAt) < 0) {
     [startAsset, endAsset] = [endAsset, startAsset];
     // eslint-disable-next-line no-useless-assignment
     [startMonthGroup, endMonthGroup] = [endMonthGroup, startMonthGroup];


### PR DESCRIPTION
## Description

Fixes #23322, #24992, #23074

This PR addresses two distinct bugs in the range selection logic of the
web timeline, both of which could cause a large number of unintended
assets to be selected instead of just the highlighted range.

### Bug 1 — Range selection iterates in the wrong direction across timezone boundaries

`retrieveRange()` in
`web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts`
was using `localDateTime` to decide which of the two selected assets
comes first in the timeline. However, `DayGroup.sortAssets()` sorts
assets by `fileCreatedAt`. These two fields can disagree when assets
were shot on devices set to different timezones: `localDateTime` stores
the local clock time as a naive UTC value (e.g. `16:52:28 UTC` meaning
"the clock showed 16:52:28"), while `fileCreatedAt` is always true UTC
(e.g. `14:52:28 UTC`).

When the two selected assets were shot in different timezones,
`retrieveRange()` could conclude that the chronologically earlier asset
was actually later, swap start and end, and then iterate in the wrong
direction — walking away from the intended end asset and selecting
everything until the end of the collection. In the worst case this
resulted in thousands of assets being unexpectedly selected.

**Fix:** use `fileCreatedAt` in `retrieveRange()` to match the field
used by `DayGroup.sortAssets()`.

**Concrete reproduction case:**

| | Photo | Video |
|---|---|---|
| Filename | `PXL_20220806_145228331.jpg` | `PXL_20220806_145238420.LS.mp4` |
| `fileCreatedAt` | `2022-08-06T14:52:28Z` | `2022-08-06T14:52:38Z` |
| `localDateTime` | `2022-08-06T16:52:28Z` | `2022-08-06T14:52:38Z` |
| `timeZone` | `UTC+2` | `UTC` |

The two assets are 10 seconds apart in true UTC and appear side by side
in the timeline. Their `localDateTime` values differ by 2 hours because
the video's EXIF data had no timezone offset, causing Immich to default
to UTC. Shift-clicking between them caused `retrieveRange()` to see a
2-hour gap, swap the iteration direction, and select 1495 assets instead
of 2.

### Bug 2 — No deterministic order for assets with identical timestamps

Assets with identical `fileCreatedAt` timestamps (common when EXIF data
is missing or invalid and a default timestamp has been assigned) had no
stable sort order. The server returned them in an arbitrary database
order, and `retrieveRange()` had no reliable way to determine which
asset came first in the display. This caused range selection to behave
unpredictably — sometimes selecting the correct range, sometimes
selecting nothing, sometimes selecting everything up to the end of the
collection, in an alternating pattern depending on which asset was
clicked first.

**Fix:** add `asset.id` as a tiebreaker in both the server time bucket
query (which determines display order) and in `retrieveRange()` on the
web side (which determines selection order), ensuring the two always
agree when timestamps are identical.

## How Has This Been Tested?

- [x] Reproduced Bug 1 with two assets shot 10 seconds apart on devices
  set to different timezones (UTC and UTC+2). Before the fix, selecting
  a range between them selected 1495 assets. After the fix, exactly 2
  assets are selected.
- [x] Reproduced Bug 2 with a group of assets sharing identical
  `fileCreatedAt` timestamps. Before the fix, range selection within the
  group was unpredictable. After the fix, the correct contiguous range
  is consistently selected regardless of which asset is clicked first.
- [x] Verified that normal range selection (assets with distinct
  timestamps, same timezone) continues to work correctly.
- [x] Verified that the archive view, photos view, and album view all
  display and select correctly after the changes.

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (**not applicable**)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (**not applicable**)
- [ ] I have written tests for new code (if applicable) (**I did not find any tests for `sortAssets()` or `retrieveRange()`)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The bugs were identified and diagnosed with the assistance of an LLM
(Claude by Anthropic). The LLM helped trace the execution path from the
user's shift-click through `retrieveRange()`, `assetsIterator()`, and
`DayGroup.sortAssets()`, identify the inconsistent use of `localDateTime`
vs `fileCreatedAt`, and understand the timezone conversion logic in
`getTimes()` and `toTimelineAsset()`. The code changes were
partly written by myself, partly by Claude, reviewed and tested by myself.
