### PR TITLE
Fix Open Graph tags on per-asset shared-link URLs

### DIFF
--- a/scripts/docker-compose.og-test.yml
+++ b/scripts/docker-compose.og-test.yml
@@ -1,0 +1,61 @@
+#
+# Minimal production-style stack for OG-tag regression testing.
+# Used exclusively by scripts/test-og-share-links.sh.
+#
+# Compared to the main docker-compose.yml:
+#   - builds immich-server locally from server/Dockerfile (so the SSR
+#     middleware has the /build/www/index.html it reads from),
+#   - drops the machine-learning service (not exercised by OG tests, saves
+#     a ~5 GB image pull),
+#   - uses a dedicated project name so teardown cannot collide with the
+#     user's real Immich deployment.
+#
+# Paths are relative to this file's location (scripts/), so the build
+# context reaches back to the repo root with "..".
+
+name: immich-og-test
+
+services:
+  immich-server:
+    container_name: immich_og_test_server
+    image: immich-server:og-test
+    build:
+      context: ..
+      dockerfile: server/Dockerfile
+    volumes:
+      - ../library:/data
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - ../docker/.env
+    ports:
+      - '2283:2283'
+    depends_on:
+      - redis
+      - database
+    restart: 'no'
+    healthcheck:
+      disable: false
+
+  redis:
+    container_name: immich_og_test_redis
+    image: docker.io/valkey/valkey:9@sha256:3b55fbaa0cd93cf0d9d961f405e4dfcc70efe325e2d84da207a0a8e6d8fde4f9
+    healthcheck:
+      test: redis-cli ping || exit 1
+    restart: 'no'
+
+  database:
+    container_name: immich_og_test_postgres
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    env_file:
+      - ../docker/.env
+    volumes:
+      - ../postgres:/var/lib/postgresql/data
+    shm_size: 128mb
+    restart: 'no'
+    healthcheck:
+      disable: false

--- a/scripts/test-og-share-links.sh
+++ b/scripts/test-og-share-links.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# test-og-share-links.sh
+#
+# End-to-end verification for the OG-tag fix on per-asset shared-link URLs
+# (issue #27786). Starts from an empty directory, clones the dev branch,
+# boots the full dev stack in Docker, seeds an album + shared link via the
+# REST API, and asserts that /share/<KEY>/photos/<ASSET_ID> returns the
+# expected og:* meta tags.
+#
+# Usage (from an empty directory):
+#   curl -fsSL https://raw.githubusercontent.com/liotier/immich/claude/fix-shared-album-links-SdKg5/scripts/test-og-share-links.sh | bash
+#
+# Or after cloning:
+#   ./scripts/test-og-share-links.sh
+
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/liotier/immich.git}"
+BRANCH="${BRANCH:-claude/fix-shared-album-links-SdKg5}"
+WORKDIR="${WORKDIR:-$(pwd)}"
+CHECKOUT_DIR="${CHECKOUT_DIR:-${WORKDIR}/immich}"
+SERVER_URL="${SERVER_URL:-http://localhost:2283}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
+ADMIN_NAME="${ADMIN_NAME:-Admin}"
+READINESS_TIMEOUT="${READINESS_TIMEOUT:-900}"   # seconds, first build is slow
+COMPOSE_FILE="docker/docker-compose.dev.yml"
+
+log()  { printf '\033[1;34m[og-test]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[og-test]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[og-test]\033[0m %s\n' "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required command missing: $1"; }
+
+for cmd in git docker curl jq python3; do need "$cmd"; done
+docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
+
+# -------------------------------------------------------------------------
+# 1. Clone or update the branch
+# -------------------------------------------------------------------------
+if [ ! -d "$CHECKOUT_DIR/.git" ]; then
+  log "Cloning $REPO_URL (branch: $BRANCH) into $CHECKOUT_DIR"
+  git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$CHECKOUT_DIR"
+else
+  log "Repo already present at $CHECKOUT_DIR, fetching latest $BRANCH"
+  git -C "$CHECKOUT_DIR" fetch origin "$BRANCH"
+  git -C "$CHECKOUT_DIR" checkout "$BRANCH"
+  git -C "$CHECKOUT_DIR" pull --ff-only origin "$BRANCH"
+fi
+
+cd "$CHECKOUT_DIR"
+
+# -------------------------------------------------------------------------
+# 2. Prepare env file + data directories
+# -------------------------------------------------------------------------
+ENV_FILE="docker/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  log "Creating $ENV_FILE from example.env"
+  cp docker/example.env "$ENV_FILE"
+fi
+mkdir -p library postgres
+
+# -------------------------------------------------------------------------
+# 3. Bring up the dev stack
+# -------------------------------------------------------------------------
+log "Starting dev stack (this can take 10+ minutes on first run)"
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+# -------------------------------------------------------------------------
+# 4. Wait for the server to be ready
+# -------------------------------------------------------------------------
+log "Waiting for $SERVER_URL/api/server/ping (up to ${READINESS_TIMEOUT}s)"
+deadline=$(( $(date +%s) + READINESS_TIMEOUT ))
+until curl -fsS --max-time 5 "$SERVER_URL/api/server/ping" >/dev/null 2>&1; do
+  if [ "$(date +%s)" -gt "$deadline" ]; then
+    docker compose -f "$COMPOSE_FILE" logs --tail=100 immich-server || true
+    die "server did not become ready within ${READINESS_TIMEOUT}s"
+  fi
+  sleep 3
+done
+log "Server is up."
+
+# -------------------------------------------------------------------------
+# 5. Admin sign-up (idempotent: ignore failure if already registered)
+# -------------------------------------------------------------------------
+log "Registering admin user (if needed): $ADMIN_EMAIL"
+curl -fsS -X POST "$SERVER_URL/api/auth/admin-sign-up" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" --arg n "$ADMIN_NAME" \
+        '{email:$e, password:$p, name:$n}')" >/dev/null || \
+  warn "admin-sign-up rejected (probably already registered) - continuing"
+
+# -------------------------------------------------------------------------
+# 6. Login, capture access token
+# -------------------------------------------------------------------------
+log "Logging in"
+TOKEN=$(curl -fsS -X POST "$SERVER_URL/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')" \
+  | jq -r '.accessToken')
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || die "login failed, no access token"
+
+auth_header="Authorization: Bearer $TOKEN"
+
+# -------------------------------------------------------------------------
+# 7. Generate a tiny JPEG and upload as an asset
+# -------------------------------------------------------------------------
+log "Generating a test JPEG"
+TMP_IMG=$(mktemp --suffix=.jpg)
+# Minimal valid JPEG (a solid colour 2x2) encoded in base64. Small enough
+# to paste inline, avoids any external download.
+base64 -d > "$TMP_IMG" <<'B64'
+/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAQABADASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oADAMB
+AAIRAxEAPwD3+iiigD//2Q==
+B64
+
+log "Uploading asset"
+UPLOAD_RESPONSE=$(curl -fsS -X POST "$SERVER_URL/api/assets" \
+  -H "$auth_header" \
+  -F "assetData=@${TMP_IMG};type=image/jpeg" \
+  -F "deviceAssetId=og-test-device-asset-1" \
+  -F "deviceId=og-test-device" \
+  -F "fileCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+  -F "fileModifiedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)")
+ASSET_ID=$(echo "$UPLOAD_RESPONSE" | jq -r '.id')
+[ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ] || die "upload did not return an asset id: $UPLOAD_RESPONSE"
+log "Uploaded asset: $ASSET_ID"
+
+# -------------------------------------------------------------------------
+# 8. Create an album and add the asset
+# -------------------------------------------------------------------------
+log "Creating album"
+ALBUM_ID=$(curl -fsS -X POST "$SERVER_URL/api/albums" \
+  -H "$auth_header" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg n "OG Test Album" --arg a "$ASSET_ID" \
+        '{albumName:$n, assetIds:[$a]}')" \
+  | jq -r '.id')
+[ -n "$ALBUM_ID" ] && [ "$ALBUM_ID" != "null" ] || die "album creation failed"
+log "Album: $ALBUM_ID"
+
+# -------------------------------------------------------------------------
+# 9. Create an ALBUM shared link
+# -------------------------------------------------------------------------
+log "Creating shared link"
+SHARE_KEY=$(curl -fsS -X POST "$SERVER_URL/api/shared-links" \
+  -H "$auth_header" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg id "$ALBUM_ID" '{type:"ALBUM", albumId:$id}')" \
+  | jq -r '.key')
+[ -n "$SHARE_KEY" ] && [ "$SHARE_KEY" != "null" ] || die "shared link creation failed"
+log "Share key: $SHARE_KEY"
+
+# -------------------------------------------------------------------------
+# 10. Fire the actual assertions
+# -------------------------------------------------------------------------
+ALBUM_URL="$SERVER_URL/share/$SHARE_KEY"
+ASSET_URL="$SERVER_URL/share/$SHARE_KEY/photos/$ASSET_ID"
+
+fetch() {
+  curl -fsS -H 'Accept: text/html' -H 'User-Agent: og-test' "$1"
+}
+
+log ""
+log "=== Regression check: album-level URL still renders og:* ==="
+ALBUM_HTML=$(fetch "$ALBUM_URL")
+echo "$ALBUM_HTML" | grep -E 'og:(title|description|image)' || {
+  warn "no og:* tags on album URL — this is the pre-existing codepath"
+  die "regression: album share link is not producing OG tags"
+}
+
+log ""
+log "=== Target case: per-asset URL must now render og:* ==="
+ASSET_HTML=$(fetch "$ASSET_URL")
+if ! echo "$ASSET_HTML" | grep -qE 'og:title'; then
+  warn "---- received HTML head ----"
+  echo "$ASSET_HTML" | head -c 2000 >&2
+  die "FAIL: no og:title on per-asset URL — the fix is NOT active"
+fi
+
+echo "$ASSET_HTML" | grep -E 'og:(title|description|image)'
+
+log ""
+log "=== Asset-specific thumbnail URL must carry ?key= ==="
+IMG_URL=$(echo "$ASSET_HTML" | grep -oE 'og:image" content="[^"]+"' | head -1 \
+                             | sed -E 's/.*content="([^"]+)"/\1/')
+log "og:image -> $IMG_URL"
+echo "$IMG_URL" | grep -q "assets/$ASSET_ID/thumbnail" \
+  || die "FAIL: og:image does not point at the requested asset ($ASSET_ID)"
+echo "$IMG_URL" | grep -q "key=$SHARE_KEY" \
+  || die "FAIL: og:image is missing key=$SHARE_KEY"
+
+log ""
+log "=== Thumbnail fetch with the embedded key returns 200 ==="
+CODE=$(curl -s -o /dev/null -w '%{http_code}' "$IMG_URL")
+[ "$CODE" = "200" ] || die "FAIL: thumbnail fetch returned HTTP $CODE"
+
+log ""
+log "ALL CHECKS PASSED"
+log "  album  URL: $ALBUM_URL"
+log "  asset  URL: $ASSET_URL"
+log ""
+log "Tear down with:  docker compose -f $COMPOSE_FILE down -v"

