### PR TITLE
Add asset sorting by size and album total size tracking

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2174,6 +2174,7 @@
   "sort_oldest": "Oldest photo",
   "sort_people_by_similarity": "Sort people by similarity",
   "sort_recent": "Most recent photo",
+  "sort_size": "Size",
   "sort_title": "Title",
   "source": "Source",
   "stack": "Stack",

--- a/mobile/lib/entities/album.entity.dart
+++ b/mobile/lib/entities/album.entity.dart
@@ -60,6 +60,9 @@ class Album {
   @ignore
   int remoteAssetCount = 0;
 
+  @ignore
+  int? totalSize;
+
   // getters
   @ignore
   bool get isRemote => remoteId != null;
@@ -157,6 +160,7 @@ class Album {
       activityEnabled: dto.isActivityEnabled,
     );
     a.remoteAssetCount = dto.assetCount;
+    a.totalSize = dto.totalSize;
     a.owner.value = await db.users.getById(dto.ownerId);
     if (dto.order != null) {
       a.sortOrder = dto.order == AssetOrder.asc ? SortOrder.asc : SortOrder.desc;

--- a/mobile/lib/providers/album/album_sort_by_options.provider.dart
+++ b/mobile/lib/providers/album/album_sort_by_options.provider.dart
@@ -70,6 +70,14 @@ class _AlbumSortHandlers {
     });
     return (isReverse ? sorted.reversed : sorted).toList();
   }
+
+  static const AlbumSortFn totalSize = _sortByTotalSize;
+  static List<Album> _sortByTotalSize(List<Album> albums, bool isReverse) {
+    final sorted = albums.sorted(
+      (a, b) => (a.totalSize ?? 0).compareTo(b.totalSize ?? 0),
+    );
+    return (isReverse ? sorted.reversed : sorted).toList();
+  }
 }
 
 // Store index allows us to re-arrange the values without affecting the saved prefs
