### PR TITLE
feat: Add toggle to disable folder collapsing in folder view

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -791,6 +791,8 @@
   "close": "Close",
   "collapse": "Collapse",
   "collapse_all": "Collapse all",
+  "collapse_folders": "Collapse folders",
+  "collapse_folders_description": "Collapse folders with only one child folder",
   "color": "Color",
   "color_theme": "Color theme",
   "command": "Command",

--- a/mobile/openapi/lib/model/folders_response.dart
+++ b/mobile/openapi/lib/model/folders_response.dart
@@ -13,9 +13,13 @@ part of openapi.api;
 class FoldersResponse {
   /// Returns a new [FoldersResponse] instance.
   FoldersResponse({
+    this.collapse = true,
     this.enabled = false,
     this.sidebarWeb = false,
   });
+
+  /// Whether to collapse folders with only one child folder
+  bool collapse;
 
   /// Whether folders are enabled
   bool enabled;
@@ -25,20 +29,23 @@ class FoldersResponse {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FoldersResponse &&
+    other.collapse == collapse &&
     other.enabled == enabled &&
     other.sidebarWeb == sidebarWeb;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (collapse.hashCode) +
     (enabled.hashCode) +
     (sidebarWeb.hashCode);
 
   @override
-  String toString() => 'FoldersResponse[enabled=$enabled, sidebarWeb=$sidebarWeb]';
+  String toString() => 'FoldersResponse[collapse=$collapse, enabled=$enabled, sidebarWeb=$sidebarWeb]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+      json[r'collapse'] = this.collapse;
       json[r'enabled'] = this.enabled;
       json[r'sidebarWeb'] = this.sidebarWeb;
     return json;
@@ -53,6 +60,7 @@ class FoldersResponse {
       final json = value.cast<String, dynamic>();
 
       return FoldersResponse(
+        collapse: mapValueOfType<bool>(json, r'collapse')!,
         enabled: mapValueOfType<bool>(json, r'enabled')!,
         sidebarWeb: mapValueOfType<bool>(json, r'sidebarWeb')!,
       );
@@ -102,6 +110,7 @@ class FoldersResponse {
 
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
+    'collapse',
     'enabled',
     'sidebarWeb',
   };

--- a/mobile/openapi/lib/model/folders_update.dart
+++ b/mobile/openapi/lib/model/folders_update.dart
@@ -13,9 +13,19 @@ part of openapi.api;
 class FoldersUpdate {
   /// Returns a new [FoldersUpdate] instance.
   FoldersUpdate({
+    this.collapse,
     this.enabled,
     this.sidebarWeb,
   });
+
+  /// Whether to collapse folders with only one child folder
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? collapse;
 
   /// Whether folders are enabled
   ///
@@ -37,20 +47,27 @@ class FoldersUpdate {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is FoldersUpdate &&
+    other.collapse == collapse &&
     other.enabled == enabled &&
     other.sidebarWeb == sidebarWeb;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (collapse == null ? 0 : collapse!.hashCode) +
     (enabled == null ? 0 : enabled!.hashCode) +
     (sidebarWeb == null ? 0 : sidebarWeb!.hashCode);
 
   @override
-  String toString() => 'FoldersUpdate[enabled=$enabled, sidebarWeb=$sidebarWeb]';
+  String toString() => 'FoldersUpdate[collapse=$collapse, enabled=$enabled, sidebarWeb=$sidebarWeb]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+    if (this.collapse != null) {
+      json[r'collapse'] = this.collapse;
+    } else {
+    //  json[r'collapse'] = null;
+    }
     if (this.enabled != null) {
       json[r'enabled'] = this.enabled;
     } else {
@@ -73,6 +90,7 @@ class FoldersUpdate {
       final json = value.cast<String, dynamic>();
 
       return FoldersUpdate(
+        collapse: mapValueOfType<bool>(json, r'collapse'),
         enabled: mapValueOfType<bool>(json, r'enabled'),
         sidebarWeb: mapValueOfType<bool>(json, r'sidebarWeb'),
       );

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -18204,6 +18204,11 @@
       },
       "FoldersResponse": {
         "properties": {
+          "collapse": {
+            "default": true,
+            "description": "Whether to collapse folders with only one child folder",
+            "type": "boolean"
+          },
           "enabled": {
             "default": false,
             "description": "Whether folders are enabled",
@@ -18216,6 +18221,7 @@
           }
         },
         "required": [
+          "collapse",
           "enabled",
           "sidebarWeb"
         ],
@@ -18223,6 +18229,10 @@
       },
       "FoldersUpdate": {
         "properties": {
+          "collapse": {
+            "description": "Whether to collapse folders with only one child folder",
+            "type": "boolean"
+          },
           "enabled": {
             "description": "Whether folders are enabled",
             "type": "boolean"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -290,6 +290,8 @@ export type EmailNotificationsResponse = {
     enabled: boolean;
 };
 export type FoldersResponse = {
+    /** Whether to collapse folders with only one child folder */
+    collapse: boolean;
     /** Whether folders are enabled */
     enabled: boolean;
     /** Whether folders appear in web sidebar */
@@ -369,6 +371,8 @@ export type EmailNotificationsUpdate = {
     enabled?: boolean;
 };
 export type FoldersUpdate = {
+    /** Whether to collapse folders with only one child folder */
+    collapse?: boolean;
     /** Whether folders are enabled */
     enabled?: boolean;
     /** Whether folders appear in web sidebar */

--- a/server/src/dtos/user-preferences.dto.ts
+++ b/server/src/dtos/user-preferences.dto.ts
@@ -38,6 +38,9 @@ class FoldersUpdate {
 
   @ValidateBoolean({ optional: true, description: 'Whether folders appear in web sidebar' })
   sidebarWeb?: boolean;
+
+  @ValidateBoolean({ optional: true, description: 'Whether to collapse folders with only one child folder' })
+  collapse?: boolean;
 }
 
 class PeopleUpdate {
@@ -210,6 +213,8 @@ class FoldersResponse {
   enabled: boolean = false;
   @ApiProperty({ description: 'Whether folders appear in web sidebar' })
   sidebarWeb: boolean = false;
+  @ApiProperty({ description: 'Whether to collapse folders with only one child folder' })
+  collapse: boolean = true;
 }
 
 class PeopleResponse {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -501,6 +501,7 @@ export type UserPreferences = {
   folders: {
     enabled: boolean;
     sidebarWeb: boolean;
+    collapse: boolean;
   };
   memories: {
     enabled: boolean;

--- a/server/src/utils/preferences.ts
+++ b/server/src/utils/preferences.ts
@@ -13,6 +13,7 @@ const getDefaultPreferences = (): UserPreferences => {
     folders: {
       enabled: false,
       sidebarWeb: false,
+      collapse: true,
     },
     memories: {
       enabled: true,

--- a/web/src/lib/components/user-settings-page/feature-settings.svelte
+++ b/web/src/lib/components/user-settings-page/feature-settings.svelte
@@ -13,6 +13,7 @@
   // Folders
   let foldersEnabled = $state($preferences?.folders?.enabled ?? false);
   let foldersSidebar = $state($preferences?.folders?.sidebarWeb ?? false);
+  let foldersCollapse = $state($preferences?.folders?.collapse ?? true);
 
   // Memories
   let memoriesEnabled = $state($preferences?.memories?.enabled ?? true);
@@ -41,7 +42,7 @@
       const data = await updateMyPreferences({
         userPreferencesUpdateDto: {
           albums: { defaultAssetOrder },
-          folders: { enabled: foldersEnabled, sidebarWeb: foldersSidebar },
+          folders: { enabled: foldersEnabled, sidebarWeb: foldersSidebar, collapse: foldersCollapse },
           memories: { enabled: memoriesEnabled, duration: memoriesDuration },
           people: { enabled: peopleEnabled, sidebarWeb: peopleSidebar },
           ratings: { enabled: ratingsEnabled },
@@ -91,6 +92,9 @@
             {#if foldersEnabled}
               <Field label={$t('sidebar')} description={$t('sidebar_display_description')}>
                 <Switch bind:checked={foldersSidebar} />
+              </Field>
+              <Field label={$t('collapse_folders')} description={$t('collapse_folders_description')}>
+                <Switch bind:checked={foldersCollapse} />
               </Field>
             {/if}
           </div>

--- a/web/src/lib/stores/folders.svelte.ts
+++ b/web/src/lib/stores/folders.svelte.ts
@@ -1,4 +1,5 @@
 import { eventManager } from '$lib/managers/event-manager.svelte';
+import { preferences } from '$lib/stores/user.store';
 import { TreeNode } from '$lib/utils/tree-utils';
 import {
   getAssetsByOriginalPath,
@@ -8,6 +9,7 @@ import {
    */
   type AssetResponseDto,
 } from '@immich/sdk';
+import { get } from 'svelte/store';
 
 type AssetCache = {
   [path: string]: AssetResponseDto[];
@@ -29,7 +31,10 @@ class FoldersStore {
       return this.folders!;
     }
     this.folders = TreeNode.fromPaths(await getUniqueOriginalPaths());
-    this.folders.collapse();
+    const shouldCollapse = get(preferences)?.folders?.collapse ?? true;
+    if (shouldCollapse) {
+      this.folders.collapse();
+    }
     this.initialized = true;
     return this.folders;
   }


### PR DESCRIPTION
## Description

This PR adds a toggle to the Folder User Preferences which controls the collapse behaviour in the tree view of the folder page. It's enabled per default, but can be turned off so folders with only one child folder don't get collapsed.
On a personal level, I really dislike that folders get collapsed because it doesn't look nice and is confusing. This PR adds a way for users to decide if collapsing should be enabled or not.

Fixes one problem in #24555.

## How Has This Been Tested?

Added an external library containing one image in a chain of subfolders.
<details><summary><h2>Screenshots</h2></summary>

Currently:
<img width="487" height="382" alt="grafik" src="https://github.com/user-attachments/assets/5957ae61-898b-4d57-8e58-c7af08f69bb9" />

When collapse is disabled:
<img width="744" height="377" alt="grafik" src="https://github.com/user-attachments/assets/533af348-1f6c-4205-8a8a-bfa1a2e2e2bb" />

</details>

## API Changes
`/api/users/me/preferences` returns a new field `collapse` inside the `folders` object:
```
    "folders": {
        "enabled": true,
        "sidebarWeb": true,
        "collapse": false
    },
```

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used a LLM to understand the code structure and how a suitable implementation could look like. The final implementation has been done by me manually.
