### PR TITLE
chore!: remove deprecated env variables

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -247,7 +247,7 @@ export const defaults = Object.freeze<SystemConfig>({
     urls: [process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003'],
     availabilityChecks: {
       enabled: true,
-      timeout: Number(process.env.IMMICH_MACHINE_LEARNING_PING_TIMEOUT) || 2000,
+      timeout: 2000,
       interval: 30_000,
     },
     clip: {

--- a/server/src/services/system-config.service.ts
+++ b/server/src/services/system-config.service.ts
@@ -15,15 +15,6 @@ export class SystemConfigService extends BaseService {
   async onBootstrap() {
     const config = await this.getConfig({ withCache: false });
     await this.eventRepository.emit('ConfigInit', { newConfig: config });
-
-    if (
-      process.env.IMMICH_MACHINE_LEARNING_PING_TIMEOUT ||
-      process.env.IMMICH_MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME
-    ) {
-      this.logger.deprecate(
-        'IMMICH_MACHINE_LEARNING_PING_TIMEOUT and MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME have been moved to system config(`machineLearning.availabilityChecks`) and will be removed in a future release.',
-      );
-    }
   }
 
   @OnEvent({ name: 'AppShutdown' })


### PR DESCRIPTION
> [!CAUTION]
># Breaking changes
> Removed `IMMICH_MACHINE_LEARNING_PING_TIMEOUT` 
> * Use admin settings instead (`machineLearning.availabilityChecks.timeout`)
