### PR TITLE
fix(web): keep face bounding box visible while assigning person

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -91,7 +91,7 @@
   const Close: ActionItem = $derived({
     title: $t('go_back'),
     icon: languageManager.rtl ? mdiArrowRight : mdiArrowLeft,
-    $if: () => !!onClose && !assetViewerManager.isFaceEditMode,
+    $if: () => !!onClose && !assetViewerManager.isFaceEditMode && !assetViewerManager.isEditFacesPanelOpen,
     onAction: () => onClose?.(),
     shortcuts: [{ key: 'Escape' }],
   });

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -173,7 +173,7 @@
 
   onDestroy(() => {
     activityManager.reset();
-    assetViewerManager.closeEditor();
+    assetViewerManager.resetPanelState();
     syncAssetViewerOpenClass(false);
     preloadManager.destroy();
   });

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -54,7 +54,7 @@
 
   let { asset, currentAlbum = null }: Props = $props();
 
-  let showEditFaces = $state(false);
+  let showEditFaces = $derived(assetViewerManager.isEditFacesPanelOpen);
   let isOwner = $derived(authManager.authenticated && authManager.user.id === asset.ownerId);
   let people = $derived(asset.people || []);
   let unassignedFaces = $derived(asset.unassignedFaces || []);
@@ -103,7 +103,7 @@
       return;
     }
 
-    showEditFaces = false;
+    assetViewerManager.closeEditFacesPanel();
     previousId = asset.id;
   });
 
@@ -119,7 +119,7 @@
 
   const handleRefreshPeople = async () => {
     asset = await getAssetInfo({ id: asset.id });
-    showEditFaces = false;
+    assetViewerManager.closeEditFacesPanel();
   };
 
   const getAssetFolderHref = (asset: AssetResponseDto) => {
@@ -214,7 +214,7 @@
               shape="round"
               color="secondary"
               variant="ghost"
-              onclick={() => (showEditFaces = true)}
+              onclick={() => assetViewerManager.openEditFacesPanel()}
             />
           {/if}
         </div>
@@ -572,7 +572,7 @@
   <PersonSidePanel
     assetId={asset.id}
     assetType={asset.type}
-    onClose={() => (showEditFaces = false)}
+    onClose={() => assetViewerManager.closeEditFacesPanel()}
     onRefresh={handleRefreshPeople}
   />
 {/if}

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -170,10 +170,17 @@
   const faces = $derived(Array.from(faceToNameMap.keys()));
 
   const handleImageMouseMove = (event: MouseEvent) => {
-    $boundingBoxesArray = [];
-    if (!assetViewerManager.imgRef || !element || assetViewerManager.isFaceEditMode || ocrManager.showOverlay) {
+    if (
+      !assetViewerManager.imgRef ||
+      !element ||
+      assetViewerManager.isFaceEditMode ||
+      assetViewerManager.isEditFacesPanelOpen ||
+      ocrManager.showOverlay
+    ) {
       return;
     }
+
+    $boundingBoxesArray = [];
 
     const natural = getNaturalSize(assetViewerManager.imgRef);
     const scaled = scaleToFit(natural, container);
@@ -196,6 +203,9 @@
   };
 
   const handleImageMouseLeave = () => {
+    if (assetViewerManager.isEditFacesPanelOpen) {
+      return;
+    }
     $boundingBoxesArray = [];
   };
 </script>

--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcut } from '$lib/actions/shortcut';
   import OnEvents from '$lib/components/OnEvents.svelte';
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
@@ -186,6 +187,19 @@
 </script>
 
 <OnEvents {onPersonThumbnailReady} />
+
+<svelte:document
+  use:shortcut={{
+    shortcut: { key: 'Escape' },
+    onShortcut: () => {
+      if (showSelectedFaces) {
+        showSelectedFaces = false;
+      } else {
+        onClose();
+      }
+    },
+  }}
+/>
 
 <section
   transition:fly={{ x: 360, duration: 100, easing: linear }}

--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -146,6 +146,7 @@
       selectedPersonToCreate[editedFace.id] = newFeaturePhoto;
     }
     showSelectedFaces = false;
+    $boundingBoxesArray = [];
   };
 
   const handleReassignFace = (person: PersonResponseDto | null) => {
@@ -153,11 +154,13 @@
       selectedPersonToReassign[editedFace.id] = person;
     }
     showSelectedFaces = false;
+    $boundingBoxesArray = [];
   };
 
   const handleFacePicker = (face: AssetFaceResponseDto) => {
     editedFace = face;
     showSelectedFaces = true;
+    $boundingBoxesArray = [face];
   };
 
   const deleteAssetFace = async (face: AssetFaceResponseDto) => {
@@ -247,7 +250,11 @@
               class="absolute start-0 top-0 h-22.5 w-22.5 cursor-default"
               onfocus={() => ($boundingBoxesArray = [peopleWithFaces[index]])}
               onmouseover={() => ($boundingBoxesArray = [peopleWithFaces[index]])}
-              onmouseleave={() => ($boundingBoxesArray = [])}
+              onmouseleave={() => {
+                if (!showSelectedFaces) {
+                  $boundingBoxesArray = [];
+                }
+              }}
             >
               <div class="relative">
                 {#if selectedPersonToCreate[face.id]}
@@ -384,7 +391,10 @@
     {editedFace}
     {assetId}
     {assetType}
-    onClose={() => (showSelectedFaces = false)}
+    onClose={() => {
+      showSelectedFaces = false;
+      $boundingBoxesArray = [];
+    }}
     onCreatePerson={handleCreatePerson}
     onReassign={handleReassignFace}
   />

--- a/web/src/lib/managers/asset-viewer-manager.svelte.ts
+++ b/web/src/lib/managers/asset-viewer-manager.svelte.ts
@@ -44,6 +44,7 @@ class AssetViewerManager extends BaseEventManager<Events> {
   isPlayingMotionPhoto = $state(false);
   isShowEditor = $state(false);
   #isFaceEditMode = $state(false);
+  #isEditFacesPanelOpen = $state(false);
   #viewingAssetStoreState = $state<AssetResponseDto>();
   #viewState = $state<boolean>(false);
   gridScrollTarget = $state<AssetGridRouteSearchParams | null | undefined>();
@@ -70,6 +71,10 @@ class AssetViewerManager extends BaseEventManager<Events> {
 
   get isFaceEditMode() {
     return this.#isFaceEditMode;
+  }
+
+  get isEditFacesPanelOpen() {
+    return this.#isEditFacesPanelOpen;
   }
 
   get zoomState() {
@@ -184,6 +189,20 @@ class AssetViewerManager extends BaseEventManager<Events> {
 
   closeFaceEditMode() {
     this.#isFaceEditMode = false;
+  }
+
+  openEditFacesPanel() {
+    this.#isEditFacesPanelOpen = true;
+  }
+
+  closeEditFacesPanel() {
+    this.#isEditFacesPanelOpen = false;
+  }
+
+  resetPanelState() {
+    this.closeEditor();
+    this.closeFaceEditMode();
+    this.closeEditFacesPanel();
   }
 
   setAsset(asset: AssetResponseDto) {


### PR DESCRIPTION
When editing faces, clicking a face to assign a person opens the picker side panel with that face's bounding box drawn on the image. However, two interactions were clearing the box mid-selection:

- Mouse move over the image
- Mouse leave on person thumbnails

The fix is to not clear the boundingBoxes. So, when you are editing a person/face, you continue to see the "active" bounding box you are working with. 