### PR TITLE
feat(web): add support for native NestJS HTTPS termination to immich-server

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -1,6 +1,12 @@
 # Reverse Proxy
 
-Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Real-IP`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
+Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. 
+
+:::info
+Immich also supports native HTTPS termination if `IMMICH_HTTPS_KEY_PATH` and `IMMICH_HTTPS_CERT_PATH` are set. See [Environment Variables](/install/environment-variables/#https) for more information.
+:::
+
+All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Real-IP`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
 
 :::caution
 Immich does not support being served on a sub-path such as `location /immich {`. It has to be served on the root path of a (sub)domain.

--- a/docs/docs/guides/remote-access.md
+++ b/docs/docs/guides/remote-access.md
@@ -50,6 +50,10 @@ If you're hosting your own reverse proxy, [Nginx](https://docs.nginx.com/nginx/a
 
 You'll also need your own certificate to authenticate https connections. If you're making Immich publicly accessible, [Let's Encrypt](https://letsencrypt.org/) can provide a free certificate for your domain and is the recommended option. Alternatively, a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate) allows you to encrypt your connection to Immich, but it raises a security warning on the client's browser.
 
+:::tip Native HTTPS
+Instead of using a reverse proxy for TLS termination, Immich can also handle HTTPS natively. To enable this, set the `IMMICH_HTTPS_KEY_PATH` and `IMMICH_HTTPS_CERT_PATH` environment variables. See [here](/install/environment-variables/#https) for more details.
+:::
+
 A remote reverse proxy like [Cloudflare](https://www.cloudflare.com/learning/cdn/glossary/reverse-proxy/) increases security by hiding the server IP address, which makes targeted attacks like [DDoS](https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/) harder.
 
 ### Pros

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -70,6 +70,21 @@ Information on the current workers can be found [here](/administration/jobs-work
 | `IMMICH_HOST` | Listening host |                 `0.0.0.0`                  | server, machine learning |
 | `IMMICH_PORT` | Listening port | `2283` (server), `3003` (machine learning) | server, machine learning |
 
+## HTTPS
+
+| Variable                 | Description                        | Default | Containers |
+| :----------------------- | :--------------------------------- | :-----: | :--------- |
+| `IMMICH_HTTPS_KEY_PATH`  | Path to the HTTPS key file         |         | server     |
+| `IMMICH_HTTPS_CERT_PATH` | Path to the HTTPS certificate file |         | server     |
+
+:::info
+If both `IMMICH_HTTPS_KEY_PATH` and `IMMICH_HTTPS_CERT_PATH` are set, the Immich server will use HTTPS. Otherwise, it will use HTTP.
+:::
+
+:::info
+If using Let's Encrypt certificates, use `fullchain.cer` for `IMMICH_HTTPS_CERT_PATH`.
+:::
+
 ## Database
 
 | Variable                            | Description                                                                            |  Default   | Containers                     |

--- a/server/src/app.common.ts
+++ b/server/src/app.common.ts
@@ -1,9 +1,10 @@
+import { NestApplicationOptions } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { json } from 'body-parser';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import helmetMiddleware from 'helmet';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import sirv from 'sirv';
 import { IMMICH_SERVER_START, excludePaths, serverVersion } from 'src/constants';
 import { MaintenanceWorkerService } from 'src/maintenance/maintenance-worker.service';
@@ -19,6 +20,18 @@ export function configureTelemetry() {
   if (telemetry.metrics.size > 0) {
     bootstrapTelemetry(telemetry.apiPort);
   }
+}
+
+export function getNestOptions(): NestApplicationOptions {
+  const { https } = new ConfigRepository().getEnv();
+  const options: NestApplicationOptions = { bufferLogs: true };
+  if (https.keyPath && https.certPath) {
+    options.httpsOptions = {
+      key: readFileSync(https.keyPath),
+      cert: readFileSync(https.certPath),
+    };
+  }
+  return options;
 }
 
 export async function configureExpress(

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -88,6 +88,14 @@ export class EnvDto {
 
   @IsString()
   @Optional()
+  IMMICH_HTTPS_KEY_PATH?: string;
+
+  @IsString()
+  @Optional()
+  IMMICH_HTTPS_CERT_PATH?: string;
+
+  @IsString()
+  @Optional()
   IMMICH_REPOSITORY?: string;
 
   @IsString()

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -19,6 +19,8 @@ const resetEnv = () => {
     'IMMICH_MICROSERVICES_METRICS_PORT',
     'IMMICH_TELEMETRY_INCLUDE',
     'IMMICH_TELEMETRY_EXCLUDE',
+    'IMMICH_HTTPS_KEY_PATH',
+    'IMMICH_HTTPS_CERT_PATH',
 
     'DB_URL',
     'DB_HOSTNAME',
@@ -80,6 +82,23 @@ describe('getEnv', () => {
 
     expect(config.plugins.external).toEqual({ allow: false });
     expect(config.setup).toEqual({ allow: true });
+    expect(config.https).toEqual({ keyPath: undefined, certPath: undefined });
+  });
+
+  describe('IMMICH_HTTPS_KEY_PATH', () => {
+    it('should set key path', () => {
+      process.env.IMMICH_HTTPS_KEY_PATH = '/path/to/key.pem';
+      const config = getEnv();
+      expect(config.https.keyPath).toBe('/path/to/key.pem');
+    });
+  });
+
+  describe('IMMICH_HTTPS_CERT_PATH', () => {
+    it('should set cert path', () => {
+      process.env.IMMICH_HTTPS_CERT_PATH = '/path/to/cert.pem';
+      const config = getEnv();
+      expect(config.https.certPath).toBe('/path/to/cert.pem');
+    });
   });
 
   describe('IMMICH_MEDIA_LOCATION', () => {

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -31,6 +31,10 @@ export interface EnvData {
   host?: string;
   port: number;
   environment: ImmichEnvironment;
+  https: {
+    keyPath?: string;
+    certPath?: string;
+  };
   configFile?: string;
   logLevel?: LogLevel;
   logFormat?: LogFormat;
@@ -263,6 +267,10 @@ const getEnv = (): EnvData => {
     host: dto.IMMICH_HOST,
     port: dto.IMMICH_PORT || 2283,
     environment,
+    https: {
+      keyPath: dto.IMMICH_HTTPS_KEY_PATH,
+      certPath: dto.IMMICH_HTTPS_CERT_PATH,
+    },
     configFile: dto.IMMICH_CONFIG_FILE,
     logLevel: dto.IMMICH_LOG_LEVEL,
     logFormat: dto.IMMICH_LOG_FORMAT || LogFormat.Console,

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { configureExpress, configureTelemetry } from 'src/app.common';
+import { configureExpress, configureTelemetry, getNestOptions } from 'src/app.common';
 import { ApiModule } from 'src/app.module';
 import { AppRepository } from 'src/repositories/app.repository';
 import { ApiService } from 'src/services/api.service';
@@ -11,7 +11,7 @@ async function bootstrap() {
 
   configureTelemetry();
 
-  const app = await NestFactory.create<NestExpressApplication>(ApiModule, { bufferLogs: true });
+  const app = await NestFactory.create<NestExpressApplication>(ApiModule, getNestOptions());
   app.get(AppRepository).setCloseFn(() => app.close());
 
   void configureExpress(app, {

--- a/server/src/workers/maintenance.ts
+++ b/server/src/workers/maintenance.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { configureExpress, configureTelemetry } from 'src/app.common';
+import { configureExpress, configureTelemetry, getNestOptions } from 'src/app.common';
 import { MaintenanceModule } from 'src/app.module';
 import { MaintenanceWorkerService } from 'src/maintenance/maintenance-worker.service';
 import { AppRepository } from 'src/repositories/app.repository';
@@ -10,7 +10,7 @@ async function bootstrap() {
   process.title = 'immich-maintenance';
   configureTelemetry();
 
-  const app = await NestFactory.create<NestExpressApplication>(MaintenanceModule, { bufferLogs: true });
+  const app = await NestFactory.create<NestExpressApplication>(MaintenanceModule, getNestOptions());
   app.get(AppRepository).setCloseFn(() => app.close());
 
   void configureExpress(app, {

--- a/server/src/workers/microservices.ts
+++ b/server/src/workers/microservices.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { isMainThread } from 'node:worker_threads';
+import { getNestOptions } from 'src/app.common';
 import { MicroservicesModule } from 'src/app.module';
 import { serverVersion } from 'src/constants';
 import { WebSocketAdapter } from 'src/middleware/websocket.adapter';
@@ -15,7 +16,7 @@ export async function bootstrap() {
     bootstrapTelemetry(telemetry.microservicesPort);
   }
 
-  const app = await NestFactory.create(MicroservicesModule, { bufferLogs: true });
+  const app = await NestFactory.create(MicroservicesModule, getNestOptions());
   const logger = await app.resolve(LoggingRepository);
   const configRepository = app.get(ConfigRepository);
   app.get(AppRepository).setCloseFn(() => app.close());


### PR DESCRIPTION
## Description

Immich currently suggests enabling HTTPS using a reverse-proxy. However, considering the fact memory has gotten way more of a scarce resource recently and the fact NestJS supports HTTPS right out of the box, baking-in support for HTTPS seems like a low-hanging fruit, as evidenced by this relatively tiny change.

## How Has This Been Tested?

Tested locally with LetsEncrypt certificates. 

- [x] Without `IMMICH_HTTPS_KEY_PATH` and `IMMICH_HTTPS_CERT_PATH` env variables set, server starts as HTTP service
- [x] With aforementioned variables configured to point to LetsEncrypt `immich.localdomain.com.key` and `fullchain.cer` (respectively), service starts as HTTPS: ` LOG [Api:Bootstrap] Immich Server is listening on https://[::1]:2283 [v2.7.3] [production] `. Web browser detects and confirms certificate is valid and in use.

I mapped the letsencrypt certs as following:
```
    environment:
      IMMICH_HTTPS_CERT_PATH: /certs/fullchain.cer
      IMMICH_HTTPS_KEY_PATH: /certs/immich.localdomain.com.key
    volumes:
      - /home/immich/.acme.sh/immich.localdomain.com_ecc:/certs:ro
```

I suppose docker-compose.yml could be edited to include those as commented-out, but I wasn't sure this is how Immich devs would prefer it.

## API Changes

No changes to API

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
   I suppose HTTPS support could be tested but generating certificates for testing purposes would add significant complexity. Besides, actual HTTPS is provided by NestJS, this change merely enables passing paths to cert and key files for NestJS to handle.
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I am not very proficient with TS, so I used LLM to double-check my solution and Gemini 3 Flash suggested a cleaner implementation of `getNestOptions()` function.

