### PR TITLE
fix(mobile): add restore option to trashed assets

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/restore_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/restore_action_button.widget.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/events.model.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
+
+class RestoreActionButton extends ConsumerWidget {
+  final ActionSource source;
+  final bool iconOnly;
+  final bool menuItem;
+
+  const RestoreActionButton({super.key, required this.source, this.iconOnly = false, this.menuItem = false});
+
+  void _onTap(BuildContext context, WidgetRef ref) async {
+    if (!context.mounted) {
+      return;
+    }
+
+    final result = await ref.read(actionProvider.notifier).restoreTrash(source);
+    ref.read(multiSelectProvider.notifier).reset();
+
+    if (source == ActionSource.viewer) {
+      EventStream.shared.emit(const ViewerReloadAssetEvent());
+    }
+
+    final successMessage = 'assets_restored_count'.t(context: context, args: {'count': result.count.toString()});
+
+    if (context.mounted) {
+      ImmichToast.show(
+        context: context,
+        msg: result.success ? successMessage : 'scaffold_body_error_occurred'.t(context: context),
+        gravity: ToastGravity.BOTTOM,
+        toastType: result.success ? ToastType.success : ToastType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BaseActionButton(
+      iconData: Icons.history_rounded,
+      label: 'restore'.t(context: context),
+      iconOnly: iconOnly,
+      menuItem: menuItem,
+      onPressed: () => _onTap(context, ref),
+      maxWidth: 100.0,
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -2,15 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/add_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_image_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/restore_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_button.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
@@ -33,19 +36,24 @@ class ViewerBottomBar extends ConsumerWidget {
     final showingDetails = ref.watch(assetViewerProvider.select((s) => s.showingDetails));
     final isInLockedView = ref.watch(inLockedViewProvider);
     final serverInfo = ref.watch(serverInfoProvider);
+    final isInTrash = ref.read(timelineServiceProvider).origin == TimelineOrigin.trash;
 
     final originalTheme = context.themeData;
 
     final actions = <Widget>[
-      const ShareActionButton(source: ActionSource.viewer),
+      if (isInTrash && isOwner && asset.hasRemote)
+        const RestoreActionButton(source: ActionSource.viewer)
+      else
+        const ShareActionButton(source: ActionSource.viewer),
 
       if (!isInLockedView) ...[
-        if (asset.isLocalOnly) const UploadActionButton(source: ActionSource.viewer),
-        // edit sync was added in 2.6.0
-        if (asset.isEditable && serverInfo.serverVersion >= const SemVer(major: 2, minor: 6, patch: 0))
-          const EditImageActionButton(),
-        if (asset.hasRemote) AddActionButton(originalTheme: originalTheme),
-
+        if (!isInTrash) ...[
+          if (asset.isLocalOnly) const UploadActionButton(source: ActionSource.viewer),
+          // edit sync was added in 2.6.0
+          if (asset.isEditable && serverInfo.serverVersion >= const SemVer(major: 2, minor: 6, patch: 0))
+            const EditImageActionButton(),
+          if (asset.hasRemote) AddActionButton(originalTheme: originalTheme),
+        ],
         if (isOwner) ...[
           asset.isLocalOnly
               ? const DeleteLocalActionButton(source: ActionSource.viewer)

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -21,6 +21,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/move_to_lock_f
 import 'package:immich_mobile/presentation/widgets/action_buttons/open_in_browser_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_album_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_lock_folder_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/restore_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/set_album_cover.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/set_profile_picture_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
@@ -81,6 +82,7 @@ enum ActionButtonType {
   moveToLockFolder,
   removeFromLockFolder,
   removeFromAlbum,
+  restoreTrash,
   trash,
   deleteLocal,
   deletePermanent,
@@ -112,7 +114,13 @@ enum ActionButtonType {
         context.isOwner && //
             !context.isInLockedView && //
             context.asset.hasRemote && //
-            context.isTrashEnabled,
+            context.isTrashEnabled && //
+            context.timelineOrigin != TimelineOrigin.trash,
+      ActionButtonType.restoreTrash =>
+        context.isOwner && //
+            !context.isInLockedView && //
+            context.asset.hasRemote && //
+            context.timelineOrigin == TimelineOrigin.trash,
       ActionButtonType.deletePermanent =>
         context.isOwner && //
                 context.asset.hasRemote && //
@@ -201,6 +209,11 @@ enum ActionButtonType {
       ),
       ActionButtonType.download => DownloadActionButton(source: context.source, iconOnly: iconOnly, menuItem: menuItem),
       ActionButtonType.trash => TrashActionButton(source: context.source, iconOnly: iconOnly, menuItem: menuItem),
+      ActionButtonType.restoreTrash => RestoreActionButton(
+        source: context.source,
+        iconOnly: iconOnly,
+        menuItem: menuItem,
+      ),
       ActionButtonType.deletePermanent => DeletePermanentActionButton(
         source: context.source,
         iconOnly: iconOnly,
@@ -292,6 +305,7 @@ enum ActionButtonType {
     ActionButtonType.moveToLockFolder => 10,
     ActionButtonType.deleteLocal => 10,
     ActionButtonType.delete => 10,
+    ActionButtonType.restoreTrash => 10,
     // 90: advancedInfo
     ActionButtonType.advancedInfo => 90,
     // 1: others
@@ -309,6 +323,7 @@ class ActionButtonBuilder {
     ActionButtonType.delete,
     ActionButtonType.archive,
     ActionButtonType.unarchive,
+    ActionButtonType.restoreTrash,
   };
 
   static List<Widget> build(ActionButtonContext context) {

--- a/mobile/test/utils_legacy/action_button_utils_test.dart
+++ b/mobile/test/utils_legacy/action_button_utils_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/utils/action_button.utils.dart';
 
 LocalAsset createLocalAsset({
@@ -457,6 +458,44 @@ void main() {
         );
 
         expect(ActionButtonType.trash.shouldShow(context), isFalse);
+      });
+    });
+
+    group('restoreTrash button', () {
+      test('should show when owner, not locked, has remote, and is in trash timeline', () {
+        final remoteAsset = createRemoteAsset();
+        final context = ActionButtonContext(
+          asset: remoteAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: true,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: false,
+          isStacked: false,
+          source: ActionSource.timeline,
+          timelineOrigin: TimelineOrigin.trash,
+        );
+
+        expect(ActionButtonType.restoreTrash.shouldShow(context), isTrue);
+      });
+
+      test('should not show when not in trash timeline', () {
+        final remoteAsset = createRemoteAsset();
+        final context = ActionButtonContext(
+          asset: remoteAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: false,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: false,
+          isStacked: false,
+          source: ActionSource.timeline,
+          timelineOrigin: TimelineOrigin.main,
+        );
+
+        expect(ActionButtonType.restoreTrash.shouldShow(context), isFalse);
       });
     });
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the mobile trash actions UI so that trashed assets expose the existing Restore action instead of unrelated actions such as Share and Move to Trash.

The underlying restore functionality already existed, but it was not being surfaced correctly in the mobile UI. As a result, users could not restore assets directly from the bottom action bar or dropdown menu while viewing trashed items.

This PR exposes the existing restoreTrash action in the appropriate mobile trash contexts and aligns the mobile behavior with the web version.

Note: The “Permanently Delete” functionality is handled separately in Immich PR #26575. This PR focuses specifically on surfacing the restore action
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #21148

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Added unit tests for restoreTrash button visibility in `mobile/test/utils/action_button_utils_test.dart`
- [X] Verifies the action is shown when the asset is owner-accessible, not locked, remote, and in the trash timeline
- [X] Verifies the action is hidden when the asset is not in the trash timeline

Manually confirmed that the UI correctly triggers the existing restoreTrash action and verified the same behavior in the menu

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="982" height="2018" alt="CleanShot 2026-04-01 at 15 58 38" src="https://github.com/user-attachments/assets/40f0fe5d-135d-4530-8c87-5e28d7a6f89d" />

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
This PR was primarily implemented manually. An LLM was used for minor assistance in wording and structuring the PR description. All code changes, and testing were done independently.
