### PR TITLE
fix(server): await response.json() inside try/catch to catch JSON parse errors

### DIFF
--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -173,7 +173,7 @@ export class MachineLearningRepository {
         const response = await fetch(new URL('/predict', url), { method: 'POST', body: formData });
         if (response.ok) {
           this.setHealthy(url, true);
-          return response.json();
+          return await response.json();
         }
 
         this.logger.warn(

--- a/server/src/repositories/server-info.repository.ts
+++ b/server/src/repositories/server-info.repository.ts
@@ -67,7 +67,7 @@ export class ServerInfoRepository {
         throw new Error(`GitHub API request failed with status ${response.status}: ${await response.text()}`);
       }
 
-      return response.json();
+      return await response.json();
     } catch (error) {
       throw new Error('Failed to fetch GitHub release', { cause: error });
     }


### PR DESCRIPTION
Fixes #27641

## What's the problem?

`response.json()` was being `return`ed without `await` inside `try/catch` blocks in two repository files:

- `ServerInfoRepository.getGitHubRelease()`
- `MachineLearningRepository.predict()`

Since `response.json()` returns a `Promise`, the `try` block exits immediately and hands the unsettled promise up the call stack. If JSON parsing later fails (e.g. the upstream server returns a non-JSON body like an HTML error page), the resulting `SyntaxError` is thrown _outside_ the `try/catch` and becomes an unhandled promise rejection — bypassing all the error-wrapping and logging logic in the `catch` handler.

## The fix

Add `await` so the promise settles inside the `try` block:

```ts
// before
return response.json();

// after
return await response.json();
```

This is a one-character-per-site change with no functional impact on the happy path, but ensures JSON parse failures are caught and handled correctly.

## Testing

- The existing unit tests still pass (no logic was changed).
- Manual verification: mock the GitHub API to return `200 OK` with a non-JSON body and confirm the error is now caught and re-thrown as `"Failed to fetch GitHub release"` instead of leaking as an unhandled rejection.