### PR TITLE
fix(mobile): use key on video controls

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -74,7 +74,7 @@ class ViewerBottomBar extends ConsumerWidget {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (asset.isVideo) VideoControls(videoPlayerName: asset.heroTag),
+                      if (asset.isVideo) VideoControls(key: ValueKey(asset.heroTag), videoPlayerName: asset.heroTag),
                       if (!isReadonlyModeEnabled)
                         Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: actions),
                     ],


### PR DESCRIPTION


## Description

The widget is not recreated correctly when videoPlayName changes, which can cause weird behaviour with hooks and timers (like timers not firing when they should do). Using a key forces flutter to recreate the widget properly and allow the assumptions in build to work correctly.

## How Has This Been Tested?

In an emulator. This fixes a specific issue where swiping from a video to another video with controls showing no longer hides the controls after 5s. 

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