--- a/scripts/test-og-share-links.sh
+++ b/scripts/test-og-share-links.sh
@@ -4,20 +4,29 @@
 # End-to-end verification for the OG-tag fix on per-asset shared-link URLs
 # (issue #27786). Three subcommands:
 #
-#   setup      Clone the dev branch, build images, start the stack,
-#              wait for the server to become healthy.
+#   setup      Clone the dev branch, build a PRODUCTION immich-server image
+#              from source, start a minimal prod-style stack (server +
+#              Valkey + Postgres, no machine-learning), wait for the server
+#              to become healthy.
 #   test       Seed an admin user + album + shared link via the REST API
 #              and assert OG tags on /share/<key>/photos/<assetId>.
-#   teardown   Remove containers, volumes, networks, dev-built images,
-#              pulled base images, the Docker build cache, and the
-#              checkout directory. Returns the host to its pre-setup
-#              state (modulo unrelated Docker state).
+#   teardown   Remove containers, volumes, networks, the built image, the
+#              Docker build cache, and the checkout directory. Cleans up
+#              state from both the og-test stack AND any leftover dev
+#              stack from earlier attempts.
+#
+# WHY A PRODUCTION BUILD?
+#   The SvelteKit frontend has SSR disabled; OG tags are injected by a
+#   NestJS middleware that reads /build/www/index.html. Only the
+#   production server image (server/Dockerfile) copies the built web UI
+#   into that path — the dev image does not. So this test must use a
+#   from-source production build to exercise the code path.
 #
 # Typical flow from an empty working directory:
 #
 #   curl -fsSLo og.sh https://raw.githubusercontent.com/liotier/immich/claude/fix-shared-album-links-SdKg5/scripts/test-og-share-links.sh
 #   chmod +x og.sh
-#   ./og.sh setup       # ~10-15 min on first run
+#   ./og.sh setup       # ~10-15 min on first run (full server image build)
 #   ./og.sh test        # a few seconds
 #   ./og.sh teardown    # prompts before pruning shared Docker state
 #
@@ -38,10 +47,18 @@ SERVER_URL="${SERVER_URL:-http://localhost:2283}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 ADMIN_NAME="${ADMIN_NAME:-Admin}"
-READINESS_TIMEOUT="${READINESS_TIMEOUT:-900}"   # seconds, first build is slow
-COMPOSE_FILE="docker/docker-compose.dev.yml"
-COMPOSE_PROJECT="immich-dev"
-DEV_IMAGES=(immich-server-dev:latest immich-web-dev:latest immich-machine-learning-dev:latest)
+READINESS_TIMEOUT="${READINESS_TIMEOUT:-1800}"   # seconds; first prod build can be slow
+
+COMPOSE_FILE="scripts/docker-compose.og-test.yml"
+COMPOSE_PROJECT="immich-og-test"
+OG_TEST_IMAGE="immich-server:og-test"
+
+# Legacy dev-stack state (from earlier iterations of this script) that
+# teardown should also clear, so users upgrading from the dev-based
+# version get a clean slate.
+LEGACY_COMPOSE_FILE="docker/docker-compose.dev.yml"
+LEGACY_COMPOSE_PROJECT="immich-dev"
+LEGACY_DEV_IMAGES=(immich-server-dev:latest immich-web-dev:latest immich-machine-learning-dev:latest)
 
 log()  { printf '\033[1;34m[og-test]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[og-test]\033[0m %s\n' "$*" >&2; }
@@ -50,7 +67,7 @@ die()  { printf '\033[1;31m[og-test]\033[0m %s\n' "$*" >&2; exit 1; }
 need() { command -v "$1" >/dev/null 2>&1 || die "required command missing: $1"; }
 
 usage() {
-  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-1}"
 }
 
