### PR TITLE
fix: allow bots to access /s/ urls 

### DIFF
--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,6 +1,7 @@
 # Allow social media access og Tags
 User-agent: *
 Allow: /share/
+Allow: /s/
 Allow: /api/assets/
 
 # https://www.robotstxt.org/robotstxt.html


### PR DESCRIPTION
## Description

My change adds `Accept: /s/` line to the robots.txt file, which allows Social Media platforms to scrape not only default share urls, but also Custom URLs.
Without it, e.g. Facebook didn't show preview block with thumbnail and album title for custom urls (first box in "Create share URL" dialog), while everything worked correctly with default url (with that box left empty).

Fixes #27548

## How Has This Been Tested?

I spun up additional instance where I replaced the robots.txt with version from this PR and exactly the same config as my first instance, created custom share link and pasted it into Messenger chat. It correctly generated preview box.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
