### PR TITLE
chore: exit open-api script on errors

### DIFF
--- a/open-api/bin/generate-open-api.sh
+++ b/open-api/bin/generate-open-api.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 OPENAPI_GENERATOR_VERSION=v7.12.0
 
+set -euo pipefail
+
 # usage: ./bin/generate-open-api.sh
 
 function dart {
@@ -39,9 +41,9 @@ function typescript {
   pnpm --filter immich sync:open-api
 )
 
-if [[ $1 == 'dart' ]]; then
+if [[ $# -ge 1 ]] && [[ $1 == 'dart' ]]; then
   dart
-elif [[ $1 == 'typescript' ]]; then
+elif [[ $# -ge 1 ]] && [[ $1 == 'typescript' ]]; then
   typescript
 else
   dart


### PR DESCRIPTION
## Description
Make the script exit on any errors. Especially useful if downloading the patches fails due to shitty internet.

## How Has This Been Tested?
- `make open-api`
- `make open-api-dart`
- `make open-api-typescript`

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