@@ -82,16 +99,17 @@ cmd_setup() {
   fi
   mkdir -p library postgres
 
-  # --- up ---
-  log "Starting dev stack (first run builds images; 10-15 min is normal)"
-  docker compose -f "$COMPOSE_FILE" up -d --build
+  # --- up (production build from source) ---
+  log "Building immich-server from source and starting og-test stack"
+  log "First build compiles the server + web UI — 10-15 min is normal"
+  docker compose --env-file docker/.env -f "$COMPOSE_FILE" -p "$COMPOSE_PROJECT" up -d --build
 
   # --- wait for readiness ---
   log "Waiting for $SERVER_URL/api/server/ping (up to ${READINESS_TIMEOUT}s)"
   deadline=$(( $(date +%s) + READINESS_TIMEOUT ))
   until curl -fsS --max-time 5 "$SERVER_URL/api/server/ping" >/dev/null 2>&1; do
     if [ "$(date +%s)" -gt "$deadline" ]; then
-      docker compose -f "$COMPOSE_FILE" logs --tail=100 immich-server || true
+      docker compose --env-file docker/.env -f "$COMPOSE_FILE" -p "$COMPOSE_PROJECT" logs --tail=100 immich-server || true
       die "server did not become ready within ${READINESS_TIMEOUT}s"
     fi
     sleep 3
@@ -222,22 +240,33 @@ B64
 # =========================================================================
 # TEARDOWN
 # =========================================================================
+# Brings down a compose project by file if present, otherwise by project label.
+_down_project() {
+  local file="$1" project="$2"
+  if [ -f "$CHECKOUT_DIR/$file" ]; then
+    local env_flag=()
+    [ -f "$CHECKOUT_DIR/docker/.env" ] && env_flag=(--env-file docker/.env)
+    (cd "$CHECKOUT_DIR" && docker compose "${env_flag[@]}" -f "$file" -p "$project" down -v --remove-orphans) || true
+  else
+    docker ps -a     --filter "label=com.docker.compose.project=$project" -q | xargs -r docker rm -fv
+    docker volume ls --filter "label=com.docker.compose.project=$project" -q | xargs -r docker volume rm
+    docker network ls --filter "label=com.docker.compose.project=$project" -q | xargs -r docker network rm || true
+  fi
+}
+
 cmd_teardown() {
   need docker
   docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
 
-  log "Step 1/4: bringing down the compose project"
-  if [ -f "$CHECKOUT_DIR/$COMPOSE_FILE" ]; then
-    (cd "$CHECKOUT_DIR" && docker compose -f "$COMPOSE_FILE" down -v --remove-orphans) || true
-  else
-    warn "compose file not found; removing by project label instead"
-    docker ps -a    --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker rm -fv
-    docker volume ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker volume rm
-    docker network ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker network rm || true
-  fi
+  log "Step 1/4: bringing down the og-test compose project"
+  _down_project "$COMPOSE_FILE" "$COMPOSE_PROJECT"
 
-  log "Step 2/4: removing dev images built from source"
-  for img in "${DEV_IMAGES[@]}"; do
+  log "Step 1b/4: bringing down any leftover dev-stack state (harmless if absent)"
+  _down_project "$LEGACY_COMPOSE_FILE" "$LEGACY_COMPOSE_PROJECT"
+
+  log "Step 2/4: removing locally built images"
+  docker image rm "$OG_TEST_IMAGE" >/dev/null 2>&1 || true
+  for img in "${LEGACY_DEV_IMAGES[@]}"; do
     docker image rm "$img" >/dev/null 2>&1 || true
   done
 

--- a/scripts/test-og-share-links.sh
+++ b/scripts/test-og-share-links.sh
@@ -2,23 +2,31 @@
 # test-og-share-links.sh
 #
 # End-to-end verification for the OG-tag fix on per-asset shared-link URLs
-# (issue #27786). Starts from an empty directory, clones the dev branch,
-# boots the full dev stack in Docker, seeds an album + shared link via the
-# REST API, and asserts that /share/<KEY>/photos/<ASSET_ID> returns the
-# expected og:* meta tags.
+# (issue #27786). Three subcommands:
 #
-# Usage (from an empty directory):
-#   curl -fsSL https://raw.githubusercontent.com/liotier/immich/claude/fix-shared-album-links-SdKg5/scripts/test-og-share-links.sh | bash
+#   setup      Clone the dev branch, build images, start the stack,
+#              wait for the server to become healthy.
+#   test       Seed an admin user + album + shared link via the REST API
+#              and assert OG tags on /share/<key>/photos/<assetId>.
+#   teardown   Remove containers, volumes, networks, dev-built images,
+#              pulled base images, the Docker build cache, and the
+#              checkout directory. Returns the host to its pre-setup
+#              state (modulo unrelated Docker state).
 #
-# Or after cloning:
-#   ./scripts/test-og-share-links.sh
+# Typical flow from an empty working directory:
 #
-# Teardown (removes containers, networks, volumes, dev images, and the
-# working directory — leaves no Docker state behind):
-#   ./scripts/test-og-share-links.sh --teardown
+#   curl -fsSLo og.sh https://raw.githubusercontent.com/liotier/immich/claude/fix-shared-album-links-SdKg5/scripts/test-og-share-links.sh
+#   chmod +x og.sh
+#   ./og.sh setup       # ~10-15 min on first run
+#   ./og.sh test        # a few seconds
+#   ./og.sh teardown    # prompts before pruning shared Docker state
 #
-# Teardown keeping the checkout (useful for re-running):
-#   KEEP_CHECKOUT=1 ./scripts/test-og-share-links.sh --teardown
+# Env overrides:
+#   REPO_URL, BRANCH, CHECKOUT_DIR, SERVER_URL,
+#   ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NAME,
+#   READINESS_TIMEOUT  (seconds to wait for server readiness)
+#   KEEP_CHECKOUT=1    (teardown: keep ./immich/)
+#   FORCE_PRUNE=1      (teardown: skip the confirmation prompt)
 
 set -euo pipefail
 
@@ -41,121 +49,91 @@ die()  { printf '\033[1;31m[og-test]\033[0m %s\n' "$*" >&2; exit 1; }
 
 need() { command -v "$1" >/dev/null 2>&1 || die "required command missing: $1"; }
 
-teardown() {
-  log "Tearing down the dev stack"
-  if [ -f "$CHECKOUT_DIR/$COMPOSE_FILE" ]; then
-    (cd "$CHECKOUT_DIR" && docker compose -f "$COMPOSE_FILE" down -v --remove-orphans) || true
-  else
-    warn "compose file not found; falling back to project-name removal"
-    # Best-effort: remove by project label
-    docker ps -a --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
-      | xargs -r docker rm -fv
-    docker volume ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
-      | xargs -r docker volume rm
-    docker network ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
-      | xargs -r docker network rm || true
-  fi
-
-  log "Removing dev images built from source"
-  for img in "${DEV_IMAGES[@]}"; do
-    docker image rm "$img" >/dev/null 2>&1 || true
-  done
-
-  if [ "${KEEP_CHECKOUT:-0}" != "1" ] && [ -d "$CHECKOUT_DIR" ]; then
-    log "Removing checkout directory: $CHECKOUT_DIR"
-    rm -rf "$CHECKOUT_DIR"
-  fi
-
-  log "Teardown complete."
-  log "Note: base images (postgres, valkey) and the Docker build cache are kept."
-  log "To prune those too:  docker image prune -a   &&   docker builder prune"
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-1}"
 }
 
-if [ "${1:-}" = "--teardown" ] || [ "${1:-}" = "-d" ]; then
-  need docker
+# =========================================================================
+# SETUP
+# =========================================================================
+cmd_setup() {
+  for c in git docker curl; do need "$c"; done
   docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
-  teardown
-  exit 0
-fi
 
-for cmd in git docker curl jq python3; do need "$cmd"; done
-docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
-
-# -------------------------------------------------------------------------
-# 1. Clone or update the branch
-# -------------------------------------------------------------------------
-if [ ! -d "$CHECKOUT_DIR/.git" ]; then
-  log "Cloning $REPO_URL (branch: $BRANCH) into $CHECKOUT_DIR"
-  git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$CHECKOUT_DIR"
-else
-  log "Repo already present at $CHECKOUT_DIR, fetching latest $BRANCH"
-  git -C "$CHECKOUT_DIR" fetch origin "$BRANCH"
-  git -C "$CHECKOUT_DIR" checkout "$BRANCH"
-  git -C "$CHECKOUT_DIR" pull --ff-only origin "$BRANCH"
-fi
-
-cd "$CHECKOUT_DIR"
-
-# -------------------------------------------------------------------------
-# 2. Prepare env file + data directories
-# -------------------------------------------------------------------------
-ENV_FILE="docker/.env"
-if [ ! -f "$ENV_FILE" ]; then
-  log "Creating $ENV_FILE from example.env"
-  cp docker/example.env "$ENV_FILE"
-fi
-mkdir -p library postgres
-
-# -------------------------------------------------------------------------
-# 3. Bring up the dev stack
-# -------------------------------------------------------------------------
-log "Starting dev stack (this can take 10+ minutes on first run)"
-docker compose -f "$COMPOSE_FILE" up -d --build
-
-# -------------------------------------------------------------------------
-# 4. Wait for the server to be ready
-# -------------------------------------------------------------------------
-log "Waiting for $SERVER_URL/api/server/ping (up to ${READINESS_TIMEOUT}s)"
-deadline=$(( $(date +%s) + READINESS_TIMEOUT ))
-until curl -fsS --max-time 5 "$SERVER_URL/api/server/ping" >/dev/null 2>&1; do
-  if [ "$(date +%s)" -gt "$deadline" ]; then
-    docker compose -f "$COMPOSE_FILE" logs --tail=100 immich-server || true
-    die "server did not become ready within ${READINESS_TIMEOUT}s"
+  # --- clone / update ---
+  if [ ! -d "$CHECKOUT_DIR/.git" ]; then
+    log "Cloning $REPO_URL (branch: $BRANCH) into $CHECKOUT_DIR"
+    git clone --branch "$BRANCH" --single-branch "$REPO_URL" "$CHECKOUT_DIR"
+  else
+    log "Repo already present at $CHECKOUT_DIR, fetching latest $BRANCH"
+    git -C "$CHECKOUT_DIR" fetch origin "$BRANCH"
+    git -C "$CHECKOUT_DIR" checkout "$BRANCH"
+    git -C "$CHECKOUT_DIR" pull --ff-only origin "$BRANCH" || \
+      warn "pull --ff-only failed (probably local commits); continuing with current checkout"
   fi
-  sleep 3
-done
-log "Server is up."
 
-# -------------------------------------------------------------------------
-# 5. Admin sign-up (idempotent: ignore failure if already registered)
-# -------------------------------------------------------------------------
-log "Registering admin user (if needed): $ADMIN_EMAIL"
-curl -fsS -X POST "$SERVER_URL/api/auth/admin-sign-up" \
-  -H 'Content-Type: application/json' \
-  -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" --arg n "$ADMIN_NAME" \
-        '{email:$e, password:$p, name:$n}')" >/dev/null || \
-  warn "admin-sign-up rejected (probably already registered) - continuing"
+  cd "$CHECKOUT_DIR"
 
-# -------------------------------------------------------------------------
-# 6. Login, capture access token
-# -------------------------------------------------------------------------
-log "Logging in"
-TOKEN=$(curl -fsS -X POST "$SERVER_URL/api/auth/login" \
-  -H 'Content-Type: application/json' \
-  -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')" \
-  | jq -r '.accessToken')
-[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || die "login failed, no access token"
+  # --- env + data dirs ---
+  if [ ! -f docker/.env ]; then
+    log "Creating docker/.env from example.env"
+    cp docker/example.env docker/.env
+  fi
+  mkdir -p library postgres
 
-auth_header="Authorization: Bearer $TOKEN"
+  # --- up ---
+  log "Starting dev stack (first run builds images; 10-15 min is normal)"
+  docker compose -f "$COMPOSE_FILE" up -d --build
 
-# -------------------------------------------------------------------------
-# 7. Generate a tiny JPEG and upload as an asset
-# -------------------------------------------------------------------------
-log "Generating a test JPEG"
-TMP_IMG=$(mktemp --suffix=.jpg)
-# Minimal valid JPEG (a solid colour 2x2) encoded in base64. Small enough
-# to paste inline, avoids any external download.
-base64 -d > "$TMP_IMG" <<'B64'
+  # --- wait for readiness ---
+  log "Waiting for $SERVER_URL/api/server/ping (up to ${READINESS_TIMEOUT}s)"
+  deadline=$(( $(date +%s) + READINESS_TIMEOUT ))
+  until curl -fsS --max-time 5 "$SERVER_URL/api/server/ping" >/dev/null 2>&1; do
+    if [ "$(date +%s)" -gt "$deadline" ]; then
+      docker compose -f "$COMPOSE_FILE" logs --tail=100 immich-server || true
+      die "server did not become ready within ${READINESS_TIMEOUT}s"
+    fi
+    sleep 3
+  done
+
+  log "Setup complete. Server is live at $SERVER_URL"
+  log "Next: $0 test"
+}
+
+# =========================================================================
+# TEST
+# =========================================================================
+cmd_test() {
+  for c in docker curl jq; do need "$c"; done
+  [ -d "$CHECKOUT_DIR" ] || die "checkout dir $CHECKOUT_DIR missing — run '$0 setup' first"
+
+  # Sanity: server reachable.
+  curl -fsS --max-time 5 "$SERVER_URL/api/server/ping" >/dev/null \
+    || die "server not reachable at $SERVER_URL — is 'setup' finished?"
+
+  # --- admin sign-up (idempotent) ---
+  log "Registering admin user (if needed): $ADMIN_EMAIL"
+  curl -fsS -X POST "$SERVER_URL/api/auth/admin-sign-up" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" --arg n "$ADMIN_NAME" \
+          '{email:$e, password:$p, name:$n}')" >/dev/null \
+    || warn "admin-sign-up rejected (probably already registered) — continuing"
+
+  # --- login ---
+  log "Logging in"
+  TOKEN=$(curl -fsS -X POST "$SERVER_URL/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e, password:$p}')" \
+    | jq -r '.accessToken')
+  [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || die "login failed, no access token"
+  auth_header="Authorization: Bearer $TOKEN"
+
+  # --- generate + upload a tiny JPEG ---
+  log "Generating a test JPEG"
+  TMP_IMG=$(mktemp --suffix=.jpg)
+  trap 'rm -f "$TMP_IMG"' RETURN
+  base64 -d > "$TMP_IMG" <<'B64'
 /9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
 HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
 MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAQABADASIA
@@ -166,90 +144,144 @@ p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oADAMB
 AAIRAxEAPwD3+iiigD//2Q==
 B64
 
-log "Uploading asset"
-UPLOAD_RESPONSE=$(curl -fsS -X POST "$SERVER_URL/api/assets" \
-  -H "$auth_header" \
-  -F "assetData=@${TMP_IMG};type=image/jpeg" \
-  -F "deviceAssetId=og-test-device-asset-1" \
-  -F "deviceId=og-test-device" \
-  -F "fileCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
-  -F "fileModifiedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)")
-ASSET_ID=$(echo "$UPLOAD_RESPONSE" | jq -r '.id')
-[ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ] || die "upload did not return an asset id: $UPLOAD_RESPONSE"
-log "Uploaded asset: $ASSET_ID"
+  log "Uploading asset"
+  UPLOAD_RESPONSE=$(curl -fsS -X POST "$SERVER_URL/api/assets" \
+    -H "$auth_header" \
+    -F "assetData=@${TMP_IMG};type=image/jpeg" \
+    -F "deviceAssetId=og-test-device-asset-$(date +%s)" \
+    -F "deviceId=og-test-device" \
+    -F "fileCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    -F "fileModifiedAt=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)")
+  ASSET_ID=$(echo "$UPLOAD_RESPONSE" | jq -r '.id')
+  [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ] || die "upload did not return an asset id: $UPLOAD_RESPONSE"
+  log "Uploaded asset: $ASSET_ID"
 
-# -------------------------------------------------------------------------
-# 8. Create an album and add the asset
-# -------------------------------------------------------------------------
-log "Creating album"
-ALBUM_ID=$(curl -fsS -X POST "$SERVER_URL/api/albums" \
-  -H "$auth_header" -H 'Content-Type: application/json' \
-  -d "$(jq -nc --arg n "OG Test Album" --arg a "$ASSET_ID" \
-        '{albumName:$n, assetIds:[$a]}')" \
-  | jq -r '.id')
-[ -n "$ALBUM_ID" ] && [ "$ALBUM_ID" != "null" ] || die "album creation failed"
-log "Album: $ALBUM_ID"
+  # --- album ---
+  log "Creating album"
+  ALBUM_ID=$(curl -fsS -X POST "$SERVER_URL/api/albums" \
+    -H "$auth_header" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg n "OG Test Album" --arg a "$ASSET_ID" \
+          '{albumName:$n, assetIds:[$a]}')" \
+    | jq -r '.id')
+  [ -n "$ALBUM_ID" ] && [ "$ALBUM_ID" != "null" ] || die "album creation failed"
+  log "Album: $ALBUM_ID"
 
-# -------------------------------------------------------------------------
-# 9. Create an ALBUM shared link
-# -------------------------------------------------------------------------
-log "Creating shared link"
-SHARE_KEY=$(curl -fsS -X POST "$SERVER_URL/api/shared-links" \
-  -H "$auth_header" -H 'Content-Type: application/json' \
-  -d "$(jq -nc --arg id "$ALBUM_ID" '{type:"ALBUM", albumId:$id}')" \
-  | jq -r '.key')
-[ -n "$SHARE_KEY" ] && [ "$SHARE_KEY" != "null" ] || die "shared link creation failed"
-log "Share key: $SHARE_KEY"
+  # --- shared link ---
+  log "Creating shared link"
+  SHARE_KEY=$(curl -fsS -X POST "$SERVER_URL/api/shared-links" \
+    -H "$auth_header" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg id "$ALBUM_ID" '{type:"ALBUM", albumId:$id}')" \
+    | jq -r '.key')
+  [ -n "$SHARE_KEY" ] && [ "$SHARE_KEY" != "null" ] || die "shared link creation failed"
+  log "Share key: $SHARE_KEY"
 
-# -------------------------------------------------------------------------
-# 10. Fire the actual assertions
-# -------------------------------------------------------------------------
-ALBUM_URL="$SERVER_URL/share/$SHARE_KEY"
-ASSET_URL="$SERVER_URL/share/$SHARE_KEY/photos/$ASSET_ID"
+  # --- assertions ---
+  ALBUM_URL="$SERVER_URL/share/$SHARE_KEY"
+  ASSET_URL="$SERVER_URL/share/$SHARE_KEY/photos/$ASSET_ID"
+  fetch() { curl -fsS -H 'Accept: text/html' -H 'User-Agent: og-test' "$1"; }
 
-fetch() {
-  curl -fsS -H 'Accept: text/html' -H 'User-Agent: og-test' "$1"
+  log ""
+  log "=== Regression check: album-level URL still renders og:* ==="
+  ALBUM_HTML=$(fetch "$ALBUM_URL")
+  echo "$ALBUM_HTML" | grep -E 'og:(title|description|image)' \
+    || die "regression: album share link is not producing OG tags"
+
+  log ""
+  log "=== Target case: per-asset URL must now render og:* ==="
+  ASSET_HTML=$(fetch "$ASSET_URL")
+  if ! echo "$ASSET_HTML" | grep -qE 'og:title'; then
+    warn "---- received HTML head ----"
+    echo "$ASSET_HTML" | head -c 2000 >&2
+    die "FAIL: no og:title on per-asset URL — the fix is NOT active"
+  fi
+  echo "$ASSET_HTML" | grep -E 'og:(title|description|image)'
+
+  log ""
+  log "=== Asset-specific thumbnail URL must carry ?key= ==="
+  IMG_URL=$(echo "$ASSET_HTML" | grep -oE 'og:image" content="[^"]+"' | head -1 \
+                               | sed -E 's/.*content="([^"]+)"/\1/')
+  log "og:image -> $IMG_URL"
+  echo "$IMG_URL" | grep -q "assets/$ASSET_ID/thumbnail" \
+    || die "FAIL: og:image does not point at the requested asset ($ASSET_ID)"
+  echo "$IMG_URL" | grep -q "key=$SHARE_KEY" \
+    || die "FAIL: og:image is missing key=$SHARE_KEY"
+
+  log ""
+  log "=== Thumbnail fetch with the embedded key returns 200 ==="
+  CODE=$(curl -s -o /dev/null -w '%{http_code}' "$IMG_URL")
+  [ "$CODE" = "200" ] || die "FAIL: thumbnail fetch returned HTTP $CODE"
+
+  log ""
+  log "ALL CHECKS PASSED"
+  log "  album  URL: $ALBUM_URL"
+  log "  asset  URL: $ASSET_URL"
+  log ""
+  log "Done. To fully clean up: $0 teardown"
 }
 
-log ""
-log "=== Regression check: album-level URL still renders og:* ==="
-ALBUM_HTML=$(fetch "$ALBUM_URL")
-echo "$ALBUM_HTML" | grep -E 'og:(title|description|image)' || {
-  warn "no og:* tags on album URL — this is the pre-existing codepath"
-  die "regression: album share link is not producing OG tags"
+# =========================================================================
+# TEARDOWN
+# =========================================================================
+cmd_teardown() {
+  need docker
+  docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
+
+  log "Step 1/4: bringing down the compose project"
+  if [ -f "$CHECKOUT_DIR/$COMPOSE_FILE" ]; then
+    (cd "$CHECKOUT_DIR" && docker compose -f "$COMPOSE_FILE" down -v --remove-orphans) || true
+  else
+    warn "compose file not found; removing by project label instead"
+    docker ps -a    --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker rm -fv
+    docker volume ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker volume rm
+    docker network ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q | xargs -r docker network rm || true
+  fi
+
+  log "Step 2/4: removing dev images built from source"
+  for img in "${DEV_IMAGES[@]}"; do
+    docker image rm "$img" >/dev/null 2>&1 || true
+  done
+
+  # --- aggressive prune (affects ALL Docker state, not just this project) ---
+  log "Step 3/4: docker image prune -a  &&  docker builder prune"
+  warn "This removes ALL unused images and the ENTIRE Docker build cache"
+  warn "on this host — not just immich-related state."
+  if [ "${FORCE_PRUNE:-0}" = "1" ]; then
+    log "FORCE_PRUNE=1 — proceeding without prompt"
+    REPLY=y
+  else
+    printf '\033[1;33m[og-test]\033[0m Continue? [y/N] ' >&2
+    read -r REPLY || REPLY=n
+  fi
+  case "$REPLY" in
+    [yY]|[yY][eE][sS])
+      docker image prune -a -f
+      docker builder prune -f
+      ;;
+    *)
+      warn "skipped image/builder prune — pulled base images and build cache retained"
+      ;;
+  esac
+
+  log "Step 4/4: removing checkout directory"
+  if [ "${KEEP_CHECKOUT:-0}" = "1" ]; then
+    log "KEEP_CHECKOUT=1 — leaving $CHECKOUT_DIR in place"
+  elif [ -d "$CHECKOUT_DIR" ]; then
+    rm -rf "$CHECKOUT_DIR"
+    log "Removed $CHECKOUT_DIR"
+  else
+    log "Checkout dir already absent"
+  fi
+
+  log "Teardown complete."
 }
 
-log ""
-log "=== Target case: per-asset URL must now render og:* ==="
-ASSET_HTML=$(fetch "$ASSET_URL")
-if ! echo "$ASSET_HTML" | grep -qE 'og:title'; then
-  warn "---- received HTML head ----"
-  echo "$ASSET_HTML" | head -c 2000 >&2
-  die "FAIL: no og:title on per-asset URL — the fix is NOT active"
-fi
-
-echo "$ASSET_HTML" | grep -E 'og:(title|description|image)'
-
-log ""
-log "=== Asset-specific thumbnail URL must carry ?key= ==="
-IMG_URL=$(echo "$ASSET_HTML" | grep -oE 'og:image" content="[^"]+"' | head -1 \
-                             | sed -E 's/.*content="([^"]+)"/\1/')
-log "og:image -> $IMG_URL"
-echo "$IMG_URL" | grep -q "assets/$ASSET_ID/thumbnail" \
-  || die "FAIL: og:image does not point at the requested asset ($ASSET_ID)"
-echo "$IMG_URL" | grep -q "key=$SHARE_KEY" \
-  || die "FAIL: og:image is missing key=$SHARE_KEY"
-
-log ""
-log "=== Thumbnail fetch with the embedded key returns 200 ==="
-CODE=$(curl -s -o /dev/null -w '%{http_code}' "$IMG_URL")
-[ "$CODE" = "200" ] || die "FAIL: thumbnail fetch returned HTTP $CODE"
-
-log ""
-log "ALL CHECKS PASSED"
-log "  album  URL: $ALBUM_URL"
-log "  asset  URL: $ASSET_URL"
-log ""
-log "Tear down everything (containers, volumes, dev images, checkout) with:"
-log "  $0 --teardown"
-log "Or keep the repo:   KEEP_CHECKOUT=1 $0 --teardown"
+# =========================================================================
+# Dispatch
+# =========================================================================
+case "${1:-}" in
+  setup)    shift; cmd_setup    "$@" ;;
+  test)     shift; cmd_test     "$@" ;;
+  teardown) shift; cmd_teardown "$@" ;;
+  -h|--help|help|"") usage 0 ;;
+  *) warn "unknown subcommand: $1"; usage 1 ;;
+esac

