### PR TITLE
feat: global job concurrency limit

### DIFF
--- a/docs/docs/administration/system-settings.md
+++ b/docs/docs/administration/system-settings.md
@@ -78,6 +78,14 @@ The Facial Recognition Concurrency value cannot be changed because
 [DBSCAN](https://www.youtube.com/watch?v=RDZUdRSDOok) is traditionally sequential, but there are parallel implementations of it out there. Our implementation isn't parallel.
 :::
 
+### Global Job Concurrency Limit
+
+The **Global job concurrency limit** caps the total number of jobs that can run simultaneously across _all_ queues. Per-queue concurrency only limits each queue in isolation, so with multiple active queues (for example, Smart Search + Face Detection + OCR) the host can still be overloaded even when each queue is set to `1`.
+
+Setting this value to a positive number restricts the total active jobs across every queue combined. Setting it to `0` (the default) disables the global cap and only the per-queue limits apply, preserving the behaviour from earlier versions.
+
+This is particularly useful on low-powered hardware such as a Raspberry Pi or a low-core NAS, where a value like `2` or `3` prevents overlapping machine-learning and thumbnail work from saturating the CPU or exhausting memory.
+
 ## External Library
 
 ### Library watching (EXPERIMENTAL)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -115,6 +115,8 @@
     "image_thumbnail_quality_description": "Thumbnail quality from 1-100. Higher is better, but produces larger files and can reduce app responsiveness.",
     "image_thumbnail_title": "Thumbnail Settings",
     "import_config_from_json_description": "Import system config by uploading a JSON config file",
+    "global_job_concurrency": "Global job concurrency limit",
+    "global_job_concurrency_description": "Maximum number of jobs that can run simultaneously across all queues. Set to 0 to disable the global limit (only per-queue limits apply). Useful for low-powered systems.",
     "job_concurrency": "{job} concurrency",
     "job_created": "Job created",
     "job_not_concurrency_safe": "This job is not concurrency-safe.",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -46,7 +46,7 @@ export type SystemConfig = {
     accelDecode: boolean;
     tonemap: ToneMapping;
   };
-  job: Record<ConcurrentQueueName, { concurrency: number }>;
+  job: Record<ConcurrentQueueName, { concurrency: number }> & { globalConcurrency: number };
   logging: {
     enabled: boolean;
     level: LogLevel;
@@ -223,6 +223,7 @@ export const defaults = Object.freeze<SystemConfig>({
     accelDecode: false,
   },
   job: {
+    globalConcurrency: 0,
     [QueueName.BackgroundTask]: { concurrency: 5 },
     [QueueName.SmartSearch]: { concurrency: 2 },
     [QueueName.MetadataExtraction]: { concurrency: 5 },

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -173,6 +173,11 @@ class JobSettingsDto {
 }
 
 class SystemConfigJobDto implements Record<ConcurrentQueueName, JobSettingsDto> {
+  @IsInt()
+  @Min(0)
+  @ApiProperty({ type: 'integer', description: 'Global concurrency limit (0 = disabled)' })
+  globalConcurrency!: number;
+
   @ApiProperty({ type: JobSettingsDto, description: undefined })
   @ValidateNested()
   @IsObject()

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -12,6 +12,7 @@ import { EventRepository } from 'src/repositories/event.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { JobCounts, JobItem, JobOf } from 'src/types';
 import { getKeyByValue, getMethodNames, ImmichStartupError } from 'src/utils/misc';
+import { AsyncSemaphore } from 'src/utils/semaphore';
 
 type JobMapItem = {
   jobName: JobName;
@@ -24,6 +25,7 @@ type JobMapItem = {
 export class JobRepository {
   private workers: Partial<Record<QueueName, Worker>> = {};
   private handlers: Partial<Record<JobName, JobMapItem>> = {};
+  private globalSemaphore: AsyncSemaphore | null = null;
 
   constructor(
     private moduleRef: ModuleRef,
@@ -90,7 +92,19 @@ export class JobRepository {
       this.logger.debug(`Starting worker for queue: ${queueName}`);
       this.workers[queueName] = new Worker(
         queueName,
-        (job) => this.eventRepository.emit('JobRun', queueName, job as JobItem),
+        async (job) => {
+          const semaphore = this.globalSemaphore;
+          if (semaphore) {
+            await semaphore.acquire();
+          }
+          try {
+            return await this.eventRepository.emit('JobRun', queueName, job as JobItem);
+          } finally {
+            if (semaphore) {
+              semaphore.release();
+            }
+          }
+        },
         { ...bull.config, concurrency: 1 },
       );
     }
@@ -114,6 +128,19 @@ export class JobRepository {
     }
 
     worker.concurrency = concurrency;
+  }
+
+  setGlobalConcurrency(limit: number) {
+    if (limit <= 0) {
+      this.globalSemaphore = null;
+      return;
+    }
+
+    if (this.globalSemaphore) {
+      this.globalSemaphore.setLimit(limit);
+    } else {
+      this.globalSemaphore = new AsyncSemaphore(limit);
+    }
   }
 
   async isActive(name: QueueName): Promise<boolean> {

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -28,6 +28,14 @@ describe(QueueService.name, () => {
       expect(mocks.job.setConcurrency).toHaveBeenNthCalledWith(7, QueueName.DuplicateDetection, 1);
       expect(mocks.job.setConcurrency).toHaveBeenNthCalledWith(8, QueueName.BackgroundTask, 5);
       expect(mocks.job.setConcurrency).toHaveBeenNthCalledWith(9, QueueName.StorageTemplateMigration, 1);
+      expect(mocks.job.setGlobalConcurrency).toHaveBeenCalledWith(0);
+    });
+
+    it('should set global concurrency from config', () => {
+      const config = { ...defaults, job: { ...defaults.job, globalConcurrency: 3 } };
+      sut.onConfigUpdate({ newConfig: config, oldConfig: {} as SystemConfig });
+
+      expect(mocks.job.setGlobalConcurrency).toHaveBeenCalledWith(3);
     });
   });
 

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -94,6 +94,9 @@ export class QueueService extends BaseService {
       this.logger.debug(`Setting ${queueName} concurrency to ${concurrency}`);
       this.jobRepository.setConcurrency(queueName, concurrency);
     }
+
+    this.logger.debug(`Setting global concurrency to ${config.job.globalConcurrency}`);
+    this.jobRepository.setGlobalConcurrency(config.job.globalConcurrency);
   }
 
   setServices(services: ClassConstructor<unknown>[]) {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -28,6 +28,7 @@ const partialConfig = {
 
 const updatedConfig = Object.freeze<SystemConfig>({
   job: {
+    globalConcurrency: 0,
     [QueueName.BackgroundTask]: { concurrency: 5 },
     [QueueName.SmartSearch]: { concurrency: 2 },
     [QueueName.MetadataExtraction]: { concurrency: 5 },

--- a/server/src/utils/semaphore.spec.ts
+++ b/server/src/utils/semaphore.spec.ts
@@ -1,0 +1,104 @@
+import { AsyncSemaphore } from 'src/utils/semaphore';
+
+describe(AsyncSemaphore.name, () => {
+  it('should acquire immediately when under limit', async () => {
+    const semaphore = new AsyncSemaphore(2);
+    await semaphore.acquire();
+    await semaphore.acquire();
+  });
+
+  it('should block when at limit and unblock on release', async () => {
+    const semaphore = new AsyncSemaphore(1);
+    await semaphore.acquire();
+
+    let resolved = false;
+    const blocked = semaphore.acquire().then(() => {
+      resolved = true;
+    });
+
+    // give microtasks a chance to run
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    semaphore.release();
+    await blocked;
+    expect(resolved).toBe(true);
+  });
+
+  it('should process waiters in FIFO order', async () => {
+    const semaphore = new AsyncSemaphore(1);
+    await semaphore.acquire();
+
+    const order: number[] = [];
+    const p1 = semaphore.acquire().then(() => order.push(1));
+    const p2 = semaphore.acquire().then(() => order.push(2));
+
+    semaphore.release();
+    await p1;
+    semaphore.release();
+    await p2;
+
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('should drain waiters when setLimit increases', async () => {
+    const semaphore = new AsyncSemaphore(1);
+    await semaphore.acquire();
+
+    let resolved1 = false;
+    let resolved2 = false;
+    const p1 = semaphore.acquire().then(() => {
+      resolved1 = true;
+    });
+    const p2 = semaphore.acquire().then(() => {
+      resolved2 = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved1).toBe(false);
+    expect(resolved2).toBe(false);
+
+    semaphore.setLimit(3);
+    await Promise.all([p1, p2]);
+    expect(resolved1).toBe(true);
+    expect(resolved2).toBe(true);
+  });
+
+  it('should block new acquires when setLimit decreases below current usage', async () => {
+    const semaphore = new AsyncSemaphore(3);
+    await semaphore.acquire();
+    await semaphore.acquire();
+
+    semaphore.setLimit(1);
+
+    let resolved = false;
+    const blocked = semaphore.acquire().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    semaphore.release();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    semaphore.release();
+    await blocked;
+    expect(resolved).toBe(true);
+  });
+
+  it('should handle release correctly after multiple acquire/release cycles', async () => {
+    const semaphore = new AsyncSemaphore(2);
+
+    await semaphore.acquire();
+    await semaphore.acquire();
+    semaphore.release();
+    semaphore.release();
+
+    await semaphore.acquire();
+    await semaphore.acquire();
+    semaphore.release();
+    semaphore.release();
+  });
+});

--- a/server/src/utils/semaphore.ts
+++ b/server/src/utils/semaphore.ts
@@ -1,0 +1,37 @@
+export class AsyncSemaphore {
+  private current = 0;
+  private limit: number;
+  private waitQueue: Array<() => void> = [];
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  setLimit(limit: number): void {
+    this.limit = limit;
+    this.drain();
+  }
+
+  async acquire(): Promise<void> {
+    if (this.current < this.limit) {
+      this.current++;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+    });
+  }
+
+  release(): void {
+    this.current--;
+    this.drain();
+  }
+
+  private drain(): void {
+    while (this.waitQueue.length > 0 && this.current < this.limit) {
+      this.current++;
+      const next = this.waitQueue.shift()!;
+      next();
+    }
+  }
+}

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -8,6 +8,7 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     startWorkers: vitest.fn(),
     run: vitest.fn(),
     setConcurrency: vitest.fn(),
+    setGlobalConcurrency: vitest.fn(),
     empty: vitest.fn(),
     pause: vitest.fn(),
     resume: vitest.fn(),

--- a/web/src/lib/components/admin-settings/JobSettings.svelte
+++ b/web/src/lib/components/admin-settings/JobSettings.svelte
@@ -55,6 +55,18 @@
 <div>
   <div in:fade={{ duration: 500 }}>
     <form autocomplete="off" onsubmit={(event) => event.preventDefault()}>
+      <div class="ms-4 mt-4 flex flex-col gap-4">
+        <SettingInputField
+          inputType={SettingInputFieldType.NUMBER}
+          {disabled}
+          label={$t('admin.global_job_concurrency')}
+          description={$t('admin.global_job_concurrency_description')}
+          bind:value={configToEdit.job.globalConcurrency}
+          required={true}
+          isEdited={!(configToEdit.job.globalConcurrency === config.job.globalConcurrency)}
+        />
+      </div>
+
       {#each queueNames as queueName (queueName)}
         <div class="ms-4 mt-4 flex flex-col gap-4">
           {#if isSystemConfigJobDto(queueName)}


### PR DESCRIPTION
## Description

Adds a **global job concurrency limit** that caps the total number of jobs running simultaneously across all BullMQ queues. On low-powered systems (Raspberry Pi, low-core NAS), even with per-queue concurrency set to 1, multiple queues (smart search + face detection + OCR, etc.) run concurrently and overwhelm CPU/memory. This change introduces a single global cap that complements the existing per-queue limits.

How it works:
- New `AsyncSemaphore` utility with FIFO waiters and dynamic limit adjustment (`server/src/utils/semaphore.ts`).
- `JobRepository` holds an optional semaphore; each BullMQ worker callback acquires a slot before executing and releases in `finally`.
- New `job.globalConcurrency` config field (default `0` = disabled, preserving current behavior).
- `QueueService.updateConcurrency()` applies the limit on `ConfigInit` / `ConfigUpdate` alongside per-queue concurrency.
- Admin UI adds a "Global job concurrency limit" field above the per-queue list.

When `globalConcurrency` is `0`, the semaphore is `null` and there is zero overhead on the worker callback path.

Note: jobs waiting on the semaphore still count as "active" in BullMQ (the worker has already pulled them). This is acceptable and avoids fighting BullMQ internals; lock renewal continues inside the callback. The semaphore applies to all queues including the 4 non-concurrent ones — they should also be throttled under resource pressure.

Fixes # (relates to discussion [#3625](https://github.com/immich-app/immich/discussions/3625))

## How Has This Been Tested?

- [x] Unit tests for `AsyncSemaphore` (acquire/release, FIFO ordering, setLimit increase/decrease)
- [x] Updated `QueueService` test — verifies `setGlobalConcurrency` is called with config value on `ConfigUpdate`
- [x] Full server unit test suite passes locally (2138 tests, 88 files)
- [ ] Manual smoke: set `globalConcurrency` to 2, trigger thumbnails + smart search + face detection simultaneously, verify only 2 jobs execute concurrently across all queues (via admin Jobs page active counts)
- [ ] Manual smoke: set `globalConcurrency` back to 0, verify per-queue limits resume and throughput returns to baseline
- [ ] Regenerate OpenAPI spec + TypeScript SDK via `make open-api` in the Docker dev environment

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## API Changes

`SystemConfigJobDto` gains a new `globalConcurrency: number` field (non-negative integer; `0` disables the global limit). The OpenAPI spec and TypeScript SDK need to be regenerated via `make open-api` before merge — I didn't have the pnpm workspace set up locally to run it.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code (Anthropic) was used heavily throughout: exploring the codebase, designing the semaphore-based approach, writing the implementation across server and web, and authoring tests and documentation. Every change was reviewed by me before committing and pushing, and I ran the full server unit test suite locally to verify no regressions.