### PR TITLE
fix(web): selection clearing on preview

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -96,7 +96,11 @@
       sidebarStore.reset();
     }
 
-    if (isAssetViewerRoute(from) && isAssetViewerRoute(to)) {
+    const fromRouteId = from?.route?.id;
+    const toRouteId = to?.route?.id;
+    const sameRouteTransition = fromRouteId && toRouteId && fromRouteId === toRouteId;
+
+    if (sameRouteTransition && (isAssetViewerRoute(from) || isAssetViewerRoute(to))) {
       return;
     }
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,7 +19,6 @@
   import { closeWebsocketConnection, openWebsocketConnection, websocketStore } from '$lib/stores/websocket';
   import { copyToClipboard } from '$lib/utils';
   import { maintenanceShouldRedirect } from '$lib/utils/maintenance';
-  import { isAssetViewerRoute } from '$lib/utils/navigation';
   import { getServerConfig } from '@immich/sdk';
   import {
     CommandPaletteDefaultProvider,
@@ -100,7 +99,7 @@
     const toRouteId = to?.route?.id;
     const sameRouteTransition = fromRouteId && toRouteId && fromRouteId === toRouteId;
 
-    if (sameRouteTransition && (isAssetViewerRoute(from) || isAssetViewerRoute(to))) {
+    if (sameRouteTransition) {
       return;
     }
 


### PR DESCRIPTION
## Description

Fixes an issue where the multi-selection would reset/clear when previewing an asset.

## How Has This Been Tested?

- [x] Select some assets
- [x] Click the preview icon on any of the asset's thumbnail
- [x] Go back
- [x] Selection is kept