### PR TITLE
fix(web): respect abort signal after timeline bucket fetches

### DIFF
--- a/web/src/lib/managers/timeline-manager/internal/load-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/load-support.svelte.ts
@@ -25,7 +25,7 @@ export async function loadFromTimeBuckets(
     { signal },
   );
 
-  if (!bucketResponse) {
+  if (!bucketResponse || signal.aborted) {
     return;
   }
 
@@ -38,7 +38,7 @@ export async function loadFromTimeBuckets(
       },
       { signal },
     );
-    if (!albumAssets) {
+    if (!albumAssets || signal.aborted) {
       return;
     }
     for (const id of albumAssets.id) {


### PR DESCRIPTION
`loadFromTimeBuckets` only checks the response after each `getTimeBucket` await, not whether the load was cancelled mid-flight. An aborted load can still mutate `albumAssets` and call `addAssets`, racing with newer loads.

This can cause the same asset being added multiple times to the same day - which can cause a `#each` iteration index violation. 

Bail out if signal.aborted after each await.