### PR TITLE
fix(server): prevent BullMQ job stalling under event loop pressure

### DIFF
--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -1,0 +1,146 @@
+import { Job, Queue, QueueEvents, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+
+const REDIS_PORT = Number(process.env.REDIS_PORT || 6380);
+
+/**
+ * Synchronously blocks the Node.js event loop for the given duration.
+ * This prevents BullMQ's internal lock renewal timer from firing,
+ * simulating heavy CPU work (e.g. sharp image processing, V8 GC pauses).
+ */
+function blockEventLoop(ms: number) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // busy-wait — the event loop cannot process any timers or I/O callbacks
+  }
+}
+
+async function connectRedis(): Promise<IORedis | null> {
+  try {
+    const redis = new IORedis({ port: REDIS_PORT, maxRetriesPerRequest: null, lazyConnect: true });
+    await redis.connect();
+    return redis;
+  } catch {
+    return null;
+  }
+}
+
+describe('BullMQ worker stall prevention', () => {
+  let redis: IORedis | null;
+
+  beforeAll(async () => {
+    redis = await connectRedis();
+  });
+
+  afterAll(async () => {
+    await redis?.quit();
+  });
+
+  it('should stall and fail a job when lockDuration is shorter than the event loop block', async () => {
+    if (!redis) {
+      return;
+    }
+
+    // THE BUG: BullMQ's default lockDuration is 30 seconds. When thumbnail
+    // generation (sharp) or video transcoding (ffmpeg) blocks the Node.js event
+    // loop, the automatic lock renewal timer cannot fire. After lockDuration
+    // expires, the stalled checker marks the job as stalled. With maxStalledCount=1,
+    // the job permanently fails. With 20 concurrent workers, ALL active jobs stall
+    // simultaneously, permanently freezing the entire queue.
+
+    const queueName = `test-stall-bug-${Date.now()}`;
+    const connection = { port: REDIS_PORT, maxRetriesPerRequest: null };
+
+    const queue = new Queue(queueName, { connection });
+    const queueEvents = new QueueEvents(queueName, { connection });
+    await queueEvents.waitUntilReady();
+
+    const stalledJobIds: string[] = [];
+    queueEvents.on('stalled', ({ jobId }) => stalledJobIds.push(jobId));
+
+    const worker = new Worker(
+      queueName,
+      async () => {
+        blockEventLoop(3000); // simulate heavy image processing
+      },
+      {
+        connection,
+        concurrency: 1,
+        lockDuration: 1000, // lock expires after 1s — too short for 3s of CPU work
+        stalledInterval: 1000,
+        maxStalledCount: 1,
+      },
+    );
+    await worker.waitUntilReady();
+
+    const job = await queue.add('thumbnail', { assetId: 'large-raw-image' });
+
+    try {
+      await job.waitUntilFinished(queueEvents, 15_000);
+      expect.unreachable('Job should have failed due to stalling');
+    } catch {
+      // expected — job stalled and was moved to failed
+    }
+
+    const state = await job.getState();
+    expect(state).toBe('failed');
+    expect(stalledJobIds).toContain(job.id);
+
+    const failed = await Job.fromId(queue, job.id!);
+    expect(failed?.failedReason).toContain('stalled');
+
+    await worker.close();
+    await queue.obliterate({ force: true });
+    await queueEvents.close();
+    await queue.close();
+  }, 20_000);
+
+  it('should complete a job when lockDuration is longer than the event loop block', async () => {
+    if (!redis) {
+      return;
+    }
+
+    // THE FIX: with lockDuration set to 10 minutes (600_000ms in production,
+    // 10s here for test speed), the Redis lock survives the event loop block.
+    // When the event loop unblocks, the worker marks the job as completed
+    // because the lock is still valid.
+
+    const queueName = `test-stall-fix-${Date.now()}`;
+    const connection = { port: REDIS_PORT, maxRetriesPerRequest: null };
+
+    const queue = new Queue(queueName, { connection });
+    const queueEvents = new QueueEvents(queueName, { connection });
+    await queueEvents.waitUntilReady();
+
+    const stalledJobIds: string[] = [];
+    queueEvents.on('stalled', ({ jobId }) => stalledJobIds.push(jobId));
+
+    const worker = new Worker(
+      queueName,
+      async () => {
+        blockEventLoop(3000); // same heavy work as above
+      },
+      {
+        connection,
+        concurrency: 1,
+        lockDuration: 10_000, // lock valid for 10s — survives a 3s block
+        stalledInterval: 10_000,
+        maxStalledCount: 1,
+      },
+    );
+    await worker.waitUntilReady();
+
+    const job = await queue.add('thumbnail', { assetId: 'large-raw-image' });
+
+    await job.waitUntilFinished(queueEvents, 15_000);
+
+    const state = await job.getState();
+    expect(state).toBe('completed');
+    expect(stalledJobIds).toHaveLength(0);
+
+    await worker.close();
+    await queue.obliterate({ force: true });
+    await queueEvents.close();
+    await queue.close();
+  }, 20_000);
+});

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -91,7 +91,7 @@ export class JobRepository {
       this.workers[queueName] = new Worker(
         queueName,
         (job) => this.eventRepository.emit('JobRun', queueName, job as JobItem),
-        { ...bull.config, concurrency: 1 },
+        { ...bull.config, concurrency: 1, lockDuration: 600_000, stalledInterval: 600_000 },
       );
     }
   }


