### PR TITLE
fix(web): normalize underscore locale codes in dynamic language selection

### DIFF
--- a/web/src/lib/i18n.spec.ts
+++ b/web/src/lib/i18n.spec.ts
@@ -50,5 +50,13 @@ describe('i18n', () => {
       expect(getClosestAvailableLocale(['zh'], allLocales)).toBeUndefined();
       expect(getClosestAvailableLocale(['de', 'zh', 'en-US'], allLocales)).toBe('en-US');
     });
+
+    it('matches underscore-based stored locale codes against normalized locale lists', () => {
+      const allLocales = ['de-CH', 'pt-BR', 'sr-Cyrl', 'zh-Hant'];
+      expect(getClosestAvailableLocale(['de_CH'], allLocales)).toBe('de_CH');
+      expect(getClosestAvailableLocale(['pt_BR'], allLocales)).toBe('pt_BR');
+      expect(getClosestAvailableLocale(['sr_Cyrl'], allLocales)).toBe('sr_Cyrl');
+      expect(getClosestAvailableLocale(['zh_Hant'], allLocales)).toBe('zh_Hant');
+    });
   });
 });

--- a/web/src/lib/utils/i18n.ts
+++ b/web/src/lib/utils/i18n.ts
@@ -19,21 +19,20 @@ const fileCodes = Object.keys(modules)
   .map((path) => path.match(/\/(\w+)\.json$/)?.[1])
   .filter(Boolean) as string[];
 
-const normalizeLocaleCode = (code: string) => code.replaceAll('_', '-');
-const convertBCP47 = (code: string) => normalizeLocaleCode(code);
+const convertBCP47 = (code: string) => code.replaceAll('_', '-');
 
 export const langCodes = fileCodes.map((code) => convertBCP47(code));
 
 // https://github.com/kaisermann/svelte-i18n/blob/780932a3e1270d521d348aac8ba03be9df309f04/src/runtime/stores/locale.ts#L11
 const getSubLocales = (locale: string) => {
-  return normalizeLocaleCode(locale)
+  return convertBCP47(locale)
     .split('-')
     .map((_, i, arr) => arr.slice(0, i + 1).join('-'))
     .reverse();
 };
 
 export const getClosestAvailableLocale = (locales: readonly string[], allLocales: readonly string[]) => {
-  const allLocalesSet = new Set(allLocales.map(normalizeLocaleCode));
+  const allLocalesSet = new Set(allLocales.map(convertBCP47));
   return locales.find((locale) => getSubLocales(locale).some((subLocale) => allLocalesSet.has(subLocale)));
 };
 

--- a/web/src/lib/utils/i18n.ts
+++ b/web/src/lib/utils/i18n.ts
@@ -32,7 +32,7 @@ const getSubLocales = (locale: string) => {
 };
 
 export const getClosestAvailableLocale = (locales: readonly string[], allLocales: readonly string[]) => {
-  const allLocalesSet = new Set(allLocales.map(convertBCP47));
+  const allLocalesSet = new Set(allLocales.map((locale) => convertBCP47(locale)));
   return locales.find((locale) => getSubLocales(locale).some((subLocale) => allLocalesSet.has(subLocale)));
 };
 

--- a/web/src/lib/utils/i18n.ts
+++ b/web/src/lib/utils/i18n.ts
@@ -19,20 +19,21 @@ const fileCodes = Object.keys(modules)
   .map((path) => path.match(/\/(\w+)\.json$/)?.[1])
   .filter(Boolean) as string[];
 
-const convertBCP47 = (code: string) => code.replace('_', '-');
+const normalizeLocaleCode = (code: string) => code.replaceAll('_', '-');
+const convertBCP47 = (code: string) => normalizeLocaleCode(code);
 
 export const langCodes = fileCodes.map((code) => convertBCP47(code));
 
 // https://github.com/kaisermann/svelte-i18n/blob/780932a3e1270d521d348aac8ba03be9df309f04/src/runtime/stores/locale.ts#L11
 const getSubLocales = (locale: string) => {
-  return locale
+  return normalizeLocaleCode(locale)
     .split('-')
     .map((_, i, arr) => arr.slice(0, i + 1).join('-'))
     .reverse();
 };
 
 export const getClosestAvailableLocale = (locales: readonly string[], allLocales: readonly string[]) => {
-  const allLocalesSet = new Set(allLocales);
+  const allLocalesSet = new Set(allLocales.map(normalizeLocaleCode));
   return locales.find((locale) => getSubLocales(locale).some((subLocale) => allLocalesSet.has(subLocale)));
 };
 


### PR DESCRIPTION
## Description

Fixes #27899.

`feat: dynamic languages` (#27869) introduced a mismatch between the locale code format used for stored web preferences and the format used for matching against the generated language list.

Today:
- `langs` keeps filename-based locale codes such as `de_CH` and `zh_Hant`
- `langCodes` normalizes those codes to hyphenated forms such as `de-CH` and `zh-Hant`
- the settings page derives the selected option with `getClosestAvailableLocale([$lang], langCodes)`

Because of that, supported underscore-based locale values no longer resolve correctly and the selector falls back instead of preserving the stored language.

This PR keeps the fix scoped to the comparison path only:
- normalize locale codes while matching
- keep loader keys and stored preference values unchanged
- add regression coverage for representative underscore-based locales

## How Has This Been Tested?

- [x] `pnpm --filter @immich/sdk build`
- [x] `pnpm --filter immich-web exec vitest run src/lib/i18n.spec.ts`
- [x] `pnpm --filter immich-web run check:typescript`
- [x] Local logic-level repro for stored underscore locale codes (`de_CH`, `pt_BR`, `sr_Cyrl`, `zh_Hant`)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No UI screenshots included. This is a small logic/regression-test fix.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Manually reviewed and rewritten before submission.