### PR TITLE
fix(mobile): add keys for person tiles in search

### DIFF
--- a/mobile/lib/presentation/pages/drift_people_collection.page.dart
+++ b/mobile/lib/presentation/pages/drift_people_collection.page.dart
@@ -89,7 +89,7 @@ class _DriftPeopleCollectionPageState extends ConsumerState<DriftPeopleCollectio
                             shape: const CircleBorder(side: BorderSide.none),
                             elevation: 3,
                             child: CircleAvatar(
-                              key: ValueKey('avatar-${person.id}'),
+                              key: ValueKey(person.id),
                               maxRadius: isTablet ? 100 / 2 : 96 / 2,
                               backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
                             ),

--- a/mobile/lib/widgets/search/search_filter/people_picker.dart
+++ b/mobile/lib/widgets/search/search_filter/people_picker.dart
@@ -74,6 +74,7 @@ class PeoplePicker extends HookConsumerWidget {
                           shape: const CircleBorder(side: BorderSide.none),
                           elevation: 3,
                           child: CircleAvatar(
+                            key: ValueKey('avatar-${person.id}'),
                             maxRadius: imageSize / 2,
                             backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
                           ),

--- a/mobile/lib/widgets/search/search_filter/people_picker.dart
+++ b/mobile/lib/widgets/search/search_filter/people_picker.dart
@@ -74,7 +74,7 @@ class PeoplePicker extends HookConsumerWidget {
                           shape: const CircleBorder(side: BorderSide.none),
                           elevation: 3,
                           child: CircleAvatar(
-                            key: ValueKey('avatar-${person.id}'),
+                            key: ValueKey(person.id),
                             maxRadius: imageSize / 2,
                             backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
                           ),

--- a/mobile/lib/widgets/search/search_filter/people_picker.dart
+++ b/mobile/lib/widgets/search/search_filter/people_picker.dart
@@ -57,6 +57,7 @@ class PeoplePicker extends HookConsumerWidget {
                   final isSelected = selectedPeople.value.contains(person);
 
                   return Padding(
+                    key: ValueKey(person.id),
                     padding: const EdgeInsets.only(bottom: 2.0),
                     child: LargeLeadingTile(
                       title: Text(


### PR DESCRIPTION
## Description

Similar to #27112 but for the search page's people picker.

Fixes the same issue as #27112 but on the search page.