### PR TITLE
chore(server): use dev version check endpoint for non-production environments

### DIFF
--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -75,6 +75,10 @@ export interface EnvData {
     server: string;
   };
 
+  versionCheck: {
+    url: string;
+  };
+
   network: {
     trustedProxies: string[];
   };
@@ -319,6 +323,10 @@ const getEnv = (): EnvData => {
     },
 
     licensePublicKey: isProd ? productionKeys : stagingKeys,
+
+    versionCheck: {
+      url: isProd ? 'https://version.immich.cloud/version' : 'https://version.dev.immich.cloud/version',
+    },
 
     network: {
       trustedProxies: dto.IMMICH_TRUSTED_PROXIES ?? ['linklocal', 'uniquelocal'],

--- a/server/src/repositories/server-info.repository.ts
+++ b/server/src/repositories/server-info.repository.ts
@@ -4,7 +4,6 @@ import { exec as execCallback } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import sharp from 'sharp';
-import { ImmichEnvironment } from 'src/enum';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 
@@ -67,10 +66,8 @@ export class ServerInfoRepository {
 
   async getLatestRelease(): Promise<VersionResponse> {
     try {
-      const { environment } = this.configRepository.getEnv();
-      const isDev = environment !== ImmichEnvironment.Production;
-      const url = isDev ? 'https://version.dev.immich.cloud/version' : 'https://version.immich.cloud/version';
-      const response = await fetch(url);
+      const { versionCheck } = this.configRepository.getEnv();
+      const response = await fetch(versionCheck.url);
 
       if (!response.ok) {
         throw new Error(`Version check request failed with status ${response.status}: ${await response.text()}`);

--- a/server/src/repositories/server-info.repository.ts
+++ b/server/src/repositories/server-info.repository.ts
@@ -4,6 +4,7 @@ import { exec as execCallback } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import sharp from 'sharp';
+import { ImmichEnvironment } from 'src/enum';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 
@@ -66,7 +67,10 @@ export class ServerInfoRepository {
 
   async getLatestRelease(): Promise<VersionResponse> {
     try {
-      const response = await fetch('https://version.immich.cloud/version');
+      const { environment } = this.configRepository.getEnv();
+      const isDev = environment !== ImmichEnvironment.Production;
+      const url = isDev ? 'https://version.dev.immich.cloud/version' : 'https://version.immich.cloud/version';
+      const response = await fetch(url);
 
       if (!response.ok) {
         throw new Error(`Version check request failed with status ${response.status}: ${await response.text()}`);

--- a/server/src/services/version.service.spec.ts
+++ b/server/src/services/version.service.spec.ts
@@ -2,9 +2,8 @@ import { DateTime } from 'luxon';
 import { SemVer } from 'semver';
 import { defaults } from 'src/config';
 import { serverVersion } from 'src/constants';
-import { ImmichEnvironment, JobName, JobStatus, SystemMetadataKey } from 'src/enum';
+import { JobName, JobStatus, SystemMetadataKey } from 'src/enum';
 import { VersionService } from 'src/services/version.service';
-import { mockEnvData } from 'test/repositories/config.repository.mock';
 import { factory } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
 
@@ -73,15 +72,6 @@ describe(VersionService.name, () => {
   });
 
   describe('handVersionCheck', () => {
-    beforeEach(() => {
-      mocks.config.getEnv.mockReturnValue(mockEnvData({ environment: ImmichEnvironment.Production }));
-    });
-
-    it('should not run in dev mode', async () => {
-      mocks.config.getEnv.mockReturnValue(mockEnvData({ environment: ImmichEnvironment.Development }));
-      await expect(sut.handleVersionCheck()).resolves.toEqual(JobStatus.Skipped);
-    });
-
     it('should not run if the last check was < 60 minutes ago', async () => {
       mocks.systemMetadata.get.mockResolvedValue({
         checkedAt: DateTime.utc().minus({ minutes: 5 }).toISO(),

--- a/server/src/services/version.service.ts
+++ b/server/src/services/version.service.ts
@@ -4,7 +4,7 @@ import semver, { SemVer } from 'semver';
 import { serverVersion } from 'src/constants';
 import { OnEvent, OnJob } from 'src/decorators';
 import { ReleaseNotification, ServerVersionResponseDto } from 'src/dtos/server.dto';
-import { DatabaseLock, ImmichEnvironment, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
+import { DatabaseLock, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
 import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { VersionCheckMetadata } from 'src/types';
@@ -70,11 +70,6 @@ export class VersionService extends BaseService {
   async handleVersionCheck(): Promise<JobStatus> {
     try {
       this.logger.debug('Running version check');
-
-      const { environment } = this.configRepository.getEnv();
-      if (environment === ImmichEnvironment.Development) {
-        return JobStatus.Skipped;
-      }
 
       const { newVersionCheck } = await this.getConfig({ withCache: true });
       if (!newVersionCheck.enabled) {

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -44,6 +44,10 @@ const envData: EnvData = {
     server: 'server-public-key',
   },
 
+  versionCheck: {
+    url: 'https://version.immich.cloud/version',
+  },
+
   network: {
     trustedProxies: [],
   },


### PR DESCRIPTION
Use version.dev.immich.cloud for development and testing environments instead of the production endpoint. Also enables version checks in dev mode, which were previously skipped entirely.