### PR TITLE
refactor(mobile): IOS replace DispatchQueue + DispatchSemaphore with OperationQueue for image processing

### DIFF
--- a/mobile/ios/Runner/Images/ImageProcessing.swift
+++ b/mobile/ios/Runner/Images/ImageProcessing.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 enum ImageProcessing {
-  static let queue = DispatchQueue(label: "thumbnail.processing", qos: .userInitiated, attributes: .concurrent)
-  static let semaphore = DispatchSemaphore(value: ProcessInfo.processInfo.activeProcessorCount * 2)
+  static let queue = {
+    let q = OperationQueue()
+    q.name = "thumbnail.processing"
+    q.qualityOfService = .userInitiated
+    q.maxConcurrentOperationCount = ProcessInfo.processInfo.activeProcessorCount * 2
+    return q
+  }()
   static let cancelledResult = Result<[String: Int64]?, any Error>.success(nil)
 }

--- a/mobile/ios/Runner/Images/LocalImagesImpl.swift
+++ b/mobile/ios/Runner/Images/LocalImagesImpl.swift
@@ -4,7 +4,7 @@ import MobileCoreServices
 import Photos
 
 class LocalImageRequest {
-  weak var workItem: DispatchWorkItem?
+  weak var operation: Operation?
   var isCancelled = false
   let callback: (Result<[String: Int64]?, any Error>) -> Void
 
@@ -50,7 +50,7 @@ class LocalImageApiImpl: LocalImageApi {
   }()
 
   func getThumbhash(thumbhash: String, completion: @escaping (Result<[String : Int64], any Error>) -> Void) {
-    ImageProcessing.queue.async {
+    ImageProcessing.queue.addOperation {
       guard let data = Data(base64Encoded: thumbhash)
       else { return completion(.failure(PigeonError(code: "", message: "Invalid base64 string: \(thumbhash)", details: nil)))}
 
@@ -66,16 +66,7 @@ class LocalImageApiImpl: LocalImageApi {
 
   func requestImage(assetId: String, requestId: Int64, width: Int64, height: Int64, isVideo: Bool, preferEncoded: Bool, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
     let request = LocalImageRequest(callback: completion)
-    let item = DispatchWorkItem {
-      if request.isCancelled {
-        return completion(ImageProcessing.cancelledResult)
-      }
-
-      ImageProcessing.semaphore.wait()
-      defer {
-        ImageProcessing.semaphore.signal()
-      }
-
+    let operation = BlockOperation {
       if request.isCancelled {
         return completion(ImageProcessing.cancelledResult)
       }
@@ -180,9 +171,9 @@ class LocalImageApiImpl: LocalImageApi {
       }
     }
 
-    request.workItem = item
+    request.operation = operation
     Self.add(requestId: requestId, request: request)
-    ImageProcessing.queue.async(execute: item)
+    ImageProcessing.queue.addOperation(operation)
   }
 
   func cancelRequest(requestId: Int64) {
@@ -201,8 +192,8 @@ class LocalImageApiImpl: LocalImageApi {
     requestQueue.async {
       guard let request = requests.removeValue(forKey: requestId) else { return }
       request.isCancelled = true
-      guard let item = request.workItem else { return }
-      if item.isCancelled {
+      guard let operation = request.operation else { return }
+      if operation.isCancelled {
         cancelQueue.async { request.callback(ImageProcessing.cancelledResult) }
       }
     }

--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -73,10 +73,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
       return request.completion(.failure(PigeonError(code: "", message: "No data received", details: nil)))
     }
 
-    ImageProcessing.queue.async {
-      ImageProcessing.semaphore.wait()
-      defer { ImageProcessing.semaphore.signal() }
-
+    ImageProcessing.queue.addOperation {
       if request.isCancelled {
         return request.completion(ImageProcessing.cancelledResult)
       }


### PR DESCRIPTION
## Description

The iOS image processing pipeline uses a concurrent DispatchQueue paired with a DispatchSemaphore to limit how many image operations run in parallel. This has small issue: 
when a task blocks (e.g. on PHAsset.fetchAssets(WithLocalIdentifiers), which does a synchronous fetch) or for example is just blocked by the semaphore, GCD sees the thread as idle and spins up a new worker thread. 
That new tasks are getting blocked by the semaphore, causing GCD to spawn yet another thread, and so on. In the crash logs from the linked issue, this is visible by the 50+ threads all stuck on semaphore_wait_trap on the thumbnail.processing queue. 

Usually, the UI/Main thread should still be doing its work. But if the UI Thread now starts to wait on something, the whole UI freezes.
The log itself, was only created later, when @Magnus987 tried to close the app. In the logs we then see that iOS tried to move the app into the background but the app didn't respond so It got killed after 5 seconds.

I guess under normal circumstances this isn't really noticeable, because the threads usually finish fast enough, to not cause stalling.

---

The fix: Instead of using DispatchQueue + DispatchSemaphore, we use OperationQueue which limits the actual threads spawned to the amount we specify. 

I am actually not sure if it fully fixes #27365 but now IOS doesn't have to kill the app anymore in such a case, and it could be that we missed some logs in the flutter because of that(?).

## How Has This Been Tested?

- IOS Simulator. Scrolling through the timeline, and opening random images 
- DISCLAIMER: Can't reproduce the crash the user had myself  

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
To discuss iOS/swift. Not really my language.