### PR TITLE
feat(server): Add support for .ts files

### DIFF
--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -28,17 +28,17 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 
 ## Video formats
 
-| Format      | Extension(s)          |     Supported?     | Notes |
-| :---------- | :-------------------- | :----------------: | :---- |
-| `3GPP`      | `.3gp` `.3gpp`        | :white_check_mark: |       |
-| `AVI`       | `.avi`                | :white_check_mark: |       |
-| `FLV`       | `.flv`                | :white_check_mark: |       |
-| `M4V`       | `.m4v`                | :white_check_mark: |       |
-| `MATROSKA`  | `.mkv`                | :white_check_mark: |       |
-| `MP2T`      | `.mts` `.m2ts` `.m2t` | :white_check_mark: |       |
-| `MP4`       | `.mp4` `.insv`        | :white_check_mark: |       |
-| `MPEG`      | `.mpg` `.mpe` `.mpeg` | :white_check_mark: |       |
-| `MXF`       | `.mxf`                | :white_check_mark: |       |
-| `QUICKTIME` | `.mov`                | :white_check_mark: |       |
-| `WEBM`      | `.webm`               | :white_check_mark: |       |
-| `WMV`       | `.wmv`                | :white_check_mark: |       |
+| Format      | Extension(s)                |     Supported?     | Notes |
+| :---------- | :-------------------------- | :----------------: | :---- |
+| `3GPP`      | `.3gp` `.3gpp`              | :white_check_mark: |       |
+| `AVI`       | `.avi`                      | :white_check_mark: |       |
+| `FLV`       | `.flv`                      | :white_check_mark: |       |
+| `M4V`       | `.m4v`                      | :white_check_mark: |       |
+| `MATROSKA`  | `.mkv`                      | :white_check_mark: |       |
+| `MP2T`      | `.mts` `.m2ts` `.m2t` `.ts` | :white_check_mark: |       |
+| `MP4`       | `.mp4` `.insv`              | :white_check_mark: |       |
+| `MPEG`      | `.mpg` `.mpe` `.mpeg`       | :white_check_mark: |       |
+| `MXF`       | `.mxf`                      | :white_check_mark: |       |
+| `QUICKTIME` | `.mov`                      | :white_check_mark: |       |
+| `WEBM`      | `.webm`                     | :white_check_mark: |       |
+| `WMV`       | `.wmv`                      | :white_check_mark: |       |

--- a/e2e/src/ui/mock-network/base-network.ts
+++ b/e2e/src/ui/mock-network/base-network.ts
@@ -173,6 +173,7 @@ export const setupBaseMockApiRoutes = async (context: BrowserContext, adminUserI
           '.mpeg',
           '.mpg',
           '.mts',
+          '.ts',
           '.vob',
           '.webm',
           '.wmv',

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -111,6 +111,7 @@ const validVideos = [
   '.mpg',
   '.mts',
   '.mxf',
+  '.ts',
   '.vob',
   '.webm',
   '.wmv',

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -83,6 +83,7 @@ describe('mimeTypes', () => {
     { mimetype: 'video/mp2t', extension: '.m2t' },
     { mimetype: 'video/mp2t', extension: '.m2ts' },
     { mimetype: 'video/mp2t', extension: '.mts' },
+    { mimetype: 'video/mp2t', extension: '.ts' },
     { mimetype: 'video/mp4', extension: '.mp4' },
     { mimetype: 'video/mpeg', extension: '.mpe' },
     { mimetype: 'video/mpeg', extension: '.mpeg' },

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -114,6 +114,7 @@ const video: Record<string, string[]> = {
   '.mpg': ['video/mpeg'],
   '.mts': ['video/mp2t'],
   '.mxf': ['application/mxf'],
+  '.ts': ['video/mp2t'],
   '.vob': ['video/mpeg'],
   '.webm': ['video/webm'],
   '.wmv': ['video/x-ms-wmv'],


### PR DESCRIPTION
## Description

.ts is another common [extension for video/MP2T](https://en.wikipedia.org/wiki/MPEG_transport_stream) and is functionally similar to .m2t files.
.ts will often be found on online/streaming content, while the other variations are more common on physical media.

## How Has This Been Tested?

- [x] Uploaded samples from https://filesamples.com/formats/ts

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="2075" height="1176" alt="Screenshot 2026-04-05 204031" src="https://github.com/user-attachments/assets/60d2aa43-6d2e-4925-b6cf-a6afcb6017fe" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs used
