### PR TITLE
fix(server): improve file deletion handling in asset deletion process

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -575,16 +575,9 @@ describe(AssetService.name, () => {
 
       await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
 
-      expect(mocks.job.queue.mock.calls).toEqual([
-        [
-          {
-            name: JobName.FileDelete,
-            data: {
-              files: [...asset.files.map(({ path }) => path), asset.originalPath],
-            },
-          },
-        ],
-      ]);
+      expect(mocks.storage.unlink.mock.calls).toEqual(
+        [...asset.files.map(({ path }) => path), asset.originalPath].map((file) => [file]),
+      );
       expect(mocks.asset.remove).toHaveBeenCalledWith(getForAssetDeletion(asset));
     });
 
@@ -613,8 +606,8 @@ describe(AssetService.name, () => {
 
       expect(mocks.job.queue.mock.calls).toEqual([
         [{ name: JobName.AssetDelete, data: { id: motionAsset.id, deleteOnDisk: true } }],
-        [{ name: JobName.FileDelete, data: { files: [asset.originalPath] } }],
       ]);
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(asset.originalPath);
     });
 
     it('should not delete a live motion part if it is being used by another asset', async () => {
@@ -624,9 +617,8 @@ describe(AssetService.name, () => {
 
       await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
 
-      expect(mocks.job.queue.mock.calls).toEqual([
-        [{ name: JobName.FileDelete, data: { files: [`/data/library/IMG_${asset.id}.jpg`] } }],
-      ]);
+      expect(mocks.job.queue.mock.calls).toEqual([]);
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(`/data/library/IMG_${asset.id}.jpg`);
     });
 
     it('should update usage', async () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -329,6 +329,11 @@ export class AssetService extends BaseService {
       return JobStatus.Failed;
     }
 
+    const fileDeletionStatus = await this.deleteAssetFiles(id, this.getFilesForDeletion(asset, deleteOnDisk));
+    if (fileDeletionStatus === JobStatus.Failed) {
+      return JobStatus.Failed;
+    }
+
     // replace the parent of the stack children with a new asset
     if (asset.stack?.primaryAssetId === id) {
       // this only includes timeline visible assets and excludes the primary asset
@@ -362,6 +367,13 @@ export class AssetService extends BaseService {
       }
     }
 
+    return JobStatus.Success;
+  }
+
+  private getFilesForDeletion(
+    asset: { files: AssetFile[]; originalPath: string; isOffline: boolean },
+    deleteOnDisk: boolean,
+  ): string[] {
     const assetFiles = getAssetFiles(asset.files ?? []);
     const files = [
       assetFiles.thumbnailFile?.path,
@@ -377,7 +389,18 @@ export class AssetService extends BaseService {
       files.push(assetFiles.sidecarFile?.path, asset.originalPath);
     }
 
-    await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: files.filter(Boolean) } });
+    return files.filter((file): file is string => file !== undefined);
+  }
+
+  private async deleteAssetFiles(assetId: string, files: string[]): Promise<JobStatus> {
+    for (const file of files) {
+      try {
+        await this.storageRepository.unlink(file);
+      } catch (error) {
+        this.logger.warn(`Unable to remove asset file for asset ${assetId}: ${file}`, error);
+        return JobStatus.Failed;
+      }
+    }
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following on from the description of the issue on Discord in #contributing
where I reported that there is a scenario where a file is returned as successfully deleted (even when it is not) and this causes its database record to be deleted and as a result the file remains on disk but never gets another chance to be deleted because the database has deleted its record.

The PR adds a fix that verifies the file is deleted from disk before it is actually deleted from the database


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
I uploaded a file and then prevented immich from deleting it by

sudo chattr +i 06210854-dffd-48c1-97ff-d5a54a42fad4.png

I verified that the file was not deleted from the disk but remained in the database with the value status = deleted and then I restored the permissions on the file to immich by

sudo chattr -i 06210854-dffd-48c1-97ff-d5a54a42fad4.png

I permanently deleted another file and verified that the log reports 2 deleted files and the file on disk was actually deleted

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Working with codex in plan mode and reviewing the code

## otherI

'm going to leave this PR in draft status as I assume there is a better/correct way to implement a fix for this.
Although I'd be happy to get feedback.
