### PR TITLE
fix(web): redirect authenticated users from login page

### DIFF
--- a/web/src/lib/managers/auth-manager.svelte.ts
+++ b/web/src/lib/managers/auth-manager.svelte.ts
@@ -41,12 +41,16 @@ class AuthManager {
     return this.#preferences;
   }
 
+  get hasSession() {
+    return this.#hasAuthCookie();
+  }
+
   async load() {
     if (authManager.authenticated) {
       return;
     }
 
-    if (!this.#hasAuthCookie()) {
+    if (!this.hasSession) {
       return;
     }
 

--- a/web/src/routes/auth/login/+page.ts
+++ b/web/src/routes/auth/login/+page.ts
@@ -1,3 +1,4 @@
+import { authManager } from '$lib/managers/auth-manager.svelte';
 import { serverConfigManager } from '$lib/managers/server-config-manager.svelte';
 import { Route } from '$lib/route';
 import { getFormatter } from '$lib/utils/i18n';
@@ -10,6 +11,13 @@ export const load = (async ({ parent, url }) => {
   if (!serverConfigManager.value.isInitialized) {
     // Admin not registered
     redirect(307, Route.register());
+  }
+
+  if (authManager.hasSession) {
+    await authManager.load();
+    if (authManager.authenticated && !serverConfigManager.value.maintenanceMode) {
+      redirect(307, url.searchParams.get('continue') || Route.photos());
+    }
   }
 
   const $t = await getFormatter();


### PR DESCRIPTION
Authenticated users visiting the login page were not redirected away. They could see the login form even though they were already signed in.

## Fix

In the login page load function, if the auth cookie is present, load the auth manager and — if a valid session was established — redirect to the `continue` query param destination (or `/photos` as fallback). Skipped when the server is in maintenance mode.

The cookie gate is exposed via a new `authManager.hasSession` getter so the cookie name stays encapsulated inside the auth manager. It also ensures the login page renders normally during logout: the server clears the cookie before the logout flow navigates here, so `hasSession` is false and no redirect fires, avoiding a bounce back to `/photos` while `authManager` is still mid-reset.
