### PR TITLE
fix: disable upgrade-insecure-requests in default CSP config

### DIFF
--- a/server/helmet.json
+++ b/server/helmet.json
@@ -15,7 +15,8 @@
       "worker-src": ["'self'", "blob:"],
       "frame-src": ["'none'"],
       "object-src": ["'none'"],
-      "base-uri": ["'self'"]
+      "base-uri": ["'self'"],
+      "upgrade-insecure-requests": null
     }
   }
 }


### PR DESCRIPTION
This is enabled in the default Helmet config that this merges into, and tells the browser to upgrade all requests to https, which breaks on http-only deployments.

Fixes #27907.

(alternatively we could just tell people to set a custom config if they're not on https)
