### PR TITLE
chore(mobile): add box shadow to asset details

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
@@ -26,6 +26,14 @@ class AssetDetails extends ConsumerWidget {
       decoration: BoxDecoration(
         color: context.colorScheme.surface,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.2),
+            offset: const Offset(0, -3),
+            blurRadius: 10,
+            spreadRadius: 2,
+          ),
+        ],
       ),
       child: SafeArea(
         top: false,


### PR DESCRIPTION


## Description

The details widget can blend with the image when they are similar colours.

## How Has This Been Tested?

Emulator

<details><summary><h2>Screenshots (before/after)</h2></summary>

<img width="676" height="545" alt="image" src="https://github.com/user-attachments/assets/691686c6-c39b-441d-ae71-9626d9c73fdd" />

<img width="679" height="559" alt="image" src="https://github.com/user-attachments/assets/0b8c3aad-793c-462c-ba6c-fc52584e77b7" />


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
