### PR TITLE
feat: sort users alphabetically when adding to album

### DIFF
--- a/web/src/lib/modals/AlbumAddUsersModal.svelte
+++ b/web/src/lib/modals/AlbumAddUsersModal.svelte
@@ -21,10 +21,13 @@
   let users: UserResponseDto[] = $state([]);
   const excludedUserIds = $derived([album.ownerId, ...album.albumUsers.map(({ user: { id } }) => id)]);
   const filteredUsers = $derived(
-    users.filter(
-      (user) =>
-        !excludedUserIds.includes(user.id) && normalizeSearchString(user.name).includes(normalizeSearchString(search)),
-    ),
+    users
+      .filter(
+        (user) =>
+          !excludedUserIds.includes(user.id) &&
+          normalizeSearchString(user.name).includes(normalizeSearchString(search)),
+      )
+      .sort((a, b) => (a.name > b.name ? 1 : b.name > a.name ? -1 : 0)),
   );
   const selectedUsers = new SvelteMap<string, UserResponseDto>();
   let loading = $state(true);

--- a/web/src/lib/modals/AlbumAddUsersModal.svelte
+++ b/web/src/lib/modals/AlbumAddUsersModal.svelte
@@ -5,6 +5,7 @@
   import { normalizeSearchString } from '$lib/utils/string-utils';
   import { searchUsers, type AlbumResponseDto, type UserResponseDto } from '@immich/sdk';
   import { FormModal, ListButton, LoadingSpinner, Stack, Text } from '@immich/ui';
+  import { sortBy } from 'lodash-es';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { SvelteMap } from 'svelte/reactivity';
@@ -21,13 +22,14 @@
   let users: UserResponseDto[] = $state([]);
   const excludedUserIds = $derived([album.ownerId, ...album.albumUsers.map(({ user: { id } }) => id)]);
   const filteredUsers = $derived(
-    users
-      .filter(
+    sortBy(
+      users.filter(
         (user) =>
           !excludedUserIds.includes(user.id) &&
           normalizeSearchString(user.name).includes(normalizeSearchString(search)),
-      )
-      .sort((a, b) => (a.name > b.name ? 1 : b.name > a.name ? -1 : 0)),
+      ),
+      ['name'],
+    ),
   );
   const selectedUsers = new SvelteMap<string, UserResponseDto>();
   let loading = $state(true);


### PR DESCRIPTION
## Description

Changed the order of users are displayed in the `AlbumAddUsersModal`, from ID-sorted to sorted alphabetically by user name. For large immich-instances it is now easier to find a specific user to share an album with.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Created multiple users in the dev container environment and check the sort order.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

### Unsorted
rev bee49cef02ea7a2fa09628d136c4606bfde385d4
<img width="520" height="366" alt="Unsorted" src="https://github.com/user-attachments/assets/807e6386-e99f-49e0-bc67-80f7e30baf04" />

### Sorted
rev d328b3153dda5f3345dace79daa6f4440ffa309d
<img width="520" height="366" alt="Sorted" src="https://github.com/user-attachments/assets/6407b2df-670a-4be8-a894-0446c67439d2" />

</details>

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable (not applicable)
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary. (none new dependencies)
- [X] I have written tests for new code (if applicable) (not applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
generated commit message
