### PR TITLE
feat(server): export face data to xmp sidecar files

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -490,4 +490,5 @@ export const lockableProperties = [
   'rating',
   'timeZone',
   'tags',
+  'faces',
 ] as const;

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -14,6 +14,7 @@ import {
   withExif,
   withExifInner,
   withFaces,
+  withFacesAndPeople,
   withFilePath,
   withFiles,
 } from 'src/utils/database';
@@ -41,6 +42,7 @@ export class AssetJobRepository {
       .where('asset.id', '=', asUuid(id))
       .select(['id', 'originalPath'])
       .select((eb) => withFiles(eb, AssetFileType.Sidecar))
+      .select((eb) => withFacesAndPeople(eb))
       .$call(withExifInner)
       .limit(1)
       .executeTakeFirst();

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -271,6 +271,21 @@ export class AssetRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [[DummyValue.UUID], ['faces']] })
+  @Chunked()
+  async lockProperties(ids: string[], properties: LockableProperty[]): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
+    await this.db
+      .updateTable('asset_exif')
+      .where('assetId', 'in', ids)
+      .set((eb) => ({
+        lockedProperties: distinctLocked(eb, properties),
+      }))
+      .execute();
+  }
+
   async upsertJobStatus(...jobStatus: Insertable<AssetJobStatusTable>[]): Promise<void> {
     if (jobStatus.length === 0) {
       return;

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -223,7 +223,8 @@ export class JobRepository {
           delay: item.data?.delay,
         };
       }
-      case JobName.StorageTemplateMigrationSingle: {
+      case JobName.StorageTemplateMigrationSingle:
+      case JobName.SidecarWrite: {
         return { jobId: item.data.id };
       }
       case JobName.PersonGenerateThumbnail: {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -446,7 +446,7 @@ export class MetadataService extends BaseService {
     const { sidecarFile } = getAssetFiles(asset.files);
     const sidecarPath = sidecarFile?.path || `${asset.originalPath}.xmp`;
 
-    const { description, dateTimeOriginal, latitude, longitude, rating, tags, timeZone } = _.pick(
+    const { description, dateTimeOriginal, latitude, longitude, rating, tags, timeZone, faces } = _.pick(
       {
         description: asset.exifInfo.description,
         dateTimeOriginal: asset.exifInfo.dateTimeOriginal,
@@ -455,6 +455,7 @@ export class MetadataService extends BaseService {
         rating: asset.exifInfo.rating ?? 0,
         tags: asset.exifInfo.tags,
         timeZone: asset.exifInfo.timeZone,
+        faces: asset.faces,
       },
       lockedProperties,
     );
@@ -472,7 +473,7 @@ export class MetadataService extends BaseService {
       _.isUndefined,
     );
 
-    const namedFaces = asset.faces?.filter((f) => f.person?.name && f.imageWidth > 0 && f.imageHeight > 0) ?? [];
+    const namedFaces = (faces ?? []).filter((f) => f.person?.name && f.imageWidth > 0 && f.imageHeight > 0);
     if (namedFaces.length > 0) {
       const { imageWidth, imageHeight } = namedFaces[0];
       exif.RegionInfo = {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -472,6 +472,25 @@ export class MetadataService extends BaseService {
       _.isUndefined,
     );
 
+    const namedFaces = asset.faces?.filter((f) => f.person?.name && f.imageWidth > 0 && f.imageHeight > 0) ?? [];
+    if (namedFaces.length > 0) {
+      const { imageWidth, imageHeight } = namedFaces[0];
+      exif.RegionInfo = {
+        AppliedToDimensions: { W: imageWidth, H: imageHeight, Unit: 'pixel' },
+        RegionList: namedFaces.map((f) => ({
+          Area: {
+            X: (f.boundingBoxX1 + f.boundingBoxX2) / 2 / imageWidth,
+            Y: (f.boundingBoxY1 + f.boundingBoxY2) / 2 / imageHeight,
+            W: (f.boundingBoxX2 - f.boundingBoxX1) / imageWidth,
+            H: (f.boundingBoxY2 - f.boundingBoxY1) / imageHeight,
+            Unit: 'normalized',
+          },
+          Type: 'Face',
+          Name: f.person!.name,
+        })),
+      };
+    }
+
     if (Object.keys(exif).length === 0) {
       return JobStatus.Skipped;
     }

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -97,6 +97,7 @@ export class PersonService extends BaseService {
         }
 
         await this.personRepository.reassignFace(face.id, personId);
+        await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
       }
 
       result.push(mapPerson(person));
@@ -121,6 +122,8 @@ export class PersonService extends BaseService {
     if (face.person && face.person.faceAssetId === face.id) {
       await this.createNewFeaturePhoto([face.person.id]);
     }
+
+    await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
 
     return await this.findOrFail(personId).then(mapPerson);
   }
@@ -217,6 +220,14 @@ export class PersonService extends BaseService {
 
     if (assetId) {
       await this.jobRepository.queue({ name: JobName.PersonGenerateThumbnail, data: { id } });
+    }
+
+    if (name !== undefined) {
+      const jobs: { name: JobName.SidecarWrite; data: { id: string } }[] = [];
+      for await (const face of this.personRepository.getAllFaces({ personId: id })) {
+        jobs.push({ name: JobName.SidecarWrite, data: { id: face.assetId } });
+      }
+      await this.jobRepository.queueAll(jobs);
     }
 
     return mapPerson(person);
@@ -603,8 +614,17 @@ export class PersonService extends BaseService {
         const mergeData: UpdateFacesData = { oldPersonId: mergeId, newPersonId: id };
         this.logger.log(`Merging ${mergeName} into ${primaryName}`);
 
+        const affectedAssetIds: string[] = [];
+        for await (const face of this.personRepository.getAllFaces({ personId: mergeId })) {
+          affectedAssetIds.push(face.assetId);
+        }
+
         await this.personRepository.reassignFaces(mergeData);
         await this.removeAllPeople([mergePerson]);
+
+        await this.jobRepository.queueAll(
+          affectedAssetIds.map((assetId) => ({ name: JobName.SidecarWrite, data: { id: assetId } }) as const),
+        );
 
         this.logger.log(`Merged ${mergeName} into ${primaryName}`);
         results.push({ id: mergeId, success: true });
@@ -697,11 +717,14 @@ export class PersonService extends BaseService {
     if (!person.faceAssetId) {
       await this.createNewFeaturePhoto([person.id]);
     }
+    await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: dto.assetId } });
   }
 
   async deleteFace(auth: AuthDto, id: string, dto: AssetFaceDeleteDto): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.FaceDelete, ids: [id] });
 
-    return dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id);
+    const face = await this.personRepository.getFaceById(id);
+    await (dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id));
+    await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
   }
 }

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -97,6 +97,7 @@ export class PersonService extends BaseService {
         }
 
         await this.personRepository.reassignFace(face.id, personId);
