### PR TITLE
fix: user-agent format

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/HttpClientManager.kt
@@ -53,7 +53,7 @@ import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509KeyManager
 import javax.net.ssl.X509TrustManager
 
-const val USER_AGENT = "Immich_Android_${BuildConfig.VERSION_NAME}"
+const val USER_AGENT = "immich-android/${BuildConfig.VERSION_NAME}"
 private const val CERT_ALIAS = "client_cert"
 private const val PREFS_NAME = "immich.ssl"
 private const val PREFS_CERT_ALIAS = "immich.client_cert"

--- a/mobile/ios/Runner/Core/URLSessionManager.swift
+++ b/mobile/ios/Runner/Core/URLSessionManager.swift
@@ -36,7 +36,7 @@ extension UserDefaults {
 /// Old sessions are kept alive by Dart's FFI retain until all isolates release them.
 class URLSessionManager: NSObject {
   static let shared = URLSessionManager()
-  
+
   private(set) var session: URLSession
   let delegate: URLSessionManagerDelegate
   private static let cacheDir: URL = {
@@ -53,7 +53,7 @@ class URLSessionManager: NSObject {
   )
   static let userAgent: String = {
     let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
-    return "Immich_iOS_\(version)"
+    return "immich-ios/\(version)"
   }()
   static let cookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: APP_GROUP)
   private static var serverUrls: [String] = []

--- a/mobile/lib/utils/user_agent.dart
+++ b/mobile/lib/utils/user_agent.dart
@@ -5,11 +5,11 @@ Future<String> getUserAgentString() async {
   final packageInfo = await PackageInfo.fromPlatform();
   String platform;
   if (Platform.isAndroid) {
-    platform = 'Android';
+    platform = 'android';
   } else if (Platform.isIOS) {
-    platform = 'iOS';
+    platform = 'ios';
   } else {
-    platform = 'Unknown';
+    platform = 'unknown';
   }
-  return 'Immich_${platform}_${packageInfo.version}';
+  return 'immich-${platform}/${packageInfo.version}';
 }

--- a/mobile/lib/utils/user_agent.dart
+++ b/mobile/lib/utils/user_agent.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+
 import 'package:package_info_plus/package_info_plus.dart';
 
 Future<String> getUserAgentString() async {
@@ -11,5 +12,5 @@ Future<String> getUserAgentString() async {
   } else {
     platform = 'unknown';
   }
-  return 'immich-${platform}/${packageInfo.version}';
+  return 'immich-$platform/${packageInfo.version}';
 }

--- a/server/src/utils/request.spec.ts
+++ b/server/src/utils/request.spec.ts
@@ -1,0 +1,29 @@
+import { getAppVersionFromUA } from 'src/utils/request';
+
+describe(getAppVersionFromUA.name, () => {
+  it('should get the app version for android', () => {
+    expect(getAppVersionFromUA('immich-android/1.123.4')).toEqual('1.123.4');
+  });
+
+  it('should get the app version for ios', () => {
+    expect(getAppVersionFromUA('immich-ios/1.123.4')).toEqual('1.123.4');
+  });
+
+  it('should get the app version for unknown', () => {
+    expect(getAppVersionFromUA('immich-unknown/1.123.4')).toEqual('1.123.4');
+  });
+
+  describe('legacy format', () => {
+    it('should get the app version from the old android format', () => {
+      expect(getAppVersionFromUA('Immich_Android_1.123.4')).toEqual('1.123.4');
+    });
+
+    it('should get the app version from the old ios format', () => {
+      expect(getAppVersionFromUA('Immich_iOS_1.123.4')).toEqual('1.123.4');
+    });
+
+    it('should get the app version from the old unknown format', () => {
+      expect(getAppVersionFromUA('Immich_Unknown_1.123.4')).toEqual('1.123.4');
+    });
+  });
+});

--- a/server/src/utils/request.ts
+++ b/server/src/utils/request.ts
@@ -7,8 +7,11 @@ export const fromChecksum = (checksum: string): Buffer => {
 
 export const fromMaybeArray = <T>(param: T | T[]) => (Array.isArray(param) ? param[0] : param);
 
-const getAppVersionFromUA = (ua: string) =>
-  ua.match(/^Immich_(?:Android|iOS)_(?<appVersion>.+)$/)?.groups?.appVersion ?? null;
+export const getAppVersionFromUA = (ua: string) =>
+  ua.match(/^immich-(?:android|ios|unknown)\/(?<appVersion>.+)$/)?.groups?.appVersion ??
+  // legacy format
+  ua.match(/^Immich_(?:Android|iOS|Unknown)_(?<appVersion>.+)$/)?.groups?.appVersion ??
+  null;
 
 export const getUserAgentDetails = (headers: IncomingHttpHeaders) => {
   const userAgent = UAParser(headers['user-agent']);


### PR DESCRIPTION
Use `immich-android/{version}` and `immich-ios/{version}` instead of `Immich_{platform}_{version}`, which matches the user agent format used by the immich-server (`immich-server/{version}`)