### PR TITLE
fix(server): add rate limit and deduplication to version check

### DIFF
--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -707,6 +707,7 @@ export enum DatabaseLock {
   BackupDatabase = 42,
   MaintenanceOperation = 621,
   MemoryCreation = 777,
+  VersionCheck = 800,
 }
 
 export enum MaintenanceAction {

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -233,6 +233,9 @@ export class JobRepository {
       case JobName.FacialRecognitionQueueAll: {
         return { jobId: JobName.FacialRecognitionQueueAll };
       }
+      case JobName.VersionCheck: {
+        return { jobId: JobName.VersionCheck };
+      }
       default: {
         return null;
       }

--- a/server/src/services/version.service.spec.ts
+++ b/server/src/services/version.service.spec.ts
@@ -47,7 +47,8 @@ describe(VersionService.name, () => {
       expect(mocks.versionHistory.create).not.toHaveBeenCalled();
     });
 
-    it('should create a version check cron job', async () => {
+    it('should create a version check cron job when the database lock is acquired', async () => {
+      mocks.database.tryLock.mockResolvedValue(true);
       mocks.versionHistory.getLatest.mockResolvedValue({
         id: 'version-1',
         createdAt: new Date(),
@@ -91,6 +92,25 @@ describe(VersionService.name, () => {
     it('should not run if version check is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ newVersionCheck: { enabled: false } });
       await expect(sut.handleVersionCheck()).resolves.toEqual(JobStatus.Skipped);
+    });
+
+    it('should skip if the last check was less than 50 seconds ago', async () => {
+      mocks.systemMetadata.get.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        checkedAt: DateTime.utc().minus({ seconds: 30 }).toISO(),
+        releaseVersion: '1.0.0',
+      });
+      await expect(sut.handleVersionCheck()).resolves.toEqual(JobStatus.Skipped);
+      expect(mocks.serverInfo.getLatestRelease).not.toHaveBeenCalled();
+    });
+
+    it('should run if the last check was more than 50 seconds ago', async () => {
+      mocks.systemMetadata.get.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        checkedAt: DateTime.utc().minus({ seconds: 60 }).toISO(),
+        releaseVersion: '1.0.0',
+      });
+      mocks.serverInfo.getLatestRelease.mockResolvedValue(mockVersionResponse(serverVersion.toString()));
+      await expect(sut.handleVersionCheck()).resolves.toEqual(JobStatus.Success);
+      expect(mocks.serverInfo.getLatestRelease).toHaveBeenCalled();
     });
 
     it('should run and notify if a new version is available', async () => {

--- a/server/src/services/version.service.ts
+++ b/server/src/services/version.service.ts
@@ -4,7 +4,7 @@ import semver, { SemVer } from 'semver';
 import { serverVersion } from 'src/constants';
 import { OnEvent, OnJob } from 'src/decorators';
 import { ReleaseNotification, ServerVersionResponseDto } from 'src/dtos/server.dto';
-import { CronJob, DatabaseLock, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
+import { CronJob, DatabaseLock, ImmichWorker, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
 import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { VersionCheckMetadata } from 'src/types';
@@ -21,18 +21,21 @@ const asNotification = ({ checkedAt, releaseVersion }: VersionCheckMetadata): Re
 
 @Injectable()
 export class VersionService extends BaseService {
-  @OnEvent({ name: 'AppBootstrap' })
+  @OnEvent({ name: 'AppBootstrap', workers: [ImmichWorker.Microservices] })
   async onBootstrap(): Promise<void> {
-    await this.handleVersionCheck();
+    const hasLock = await this.databaseRepository.tryLock(DatabaseLock.VersionCheck);
+    if (hasLock) {
+      await this.handleVersionCheck();
 
-    const randomMinute = Math.floor(Math.random() * 60);
-    const expression = `${randomMinute} * * * *`;
-    this.logger.debug(`Scheduling version check for cron ${expression}`);
-    this.cronRepository.create({
-      name: CronJob.VersionCheck,
-      expression,
-      onTick: () => handlePromiseError(this.handleQueueVersionCheck(), this.logger),
-    });
+      const randomMinute = Math.floor(Math.random() * 60);
+      const expression = `${randomMinute} * * * *`;
+      this.logger.debug(`Scheduling version check for cron ${expression}`);
+      this.cronRepository.create({
+        name: CronJob.VersionCheck,
+        expression,
+        onTick: () => handlePromiseError(this.handleQueueVersionCheck(), this.logger),
+      });
+    }
 
     await this.databaseRepository.withLock(DatabaseLock.VersionHistory, async () => {
       const previous = await this.versionRepository.getLatest();
@@ -84,6 +87,15 @@ export class VersionService extends BaseService {
       const { newVersionCheck } = await this.getConfig({ withCache: true });
       if (!newVersionCheck.enabled) {
         return JobStatus.Skipped;
+      }
+
+      const versionCheck = await this.systemMetadataRepository.get(SystemMetadataKey.VersionCheckState);
+      if (versionCheck?.checkedAt) {
+        const lastUpdate = DateTime.fromISO(versionCheck.checkedAt);
+        const elapsedTime = DateTime.now().diff(lastUpdate).as('seconds');
+        if (elapsedTime < 50) {
+          return JobStatus.Skipped;
+        }
       }
 
       const { version: releaseVersion, published_at: publishedAt } = await this.serverInfoRepository.getLatestRelease();


### PR DESCRIPTION
- restore 50 second rate limit to prevent excessive requests to version.immich.cloud from multi-node deployments and restarts
- use database advisory lock so only one instance creates the cron job
- add jobId to version check jobs for queue deduplication