--- a/scripts/test-og-share-links.sh
+++ b/scripts/test-og-share-links.sh
@@ -12,6 +12,13 @@
 #
 # Or after cloning:
 #   ./scripts/test-og-share-links.sh
+#
+# Teardown (removes containers, networks, volumes, dev images, and the
+# working directory — leaves no Docker state behind):
+#   ./scripts/test-og-share-links.sh --teardown
+#
+# Teardown keeping the checkout (useful for re-running):
+#   KEEP_CHECKOUT=1 ./scripts/test-og-share-links.sh --teardown
 
 set -euo pipefail
 
@@ -25,12 +32,51 @@ ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 ADMIN_NAME="${ADMIN_NAME:-Admin}"
 READINESS_TIMEOUT="${READINESS_TIMEOUT:-900}"   # seconds, first build is slow
 COMPOSE_FILE="docker/docker-compose.dev.yml"
+COMPOSE_PROJECT="immich-dev"
+DEV_IMAGES=(immich-server-dev:latest immich-web-dev:latest immich-machine-learning-dev:latest)
 
 log()  { printf '\033[1;34m[og-test]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[og-test]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[og-test]\033[0m %s\n' "$*" >&2; exit 1; }
 
 need() { command -v "$1" >/dev/null 2>&1 || die "required command missing: $1"; }
