### PR TITLE
chore(web): add three to deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.2)
+      three:
+        specifier: ^0.183.2
+        version: 0.183.2
       thumbhash:
         specifier: ^0.1.1
         version: 0.1.1
@@ -11511,8 +11514,8 @@ packages:
   three@0.179.1:
     resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
 
-  three@0.182.0:
-    resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -16168,7 +16171,7 @@ snapshots:
     dependencies:
       '@photo-sphere-viewer/core': 5.14.1
       '@photo-sphere-viewer/video-plugin': 5.14.1(@photo-sphere-viewer/core@5.14.1)
-      three: 0.182.0
+      three: 0.183.2
 
   '@photo-sphere-viewer/markers-plugin@5.14.1(@photo-sphere-viewer/core@5.14.1)':
     dependencies:
@@ -16186,7 +16189,7 @@ snapshots:
   '@photo-sphere-viewer/video-plugin@5.14.1(@photo-sphere-viewer/core@5.14.1)':
     dependencies:
       '@photo-sphere-viewer/core': 5.14.1
-      three: 0.182.0
+      three: 0.183.2
 
   '@photostructure/tz-lookup@11.5.0': {}
 
@@ -25028,7 +25031,7 @@ snapshots:
 
   three@0.179.1: {}
 
-  three@0.182.0: {}
+  three@0.183.2: {}
 
   throttleit@2.1.0: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -62,6 +62,7 @@
     "tabbable": "^6.2.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
+    "three": "^0.183.2",
     "thumbhash": "^0.1.1",
     "transformation-matrix": "^3.1.0",
     "uplot": "^1.6.32"


### PR DESCRIPTION
## Description

otherwise `vite rollup` fails to resolve this transitive dependency for photo-sphere-viewer when building without adding `--force` to `pnpm install`

## How Has This Been Tested?

the changes were made through a command, the addition of which to the AUR `immich-server` package's build() function allowed it to build without using `pnpm install --force` and allowed migration to `pnpm install`

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

i used `pnpm add` which is an algorithm therefore it's AI