### PR TITLE
fix(mobile): negative backup remainder

### DIFF
--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -267,7 +267,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
       _cancelToken!,
       callbacks: UploadCallbacks(
         onProgress: _handleForegroundBackupProgress,
-        onSuccess: _handleForegroundBackupSuccess,
+        onSuccess: (localAssetId) => _handleForegroundBackupSuccess(localAssetId, userId),
         onError: _handleForegroundBackupError,
         onICloudProgress: _handleICloudProgress,
       ),
@@ -329,9 +329,9 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     }
   }
 
-  void _handleForegroundBackupSuccess(String localAssetId, String remoteAssetId) {
-    state = state.copyWith(backupCount: state.backupCount + 1, remainderCount: state.remainderCount - 1);
+  void _handleForegroundBackupSuccess(String localAssetId, String userId) {
     _uploadSpeedManager.removeTask(localAssetId);
+    getBackupStatus(userId);
 
     Future.delayed(const Duration(milliseconds: 1000), () {
       _removeUploadItem(localAssetId);

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -470,7 +470,7 @@ class ActionNotifier extends Notifier<void> {
             final progress = totalBytes > 0 ? bytes / totalBytes : 0.0;
             progressNotifier.setProgress(localAssetId, progress);
           },
-          onSuccess: (localAssetId, remoteAssetId) {
+          onSuccess: (localAssetId) {
             progressNotifier.remove(localAssetId);
           },
           onError: (localAssetId, errorMessage) {

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -26,7 +26,7 @@ import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
 /// Callbacks for upload progress and status updates
 class UploadCallbacks {
   final void Function(String id, String filename, int bytes, int totalBytes)? onProgress;
-  final void Function(String localId, String remoteId)? onSuccess;
+  final void Function(String localId)? onSuccess;
   final void Function(String id, String errorMessage)? onError;
   final void Function(String id, double progress)? onICloudProgress;
 
@@ -386,8 +386,8 @@ class ForegroundUploadService {
         logContext: 'asset[${asset.localId}]',
       );
 
-      if (result.isSuccess && result.remoteAssetId != null) {
-        callbacks.onSuccess?.call(asset.localId!, result.remoteAssetId!);
+      if (result.isSuccess) {
+        callbacks.onSuccess?.call(asset.localId!);
       } else if (result.isCancelled) {
         _logger.warning(() => "Backup was cancelled by the user");
         shouldAbortUpload = true;

--- a/mobile/test/providers/backup/drift_backup_provider_test.dart
+++ b/mobile/test/providers/backup/drift_backup_provider_test.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+import 'package:immich_mobile/services/foreground_upload.service.dart';
+import 'package:immich_mobile/utils/upload_speed_calculator.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockForegroundUploadService extends Mock
+    implements ForegroundUploadService {}
+
+class MockBackgroundUploadService extends Mock
+    implements BackgroundUploadService {}
+
+void main() {
+  late DriftBackupNotifier sut;
+  late MockForegroundUploadService mockForegroundService;
+  late MockBackgroundUploadService mockBackgroundService;
+
+  setUpAll(() {
+    registerFallbackValue(Completer<void>());
+    registerFallbackValue(const UploadCallbacks());
+  });
+
+  setUp(() {
+    mockForegroundService = MockForegroundUploadService();
+    mockBackgroundService = MockBackgroundUploadService();
+    sut = DriftBackupNotifier(
+      mockForegroundService,
+      mockBackgroundService,
+      UploadSpeedManager(),
+    );
+  });
+
+  tearDown(() {
+    sut.dispose();
+  });
+
+  group('_handleForegroundBackupSuccess', () {
+    test(
+      'remainderCount should not go negative when getBackupStatus refreshes before success callback',
+      () async {
+        const userId = 'test-user';
+
+
+        when(() => mockForegroundService.getBackupCounts(userId)).thenAnswer(
+          (_) async => (total: 5, remainder: 1, processing: 0),
+        );
+        await sut.getBackupStatus(userId);
+        expect(sut.state.remainderCount, 1);
+
+
+        late void Function(String localId) onSuccess;
+        when(
+          () => mockForegroundService.uploadCandidates(
+            any(),
+            any(),
+            callbacks: any(named: 'callbacks'),
+            useSequentialUpload: any(named: 'useSequentialUpload'),
+          ),
+        ).thenAnswer((invocation) async {
+          final callbacks =
+              invocation.namedArguments[#callbacks] as UploadCallbacks;
+          onSuccess = callbacks.onSuccess!;
+        });
+
+        await sut.startForegroundBackup(userId);
+
+        when(() => mockForegroundService.getBackupCounts(userId)).thenAnswer(
+          (_) async => (total: 5, remainder: 0, processing: 0),
+        );
+        await sut.getBackupStatus(userId);
+        expect(sut.state.remainderCount, 0);
+
+        onSuccess('asset-1');
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(sut.state.remainderCount, greaterThanOrEqualTo(0));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

The backup remainder count could go negative due to a race condition between `_handleForegroundBackupSuccess` and `getBackupStatus()`.
The success callback decremented `remainderCount` locally (`remainderCount - 1`), but `getBackupStatus()` could be called concurrently from the UI (e.g. returning from album selection, after a sync) and reset the counts with absolute values from the database.
If the DB already reflected a completed upload, the decrement double-counted it, pushing `remainderCount` below zero.

The fix replaces the local decrement with a call to `getBackupStatus()`, which reads the counts from the database. Also removes the unused `remoteAssetId` parameter from `UploadCallbacks.onSuccess`.

Fixes #26215

## How Has This Been Tested?
- [x] Triggered a backup with a small number of assets while navigating to album selection and back. Remainder count stays at 0 and never goes negative
- [x] Normal backup flow with multiple assets — remainder count decrements correctly until reaching 0

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
