### PR TITLE
fix(mobile): include thumbhash cache in image cache metrics and operations

### DIFF
--- a/mobile/lib/utils/cache/custom_image_cache.dart
+++ b/mobile/lib/utils/cache/custom_image_cache.dart
@@ -26,12 +26,14 @@ final class CustomImageCache implements ImageCache {
   void clear() {
     _small.clear();
     _large.clear();
+    _thumbhash.clear();
   }
 
   @override
   void clearLiveImages() {
     _small.clearLiveImages();
     _large.clearLiveImages();
+    _thumbhash.clearLiveImages();
   }
 
   /// Gets the cache for the given key
@@ -51,19 +53,19 @@ final class CustomImageCache implements ImageCache {
   }
 
   @override
-  int get currentSize => _small.currentSize + _large.currentSize;
+  int get currentSize => _small.currentSize + _large.currentSize + _thumbhash.currentSize;
 
   @override
-  int get currentSizeBytes => _small.currentSizeBytes + _large.currentSizeBytes;
+  int get currentSizeBytes => _small.currentSizeBytes + _large.currentSizeBytes + _thumbhash.currentSizeBytes;
 
   @override
   bool evict(Object key, {bool includeLive = true}) => _cacheForKey(key).evict(key, includeLive: includeLive);
 
   @override
-  int get liveImageCount => _small.liveImageCount + _large.liveImageCount;
+  int get liveImageCount => _small.liveImageCount + _large.liveImageCount + _thumbhash.liveImageCount;
 
   @override
-  int get pendingImageCount => _small.pendingImageCount + _large.pendingImageCount;
+  int get pendingImageCount => _small.pendingImageCount + _large.pendingImageCount + _thumbhash.pendingImageCount;
 
   @override
   ImageStreamCompleter? putIfAbsent(


### PR DESCRIPTION
## Description

Even if `maximumSize` for the thumbhashes is set to 0, live images are still tracked in the cache (don't know why, its a flutter mechanic) and the internal cache listener is attached to it.

If flutter wants to clear the cache we should probably respect that.
`.clear` in our case just removes the cache internal listener if its still attached
`.clearLiveImages` clears the internal liveImageCache 

Regarding the stats:

- _thumbhash.currentSize is 0 all the time
- _thumbhash.currentSizeBytes is 0 all the time
- _thumbhash.liveImageCount is however many images are currently live
- _thumbhash.pendingImageCount is also 0 all the time

I just added these for completeness sake. 

@mertalev any reason why this wasn't done previously?

## How Has This Been Tested?

- don't really know how

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/
