### PR TITLE
fix(server): hide original filename in shared links when showMetadata is disabled

### DIFF
--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -212,9 +212,14 @@ export class AssetMediaService extends BaseService {
 
     const path = editedPath ?? originalPath!;
 
+    // Don't expose original filename when showMetadata is disabled for shared links
+    const shouldShowFilename = !auth.sharedLink || auth.sharedLink.showExif;
+
     return new ImmichFileResponse({
       path,
-      fileName: getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
+      fileName: shouldShowFilename
+        ? getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path)
+        : undefined,
       contentType: mimeTypes.lookup(path),
       cacheControl: CacheControl.PrivateWithCache,
     });
@@ -257,7 +262,11 @@ export class AssetMediaService extends BaseService {
       throw new NotFoundException('Asset media not found');
     }
 
-    const fileName = `${getFileNameWithoutExtension(originalFileName)}_${size}${getFilenameExtension(path)}`;
+    // Don't expose original filename when showMetadata is disabled for shared links
+    const shouldShowFilename = !auth.sharedLink || auth.sharedLink.showExif;
+    const fileName = shouldShowFilename
+      ? `${getFileNameWithoutExtension(originalFileName)}_${size}${getFilenameExtension(path)}`
+      : undefined;
 
     return new ImmichFileResponse({
       fileName,


### PR DESCRIPTION
## Description

When sharing photos with 'Show metadata' disabled, the original filename was still being exposed in the Content-Disposition header. This could compromise privacy as filenames often contain timestamps (e.g., IMG_20260331_....jpg).

## Changes

- Modified `downloadOriginal` to check if the request is from a shared link with `showExif=false`
- Modified `viewThumbnail` with the same check
- When metadata should be hidden, the filename is omitted from the response
- This prevents exposure of potentially sensitive information in the filename

## Security/Privacy Impact

This fixes a privacy issue where users sharing photos without metadata could still have the original filename exposed, which often contains:
- Date and time the photo was taken (e.g., IMG_20260331_143022.jpg)
- Device information
- Location hints

## Related Issue

Fixes #27495