### PR TITLE
fix: make web build stage deterministic

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,9 @@ RUN --mount=type=cache,id=pnpm-server,target=/buildcache/pnpm-store \
 
 FROM builder AS web
 
+ARG BUILD_ID
+ENV IMMICH_BUILD=${BUILD_ID}
+
 WORKDIR /usr/src/app
 COPY ./web ./web/
 COPY ./i18n ./i18n/

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -15,6 +15,9 @@ const config = {
   },
   preprocess: vitePreprocess(),
   kit: {
+    version: {
+      name: process.env.IMMICH_BUILD || Date.now().toString(),
+    },
     paths: {
       relative: false,
     },


### PR DESCRIPTION
Previously, the sveltekit build would default to using the current time for kit.version.name, which breaks on multiarch because the different architectures are built on separate runners (and thus, at slightly different moments). 

Fixes #27803