### PR TITLE
fix(server): anonymize filename in shared links when showExif is false

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -567,6 +567,23 @@ describe(AssetMediaService.name, () => {
         }),
       );
     });
+
+    it('should use a generic filename when downloading via a shared link with showExif=false', async () => {
+      const asset = AssetFactory.create();
+      mocks.access.asset.checkSharedLinkAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForOriginal.mockResolvedValue(asset);
+
+      await expect(
+        sut.downloadOriginal(AuthFactory.from().sharedLink({ showExif: false }).build(), asset.id, {}),
+      ).resolves.toEqual(
+        new ImmichFileResponse({
+          path: asset.originalPath,
+          fileName: 'photo.jpg',
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+      );
+    });
   });
 
   describe('viewThumbnail', () => {
@@ -691,6 +708,24 @@ describe(AssetMediaService.name, () => {
         }),
       );
       expect(mocks.asset.getForThumbnail).toHaveBeenCalledWith(asset.id, AssetFileType.Thumbnail, true);
+    });
+
+    it('should use a generic filename when viewing via a shared link with showExif=false', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Thumbnail }).build();
+      mocks.access.asset.checkSharedLinkAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForThumbnail.mockResolvedValue({ ...asset, path: asset.files[0].path });
+      await expect(
+        sut.viewThumbnail(AuthFactory.from().sharedLink({ showExif: false }).build(), asset.id, {
+          size: AssetMediaSize.THUMBNAIL,
+        }),
+      ).resolves.toEqual(
+        new ImmichFileResponse({
+          path: asset.files[0].path,
+          cacheControl: CacheControl.PrivateWithCache,
+          contentType: 'image/jpeg',
+          fileName: 'photo_thumbnail.jpg',
+        }),
+      );
     });
   });
 

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -212,9 +212,12 @@ export class AssetMediaService extends BaseService {
 
     const path = editedPath ?? originalPath!;
 
+    const baseName =
+      auth.sharedLink && !auth.sharedLink.showExif ? 'photo' : getFileNameWithoutExtension(originalFileName);
+
     return new ImmichFileResponse({
       path,
-      fileName: getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
+      fileName: baseName + getFilenameExtension(path),
       contentType: mimeTypes.lookup(path),
       cacheControl: CacheControl.PrivateWithCache,
     });
@@ -257,7 +260,9 @@ export class AssetMediaService extends BaseService {
       throw new NotFoundException('Asset media not found');
     }
 
-    const fileName = `${getFileNameWithoutExtension(originalFileName)}_${size}${getFilenameExtension(path)}`;
+    const baseName =
+      auth.sharedLink && !auth.sharedLink.showExif ? 'photo' : getFileNameWithoutExtension(originalFileName);
+    const fileName = `${baseName}_${size}${getFilenameExtension(path)}`;
 
     return new ImmichFileResponse({
       fileName,


### PR DESCRIPTION
Fixes #27495

## Problem

When a shared link is created with "Show metadata" disabled (`showExif = false`), the original filename is still exposed in the `Content-Disposition` header when viewing or downloading assets. This allows visitors to see the original filename (e.g. `IMG_20260331_123456.jpg`), which may reveal the date and time the photo was taken — defeating the purpose of disabling metadata.

**Steps to reproduce:**
1. Open a photo
2. Click share icon → disable "Show metadata" → create link
3. Open the share link in another browser
4. Right-click the photo → "Save image as" / open in new tab
5. The original filename (e.g. `IMG_20260331_123456.jpg`) is visible

## Solution

When serving thumbnails or original files via a shared link with `showExif = false`, replace the filename base with `'photo'` while preserving the file extension. For example:
- `IMG_20260331_123456_thumbnail.jpg` → `photo_thumbnail.jpg`
- `IMG_20260331_123456.jpg` → `photo.jpg`

This affects two methods in `asset-media.service.ts`:
- `viewThumbnail` — used when viewing images inline
- `downloadOriginal` — used when downloading files

## Testing

- Added unit tests for both `viewThumbnail` and `downloadOriginal` that verify a generic filename is returned when `showExif = false` via a shared link.
- Existing tests continue to pass (132 total).