@@ -79,7 +87,8 @@ enum AlbumSortMode {
   lastModified(3, "library_page_sort_last_modified", _AlbumSortHandlers.lastModified, SortOrder.desc),
   created(0, "library_page_sort_created", _AlbumSortHandlers.created, SortOrder.desc),
   mostRecent(2, "sort_recent", _AlbumSortHandlers.mostRecent, SortOrder.desc),
-  mostOldest(5, "sort_oldest", _AlbumSortHandlers.mostOldest, SortOrder.asc);
+  mostOldest(5, "sort_oldest", _AlbumSortHandlers.mostOldest, SortOrder.asc),
+  totalSize(6, "sort_size", _AlbumSortHandlers.totalSize, SortOrder.desc);
 
   final int storeIndex;
   final String label;

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -389,6 +389,7 @@ Class | Method | HTTP request | Description
  - [AssetOcrResponseDto](doc//AssetOcrResponseDto.md)
  - [AssetOrder](doc//AssetOrder.md)
  - [AssetResponseDto](doc//AssetResponseDto.md)
+ - [AssetSortField](doc//AssetSortField.md)
  - [AssetStackResponseDto](doc//AssetStackResponseDto.md)
  - [AssetStatsResponseDto](doc//AssetStatsResponseDto.md)
  - [AssetTypeEnum](doc//AssetTypeEnum.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -127,6 +127,7 @@ part 'model/asset_metadata_upsert_item_dto.dart';
 part 'model/asset_ocr_response_dto.dart';
 part 'model/asset_order.dart';
 part 'model/asset_response_dto.dart';
+part 'model/asset_sort_field.dart';
 part 'model/asset_stack_response_dto.dart';
 part 'model/asset_stats_response_dto.dart';
 part 'model/asset_type_enum.dart';

--- a/mobile/openapi/lib/api/timeline_api.dart
+++ b/mobile/openapi/lib/api/timeline_api.dart
@@ -49,6 +49,9 @@ class TimelineApi {
   ///
   /// * [String] slug:
   ///
+  /// * [AssetSortField] sortBy:
+  ///   Field to sort assets by (date or size)
+  ///
   /// * [String] tagId:
   ///   Filter assets with a specific tag
   ///
@@ -66,7 +69,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, AssetSortField? sortBy, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/bucket';
 
@@ -100,6 +103,9 @@ class TimelineApi {
     }
     if (slug != null) {
       queryParams.addAll(_queryParams('', 'slug', slug));
+    }
+    if (sortBy != null) {
+      queryParams.addAll(_queryParams('', 'sortBy', sortBy));
     }
     if (tagId != null) {
       queryParams.addAll(_queryParams('', 'tagId', tagId));
@@ -166,6 +172,9 @@ class TimelineApi {
   ///
   /// * [String] slug:
   ///
+  /// * [AssetSortField] sortBy:
+  ///   Field to sort assets by (date or size)
+  ///
   /// * [String] tagId:
   ///   Filter assets with a specific tag
   ///
@@ -183,8 +192,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
-    final response = await getTimeBucketWithHttpInfo(timeBucket,  albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
+  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, AssetSortField? sortBy, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+    final response = await getTimeBucketWithHttpInfo(timeBucket,  albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, personId: personId, slug: slug, sortBy: sortBy, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -228,6 +237,9 @@ class TimelineApi {
   ///
   /// * [String] slug:
   ///
+  /// * [AssetSortField] sortBy:
+  ///   Field to sort assets by (date or size)
+  ///
   /// * [String] tagId:
   ///   Filter assets with a specific tag
   ///
@@ -245,7 +257,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, AssetSortField? sortBy, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/buckets';
 
@@ -279,6 +291,9 @@ class TimelineApi {
     }
     if (slug != null) {
       queryParams.addAll(_queryParams('', 'slug', slug));
+    }
+    if (sortBy != null) {
+      queryParams.addAll(_queryParams('', 'sortBy', sortBy));
     }
     if (tagId != null) {
       queryParams.addAll(_queryParams('', 'tagId', tagId));
@@ -341,6 +356,9 @@ class TimelineApi {
   ///
   /// * [String] slug:
   ///
+  /// * [AssetSortField] sortBy:
+  ///   Field to sort assets by (date or size)
+  ///
   /// * [String] tagId:
   ///   Filter assets with a specific tag
   ///
@@ -358,8 +376,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
-    final response = await getTimeBucketsWithHttpInfo( albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
+  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, String? personId, String? slug, AssetSortField? sortBy, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+    final response = await getTimeBucketsWithHttpInfo( albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, personId: personId, slug: slug, sortBy: sortBy, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -300,6 +300,8 @@ class ApiClient {
           return AssetOrderTypeTransformer().decode(value);
         case 'AssetResponseDto':
           return AssetResponseDto.fromJson(value);
+        case 'AssetSortField':
+          return AssetSortFieldTypeTransformer().decode(value);
         case 'AssetStackResponseDto':
           return AssetStackResponseDto.fromJson(value);
         case 'AssetStatsResponseDto':

--- a/mobile/openapi/lib/api_helper.dart
+++ b/mobile/openapi/lib/api_helper.dart
@@ -73,6 +73,9 @@ String parameterToString(dynamic value) {
   if (value is AssetOrder) {
     return AssetOrderTypeTransformer().encode(value).toString();
   }
+  if (value is AssetSortField) {
+    return AssetSortFieldTypeTransformer().encode(value).toString();
+  }
   if (value is AssetTypeEnum) {
     return AssetTypeEnumTypeTransformer().encode(value).toString();
   }

--- a/mobile/openapi/lib/model/album_response_dto.dart
+++ b/mobile/openapi/lib/model/album_response_dto.dart
@@ -31,6 +31,7 @@ class AlbumResponseDto {
     required this.ownerId,
     required this.shared,
     this.startDate,
+    this.totalSize,
     required this.updatedAt,
   });
 
@@ -108,6 +109,15 @@ class AlbumResponseDto {
   ///
   DateTime? startDate;
 
+  /// Total size of all assets in the album in bytes
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  int? totalSize;
+
   /// Last update date
   DateTime updatedAt;
 
@@ -131,6 +141,7 @@ class AlbumResponseDto {
     other.ownerId == ownerId &&
     other.shared == shared &&
     other.startDate == startDate &&
+    other.totalSize == totalSize &&
     other.updatedAt == updatedAt;
 
   @override
@@ -154,10 +165,11 @@ class AlbumResponseDto {
     (ownerId.hashCode) +
     (shared.hashCode) +
     (startDate == null ? 0 : startDate!.hashCode) +
+    (totalSize == null ? 0 : totalSize!.hashCode) +
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'AlbumResponseDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, albumUsers=$albumUsers, assetCount=$assetCount, assets=$assets, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, order=$order, owner=$owner, ownerId=$ownerId, shared=$shared, startDate=$startDate, updatedAt=$updatedAt]';
+  String toString() => 'AlbumResponseDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, albumUsers=$albumUsers, assetCount=$assetCount, assets=$assets, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, order=$order, owner=$owner, ownerId=$ownerId, shared=$shared, startDate=$startDate, totalSize=$totalSize, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -199,6 +211,11 @@ class AlbumResponseDto {
     } else {
     //  json[r'startDate'] = null;
     }
+    if (this.totalSize != null) {
+      json[r'totalSize'] = this.totalSize;
+    } else {
+    //  json[r'totalSize'] = null;
+    }
       json[r'updatedAt'] = this.updatedAt.toUtc().toIso8601String();
     return json;
   }
@@ -230,6 +247,7 @@ class AlbumResponseDto {
         ownerId: mapValueOfType<String>(json, r'ownerId')!,
         shared: mapValueOfType<bool>(json, r'shared')!,
         startDate: mapDateTime(json, r'startDate', r''),
+        totalSize: mapValueOfType<int>(json, r'totalSize'),
         updatedAt: mapDateTime(json, r'updatedAt', r'')!,
       );
     }

--- a/mobile/openapi/lib/model/asset_sort_field.dart
+++ b/mobile/openapi/lib/model/asset_sort_field.dart
@@ -1,0 +1,85 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+/// Field to sort assets by (date or size)
+class AssetSortField {
+  /// Instantiate a new enum with the provided [value].
+  const AssetSortField._(this.value);
+
+  /// The underlying value of this enum member.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  String toJson() => value;
+
+  static const date = AssetSortField._(r'date');
+  static const size = AssetSortField._(r'size');
+
+  /// List of all possible values in this [enum][AssetSortField].
+  static const values = <AssetSortField>[
+    date,
+    size,
+  ];
+
+  static AssetSortField? fromJson(dynamic value) => AssetSortFieldTypeTransformer().decode(value);
+
+  static List<AssetSortField> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <AssetSortField>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = AssetSortField.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+}
+
+/// Transformation class that can [encode] an instance of [AssetSortField] to String,
+/// and [decode] dynamic data back to [AssetSortField].
+class AssetSortFieldTypeTransformer {
+  factory AssetSortFieldTypeTransformer() => _instance ??= const AssetSortFieldTypeTransformer._();
+
+  const AssetSortFieldTypeTransformer._();
+
+  String encode(AssetSortField data) => data.value;
+
+  /// Decodes a [dynamic value][data] to a AssetSortField.
+  ///
+  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
+  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
+  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
+  ///
+  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
+  /// and users are still using an old app with the old code.
+  AssetSortField? decode(dynamic data, {bool allowNull = true}) {
+    if (data != null) {
+      switch (data) {
+        case r'date': return AssetSortField.date;
+        case r'size': return AssetSortField.size;
+        default:
+          if (!allowNull) {
+            throw ArgumentError('Unknown enum value to decode: $data');
+          }
+      }
+    }
+    return null;
+  }
+
+  /// Singleton [AssetSortFieldTypeTransformer] instance.
+  static AssetSortFieldTypeTransformer? _instance;
+}
+

--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -42,6 +42,7 @@ class MetadataSearchDto {
     this.previewPath,
     this.rating,
     this.size,
+    this.sortBy,
     this.state,
     this.tagIds = const [],
     this.takenAfter,
@@ -274,6 +275,15 @@ class MetadataSearchDto {
   ///
   num? size;
 
+  /// Field to sort assets by (date or size)
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  AssetSortField? sortBy;
+
   /// Filter by state/province name
   String? state;
 
@@ -428,6 +438,7 @@ class MetadataSearchDto {
     other.previewPath == previewPath &&
     other.rating == rating &&
     other.size == size &&
+    other.sortBy == sortBy &&
     other.state == state &&
     _deepEquality.equals(other.tagIds, tagIds) &&
     other.takenAfter == takenAfter &&
@@ -476,6 +487,7 @@ class MetadataSearchDto {
     (previewPath == null ? 0 : previewPath!.hashCode) +
     (rating == null ? 0 : rating!.hashCode) +
     (size == null ? 0 : size!.hashCode) +
+    (sortBy == null ? 0 : sortBy!.hashCode) +
     (state == null ? 0 : state!.hashCode) +
     (tagIds == null ? 0 : tagIds!.hashCode) +
     (takenAfter == null ? 0 : takenAfter!.hashCode) +
@@ -493,7 +505,7 @@ class MetadataSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, ocr=$ocr, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, ocr=$ocr, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, sortBy=$sortBy, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -630,6 +642,11 @@ class MetadataSearchDto {
     } else {
     //  json[r'size'] = null;
     }
+    if (this.sortBy != null) {
+      json[r'sortBy'] = this.sortBy;
+    } else {
+    //  json[r'sortBy'] = null;
+    }
     if (this.state != null) {
       json[r'state'] = this.state;
     } else {
@@ -752,6 +769,7 @@ class MetadataSearchDto {
             ? null
             : num.parse('${json[r'rating']}'),
         size: num.parse('${json[r'size']}'),
+        sortBy: AssetSortField.fromJson(json[r'sortBy']),
         state: mapValueOfType<String>(json, r'state'),
         tagIds: json[r'tagIds'] is Iterable
             ? (json[r'tagIds'] as Iterable).cast<String>().toList(growable: false)

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -13600,6 +13600,15 @@
             }
           },
           {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "description": "Field to sort assets by (date or size)",
+            "schema": {
+              "$ref": "#/components/schemas/AssetSortField"
+            }
+          },
+          {
             "name": "tagId",
             "required": false,
             "in": "query",
@@ -13783,6 +13792,15 @@
             "in": "query",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "description": "Field to sort assets by (date or size)",
+            "schema": {
+              "$ref": "#/components/schemas/AssetSortField"
             }
           },
           {
@@ -15699,6 +15717,10 @@
             "format": "date-time",
             "type": "string"
           },
+          "totalSize": {
+            "description": "Total size of all assets in the album in bytes",
+            "type": "integer"
+          },
           "updatedAt": {
             "description": "Last update date",
             "format": "date-time",
@@ -17233,6 +17255,14 @@
           "width"
         ],
         "type": "object"
+      },
+      "AssetSortField": {
+        "description": "Field to sort assets by (date or size)",
+        "enum": [
+          "date",
+          "size"
+        ],
+        "type": "string"
       },
       "AssetStackResponseDto": {
         "properties": {
@@ -19178,6 +19208,14 @@
             "maximum": 1000,
             "minimum": 1,
             "type": "number"
+          },
+          "sortBy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AssetSortField"
+              }
+            ],
+            "description": "Field to sort assets by (date or size)"
           },
           "state": {
             "description": "Filter by state/province name",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -668,6 +668,8 @@ export type AlbumResponseDto = {
     shared: boolean;
     /** Start date (earliest asset) */
     startDate?: string;
+    /** Total size of all assets in the album in bytes */
+    totalSize?: number;
     /** Last update date */
     updatedAt: string;
 };
@@ -1730,6 +1732,8 @@ export type MetadataSearchDto = {
     rating?: number | null;
     /** Number of results to return */
     size?: number;
+    /** Field to sort assets by (date or size) */
+    sortBy?: AssetSortField;
     /** Filter by state/province name */
     state?: string | null;
     /** Filter by tag IDs */
@@ -6446,7 +6450,7 @@ export function tagAssets({ id, bulkIdsDto }: {
 /**
  * Get time bucket
  */
-export function getTimeBucket({ albumId, bbox, isFavorite, isTrashed, key, order, personId, slug, tagId, timeBucket, userId, visibility, withCoordinates, withPartners, withStacked }: {
+export function getTimeBucket({ albumId, bbox, isFavorite, isTrashed, key, order, personId, slug, sortBy, tagId, timeBucket, userId, visibility, withCoordinates, withPartners, withStacked }: {
     albumId?: string;
     bbox?: string;
     isFavorite?: boolean;
@@ -6455,6 +6459,7 @@ export function getTimeBucket({ albumId, bbox, isFavorite, isTrashed, key, order
     order?: AssetOrder;
     personId?: string;
     slug?: string;
+    sortBy?: AssetSortField;
     tagId?: string;
     timeBucket: string;
     userId?: string;
@@ -6475,6 +6480,7 @@ export function getTimeBucket({ albumId, bbox, isFavorite, isTrashed, key, order
         order,
         personId,
         slug,
+        sortBy,
         tagId,
         timeBucket,
         userId,
@@ -6489,7 +6495,7 @@ export function getTimeBucket({ albumId, bbox, isFavorite, isTrashed, key, order
 /**
  * Get time buckets
  */
-export function getTimeBuckets({ albumId, bbox, isFavorite, isTrashed, key, order, personId, slug, tagId, userId, visibility, withCoordinates, withPartners, withStacked }: {
+export function getTimeBuckets({ albumId, bbox, isFavorite, isTrashed, key, order, personId, slug, sortBy, tagId, userId, visibility, withCoordinates, withPartners, withStacked }: {
     albumId?: string;
     bbox?: string;
     isFavorite?: boolean;
@@ -6498,6 +6504,7 @@ export function getTimeBuckets({ albumId, bbox, isFavorite, isTrashed, key, orde
     order?: AssetOrder;
     personId?: string;
     slug?: string;
+    sortBy?: AssetSortField;
     tagId?: string;
     userId?: string;
     visibility?: AssetVisibility;
@@ -6517,6 +6524,7 @@ export function getTimeBuckets({ albumId, bbox, isFavorite, isTrashed, key, orde
         order,
         personId,
         slug,
+        sortBy,
         tagId,
         userId,
         visibility,
@@ -7246,6 +7254,10 @@ export enum JobName {
     OcrQueueAll = "OcrQueueAll",
     Ocr = "Ocr",
     WorkflowRun = "WorkflowRun"
+}
+export enum AssetSortField {
+    Date = "date",
+    Size = "size"
 }
 export enum SearchSuggestionType {
     Country = "country",

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -185,6 +185,8 @@ export class AlbumResponseDto {
   isActivityEnabled!: boolean;
   @ValidateEnum({ enum: AssetOrder, name: 'AssetOrder', description: 'Asset sort order', optional: true })
   order?: AssetOrder;
+  @ApiPropertyOptional({ type: 'integer', description: 'Total size of all assets in the album in bytes' })
+  totalSize?: number;
 
   // Description lives on schema to avoid duplication
   @ApiPropertyOptional({ description: undefined })

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -5,7 +5,7 @@ import { Place } from 'src/database';
 import { HistoryBuilder, Property } from 'src/decorators';
 import { AlbumResponseDto } from 'src/dtos/album.dto';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
-import { AssetOrder, AssetType, AssetVisibility } from 'src/enum';
+import { AssetOrder, AssetSortField, AssetType, AssetVisibility } from 'src/enum';
 import { Optional, ValidateBoolean, ValidateDate, ValidateEnum, ValidateString, ValidateUUID } from 'src/validation';
 
 class BaseSearchDto {
@@ -213,6 +213,14 @@ export class MetadataSearchDto extends RandomSearchDto {
     description: 'Sort order',
   })
   order?: AssetOrder;
+
+  @ValidateEnum({
+    enum: AssetSortField,
+    name: 'AssetSortField',
+    optional: true,
+    description: 'Field to sort assets by (date or size)',
+  })
+  sortBy?: AssetSortField;
 
   @ApiPropertyOptional({ type: 'number', description: 'Page number', minimum: 1 })
   @IsInt()

--- a/server/src/dtos/time-bucket.dto.ts
+++ b/server/src/dtos/time-bucket.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 import type { BBoxDto } from 'src/dtos/bbox.dto';
-import { AssetOrder, AssetVisibility } from 'src/enum';
+import { AssetOrder, AssetSortField, AssetVisibility } from 'src/enum';
 import { ValidateBBox } from 'src/utils/bbox';
 import { ValidateBoolean, ValidateEnum, ValidateUUID } from 'src/validation';
 
@@ -46,6 +46,14 @@ export class TimeBucketDto {
     optional: true,
   })
   order?: AssetOrder;
+
+  @ValidateEnum({
+    enum: AssetSortField,
+    name: 'AssetSortField',
+    description: 'Field to sort assets by (date or size)',
+    optional: true,
+  })
+  sortBy?: AssetSortField;
 
   @ValidateEnum({
     enum: AssetVisibility,

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -63,6 +63,11 @@ export enum AssetOrder {
   Desc = 'desc',
 }
 
+export enum AssetSortField {
+  Date = 'date',
+  Size = 'size',
+}
+
 export enum DatabaseAction {
   Create = 'CREATE',
   Update = 'UPDATE',

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -25,6 +25,7 @@ export interface AlbumAssetCount {
   startDate: Date | null;
   endDate: Date | null;
   lastModifiedAssetTimestamp: Date | null;
+  totalSize: number;
 }
 
 export interface AlbumInfoOptions {
@@ -176,12 +177,14 @@ export class AlbumRepository {
         .selectFrom('asset')
         .$call(withDefaultVisibility)
         .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
+        .leftJoin('asset_exif', 'asset.id', 'asset_exif.assetId')
         .select('album_asset.albumId as albumId')
         .select((eb) => eb.fn.min(sql<Date>`("asset"."localDateTime" AT TIME ZONE 'UTC'::text)::date`).as('startDate'))
         .select((eb) => eb.fn.max(sql<Date>`("asset"."localDateTime" AT TIME ZONE 'UTC'::text)::date`).as('endDate'))
         // lastModifiedAssetTimestamp is only used in mobile app, please remove if not need
         .select((eb) => eb.fn.max('asset.updatedAt').as('lastModifiedAssetTimestamp'))
         .select((eb) => sql<number>`${eb.fn.count('asset.id')}::int`.as('assetCount'))
+        .select((eb) => sql<number>`coalesce(${eb.fn.sum('asset_exif.fileSizeInByte')}, 0)::bigint`.as('totalSize'))
         .where('album_asset.albumId', 'in', ids)
         .where('asset.deletedAt', 'is', null)
         .groupBy('album_asset.albumId')

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -17,7 +17,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { LockableProperty, Stack } from 'src/database';
 import { Chunked, ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { AssetFileType, AssetOrder, AssetStatus, AssetType, AssetVisibility } from 'src/enum';
+import { AssetFileType, AssetOrder, AssetSortField, AssetStatus, AssetType, AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
 import { AssetFileTable } from 'src/schema/tables/asset-file.table';
@@ -88,6 +88,7 @@ interface AssetBuilderOptions {
 
 export interface TimeBucketOptions extends AssetBuilderOptions {
   order?: AssetOrder;
+  sortBy?: AssetSortField;
 }
 
 export interface TimeBucketItem {
@@ -848,8 +849,14 @@ export class AssetRepository {
           )
           .$if(!!options.isTrashed, (qb) => qb.where('asset.status', '!=', AssetStatus.Deleted))
           .$if(!!options.tagId, (qb) => withTagId(qb, options.tagId!))
-          .orderBy(sql`(asset."localDateTime" AT TIME ZONE 'UTC')::date`, order)
-          .orderBy('asset.fileCreatedAt', order),
+          .$if(options.sortBy === AssetSortField.Size, (qb) =>
+            qb.orderBy('asset_exif.fileSizeInByte', order).orderBy('asset.fileCreatedAt', order),
+          )
+          .$if(options.sortBy !== AssetSortField.Size, (qb) =>
+            qb
+              .orderBy(sql`(asset."localDateTime" AT TIME ZONE 'UTC')::date`, order)
+              .orderBy('asset.fileCreatedAt', order),
+          ),
       )
       .with('agg', (qb) =>
         qb

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -102,6 +102,7 @@ export interface SearchAlbumOptions {
 
 export interface SearchOrderOptions {
   orderDirection?: 'asc' | 'desc';
+  sortBy?: 'date' | 'size';
 }
 
 export interface SearchPaginationOptions {
@@ -201,7 +202,10 @@ export class SearchRepository {
     const orderDirection = (options.orderDirection?.toLowerCase() || 'desc') as OrderByDirection;
     const items = await searchAssetBuilder(this.db, options)
       .selectAll('asset')
-      .orderBy('asset.fileCreatedAt', orderDirection)
+      .$if(options.sortBy === 'size', (qb) =>
+        qb.innerJoin('asset_exif', 'asset.id', 'asset_exif.assetId').orderBy('asset_exif.fileSizeInByte', orderDirection),
+      )
+      .$if(options.sortBy !== 'size', (qb) => qb.orderBy('asset.fileCreatedAt', orderDirection))
       .limit(pagination.size + 1)
       .offset((pagination.page - 1) * pagination.size)
       .execute();

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -53,6 +53,7 @@ describe(AlbumService.name, () => {
           startDate: null,
           endDate: null,
           lastModifiedAssetTimestamp: null,
+          totalSize: 0,
         },
         {
           albumId: sharedWithUserAlbum.id,
@@ -60,6 +61,7 @@ describe(AlbumService.name, () => {
           startDate: null,
           endDate: null,
           lastModifiedAssetTimestamp: null,
+          totalSize: 0,
         },
       ]);
 
@@ -84,6 +86,7 @@ describe(AlbumService.name, () => {
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
           lastModifiedAssetTimestamp: new Date('1970-01-01'),
+          totalSize: 0,
         },
       ]);
 
@@ -103,6 +106,7 @@ describe(AlbumService.name, () => {
           startDate: null,
           endDate: null,
           lastModifiedAssetTimestamp: null,
+          totalSize: 0,
         },
       ]);
 
@@ -122,6 +126,7 @@ describe(AlbumService.name, () => {
           startDate: null,
           endDate: null,
           lastModifiedAssetTimestamp: null,
+          totalSize: 0,
         },
       ]);
 
@@ -142,6 +147,7 @@ describe(AlbumService.name, () => {
         startDate: new Date('1970-01-01'),
         endDate: new Date('1970-01-01'),
         lastModifiedAssetTimestamp: new Date('1970-01-01'),
+        totalSize: 0,
       },
     ]);
 
@@ -560,6 +566,7 @@ describe(AlbumService.name, () => {
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
           lastModifiedAssetTimestamp: new Date('1970-01-01'),
+          totalSize: 0,
         },
       ]);
 
@@ -580,6 +587,7 @@ describe(AlbumService.name, () => {
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
           lastModifiedAssetTimestamp: new Date('1970-01-01'),
+          totalSize: 0,
         },
       ]);
 
@@ -602,6 +610,7 @@ describe(AlbumService.name, () => {
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
           lastModifiedAssetTimestamp: new Date('1970-01-01'),
+          totalSize: 0,
         },
       ]);
 

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -68,6 +68,7 @@ export class AlbumService extends BaseService {
       startDate: asDateString(albumMetadata[album.id]?.startDate ?? undefined),
       endDate: asDateString(albumMetadata[album.id]?.endDate ?? undefined),
       assetCount: albumMetadata[album.id]?.assetCount ?? 0,
+      totalSize: albumMetadata[album.id]?.totalSize ?? 0,
       // lastModifiedAssetTimestamp is only used in mobile app, please remove if not need
       lastModifiedAssetTimestamp: asDateString(albumMetadata[album.id]?.lastModifiedAssetTimestamp ?? undefined),
     }));
@@ -89,6 +90,7 @@ export class AlbumService extends BaseService {
       startDate: asDateString(albumMetadataForIds?.startDate ?? undefined),
       endDate: asDateString(albumMetadataForIds?.endDate ?? undefined),
       assetCount: albumMetadataForIds?.assetCount ?? 0,
+      totalSize: albumMetadataForIds?.totalSize ?? 0,
       lastModifiedAssetTimestamp: asDateString(albumMetadataForIds?.lastModifiedAssetTimestamp ?? undefined),
       contributorCounts: isShared ? await this.albumRepository.getContributorCounts(album.id) : undefined,
     };

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -282,6 +282,7 @@ describe(StorageTemplateService.name, () => {
           albumId: album.id,
           assetCount: 1,
           lastModifiedAssetTimestamp: null,
+          totalSize: 0,
         },
       ]);
 

--- a/web/src/lib/components/album-page/albums-controls.svelte
+++ b/web/src/lib/components/album-page/albums-controls.svelte
@@ -103,6 +103,7 @@
     [AlbumSortBy.DateCreated]: $t('sort_created'),
     [AlbumSortBy.MostRecentPhoto]: $t('sort_recent'),
     [AlbumSortBy.OldestPhoto]: $t('sort_oldest'),
+    [AlbumSortBy.Size]: $t('sort_size'),
   });
 
   let albumGroupByNames: Record<AlbumGroupBy, string> = $derived({

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -114,6 +114,7 @@ export enum AlbumSortBy {
   DateCreated = 'DateCreated',
   MostRecentPhoto = 'MostRecentPhoto',
   OldestPhoto = 'OldestPhoto',
+  Size = 'Size',
 }
 
 export const albumViewSettings = persisted<AlbumViewSettings>('album-view-settings', {

--- a/web/src/lib/utils/album-utils.ts
+++ b/web/src/lib/utils/album-utils.ts
@@ -87,6 +87,11 @@ export const sortOptionsMetadata: AlbumSortOptionMetadata[] = [
     defaultOrder: SortOrder.Desc,
     columnStyle: 'text-center hidden xl:block xl:w-[15%] 2xl:w-[12%]',
   },
+  {
+    id: AlbumSortBy.Size,
+    defaultOrder: SortOrder.Desc,
+    columnStyle: 'text-center hidden xl:block xl:w-[15%] 2xl:w-[12%]',
+  },
 ];
 
 export const findSortOptionMetadata = (sortBy: string) => {
@@ -254,6 +259,11 @@ const sortOptions: AlbumSortOption = {
   [AlbumSortBy.OldestPhoto]: (order, albums) => {
     albums = orderBy(albums, [({ startDate }) => (startDate ? new Date(startDate) : '')], [order]);
     return albums.sort(sortUnknownYearAlbums);
+  },
+
+  /** Sort by total album size */
+  [AlbumSortBy.Size]: (order, albums) => {
+    return orderBy(albums, [({ totalSize }) => totalSize ?? 0], [order]);
   },
 };
 


### PR DESCRIPTION
## Description

This PR adds support for sorting assets by file size in addition to the existing date-based sorting, and introduces total size tracking for albums.

### Changes Made

**Core Features:**
- Added `AssetSortField` enum with `Date` and `Size` options to support sorting assets by creation date or file size
- Implemented size-based sorting in the timeline/bucket endpoints by conditionally ordering by `asset_exif.fileSizeInByte` when `sortBy=size` is specified
- Added `totalSize` field to `AlbumResponseDto` to track the total size in bytes of all assets in an album
- Updated album repository queries to calculate and return the total size of assets in each album

**API Updates:**
- Added optional `sortBy` query parameter to `/timeline/bucket` and `/timeline/buckets` endpoints
- Added `sortBy` field to `MetadataSearchDto` for search operations
- Updated OpenAPI specification to include the new `AssetSortField` enum and parameter definitions

**UI/Client Updates:**
- Added `AlbumSortMode.totalSize` to mobile album sorting options
- Added `AlbumSortBy.Size` to web album sorting with corresponding UI metadata
- Updated album sort handlers in mobile to support sorting by total size
- Added localization string `sort_size` for the new sort option
- Generated TypeScript SDK types for the new `AssetSortField` enum and updated function signatures

**Generated Code:**
- Created `AssetSortField` model class in mobile OpenAPI client with serialization/deserialization support
- Updated all affected API client methods to include the new `sortBy` parameter
- Updated model classes (`AlbumResponseDto`, `MetadataSearchDto`) to include new fields

### Testing

The changes include updates to existing unit tests in `album.service.spec.ts` and `storage-template.service.spec.ts` to account for the new `totalSize` field in album metadata responses.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls
- [x] All code in `src/repositories/` is basic/simple without immich-specific logic

https://claude.ai/code/session_015g436WFXKFZbrBAdFD6bsB