### PR TITLE
feat(web): persist state of file path information in details panel

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -55,7 +55,6 @@
 
   let { asset, currentAlbum = null }: Props = $props();
 
-  let showAssetPath = $state(false);
   let showEditFaces = $state(false);
   let isOwner = $derived($user?.id === asset.ownerId);
   let people = $derived(asset.people || []);
@@ -128,8 +127,6 @@
     // Remove the last part of the path to get the parent path
     return Route.folders({ path: getParentPath(asset.originalPath) });
   };
-
-  const toggleAssetPath = () => (showAssetPath = !showAssetPath);
 
   const handleChangeDate = async () => {
     if (!isOwner) {
@@ -369,11 +366,11 @@
               shape="round"
               color="secondary"
               variant="ghost"
-              onclick={toggleAssetPath}
+              onclick={() => assetViewerManager.toggleAssetPath()}
             />
           {/if}
         </p>
-        {#if showAssetPath}
+        {#if assetViewerManager.isShowAssetPath}
           <p class="text-xs opacity-50 break-all pb-2 hover:text-primary" transition:slide={{ duration: 250 }}>
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve this is supposed to be treated as an absolute/external link -->
             <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')} class="whitespace-pre-wrap">

--- a/web/src/lib/managers/asset-viewer-manager.svelte.ts
+++ b/web/src/lib/managers/asset-viewer-manager.svelte.ts
@@ -9,6 +9,7 @@ import type { ZoomImageWheelState } from '@zoom-image/core';
 import { cubicOut } from 'svelte/easing';
 
 const isShowDetailPanel = new PersistedLocalStorage<boolean>('asset-viewer-state', false);
+const isShowAssetPath = new PersistedLocalStorage<boolean>('asset-viewer-show-path', false);
 
 const createDefaultZoomState = (): ZoomImageWheelState => ({
   currentRotation: 0,
@@ -63,6 +64,10 @@ class AssetViewerManager extends BaseEventManager<Events> {
     return isShowDetailPanel.current;
   }
 
+  get isShowAssetPath() {
+    return isShowAssetPath.current;
+  }
+
   get isFaceEditMode() {
     return this.#isFaceEditMode;
   }
@@ -99,6 +104,10 @@ class AssetViewerManager extends BaseEventManager<Events> {
 
   private set isShowDetailPanel(value: boolean) {
     isShowDetailPanel.current = value;
+  }
+
+  private set isShowAssetPath(value: boolean) {
+    isShowAssetPath.current = value;
   }
 
   onZoomChange(state: ZoomImageWheelState) {
@@ -145,6 +154,10 @@ class AssetViewerManager extends BaseEventManager<Events> {
 
   closeActivityPanel() {
     this.isShowActivityPanel = false;
+  }
+
+  toggleAssetPath() {
+    this.isShowAssetPath = !this.isShowAssetPath;
   }
 
   toggleDetailPanel() {


### PR DESCRIPTION
## Description
This PR adds a minor UX enhancement and persist the state of the file path information in localstorage. This is consistent with the behavior of the parent details panel and done in similar fashion.

## How Has This Been Tested?
- [X] Open details panel
- [X] Click "i" button next to file name. File path appears.
- [X] Close asset viewer
- [X] Open another asset, details panel is open again, and file information as well.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Needed a small hint, to find the connection between persistence for details panel and asset-viewer manager and had it explained.
