### PR TITLE
fix(machine-learning): align OCR detection normalization with Paddle PP-OCRv5

### DIFF
--- a/machine-learning/immich_ml/models/ocr/detection.py
+++ b/machine-learning/immich_ml/models/ocr/detection.py
@@ -25,8 +25,12 @@ class TextDetector(InferenceModel):
     def __init__(self, model_name: str, min_score: float = 0.5, **model_kwargs: Any) -> None:
         super().__init__(model_name.split("__")[-1], **model_kwargs, model_format=ModelFormat.ONNX)
         self.max_resolution = 736
-        self.mean = np.array([0.5, 0.5, 0.5], dtype=np.float32)
-        self.std_inv = np.float32(1.0) / (np.array([0.5, 0.5, 0.5], dtype=np.float32) * 255.0)
+        # Align with Paddle NormalizeImage:
+        # scale=1/255, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+        # This implementation works on raw 0..255 pixels, so we fold scale into mean/std:
+        # (x/255 - mean) / std == (x - mean*255) / (std*255)
+        self.mean = np.array([0.485, 0.456, 0.406], dtype=np.float32) * 255.0
+        self.std_inv = np.float32(1.0) / (np.array([0.229, 0.224, 0.225], dtype=np.float32) * 255.0)
         self._empty: TextDetectionOutput = {
             "boxes": np.empty(0, dtype=np.float32),
             "scores": np.empty(0, dtype=np.float32),


### PR DESCRIPTION
## Description

This PR updates OCR detection preprocessing to match the official PaddleOCR PP-OCRv5 server det config.
Source of truth (Paddle inference config):
- `PP-OCRv5_server_det_infer/inference.yml` (from Paddle model package)
Verbatim parameters from `inference.yml`:

```
- NormalizeImage:
  mean:
    - 0.485
    - 0.456
    - 0.406
  order: hwc
  scale: 1./255.
  std:
    - 0.229
    - 0.224
    - 0.225
 ```

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
using codex gpt-5.4