+
+teardown() {
+  log "Tearing down the dev stack"
+  if [ -f "$CHECKOUT_DIR/$COMPOSE_FILE" ]; then
+    (cd "$CHECKOUT_DIR" && docker compose -f "$COMPOSE_FILE" down -v --remove-orphans) || true
+  else
+    warn "compose file not found; falling back to project-name removal"
+    # Best-effort: remove by project label
+    docker ps -a --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
+      | xargs -r docker rm -fv
+    docker volume ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
+      | xargs -r docker volume rm
+    docker network ls --filter "label=com.docker.compose.project=$COMPOSE_PROJECT" -q \
+      | xargs -r docker network rm || true
+  fi
+
+  log "Removing dev images built from source"
+  for img in "${DEV_IMAGES[@]}"; do
+    docker image rm "$img" >/dev/null 2>&1 || true
+  done
+
+  if [ "${KEEP_CHECKOUT:-0}" != "1" ] && [ -d "$CHECKOUT_DIR" ]; then
+    log "Removing checkout directory: $CHECKOUT_DIR"
+    rm -rf "$CHECKOUT_DIR"
+  fi
+
+  log "Teardown complete."
+  log "Note: base images (postgres, valkey) and the Docker build cache are kept."
+  log "To prune those too:  docker image prune -a   &&   docker builder prune"
+}
+
+if [ "${1:-}" = "--teardown" ] || [ "${1:-}" = "-d" ]; then
+  need docker
+  docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
+  teardown
+  exit 0
+fi
 
 for cmd in git docker curl jq python3; do need "$cmd"; done
 docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin is required"
