### PR TITLE
fix: scrollbar ui theme colors

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -128,25 +128,24 @@
 
   /* Track */
   html::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 16px;
+    background-color: var(--immich-ui-light-100);
+    border-radius: 4px;
   }
 
   /* Handle */
   html::-webkit-scrollbar-thumb {
-    background: rgba(85, 86, 87, 0.408);
-    border-radius: 16px;
+    background-color: color-mix(in oklab, var(--immich-ui-light-600) 40%, transparent);
+    border-radius: 4px;
   }
 
   /* Handle on hover */
   html::-webkit-scrollbar-thumb:hover {
-    background: #4250afad;
-    border-radius: 16px;
+    background-color: color-mix(in oklab, var(--immich-ui-primary-500) 70%, transparent);
   }
 
   body {
     margin: 0;
-    color: #3a3a3a;
+    color: var(--immich-ui-dark);
   }
 
   body.asset-viewer-open {


### PR DESCRIPTION
## Description
Same as https://github.com/immich-app/ui/pull/652

Uses close approximations of the hardcoded values using immich UI theme colors. The border radius of 4px makes more sense than 16px at a size of 8px.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