+        await this.assetRepository.lockProperties([face.assetId], ['faces']);
         await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
       }
 
@@ -123,6 +124,7 @@ export class PersonService extends BaseService {
       await this.createNewFeaturePhoto([face.person.id]);
     }
 
+    await this.assetRepository.lockProperties([face.assetId], ['faces']);
     await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
 
     return await this.findOrFail(personId).then(mapPerson);
@@ -223,10 +225,13 @@ export class PersonService extends BaseService {
     }
 
     if (name !== undefined) {
+      const assetIds: string[] = [];
       const jobs: { name: JobName.SidecarWrite; data: { id: string } }[] = [];
       for await (const face of this.personRepository.getAllFaces({ personId: id })) {
+        assetIds.push(face.assetId);
         jobs.push({ name: JobName.SidecarWrite, data: { id: face.assetId } });
       }
+      await this.assetRepository.lockProperties(assetIds, ['faces']);
       await this.jobRepository.queueAll(jobs);
     }
 
@@ -622,6 +627,7 @@ export class PersonService extends BaseService {
         await this.personRepository.reassignFaces(mergeData);
         await this.removeAllPeople([mergePerson]);
 
+        await this.assetRepository.lockProperties(affectedAssetIds, ['faces']);
         await this.jobRepository.queueAll(
           affectedAssetIds.map((assetId) => ({ name: JobName.SidecarWrite, data: { id: assetId } }) as const),
         );
@@ -717,6 +723,7 @@ export class PersonService extends BaseService {
     if (!person.faceAssetId) {
       await this.createNewFeaturePhoto([person.id]);
     }
+    await this.assetRepository.lockProperties([dto.assetId], ['faces']);
     await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: dto.assetId } });
   }
 
@@ -725,6 +732,7 @@ export class PersonService extends BaseService {
 
     const face = await this.personRepository.getFaceById(id);
     await (dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id));
+    await this.assetRepository.lockProperties([face.assetId], ['faces']);
     await this.jobRepository.queue({ name: JobName.SidecarWrite, data: { id: face.assetId } });
   }
 }

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -10,6 +10,7 @@ export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetReposi
     updateAllExif: vitest.fn(),
     updateDateTimeOriginal: vitest.fn().mockResolvedValue([]),
     unlockProperties: vitest.fn().mockResolvedValue([]),
+    lockProperties: vitest.fn().mockResolvedValue(undefined),
     upsertJobStatus: vitest.fn(),
     getForCopy: vitest.fn(),
     getByDayOfYear: vitest.fn(),


### PR DESCRIPTION
## Description
This PR adds the ability to export face information of assets to corresponding .xmp files. The format used is identical to the format that immich already can read to import face information.
As per my understanding the xmp files are written in all situations, when there is an update of a face or person, given the person is named.
There is no initial "export all faces" job yet. Wanted to get started with something small.
Also not included yet, is to automatically write the xmp if a known person deteced in new photo.

## How Has This Been Tested?
- [X] Manually add a face, xmp is updated
- [X] Update Tag, location or anything else that triggers xmp update, xmp of that asset is updated.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Had help in regards of deduplication, to avoid, that multiple updates to the xmp file of the same asset happen.