### PR TITLE
fix(mobile): get provider refs before async gaps in backup page

### DIFF
--- a/mobile/lib/pages/backup/drift_backup.page.dart
+++ b/mobile/lib/pages/backup/drift_backup.page.dart
@@ -45,14 +45,17 @@ class _DriftBackupPageState extends ConsumerState<DriftBackupPage> {
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await ref.read(driftBackupProvider.notifier).getBackupStatus(currentUser.id);
+      final backupNotifier = ref.read(driftBackupProvider.notifier);
+      final syncManager = ref.read(backgroundSyncProvider);
 
-      ref.read(driftBackupProvider.notifier).updateSyncing(true);
-      syncSuccess = await ref.read(backgroundSyncProvider).syncRemote();
-      ref.read(driftBackupProvider.notifier).updateSyncing(false);
+      await backupNotifier.getBackupStatus(currentUser.id);
+
+      backupNotifier.updateSyncing(true);
+      syncSuccess = await syncManager.syncRemote();
+      backupNotifier.updateSyncing(false);
 
       if (mounted) {
-        await ref.read(driftBackupProvider.notifier).getBackupStatus(currentUser.id);
+        await backupNotifier.getBackupStatus(currentUser.id);
       }
     });
   }

--- a/mobile/lib/pages/backup/drift_backup.page.dart
+++ b/mobile/lib/pages/backup/drift_backup.page.dart
@@ -85,9 +85,9 @@ class _DriftBackupPageState extends ConsumerState<DriftBackupPage> {
       }
 
       if (syncSuccess == null) {
-        ref.read(driftBackupProvider.notifier).updateSyncing(true);
+        backupNotifier.updateSyncing(true);
         syncSuccess = await backupSyncManager.syncRemote();
-        ref.read(driftBackupProvider.notifier).updateSyncing(false);
+        backupNotifier.updateSyncing(false);
       }
 
       await backupNotifier.getBackupStatus(currentUser.id);


### PR DESCRIPTION
## Description

I actually had this in my logs now way to often, finally took the time to look into what's failing.

In the backup page we wait on the `getBackupStatus/syncRemote` if a user closes the page when its still loading we get this error afterwards:

```
Bad state: Cannot use "ref" after the widget was disposed.
#0      ConsumerStatefulElement._assertNotDisposed (package:flutter_riverpod/src/consumer.dart:550)
#1      ConsumerStatefulElement.read (package:flutter_riverpod/src/consumer.dart:619)
#2      _DriftBackupPageState.initState.<anonymous closure> (package:immich_mobile/pages/backup/drift_backup.page.dart:52)
<asynchronous suspension>
```

To fix the issue, I read the providers at the beginning of the function so we can still call `backupNotifier.updateSyncing` after the widget has been disposed. 

## How Has This Been Tested?

- manual ui test


## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/