@@ -204,4 +250,6 @@ log "ALL CHECKS PASSED"
 log "  album  URL: $ALBUM_URL"
 log "  asset  URL: $ASSET_URL"
 log ""
-log "Tear down with:  docker compose -f $COMPOSE_FILE down -v"
+log "Tear down everything (containers, volumes, dev images, checkout) with:"
+log "  $0 --teardown"
+log "Or keep the repo:   KEEP_CHECKOUT=1 $0 --teardown"

--- a/scripts/test-og-share-links.sh
+++ b/scripts/test-og-share-links.sh
@@ -226,8 +226,15 @@ B64
 
   log ""
   log "=== Thumbnail fetch with the embedded key returns 200 ==="
-  CODE=$(curl -s -o /dev/null -w '%{http_code}' "$IMG_URL")
-  [ "$CODE" = "200" ] || die "FAIL: thumbnail fetch returned HTTP $CODE"
+  # Thumbnails are generated asynchronously by a background worker, so
+  # poll briefly after upload.
+  CODE=000
+  for i in $(seq 1 30); do
+    CODE=$(curl -s -o /dev/null -w '%{http_code}' "$IMG_URL")
+    [ "$CODE" = "200" ] && break
+    sleep 2
+  done
+  [ "$CODE" = "200" ] || die "FAIL: thumbnail fetch returned HTTP $CODE after polling"
 
   log ""
   log "ALL CHECKS PASSED"