### PR DESCRIPTION
## Description

Fixes a bug where job queues (most commonly thumbnail generation) permanently freeze under load. BullMQ workers are created with the default `lockDuration` of 30 seconds. When the Node.js event loop gets blocked, the automatic lock renewal timer cannot fire, the lock expires in Redis, and BullMQ marks the job as stalled/failed. With high concurrency (e.g. 20 thumbnail generation workers), all active jobs stall simultaneously, permanently freezing the entire queue with thousands of items stuck.

### How to reproduce

1. Run Immich on a machine with limited CPU (e.g. 2 cores) and thumbnail generation concurrency at 20
2. Upload a large batch of photos (including large RAW files or high-resolution images)
3. Observe that the "Generate Thumbnails" queue initially picks up 20 jobs, then stops progressing entirely
4. In the admin panel, the queue shows thousands of items waiting but the count never decreases
5. The server container shows near-zero CPU usage despite having active jobs

### Root cause

BullMQ's default `lockDuration` is 30 seconds. When a worker picks up a job, it acquires a Redis lock with a 30s TTL that is auto-renewed every 15s via a JS timer. When sharp image processing or V8 GC pressure blocks the event loop, the renewal timer cannot fire, the Redis lock expires, and BullMQ marks all active jobs as stalled. With high concurrency all workers share the same event loop, so all jobs stall simultaneously.

### What was observed in production

On a Synology NAS running Immich v2.7.4 (2 CPU cores, 17GB RAM):
- Redis: **6,359 jobs waiting**, **20 stuck in "active"** for 27 hours
- Server CPU at **0.07%** — workers completely idle despite holding active jobs
- Failed jobs: `UnrecoverableError: job stalled more than allowable limit`

### Fix

Set `lockDuration: 600_000` (10 minutes) and `stalledInterval: 600_000` on BullMQ Workers. Locks auto-renew every 5 minutes, so under normal operation they never expire. A true worker crash is detected within ~10 minutes.

## How Has This Been Tested?

- [x] Integration test using real BullMQ + Redis: worker with short `lockDuration` (1s) and 3s event loop block → job stalls and fails (demonstrates the bug)
- [x] Integration test using real BullMQ + Redis: worker with long `lockDuration` (10s) and 3s event loop block → job completes successfully (demonstrates the fix)
- [x] Full unit test suite passes (2131 tests, 0 failures)
- [x] Verified on production Synology NAS — queue drained successfully after restart with fix

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — backend fix, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No.