### PR TITLE
fix(server): hide original filename when not showing metadata

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -692,6 +692,24 @@ describe(AssetMediaService.name, () => {
       );
       expect(mocks.asset.getForThumbnail).toHaveBeenCalledWith(asset.id, AssetFileType.Thumbnail, true);
     });
+
+    it('should not include original filename if requested using a shared link with showExif false', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).build();
+
+      mocks.access.asset.checkSharedLinkAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForThumbnail.mockResolvedValue({ ...asset, path: asset.files[0].path });
+
+      const auth = AuthFactory.from().sharedLink({ showExif: false }).build();
+
+      await expect(sut.viewThumbnail(auth, asset.id, { size: AssetMediaSize.PREVIEW })).resolves.toEqual(
+        new ImmichFileResponse({
+          path: asset.files[0].path,
+          cacheControl: CacheControl.PrivateWithCache,
+          contentType: 'image/jpeg',
+          fileName: `${asset.id}_preview.jpg`,
+        }),
+      );
+    });
   });
 
   describe('playbackVideo', () => {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -257,7 +257,9 @@ export class AssetMediaService extends BaseService {
       throw new NotFoundException('Asset media not found');
     }
 
-    const fileName = `${getFileNameWithoutExtension(originalFileName)}_${size}${getFilenameExtension(path)}`;
+    const fileNameBase =
+      auth.sharedLink && !auth.sharedLink.showExif ? id : getFileNameWithoutExtension(originalFileName);
+    const fileName = `${fileNameBase}_${size}${getFilenameExtension(path)}`;
 
     return new ImmichFileResponse({
       fileName,


### PR DESCRIPTION
## Description
Don't attach the original filename to generated thumb/preview, when viewing from a shared link with "show metadata" / `showExif` is disabled/false.

Fixes #27495

## How Has This Been Tested?
- New test case
- Tested in browser

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
