### PR TITLE
fix(docs): typo 'Start rating' to 'Star rating'

### DIFF
--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -26,7 +26,7 @@ You can search the following types of content:
 | Time frame                          | Start and end date of a specific time bucket          |
 | Media type                          | Image or video or both                                |
 | Display options                     | In Archive, in Favorites or Not in any album          |
-| Start rating                        | User-assigned start rating                            |
+| Star rating                         | User-assigned star rating                             |
 
 <img src={require('./img/advanced-search-filters.webp').default} width="70%" title='Advanced search filters' />
 


### PR DESCRIPTION
Fix small type in documentation