### PR TITLE
fix(web): use event for zooming out after opening face editor

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -106,13 +106,13 @@
     assetViewerManager.animatedZoom(targetZoom);
   };
 
-  const onPlaySlideshow = () => ($slideshowState = SlideshowState.PlaySlideshow);
-
-  $effect(() => {
-    if (assetViewerManager.isFaceEditMode && assetViewerManager.zoom > 1) {
+  const onFaceEditModeChange = (isFaceEditMode: boolean) => {
+    if (isFaceEditMode && assetViewerManager.zoom > 1) {
       onZoom();
     }
-  });
+  };
+
+  const onPlaySlideshow = () => ($slideshowState = SlideshowState.PlaySlideshow);
 
   // TODO move to action + command palette
   const onCopyShortcut = (event: KeyboardEvent) => {
@@ -200,7 +200,7 @@
   };
 </script>
 
-<AssetViewerEvents {onCopy} {onZoom} />
+<AssetViewerEvents {onCopy} {onZoom} {onFaceEditModeChange} />
 
 <svelte:document
   use:shortcuts={[

--- a/web/src/lib/managers/asset-viewer-manager.svelte.ts
+++ b/web/src/lib/managers/asset-viewer-manager.svelte.ts
@@ -23,6 +23,7 @@ export type Events = {
   Zoom: [];
   ZoomChange: [ZoomImageWheelState];
   Copy: [];
+  FaceEditModeChange: [boolean];
 };
 
 class AssetViewerManager extends BaseEventManager<Events> {
@@ -180,9 +181,13 @@ class AssetViewerManager extends BaseEventManager<Events> {
 
   toggleFaceEditMode() {
     this.#isFaceEditMode = !this.#isFaceEditMode;
+    this.emit('FaceEditModeChange', this.#isFaceEditMode);
   }
 
   closeFaceEditMode() {
+    if (this.#isFaceEditMode) {
+      this.emit('FaceEditModeChange', false);
+    }
     this.#isFaceEditMode = false;
   }
 


### PR DESCRIPTION
## Description
Opening the face editor zooms out the image, but the animated zoom keeps updating the zoom state, so we got stuck in an $effect loop, zooming out ever slightly more but never to zoom level 1. I added a `FaceEditModeChange` event to the asset viewer manager which fires only once, and use that to start the (animated) zoom.

Fixes #27734

## How Has This Been Tested?
- Zoom in; start tagging a face; the image zooms out.
  - Notice that on main, the zoom is not cubic and the magnifying glass remains in its 'zoomed in' state.
  - On this branch, the zoom is cubic and the images is fully zoomed out
- Insert console.log statement in `assetViewerManager.animatedZoom` to check when it's triggered
  - On main, a seemingly infinite number of times
  - On this branch, only once

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
