### PR TITLE
fix(web): svelte regression - cancel video preview fetch when bind:this is cleared early

### DIFF
--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -36,14 +36,18 @@
 
   $effect(() => {
     if (!enablePlayback) {
-      // Reset remaining time when playback is disabled.
       remainingSeconds = durationInSeconds;
-
-      if (player) {
-        // Cancel video buffering.
-        player.src = '';
-      }
+      return;
     }
+    if (!player) {
+      return;
+    }
+    const video = player;
+    return () => {
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
+    };
   });
   const onMouseEnter = () => {
     if (playbackOnIconHover) {


### PR DESCRIPTION
## Description

This was actually a regression from #27109 which updated svelte. Svelte [5.53.9](https://github.com/sveltejs/svelte/pull/17885) had "fix: better bind:this cleanup timing". This svelte change  clears bind:this references earlier in the unmount sequence — before sibling $effects observing the same gating state get to read them. 

The fix is to capture the video element BEFORE it is cleaned up by svelte, so that we can remove the src attribute (which firefox uses to stop a video from playing - chrome was unaffected) 

Fixes #27585

## How Has This Been Tested?


## Checklist:


## Please describe to which degree, if any, an LLM was used in creating this pull request.



