### PR TITLE
fix(web): scrubber drag handles mouseup outside window

### DIFF
--- a/web/src/lib/components/timeline/Scrubber.svelte
+++ b/web/src/lib/components/timeline/Scrubber.svelte
@@ -493,7 +493,13 @@
 
 <svelte:window
   bind:innerHeight={windowHeight}
-  onmousemove={({ clientY }) => (isDragging || isHover) && handleMouseEvent({ clientY })}
+  onmousemove={(e) => {
+    if (isDragging && (e.buttons & 1) === 0) {
+      handleMouseEvent({ clientY: e.clientY, isDragging: false });
+    } else if (isDragging || isHover) {
+      handleMouseEvent({ clientY: e.clientY });
+    }
+  }}
   onmousedown={({ clientY }) => isHover && handleMouseEvent({ clientY, isDragging: true })}
   onmouseup={({ clientY }) => handleMouseEvent({ clientY, isDragging: false })}
 />


### PR DESCRIPTION
## Problem
Releasing the mouse outside the browser window during a scrubber drag leaves
`isDragging` stuck on, so the timeline keeps scrubbing the next time the cursor
re-enters. The window-level `mouseup` listener never fires because the release
happens on an element outside the document.

## Fix
On `mousemove`, end the drag if the primary button is no longer held
(`(e.buttons & 1) === 0`).