### PR TITLE
fix(mobile): thumbnail transition to asset viewer

### DIFF
--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -129,7 +129,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                       }
 
                       animation.addStatusListener(animationStatusListener);
-                      return to.widget;
+                      return direction == HeroFlightDirection.push ? from.widget : to.widget;
                     },
                   ),
                 ),


### PR DESCRIPTION
## Description

Use the source thumbnail as flight shuttle when pushing to the asset viewer, and the destination when going back.
We previously used `to.widget` in both directions, which caused an instant switch from `BoxFit.cover` to `Boxfit.contain` when navigating to the asset viewer.

See the screenshot section below.

## How Has This Been Tested?

- simulator


<details><summary><h2>Screenshots</h2></summary>

https://github.com/user-attachments/assets/a438a1dd-ebe0-4f9f-933a-eabb84c09bbb


</details>


## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/