### PR TITLE
chore(mobile): update special format column detection

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -94,11 +94,12 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
     const val HASH_BUFFER_SIZE = 2 * 1024 * 1024
 
-    // _special_format requires S Extensions 21+
+    // _special_format: added in API level 37, also in S Extensions 21+
     // https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT
     private fun hasSpecialFormatColumn(): Boolean =
-      Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-        SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 21
+      Build.VERSION.SDK_INT >= 37 ||
+        (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+          SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 21)
   }
 
   protected fun getCursor(


### PR DESCRIPTION
## Description

Special Format column is now not only marked as available in Extension S 21, but also in general API Version 37. ([see here](https://developer.android.com/reference/android/provider/MediaStore.Files.FileColumns#SPECIAL_FORMAT))  

So I changed the check to reflect that.

## How Has This Been Tested?

- with API 37 Emulator (Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image API 37.0 (revision 3))

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/