--- a/server/src/services/api.service.ts
+++ b/server/src/services/api.service.ts
@@ -77,23 +77,23 @@ export class ApiService {
 
       let meta: OpenGraphTags | null = null;
 
-      const shareKey = request.url.match(/^\/share\/(.+)$/);
+      const shareKey = request.path.match(/^\/share\/([^/]+)(?:\/photos\/([^/]+))?/);
       if (shareKey) {
         try {
-          const key = shareKey[1];
+          const [, key, assetId] = shareKey;
           const auth = await this.authService.validateSharedLinkKey(key);
-          meta = await this.sharedLinkService.getMetadataTags(auth, defaultDomain);
+          meta = await this.sharedLinkService.getMetadataTags(auth, { defaultDomain, assetId });
         } catch {
           status = 404;
         }
       }
 
-      const shareSlug = request.url.match(/^\/s\/(.+)$/);
+      const shareSlug = request.path.match(/^\/s\/([^/]+)(?:\/photos\/([^/]+))?/);
       if (shareSlug) {
         try {
-          const slug = shareSlug[1];
+          const [, slug, assetId] = shareSlug;
           const auth = await this.authService.validateSharedLinkSlug(slug);
-          meta = await this.sharedLinkService.getMetadataTags(auth, defaultDomain);
+          meta = await this.sharedLinkService.getMetadataTags(auth, { defaultDomain, assetId });
         } catch {
           status = 404;
         }

--- a/server/src/services/shared-link.service.spec.ts
+++ b/server/src/services/shared-link.service.spec.ts
@@ -394,5 +394,50 @@ describe(SharedLinkService.name, () => {
 
       expect(mocks.sharedLink.get).toHaveBeenCalled();
     });
+
+    it('should honor the defaultDomain option', async () => {
+      const sharedLink = SharedLinkFactory.from({ description: null })
+        .asset({}, (builder) => builder.exif())
+        .build();
+      mocks.sharedLink.get.mockResolvedValue(getForSharedLink(sharedLink));
+
+      await expect(
+        sut.getMetadataTags(authStub.adminSharedLink, { defaultDomain: 'https://example.com' }),
+      ).resolves.toEqual({
+        description: '1 shared photos & videos',
+        imageUrl: `https://example.com/api/assets/${sharedLink.assets[0].id}/thumbnail?key=${sharedLink.key.toString('base64url')}`,
+        title: 'Public Share',
+      });
+    });
+
+    it('should scope metadata to a specific asset when the assetId belongs to an individual share', async () => {
+      const sharedLink = SharedLinkFactory.from({ description: null })
+        .asset({}, (builder) => builder.exif())
+        .asset({}, (builder) => builder.exif())
+        .build();
+      mocks.sharedLink.get.mockResolvedValue(getForSharedLink(sharedLink));
+      const assetId = sharedLink.assets[1].id;
+
+      await expect(sut.getMetadataTags(authStub.adminSharedLink, { assetId })).resolves.toEqual({
+        description: 'Shared photo',
+        imageUrl: `https://my.immich.app/api/assets/${assetId}/thumbnail?key=${sharedLink.key.toString('base64url')}`,
+        title: 'Shared photo',
+      });
+    });
+
+    it('should fall back to the album thumbnail when the requested assetId is not part of the share', async () => {
+      const sharedLink = SharedLinkFactory.from({ description: null })
+        .asset({}, (builder) => builder.exif())
+        .build();
+      mocks.sharedLink.get.mockResolvedValue(getForSharedLink(sharedLink));
+
+      await expect(
+        sut.getMetadataTags(authStub.adminSharedLink, { assetId: 'not-in-share' }),
+      ).resolves.toEqual({
+        description: '1 shared photos & videos',
+        imageUrl: `https://my.immich.app/api/assets/${sharedLink.assets[0].id}/thumbnail?key=${sharedLink.key.toString('base64url')}`,
+        title: 'Public Share',
+      });
+    });
   });
 });

--- a/server/src/services/shared-link.service.ts
+++ b/server/src/services/shared-link.service.ts
@@ -221,22 +221,44 @@ export class SharedLinkService extends BaseService {
     return results;
   }
 
