### PR TITLE
fix(server): require at least one field to be set when updating memory

### DIFF
--- a/server/src/controllers/memory.controller.spec.ts
+++ b/server/src/controllers/memory.controller.spec.ts
@@ -96,6 +96,12 @@ describe(MemoryController.name, () => {
       expect(status).toBe(400);
       expect(body).toEqual(errorDto.badRequest(['Invalid input: expected object, received undefined']));
     });
+
+    it('should require at least one field', async () => {
+      const { status, body } = await request(ctx.getHttpServer()).put(`/memories/${factory.uuid()}`).send({});
+      expect(status).toBe(400);
+      expect(body).toEqual(errorDto.badRequest(['At least one field must be provided']));
+    });
   });
 
   describe('DELETE /memories/:id', () => {

--- a/server/src/dtos/memory.dto.ts
+++ b/server/src/dtos/memory.dto.ts
@@ -4,7 +4,7 @@ import { HistoryBuilder } from 'src/decorators';
 import { AssetResponseSchema, mapAsset } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetOrderWithRandomSchema, MemoryType, MemoryTypeSchema } from 'src/enum';
-import { isoDatetimeToDate, stringToBool } from 'src/validation';
+import { isoDatetimeToDate, nonEmptyPartial, stringToBool } from 'src/validation';
 import z from 'zod';
 
 const MemorySearchSchema = z
@@ -26,13 +26,11 @@ const OnThisDaySchema = z
 
 type MemoryData = z.infer<typeof OnThisDaySchema>;
 
-const MemoryUpdateSchema = z
-  .object({
-    isSaved: z.boolean().optional().describe('Is memory saved'),
-    seenAt: isoDatetimeToDate.optional().describe('Date when memory was seen'),
-    memoryAt: isoDatetimeToDate.optional().describe('Memory date'),
-  })
-  .meta({ id: 'MemoryUpdateDto' });
+const MemoryUpdateSchema = nonEmptyPartial({
+  isSaved: z.boolean().describe('Is memory saved'),
+  seenAt: isoDatetimeToDate.describe('Date when memory was seen'),
+  memoryAt: isoDatetimeToDate.describe('Memory date'),
+}).meta({ id: 'MemoryUpdateDto' });
 
 const MemoryCreateSchema = z
   .object({

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -33,6 +33,22 @@ export function IsIPRange(options?: IsIPRangeOptions) {
 }
 
 /**
+ * Like z.object().partial(), but rejects objects where every field is undefined.
+ * Use for update/patch DTOs where at least one field must be provided.
+ *
+ * @example
+ * nonEmptyPartial({ name: z.string(), bio: z.string() }).meta({ id: 'UpdateDto' });
+ */
+export function nonEmptyPartial<T extends z.ZodRawShape>(shape: T) {
+  return z
+    .object(shape)
+    .partial()
+    .refine((data) => Object.values(data as Record<string, unknown>).some((value) => value !== undefined), {
+      message: 'At least one field must be provided',
+    });
+}
+
+/**
  * Zod schema that validates sibling-exclusion for object schemas.
  * Validation passes when the target property is missing, or when none of the sibling properties are present.
  * Use with .pipe() like IsIPRange.


### PR DESCRIPTION
## Description

Adds a nonEmptyPartial zod utility in src/validation.ts - works like z.object().partial() but rejects objects where every field is undefined. 

Uses it on MemoryUpdateSchema so empty PUT bodies are caught at the validation layer before reaching the service.

Fixes #27833

## How Has This Been Tested?

Before this change, PUT with an empty body to `/api/memories/{id}` returns a 500.

After this change, the same request returns a 400.

Requests with content still return 200.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help write the curls to reproduce the issue and test the fix. The code execution is my own.