### PR TITLE
fix(web): remove json title from duplicate tool thumbnail

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -33,7 +33,6 @@
   let { assets, asset, isSelected, onSelectAsset, onViewAsset }: Props = $props();
 
   let isFromExternalLibrary = $derived(!!asset.libraryId);
-  let assetData = $derived(JSON.stringify(asset, null, 2));
 
   let locationParts = $derived([asset.exifInfo?.city, asset.exifInfo?.state, asset.exifInfo?.country].filter(Boolean));
 
@@ -114,7 +113,6 @@
       <img
         src={getAssetMediaUrl({ id: asset.id })}
         alt={$getAltText(toTimelineAsset(asset))}
-        title={assetData}
         class="h-60 object-cover w-full rounded-t-md"
         draggable="false"
       />


### PR DESCRIPTION
## Description
Remove the title (and browser tooltip) from the thumbs in the duplicate review tool. With the new system showing much more info, I don't think it's required anymore. Also, for more info, users can click the preview button to open the asset viewer.

Fixes #10205

