### PR TITLE
chore: stop using legacy partner create endpoint

### DIFF
--- a/mobile/lib/repositories/partner_api.repository.dart
+++ b/mobile/lib/repositories/partner_api.repository.dart
@@ -21,8 +21,8 @@ class PartnerApiRepository extends ApiRepository {
     return response.map(UserConverter.fromPartnerDto).toList();
   }
 
-  Future<UserDto> create(String id) async {
-    final dto = await checkNull(_api.createPartnerDeprecated(id));
+  Future<UserDto> create(String sharedWithId) async {
+    final dto = await checkNull(_api.createPartner(PartnerCreateDto(sharedWithId: sharedWithId)));
     return UserConverter.fromPartnerDto(dto);
   }
 


### PR DESCRIPTION
We should remove `createPartnerDeprecated` in `v4` since it was being used through v2.7.5...