### PR TITLE
fix(web): add consistent focus-visible outlines for keyboard navigation

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -81,6 +81,12 @@
   [role='button']:not(:disabled) {
     cursor: pointer;
   }
+
+  /* Provide a consistent focus-visible outline for all interactive elements */
+  :focus-visible {
+    outline: 2px solid var(--immich-ui-primary-500, currentColor);
+    outline-offset: 2px;
+  }
 }
 
 @layer utilities {
@@ -153,8 +159,8 @@
   }
 
   input:focus-visible {
-    outline-offset: 0px !important;
-    outline: none !important;
+    outline: 2px solid var(--immich-ui-primary-500, currentColor);
+    outline-offset: 0px;
   }
 
   .text-white-shadow {

--- a/web/src/lib/components/layouts/user-page-layout.svelte
+++ b/web/src/lib/components/layouts/user-page-layout.svelte
@@ -53,7 +53,7 @@
 </header>
 <div
   tabindex="-1"
-  class="relative z-0 grid grid-cols-[--spacing(0)_auto] overflow-hidden sidebar:grid-cols-[--spacing(64)_auto]
+  class="relative z-0 grid grid-cols-[--spacing(0)_auto] overflow-clip sidebar:grid-cols-[--spacing(64)_auto]
     {hideNavbar ? 'h-dvh' : 'h-[calc(100dvh-var(--navbar-height))] max-md:h-[calc(100dvh-var(--navbar-height-md))]'}
     {hideNavbar ? 'pt-(--navbar-height)' : ''}
     {hideNavbar ? 'max-md:pt-(--navbar-height-md)' : ''}"

--- a/web/src/lib/components/shared-components/context-menu/menu-option.svelte
+++ b/web/src/lib/components/shared-components/context-menu/menu-option.svelte
@@ -53,7 +53,7 @@
   onclick={handleClick}
   onmouseover={() => ($selectedIdStore = id)}
   onmouseleave={() => ($selectedIdStore = undefined)}
-  class="w-full p-4 text-start text-sm font-medium {textColor} focus:outline-none focus:ring-2 focus:ring-inset cursor-pointer border-gray-200 flex gap-2 items-center {isActive
+  class="w-full p-4 text-start text-sm font-medium {textColor} outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer border-gray-200 flex gap-2 items-center {isActive
     ? activeColor
     : 'bg-slate-100'}"
   role="menuitem"

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -169,7 +169,7 @@
         >
           <button
             type="button"
-            class="flex ps-2"
+            class="flex rounded-full ps-2 outline-offset-2 focus-visible:outline-2 focus-visible:outline-primary"
             onclick={() => (shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel)}
             title={`${$user.name} (${$user.email})`}
           >

--- a/web/src/lib/components/shared-components/navigation-bar/notification-item.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/notification-item.svelte
@@ -100,7 +100,7 @@
 </script>
 
 <button
-  class="min-h-20 p-2 py-3 hover:bg-immich-primary/10 dark:hover:bg-immich-dark-primary/10 border-b border-gray-200 dark:border-immich-dark-gray w-full"
+  class="min-h-20 p-2 py-3 hover:bg-immich-primary/10 dark:hover:bg-immich-dark-primary/10 border-b border-gray-200 dark:border-immich-dark-gray w-full outline-offset-[-2px] focus-visible:outline-2 focus-visible:outline-primary"
   type="button"
   onclick={() => onclick(notification)}
   title={notification.createdAt}

--- a/web/src/lib/components/shared-components/settings/setting-accordion.svelte
+++ b/web/src/lib/components/shared-components/settings/setting-accordion.svelte
@@ -73,7 +73,7 @@
     type="button"
     aria-expanded={isOpen}
     {onclick}
-    class="flex w-full place-items-center justify-between text-start"
+    class="flex w-full place-items-center justify-between rounded-xl text-start outline-offset-2 focus-visible:outline-2 focus-visible:outline-primary"
   >
     <div>
       <div class="flex gap-2 place-items-center">


### PR DESCRIPTION
## Summary
- Add a global `focus-visible` rule in `app.css` to provide consistent outline styles (2px solid primary color with 2px offset) for all interactive elements, ensuring keyboard users always see a focus indicator
- Fix the `input:focus-visible` override that was using `outline: none !important` to completely remove focus outlines from inputs — now shows a proper primary-colored outline
- Change `overflow-hidden` to `overflow-clip` in `user-page-layout.svelte` to prevent clipping of focus outlines while still hiding overflow content
- Add explicit `focus-visible` styles to specific components that benefit from tailored outlines: setting accordion buttons, navigation bar avatar button, notification items, and context menu options

Closes #19498

## Test plan
- [ ] Tab through the admin settings page — accordion expand/collapse buttons should show a visible focus ring
- [ ] Tab through the navigation bar — avatar button and other interactive elements show focus outlines
- [ ] Tab through context menu options — items show an inset ring on focus
- [ ] Verify that clicking interactive elements does NOT show outlines (focus-visible, not focus)
- [ ] Verify dark mode: focus outlines should be visible against dark backgrounds
- [ ] Verify the user page layout sidebar and content area: focus outlines should no longer be clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)