### PR TITLE
chore: enhance documentation on wildcard and exclusion patterns

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -50,6 +50,8 @@ Some basic examples:
 - `**/Raw/**` will exclude all files in any directory named `Raw`
 - `**/*.{tif,jpg}` will exclude all files with the extension `.tif` or `.jpg`
 
+Note that `*` is a wildcard matching zero or more characters (i.e., withinin a filename or single directory name).  `**` matches zero or more subdirectories, recursively. It also includes any/all files within a subdirectory, i.e., when used at the end of a pattern. For example, `**/exclude_me/**` will exclude all files in any directory named `exclude_me`, as well as all files in any subdirectories of `exclude_me`, recursively.
+
 Special characters such as @ should be escaped, for instance:
 
 - `**/\@eaDir/**` will exclude all files in any directory named `@eaDir`

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -50,7 +50,7 @@ Some basic examples:
 - `**/Raw/**` will exclude all files in any directory named `Raw`
 - `**/*.{tif,jpg}` will exclude all files with the extension `.tif` or `.jpg`
 
-Note that `*` is a wildcard matching zero or more characters (i.e., withinin a filename or single directory name).  `**` matches zero or more subdirectories, recursively. It also includes any/all files within a subdirectory, i.e., when used at the end of a pattern. For example, `**/exclude_me/**` will exclude all files in any directory named `exclude_me`, as well as all files in any subdirectories of `exclude_me`, recursively.
+Note that `*` is a wildcard matching zero or more characters (i.e., withinin a filename or single directory name). `**` matches zero or more subdirectories, recursively. It also includes any/all files within a subdirectory, i.e., when used at the end of a pattern. For example, `**/exclude_me/**` will exclude all files in any directory named `exclude_me`, as well as all files in any subdirectories of `exclude_me`, recursively.
 
 Special characters such as @ should be escaped, for instance:
 


### PR DESCRIPTION
In online documentation, clarify wildcard usage and special character escaping in exclusion patterns, which can be a little confusing to anyone who doesn't use glob frequently.

## Description

On the page documenting External Libraries, explains the use of glob wildcards in external library exclusion patterns a little more thoroughly (just covering the most common use cases).

I was updating my own External Library exclusion patterns, was confused by the use of * and ** as on glob, and thought many other users will likely have the same issue, would can be easily solved with a couple of sentences of explanation.

Fixes # (issue)

## How Has This Been Tested?
This is a suggested update to the documentation. I did proofread it several times.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [N/A] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.

...
