### PR TITLE
fix(mobile): improve image load cancellation handling

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -19,6 +19,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
   static final _log = Logger('CancellableImageProviderMixin');
 
   bool isCancelled = false;
+  bool isFinished = false;
   ImageRequest? request;
   CancelableOperation<ImageInfo?>? cachedOperation;
 
@@ -53,13 +54,15 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
   Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode, {bool evictOnError = true}) async* {
     if (isCancelled) {
       this.request = null;
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
     try {
       final image = await request.load(decode);
-      if ((image == null && evictOnError) || isCancelled) {
+      if (isCancelled) {
+        return;
+      }
+      if (image == null && evictOnError) {
         PaintingBinding.instance.imageCache.evict(this);
         return;
       } else if (image == null) {
@@ -67,6 +70,9 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
       }
       yield image;
     } catch (e, stack) {
+      if (isCancelled) {
+        return;
+      }
       if (evictOnError) {
         PaintingBinding.instance.imageCache.evict(this);
         rethrow;
@@ -80,20 +86,24 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
   Future<ui.Codec?> loadCodecRequest(ImageRequest request) async {
     if (isCancelled) {
       this.request = null;
-      PaintingBinding.instance.imageCache.evict(this);
       return null;
     }
 
     try {
       final codec = await request.loadCodec();
-      if (codec == null || isCancelled) {
+      if (isCancelled) {
         codec?.dispose();
+        return null;
+      }
+      if (codec == null) {
         PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
       return codec;
     } catch (e) {
-      PaintingBinding.instance.imageCache.evict(this);
+      if (!isCancelled) {
+        PaintingBinding.instance.imageCache.evict(this);
+      }
       rethrow;
     } finally {
       this.request = null;
@@ -121,6 +131,8 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
   @override
   void cancel() {
     isCancelled = true;
+    final hasActiveWork = !isFinished;
+
     final request = this.request;
     if (request != null) {
       this.request = null;
@@ -131,6 +143,10 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     if (operation != null) {
       cachedOperation = null;
       operation.cancel();
+    }
+
+    if (hasActiveWork) {
+      PaintingBinding.instance.imageCache.evict(this);
     }
   }
 }

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -100,7 +100,6 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     yield* initialImageStream();
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -113,24 +112,24 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     yield* loadRequest(request, decode);
 
     if (!Store.get(StoreKey.loadOriginal, false)) {
+      isFinished = true;
       return;
     }
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
     request = this.request = LocalImageRequest(localId: key.id, assetType: key.assetType, size: Size.zero);
 
     yield* loadRequest(request, decode);
+    isFinished = true;
   }
 
   Stream<Object> _animatedCodec(LocalFullImageProvider key, ImageDecoderCallback decode) async* {
     yield* initialImageStream();
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -143,7 +142,6 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     yield* loadRequest(previewRequest, decode);
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -151,9 +149,11 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     final originalRequest = request = LocalImageRequest(localId: key.id, size: Size.zero, assetType: key.assetType);
     final codec = await loadCodecRequest(originalRequest);
     if (codec == null) {
+      if (isCancelled) return;
       throw StateError('Failed to load animated codec for local asset ${key.id}');
     }
     yield codec;
+    isFinished = true;
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -105,7 +105,6 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     yield* initialImageStream();
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -116,23 +115,23 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     yield* loadRequest(previewRequest, decode, evictOnError: !loadOriginal);
 
     if (!loadOriginal) {
+      isFinished = true;
       return;
     }
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
     final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId));
     yield* loadRequest(originalRequest, decode);
+    isFinished = true;
   }
 
   Stream<Object> _animatedCodec(RemoteFullImageProvider key, ImageDecoderCallback decode) async* {
     yield* initialImageStream();
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -142,7 +141,6 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     yield* loadRequest(previewRequest, decode, evictOnError: false);
 
     if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
       return;
     }
 
@@ -150,9 +148,13 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId));
     final codec = await loadCodecRequest(originalRequest);
     if (codec == null) {
+      if (isCancelled) {
+        return;
+      }
       throw StateError('Failed to load animated codec for asset ${key.assetId}');
     }
     yield codec;
+    isFinished = true;
   }
 
   @override


### PR DESCRIPTION
## Description

Instantly evicts images from cache when we don't need them anymore.
This also means, we can't call evict again when we exit early with `isCancelled` is true, as that could remove already new cache values. 
So I hope I didn't miss an exit condition where we can't call `evict(true)`. 

## How Has This Been Tested?

- Simulator

## Checklist:

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/