### PR TITLE
fix(mobile): fix flutter cache eviction on thumbnails   

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -59,12 +59,8 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
     try {
       final image = await request.load(decode);
-      if (isCancelled) {
+      if (isCancelled || image == null) {
         image?.dispose();
-        return;
-      }
-      if (image == null) {
-        if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return;
       }
       isFinished = isFinal;
@@ -91,12 +87,8 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
     try {
       final codec = await request.loadCodec();
-      if (isCancelled) {
+      if (isCancelled || codec == null) {
         codec?.dispose();
-        return null;
-      }
-      if (codec == null) {
-        if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
       isFinished = isFinal;

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -67,7 +67,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return;
       }
-      if (isFinal) isFinished = true;
+      isFinished = isFinal;
       yield image;
     } catch (e, stack) {
       if (isCancelled) {
@@ -99,7 +99,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
-      if (isFinal) isFinished = true;
+      isFinished = isFinal;
       return codec;
     } catch (e) {
       if (!isCancelled) {

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -95,7 +95,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
       isFinished = isFinal;
       return codec;
     } catch (e) {
-      if(isFinal){
+      if (isFinal) {
         isFinished = true;
         PaintingBinding.instance.imageCache.evict(this);
         rethrow;

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -51,12 +51,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     return null;
   }
 
-  Stream<ImageInfo> loadRequest(
-    ImageRequest request,
-    ImageDecoderCallback decode, {
-    bool evictOnError = true,
-    bool markFinished = true,
-  }) async* {
+  Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode, {required bool isFinal}) async* {
     if (isCancelled) {
       this.request = null;
       return;
@@ -65,21 +60,20 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     try {
       final image = await request.load(decode);
       if (isCancelled) {
+        image?.dispose();
         return;
       }
-      if (image == null && evictOnError) {
-        PaintingBinding.instance.imageCache.evict(this);
-        return;
-      } else if (image == null) {
+      if (image == null) {
+        if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return;
       }
-      if (markFinished) isFinished = true;
+      if (isFinal) isFinished = true;
       yield image;
     } catch (e, stack) {
       if (isCancelled) {
         return;
       }
-      if (evictOnError) {
+      if (isFinal) {
         PaintingBinding.instance.imageCache.evict(this);
         rethrow;
       }
@@ -89,7 +83,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     }
   }
 
-  Future<ui.Codec?> loadCodecRequest(ImageRequest request, {bool markFinished = true}) async {
+  Future<ui.Codec?> loadCodecRequest(ImageRequest request, {required bool isFinal}) async {
     if (isCancelled) {
       this.request = null;
       return null;
@@ -102,10 +96,10 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         return null;
       }
       if (codec == null) {
-        PaintingBinding.instance.imageCache.evict(this);
+        if (isFinal) PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
-      if (markFinished) isFinished = true;
+      if (isFinal) isFinished = true;
       return codec;
     } catch (e) {
       if (!isCancelled) {

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -51,7 +51,12 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     return null;
   }
 
-  Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode, {bool evictOnError = true}) async* {
+  Stream<ImageInfo> loadRequest(
+    ImageRequest request,
+    ImageDecoderCallback decode, {
+    bool evictOnError = true,
+    bool markFinished = true,
+  }) async* {
     if (isCancelled) {
       this.request = null;
       return;
@@ -68,6 +73,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
       } else if (image == null) {
         return;
       }
+      if (markFinished) isFinished = true;
       yield image;
     } catch (e, stack) {
       if (isCancelled) {
@@ -83,7 +89,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     }
   }
 
-  Future<ui.Codec?> loadCodecRequest(ImageRequest request) async {
+  Future<ui.Codec?> loadCodecRequest(ImageRequest request, {bool markFinished = true}) async {
     if (isCancelled) {
       this.request = null;
       return null;
@@ -99,6 +105,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         PaintingBinding.instance.imageCache.evict(this);
         return null;
       }
+      if (markFinished) isFinished = true;
       return codec;
     } catch (e) {
       if (!isCancelled) {

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -70,6 +70,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         return;
       }
       if (isFinal) {
+        isFinished = true;
         PaintingBinding.instance.imageCache.evict(this);
         rethrow;
       }
@@ -94,10 +95,12 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
       isFinished = isFinal;
       return codec;
     } catch (e) {
-      if (!isCancelled) {
+      if(isFinal){
+        isFinished = true;
         PaintingBinding.instance.imageCache.evict(this);
+        rethrow;
       }
-      rethrow;
+      return null;
     } finally {
       this.request = null;
     }

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -36,7 +36,7 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
 
   Stream<ImageInfo> _codec(LocalThumbProvider key, ImageDecoderCallback decode) {
     final request = this.request = LocalImageRequest(localId: key.id, size: key.size, assetType: key.assetType);
-    return loadRequest(request, decode);
+    return loadRequest(request, decode, isFinal: true);
   }
 
   @override
@@ -103,16 +103,16 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       return;
     }
 
+    final loadOriginal = Store.get(StoreKey.loadOriginal, false);
     final devicePixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
     var request = this.request = LocalImageRequest(
       localId: key.id,
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
-    yield* loadRequest(request, decode, markFinished: false);
+    yield* loadRequest(request, decode, isFinal: !loadOriginal);
 
-    if (!Store.get(StoreKey.loadOriginal, false)) {
-      isFinished = true;
+    if (!loadOriginal) {
       return;
     }
 
@@ -122,7 +122,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
 
     request = this.request = LocalImageRequest(localId: key.id, assetType: key.assetType, size: Size.zero);
 
-    yield* loadRequest(request, decode);
+    yield* loadRequest(request, decode, isFinal: true);
   }
 
   Stream<Object> _animatedCodec(LocalFullImageProvider key, ImageDecoderCallback decode) async* {
@@ -138,7 +138,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
-    yield* loadRequest(previewRequest, decode, markFinished: false);
+    yield* loadRequest(previewRequest, decode, isFinal: false);
 
     if (isCancelled) {
       return;
@@ -146,7 +146,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
 
     // always try original for animated, since previews don't support animation
     final originalRequest = request = LocalImageRequest(localId: key.id, size: Size.zero, assetType: key.assetType);
-    final codec = await loadCodecRequest(originalRequest);
+    final codec = await loadCodecRequest(originalRequest, isFinal: true);
     if (codec == null) {
       if (isCancelled) return;
       throw StateError('Failed to load animated codec for local asset ${key.id}');

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -109,7 +109,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
-    yield* loadRequest(request, decode);
+    yield* loadRequest(request, decode, markFinished: false);
 
     if (!Store.get(StoreKey.loadOriginal, false)) {
       isFinished = true;
@@ -123,7 +123,6 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     request = this.request = LocalImageRequest(localId: key.id, assetType: key.assetType, size: Size.zero);
 
     yield* loadRequest(request, decode);
-    isFinished = true;
   }
 
   Stream<Object> _animatedCodec(LocalFullImageProvider key, ImageDecoderCallback decode) async* {
@@ -139,7 +138,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
-    yield* loadRequest(previewRequest, decode);
+    yield* loadRequest(previewRequest, decode, markFinished: false);
 
     if (isCancelled) {
       return;
@@ -153,7 +152,6 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       throw StateError('Failed to load animated codec for local asset ${key.id}');
     }
     yield codec;
-    isFinished = true;
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -112,7 +112,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
     );
     final loadOriginal = assetType == AssetType.image && AppSetting.get(Setting.loadOriginal);
-    yield* loadRequest(previewRequest, decode, evictOnError: !loadOriginal);
+    yield* loadRequest(previewRequest, decode, evictOnError: !loadOriginal, markFinished: false);
 
     if (!loadOriginal) {
       isFinished = true;
@@ -125,7 +125,6 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
 
     final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId));
     yield* loadRequest(originalRequest, decode);
-    isFinished = true;
   }
 
   Stream<Object> _animatedCodec(RemoteFullImageProvider key, ImageDecoderCallback decode) async* {
@@ -138,7 +137,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     final previewRequest = request = RemoteImageRequest(
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
     );
-    yield* loadRequest(previewRequest, decode, evictOnError: false);
+    yield* loadRequest(previewRequest, decode, evictOnError: false, markFinished: false);
 
     if (isCancelled) {
       return;
@@ -154,7 +153,6 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
       throw StateError('Failed to load animated codec for asset ${key.assetId}');
     }
     yield codec;
-    isFinished = true;
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -38,7 +38,7 @@ class RemoteImageProvider extends CancellableImageProvider<RemoteImageProvider>
 
   Stream<ImageInfo> _codec(RemoteImageProvider key, ImageDecoderCallback decode) {
     final request = this.request = RemoteImageRequest(uri: key.url);
-    return loadRequest(request, decode);
+    return loadRequest(request, decode, isFinal: true);
   }
 
   @override
@@ -112,10 +112,9 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
     );
     final loadOriginal = assetType == AssetType.image && AppSetting.get(Setting.loadOriginal);
-    yield* loadRequest(previewRequest, decode, evictOnError: !loadOriginal, markFinished: false);
+    yield* loadRequest(previewRequest, decode, isFinal: !loadOriginal);
 
     if (!loadOriginal) {
-      isFinished = true;
       return;
     }
 
@@ -124,7 +123,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     }
 
     final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId));
-    yield* loadRequest(originalRequest, decode);
+    yield* loadRequest(originalRequest, decode, isFinal: true);
   }
 
   Stream<Object> _animatedCodec(RemoteFullImageProvider key, ImageDecoderCallback decode) async* {
@@ -137,7 +136,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     final previewRequest = request = RemoteImageRequest(
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
     );
-    yield* loadRequest(previewRequest, decode, evictOnError: false, markFinished: false);
+    yield* loadRequest(previewRequest, decode, isFinal: false);
 
     if (isCancelled) {
       return;
@@ -145,7 +144,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
 
     // always try original for animated, since previews don't support animation
     final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId));
-    final codec = await loadCodecRequest(originalRequest);
+    final codec = await loadCodecRequest(originalRequest, isFinal: true);
     if (codec == null) {
       if (isCancelled) {
         return;

--- a/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
+++ b/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
@@ -22,7 +22,7 @@ class ThumbHashProvider extends CancellableImageProvider<ThumbHashProvider>
 
   Stream<ImageInfo> _loadCodec(ThumbHashProvider key, ImageDecoderCallback decode) {
     final request = this.request = ThumbhashImageRequest(thumbhash: key.thumbHash);
-    return loadRequest(request, decode);
+    return loadRequest(request, decode, isFinal: true);
   }
 
   @override


### PR DESCRIPTION
## Description

In #27624 we fixed that requests get evicted from cache too late. When creating the PR I was too invested in checking that we don't do double evictions anywhere anymore and  forgot that the FullImageProvider isn't actually everything and especially not what we use for thumbnails. The flag is missing from thumbhash providers and "normal" ImageProviders (which we use for thumbnails). 
That currently results in the cache always being evicted for these images, after the corresponding widget is disposed, even if they are fully loaded.

Setting isFinished manually everywhere we need, is kind of a hassle and easily forgotten. (as noticed through this PR)
Thats why I made it part of the loadRequest methods, so it's part of the whole CancellableImageProviderMixin contract. And you actually have to opt out of setting the flag, which the "special" providers then have to do (eg. FullImageProvider). 
Which means ThumbhashProvider and "normal" image provider don't have to set the flag. 

@mertalev Sorry for the inconvenience.

Fixes #27679

## How Has This Been Tested?

- verified that the flag is now actually set to true (debugged this)

## Checklist:

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/