-  async getMetadataTags(auth: AuthDto, defaultDomain?: string): Promise<null | OpenGraphTags> {
+  async getMetadataTags(
+    auth: AuthDto,
+    { defaultDomain, assetId: requestedAssetId }: { defaultDomain?: string; assetId?: string } = {},
+  ): Promise<null | OpenGraphTags> {
     if (!auth.sharedLink || auth.sharedLink.password) {
       return null;
     }
 
     const config = await this.getConfig({ withCache: true });
     const sharedLink = await this.findOrFail(auth.sharedLink.userId, auth.sharedLink.id);
-    const assetId = sharedLink.album?.albumThumbnailAssetId || sharedLink.assets[0]?.id;
-    const assetCount = sharedLink.assets.length > 0 ? sharedLink.assets.length : sharedLink.album?.assets?.length || 0;
-    const imagePath = assetId
-      ? `/api/assets/${assetId}/thumbnail?key=${sharedLink.key.toString('base64url')}`
-      : '/feature-panel.png';
+
+    const albumAssets = sharedLink.album?.assets ?? [];
+    const linkAssets = sharedLink.assets;
+    const isAssetInShare = (id: string) =>
+      linkAssets.some((asset) => asset.id === id) || albumAssets.some((asset) => asset.id === id);
+
+    const scopedAssetId = requestedAssetId && isAssetInShare(requestedAssetId) ? requestedAssetId : undefined;
+    const fallbackAssetId = sharedLink.album?.albumThumbnailAssetId || linkAssets[0]?.id;
+    const assetId = scopedAssetId ?? fallbackAssetId;
+    const assetCount = linkAssets.length > 0 ? linkAssets.length : albumAssets.length;
+    const key = sharedLink.key.toString('base64url');
+    const imagePath = assetId ? `/api/assets/${assetId}/thumbnail?key=${key}` : '/feature-panel.png';
+
+    const albumName = sharedLink.album?.albumName;
+    const defaultTitle = albumName ?? 'Public Share';
+    const defaultDescription = sharedLink.description || `${assetCount} shared photos & videos`;
+
+    let title = defaultTitle;
+    let description = defaultDescription;
+
+    if (scopedAssetId) {
+      title = albumName ? `Photo in ${albumName}` : 'Shared photo';
+      description = sharedLink.description || (albumName ? `Photo in ${albumName}` : 'Shared photo');
+    }
 
     return {
-      title: sharedLink.album ? sharedLink.album.albumName : 'Public Share',
-      description: sharedLink.description || `${assetCount} shared photos & videos`,
+      title,
+      description,
       imageUrl: new URL(imagePath, getExternalDomain(config.server, defaultDomain)).href,
     };
   }

--- a/web/src/lib/utils/shared-links.ts
+++ b/web/src/lib/utils/shared-links.ts
@@ -35,16 +35,19 @@ export const loadSharedLink = async ({
     const [sharedLink, asset] = await Promise.all([getMySharedLink({ key, slug }), getAssetInfoFromParam(params)]);
     setSharedLink(sharedLink);
     const assetCount = sharedLink.assets.length;
-    const assetId = sharedLink.album?.albumThumbnailAssetId || sharedLink.assets[0]?.id;
-    const assetPath = assetId ? getAssetMediaUrl({ id: assetId }) : '/feature-panel.png';
+    const previewAssetId = asset?.id || sharedLink.album?.albumThumbnailAssetId || sharedLink.assets[0]?.id;
+    const assetPath = previewAssetId ? getAssetMediaUrl({ id: previewAssetId }) : '/feature-panel.png';
+    const albumTitle = sharedLink.album ? sharedLink.album.albumName : $t('public_share');
+    const fallbackDescription =
+      sharedLink.description || $t('shared_photos_and_videos_count', { values: { assetCount } });
 
     return {
       ...common,
       sharedLink,
       asset,
       meta: {
-        title: sharedLink.album ? sharedLink.album.albumName : $t('public_share'),
-        description: sharedLink.description || $t('shared_photos_and_videos_count', { values: { assetCount } }),
+        title: albumTitle,
+        description: asset ? sharedLink.description || albumTitle : fallbackDescription,
         imageUrl: assetPath,
       },
     };


### PR DESCRIPTION
## Description

Closes #27786 (which, I'm sorry, I submitted before having fully baked the idea — I hope this tested PR makes up for it).

### The bug

Sharing an album link like `https://photos.example.com/share/<KEY>` produces a proper link preview (title, description, thumbnail) when pasted into Discord, Slack, WhatsApp, iMessage, Signal, Facebook, etc. — great.

Sharing a **specific photo** inside that album — `https://photos.example.com/share/<KEY>/photos/<ASSET_ID>` — produces nothing: a bare URL with no preview card. This is the natural URL users copy from the address bar when they want to share *one* picture from an album, so the failure mode is high-visibility: users think Immich's share links are simply broken.

### Root cause

OG tags are injected server-side by a NestJS middleware (`ApiService.ssr`, `server/src/services/api.service.ts`) that replaces a `<!-- metadata:tags -->` placeholder in `index.html`. The SvelteKit frontend itself has SSR disabled, so the middleware is the only place OG tags come from.

The middleware matched share URLs with:

```ts
const shareKey = request.url.match(/^\/share\/(.+)$/);
// key = "<KEY>/photos/<ASSET_ID>"
```

`.+` is greedy, so for `/share/<KEY>/photos/<ASSET_ID>` the captured "key" included the rest of the path, `validateSharedLinkKey` rejected it, the `catch` set `status = 404`, and `meta` stayed `null` — so no OG tags were rendered. Matching `request.url` instead of `request.path` also meant any query string leaked into the captured key.

### The fix

Three changes — about 90 lines total.

**1. `server/src/services/api.service.ts`** — anchor the regex properly and optionally capture an asset id:

```ts
const shareKey = request.path.match(/^\/share\/([^/]+)(?:\/photos\/([^/]+))?/);
if (shareKey) {
  const [, key, assetId] = shareKey;
  const auth = await this.authService.validateSharedLinkKey(key);
  meta = await this.sharedLinkService.getMetadataTags(auth, { defaultDomain, assetId });
}
```

Same change for `/s/<slug>` URLs. Switched to `request.path` so query strings can't pollute the captured key/slug.

**2. `server/src/services/shared-link.service.ts`** — teach `getMetadataTags` about an optional asset scope. When the requested `assetId` belongs to the share it becomes the preview asset (title `"Photo in <album>"` for albums, or `"Shared photo"` for INDIVIDUAL-type shares). When it doesn't, we fall back to the album thumbnail / first asset — the previous behaviour — so album-level URLs render identically to before this PR.

**3. `web/src/lib/utils/shared-links.ts`** — mirror the backend for the client-side OG helper so that navigating between assets in the viewer keeps the `og:image` in sync with what the user is actually looking at.

Signature change:

```diff
- getMetadataTags(auth: AuthDto, defaultDomain?: string)
+ getMetadataTags(
+   auth: AuthDto,
+   { defaultDomain, assetId }: { defaultDomain?: string; assetId?: string } = {},
+ )
```

The two callers in this repo are both updated. There are no other internal consumers and the method isn't part of a documented API surface.

### Risk assessment

Small. The regex change is strictly more permissive for *matching* but strictly stricter for *capturing* — `[^/]+` means a malformed key with a slash in it now yields no match rather than being passed to the validator that would have rejected it anyway. The `getMetadataTags` signature change is internal; both in-repo callers are updated in this PR. Album-level share URLs, password-protected shares, and INDIVIDUAL-type shares all retain their prior behaviour — the new asset-scoped path is only taken when `/photos/<id>` is present *and* the asset is part of the share.

### Why it's worth merging

- Share-URL previews are a primary UX surface: they're what recipients see before they click.
- The failure is silent — no error, no log, just a cold dead URL in the chat.
- The original issue (#27786) was closed as a duplicate, but the referenced duplicates address the **album-level** case that already works. The **per-asset** case is genuinely broken and, as far as I can tell, not addressed by any open or closed PR.
- Fix is small, localized, unit-tested, and backed by a reproducible end-to-end verification run.

Fixes #27786

## How Has This Been Tested?

**Unit tests** — three tests added to `shared-link.service.spec.ts`:

- [x] `defaultDomain` option is honoured
- [x] Asset-scoped metadata uses the requested asset and its album for title/description
- [x] Metadata falls back to the album thumbnail when `assetId` is not in the share

**End-to-end** — this PR also ships `scripts/test-og-share-links.sh`, a three-subcommand harness (`setup` / `test` / `teardown`) that spins up a **production build from source** (the SSR code path only exists in the prod image — the dev image does not copy the built web UI into `/build/www/`), seeds an admin + album + shared link via the REST API, and asserts:

- [x] the album URL still renders `og:title`/`og:description`/`og:image` (regression guard)
- [x] the per-asset URL now renders `og:title`/`og:description`/`og:image`
- [x] `og:image` points at `/api/assets/<requestedAssetId>/thumbnail`, not a default
- [x] `og:image` carries `?key=<shareKey>` so unauthenticated crawlers can fetch it
- [x] that URL actually returns 200

To reproduce:

```bash
curl -fsSLo og.sh https://raw.githubusercontent.com/liotier/immich/claude/fix-shared-album-links-SdKg5/scripts/test-og-share-links.sh
chmod +x og.sh
./og.sh setup     # ~10-15 min first run (full server image build from source)
./og.sh test
./og.sh teardown
```

The harness is opt-in, lives under `scripts/`, and is not wired into CI — it's there so the next person touching SSR metadata can verify a real browser-facing code path end-to-end, not just unit tests. Happy to drop it from the PR on request.

<details><summary>Run log from a fresh build</summary>

```
jm@kitandara:~/projects/Immich$ ./og.sh test
[og-test] Registering admin user (if needed): admin@example.com
curl: (22) The requested URL returned error: 400
[og-test] admin-sign-up rejected (probably already registered) — continuing
[og-test] Logging in
[og-test] Generating a test JPEG
[og-test] Uploading asset
[og-test] Uploaded asset: 3a6e25ab-62da-42fd-83f0-b1256ab6eeb9
[og-test] Creating album
[og-test] Album: bd3eee9c-3dfa-41d8-9b50-ff0548de5621
[og-test] Creating shared link
[og-test] Share key: YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o
[og-test]
[og-test] === Regression check: album-level URL still renders og:* ===
    <meta property="og:title" content="OG Test Album" />
    <meta property="og:description" content="1 shared photos &amp; videos" />
    <meta property="og:image" content="http://localhost:2283/api/assets/3a6e25ab-62da-42fd-83f0-b1256ab6eeb9/thumbnail?key=YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o" />
[og-test]
[og-test] === Target case: per-asset URL must now render og:* ===
    <meta property="og:title" content="Photo in OG Test Album" />
    <meta property="og:description" content="Photo in OG Test Album" />
    <meta property="og:image" content="http://localhost:2283/api/assets/3a6e25ab-62da-42fd-83f0-b1256ab6eeb9/thumbnail?key=YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o" />
[og-test]
[og-test] === Asset-specific thumbnail URL must carry ?key= ===
[og-test] og:image -> http://localhost:2283/api/assets/3a6e25ab-62da-42fd-83f0-b1256ab6eeb9/thumbnail?key=YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o
[og-test]
[og-test] === Thumbnail fetch with the embedded key returns 200 ===
[og-test]
[og-test] ALL CHECKS PASSED
[og-test]   album  URL: http://localhost:2283/share/YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o
[og-test]   asset  URL: http://localhost:2283/share/YGofSNWPFkTwRxqRWPkeYwBcBcg0vbfT0v_VLrHRccc0Vj4dYD-VBLLLWKG7OdBiC_o/photos/3a6e25ab-62da-42fd-83f0-b1256ab6eeb9
[og-test]
[og-test] Done. To fully clean up: ./og.sh teardown
```

</details>

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — the change is in server-side HTML `<meta>` output. The run log above shows the rendered OG tags.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (none needed — no user-facing setting or API change)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (no new runtime dependencies; the `scripts/` harness uses only curl/jq/docker, which are not added to the repo)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This contribution rides entirely on Claude Opus 4.6 - the fix, the added unit tests and, the end-to-end harness. I reviewed the changes, ran the test harness end-to-end locally against a from-source production build (run log above). The diagnosis that the OG-tag SSR path runs only in the prod image because the dev image doesn't populate `/build/www/` was a non-trivial discovery and is the reason why I added an end-to-end test harness.
