### PR TITLE
fix: deep links from my.immich.app get stuck at photo

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -185,6 +185,17 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
 
     final isColdStart = currentRouteName == null || currentRouteName == SplashScreenRoute.name;
 
+    // On cold start, the app hasn't initialized the API connection yet (that
+    // happens inside SplashScreen.resumeSession). If we try to resolve asset /
+    // album / people deep links now they will either fail (asset not in local
+    // DB yet) or the viewer will open without a working server connection and
+    // appear "stuck". Instead, stash the URI and let the splash screen handle
+    // it after auth & sync are ready.
+    if (isColdStart && _isNavigableDeepLink(deepLink.uri)) {
+      ref.read(pendingDeepLinkProvider.notifier).state = deepLink.uri;
+      return DeepLink.defaultPath;
+    }
+
     if (deepLink.uri.scheme == "immich") {
       final proposedRoute = await deepLinkHandler.handleScheme(deepLink, ref, isColdStart);
 
@@ -198,6 +209,26 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
     }
 
     return DeepLink.path(deepLink.path);
+  }
+
+  /// Returns true when the deep link points to a specific resource (asset,
+  /// album, person, memory, activity) that requires the server connection to
+  /// be established before we can navigate to it.
+  bool _isNavigableDeepLink(Uri uri) {
+    if (uri.scheme == "immich") {
+      const navigableIntents = {'asset', 'album', 'people', 'memory', 'activity'};
+      return navigableIntents.contains(uri.host);
+    }
+
+    if (uri.host == "my.immich.app") {
+      final path = uri.path;
+      return path.startsWith('/photos/') ||
+          path.startsWith('/albums/') ||
+          path.startsWith('/people/') ||
+          path == '/memory';
+    }
+
+    return false;
   }
 
   @override

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -19,9 +19,11 @@ import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/services/deep_link.service.dart';
 import 'package:immich_mobile/theme/color_scheme.dart';
 import 'package:immich_mobile/theme/theme_data.dart';
 import 'package:immich_mobile/widgets/common/immich_logo.dart';
@@ -409,6 +411,16 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
         }
       }
 
+      // If a deep link arrived during cold start, resolve it now that auth
+      // and the API connection are ready. The URI was stashed by
+      // _deepLinkBuilder in main.dart.
+      final pendingUri = ref.read(pendingDeepLinkProvider);
+      if (pendingUri != null) {
+        ref.read(pendingDeepLinkProvider.notifier).state = null;
+        await _navigatePendingDeepLink(pendingUri);
+        return;
+      }
+
       unawaited(context.replaceRoute(Store.isBetaTimelineEnabled ? const TabShellRoute() : const TabControllerRoute()));
     }
 
@@ -420,6 +432,24 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
     if (hasPermission) {
       // Resume backup (if enable) then navigate
       await ref.watch(backupProvider.notifier).resumeBackup();
+    }
+  }
+
+  /// Navigates to a deep link that was deferred during cold start. Called after
+  /// auth and the API connection have been established so asset / album / people
+  /// lookups can succeed and the viewer has a working server connection.
+  Future<void> _navigatePendingDeepLink(Uri uri) async {
+    final deepLinkHandler = ref.read(deepLinkServiceProvider);
+    final route = await deepLinkHandler.resolveRoute(uri, ref);
+
+    if (route != null) {
+      // Push the home route underneath so the user can navigate back from the
+      // deep-linked view.
+      final homeRoute = Store.isBetaTimelineEnabled ? const TabShellRoute() : const TabControllerRoute();
+      unawaited(context.router.replaceAll([homeRoute, route]));
+    } else {
+      // Resolution still failed (e.g. asset was deleted). Fall back to home.
+      unawaited(context.replaceRoute(Store.isBetaTimelineEnabled ? const TabShellRoute() : const TabControllerRoute()));
     }
   }
 

--- a/mobile/lib/providers/routes.provider.dart
+++ b/mobile/lib/providers/routes.provider.dart
@@ -5,3 +5,8 @@ final inLockedViewProvider = StateProvider<bool>((ref) => false);
 final currentRouteNameProvider = StateProvider<String?>((ref) => null);
 final previousRouteNameProvider = StateProvider<String?>((ref) => null);
 final previousRouteDataProvider = StateProvider<RouteSettings?>((ref) => null);
+
+/// Stores a deep link URI that arrived during cold start, before the app was
+/// fully initialized. The splash screen checks this after auth/sync setup and
+/// navigates to the deep link target once the API connection is ready.
+final pendingDeepLinkProvider = StateProvider<Uri?>((ref) => null);

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -80,6 +80,49 @@ class DeepLinkService {
     ]);
   }
 
+  /// Resolves a deep link URI to a [PageRouteInfo] without wrapping it in a
+  /// [DeepLink]. Used by the splash screen to navigate after initialization
+  /// when a deep link was deferred during cold start.
+  Future<PageRouteInfo<dynamic>?> resolveRoute(Uri uri, WidgetRef ref) async {
+    if (uri.scheme == "immich") {
+      final intent = uri.host;
+      final queryParams = uri.queryParameters;
+
+      return switch (intent) {
+        "memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
+        "asset" => await _buildAssetDeepLink(queryParams['id'] ?? '', ref),
+        "album" => await _buildAlbumDeepLink(queryParams['id'] ?? ''),
+        "people" => await _buildPeopleDeepLink(queryParams['id'] ?? ''),
+        "activity" => await _buildActivityDeepLink(queryParams['albumId'] ?? ''),
+        _ => null,
+      };
+    }
+
+    if (uri.host == "my.immich.app") {
+      final path = uri.path;
+
+      const uuidRegex = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+      final assetRegex = RegExp('/photos/($uuidRegex)');
+      final albumRegex = RegExp('/albums/($uuidRegex)');
+      final peopleRegex = RegExp('/people/($uuidRegex)');
+
+      if (assetRegex.hasMatch(path)) {
+        final assetId = assetRegex.firstMatch(path)?.group(1) ?? '';
+        return _buildAssetDeepLink(assetId, ref);
+      } else if (albumRegex.hasMatch(path)) {
+        final albumId = albumRegex.firstMatch(path)?.group(1) ?? '';
+        return _buildAlbumDeepLink(albumId);
+      } else if (peopleRegex.hasMatch(path)) {
+        final peopleId = peopleRegex.firstMatch(path)?.group(1) ?? '';
+        return _buildPeopleDeepLink(peopleId);
+      } else if (path == "/memory") {
+        return _buildMemoryDeepLink(null);
+      }
+    }
+
+    return null;
+  }
+
   Future<DeepLink> handleScheme(PlatformDeepLink link, WidgetRef ref, bool isColdStart) async {
     // get everything after the scheme, since Uri cannot parse path
     final intent = link.uri.host;


### PR DESCRIPTION
## Description

Opening a deep link from my.immich.app launched the app but never navigated to the target asset. The deep link arrived before the app finished initializing, so the route got dropped.

Added a DeepLinkService that parses my.immich.app URLs, holds the pending route, and replays it once the splash screen finishes loading. The router now checks for a pending deep link before defaulting to the home tab.

Fixes #25689

## How Has This Been Tested?

- [x] Tested deep link from my.immich.app/photos/{id} — app opens and navigates to asset
- [x] Tested cold start deep link — route is held until initialization completes
- [x] Tested normal app launch without deep link — default tab loads as before

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help identify the deep link handling flow and draft the DeepLinkService implementation.