### PR TITLE
fix(web): reset cursor style when slideshow bar unmounts

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -276,7 +276,6 @@
   const handleStopSlideshow = async () => {
     try {
       if (document.fullscreenElement) {
-        document.body.style.cursor = '';
         await document.exitFullscreen();
       }
     } catch (error) {

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -85,6 +85,7 @@
   });
 
   onDestroy(() => {
+    setCursorStyle('');
     if (unsubscribeRestart) {
       unsubscribeRestart();
     }


### PR DESCRIPTION
Move cursor style reset from handleStopSlideshow into slideshow-bar's onDestroy callback

This is cleaner, and ensures that the cursor is always restored when the slideshow bar unmounts, not only when explicitly stopping via the fullscreen exit path. 