### PR TITLE
fix(server): return 0 instead of NaN for diskUsagePercentage when total is 0

### DIFF
--- a/server/src/services/server.service.spec.ts
+++ b/server/src/services/server.service.spec.ts
@@ -122,6 +122,22 @@ describe(ServerService.name, () => {
 
       expect(mocks.storage.checkDiskUsage).toHaveBeenCalledWith(expect.stringContaining('/data/library'));
     });
+
+    it('should return 0% usage when total disk size is 0', async () => {
+      mocks.storage.checkDiskUsage.mockResolvedValue({ free: 0, available: 0, total: 0 });
+
+      await expect(sut.getStorage()).resolves.toEqual({
+        diskAvailable: '0 B',
+        diskAvailableRaw: 0,
+        diskSize: '0 B',
+        diskSizeRaw: 0,
+        diskUsagePercentage: 0,
+        diskUse: '0 B',
+        diskUseRaw: 0,
+      });
+
+      expect(mocks.storage.checkDiskUsage).toHaveBeenCalledWith(expect.stringContaining('/data/library'));
+    });
   });
 
   describe('ping', () => {

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -68,7 +68,8 @@ export class ServerService extends BaseService {
     const libraryBase = StorageCore.getBaseFolder(StorageFolder.Library);
     const diskInfo = await this.storageRepository.checkDiskUsage(libraryBase);
 
-    const usagePercentage = (((diskInfo.total - diskInfo.free) / diskInfo.total) * 100).toFixed(2);
+    const usagePercentage =
+      diskInfo.total === 0 ? 0 : Number.parseFloat((((diskInfo.total - diskInfo.free) / diskInfo.total) * 100).toFixed(2));
 
     const serverInfo = new ServerStorageResponseDto();
     serverInfo.diskAvailable = asHumanReadable(diskInfo.available);
@@ -77,7 +78,7 @@ export class ServerService extends BaseService {
     serverInfo.diskAvailableRaw = diskInfo.available;
     serverInfo.diskSizeRaw = diskInfo.total;
     serverInfo.diskUseRaw = diskInfo.total - diskInfo.free;
-    serverInfo.diskUsagePercentage = Number.parseFloat(usagePercentage);
+    serverInfo.diskUsagePercentage = usagePercentage;
     return serverInfo;
   }
 


### PR DESCRIPTION
Fixes #27643

## What's the problem?

`getStorage()` calculates disk usage percentage via:

```ts
const usagePercentage = (((diskInfo.total - diskInfo.free) / diskInfo.total) * 100).toFixed(2);
```

When `diskInfo.total === 0` — which can happen on certain storage backends, network-mounted filesystems, or during early startup — this is a division by zero. JavaScript gives `NaN`, which then gets stored in `diskUsagePercentage` and returned from the API. JSON serializes `NaN` as `null`, which breaks the storage dashboard.

## Fix

Guard against `total === 0` and return `0` in that case:

```ts
const usagePercentage =
  diskInfo.total === 0 ? 0 : Number.parseFloat((((diskInfo.total - diskInfo.free) / diskInfo.total) * 100).toFixed(2));
```

Also cleans up a redundant `Number.parseFloat()` call on the assignment line, since parsing is now done inline.

## Testing

Added a test case to `server.service.spec.ts` that mocks `checkDiskUsage` returning `{ free: 0, available: 0, total: 0 }` and asserts `diskUsagePercentage` is `0`.