### PR TITLE
fix(mobile): fix stale refs in use timer

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -74,7 +74,7 @@ class ViewerBottomBar extends ConsumerWidget {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (asset.isVideo) VideoControls(key: ValueKey(asset.heroTag), videoPlayerName: asset.heroTag),
+                      if (asset.isVideo) VideoControls(videoPlayerName: asset.heroTag),
                       if (!isReadonlyModeEnabled)
                         Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: actions),
                     ],

--- a/mobile/lib/utils/hooks/timer_hook.dart
+++ b/mobile/lib/utils/hooks/timer_hook.dart
@@ -1,36 +1,17 @@
 import 'package:async/async.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-RestartableTimer useTimer(Duration duration, void Function() callback) {
-  return use(_TimerHook(duration: duration, callback: callback));
-}
+RestartableTimer useTimer(Duration duration, VoidCallback callback) {
+  final latest = useRef(callback);
+  latest.value = callback;
 
-class _TimerHook extends Hook<RestartableTimer> {
-  final Duration duration;
-  final void Function() callback;
+  final timer = useMemoized(
+    () => RestartableTimer(duration, () => latest.value()),
+    [duration],
+  );
 
-  const _TimerHook({required this.duration, required this.callback});
-  @override
-  HookState<RestartableTimer, Hook<RestartableTimer>> createState() => _TimerHookState();
-}
+  useEffect(() => timer.cancel, [timer]);
 
-class _TimerHookState extends HookState<RestartableTimer, _TimerHook> {
-  late RestartableTimer timer;
-  @override
-  void initHook() {
-    super.initHook();
-    timer = RestartableTimer(hook.duration, hook.callback);
-  }
-
-  @override
-  RestartableTimer build(BuildContext context) {
-    return timer;
-  }
-
-  @override
-  void dispose() {
-    timer.cancel();
-    super.dispose();
-  }
+  return timer;
 }


### PR DESCRIPTION


## Description

The timer hook preserved the values of the original local variables, which caused issues when hiding controls for videos. The callback can be changed so that it always sees the latest value with useRef, and it can be simplified significantly using a function rather than state class.

Followup from https://github.com/immich-app/immich/pull/27512. 

## How Has This Been Tested?

In an emulator.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
