### PR TITLE
feat(mobile): cancel BlockOperation in iOS RemoteImageImpl

### DIFF
--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -4,17 +4,23 @@ import MobileCoreServices
 import Photos
 
 class RemoteImageRequest: ImageRequest {
+  private let operationLock = UnfairLock()
   weak var task: URLSessionDataTask?
-  let id: Int64
-
-  init(id: Int64, task: URLSessionDataTask, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
-    self.id = id
-    self.task = task
-    super.init(callback: completion)
+  private weak var _operation: Operation?
+  // This needs to be thread safe because operation is set from a background thread, while onCancel is called from the main thread
+  weak var operation: Operation? {
+    get { operationLock.withLock { _operation } }
+    set { operationLock.withLock { _operation = newValue } }
   }
+
+  init(task: URLSessionDataTask, completion: @escaping (Result<[String: Int64]?, any Error>) -> Void) {
+      self.task = task
+      super.init(callback: completion)
+    }
 
   override func onCancel() {
     task?.cancel()
+    operation?.cancel()
   }
 }
 
@@ -42,7 +48,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
       Self.handleCompletion(requestId: requestId, encoded: preferEncoded, data: data, response: response, error: error)
     }
 
-    let request = RemoteImageRequest(id: requestId, task: task) { result in
+    let request = RemoteImageRequest(task: task) { result in
       Self.registry.remove(requestId: requestId)
       completion(result)
     }
@@ -70,7 +76,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
       return request.finish(with: .failure(PigeonError(code: "", message: "No data received", details: nil)))
     }
 
-    ImageProcessing.queue.addOperation {
+    let operation = BlockOperation {
       if request.isCancelled { return }
 
       // Return raw encoded bytes when requested (for animated images)
@@ -91,6 +97,9 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
         return request.finish(with: .failure(PigeonError(code: "", message: "Failed to convert image for request: \(error)", details: nil)))
       }
     }
+
+    request.operation = operation
+    ImageProcessing.queue.addOperation(operation)
   }
 
   func cancelRequest(requestId: Int64) {


### PR DESCRIPTION
## Description

Previously we could have queued a BlockOperation, cancelled it, and it would have launched a new thread just to check isCancelled.
With the changes in this PR the BlockOperation does internally in its start method see that the request got cancelled and just aborts launching a new thread.
I made the BlockOperation a part of the RemoteImageRequest and also cancel it incase request.cancel is called. 

**The kind of annoying part**: we need another lock because we add the BlockOperation in the request thread, and read it from the main thread to call cancel on it.

I think conceptually this is cleaner, but performance wise I didn't see any positive/negative impact when comparing request/cancellation timings.
 
I also thought about just creating an empty BlockOperation in the main thread when creating the request, but then we would have to call operation.addExecutionBlock later. I think the whole BlockOperation is thread safe so this shouldn't be a problem. But I am then not sure what kind of lock they are using internally and that could be anything (possibly worse in performance than the UnsafeLock). 

(Also removed id property from RemoteRequest as this wasn't used anywhere)

## How Has This Been Tested?

- Simulator: scrolling thought the timeline
- Compared request/cancel timings vs the base in #27489 Didn't find any meaning full difference.


## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
-