### PR TITLE
fix(mobile): clear local data on forced logout

### DIFF
--- a/mobile/lib/routing/auth_guard.dart
+++ b/mobile/lib/routing/auth_guard.dart
@@ -7,13 +7,15 @@ import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/auth.service.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 
 class AuthGuard extends AutoRouteGuard {
   final ApiService _apiService;
+  final AuthService _authService;
   final _log = Logger("AuthGuard");
-  AuthGuard(this._apiService);
+  AuthGuard(this._apiService, this._authService);
   @override
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
     resolver.next(true);
@@ -27,7 +29,7 @@ class AuthGuard extends AutoRouteGuard {
       if (res == null || res.authStatus != true) {
         // If the access token is invalid, take user back to login
         _log.fine('User token is invalid. Redirecting to login');
-        unawaited(router.replaceAll([const LoginRoute()]));
+        unawaited(router.replaceAll([const LoginRoute()]).then((_) => _authService.clearLocalData()));
       }
     } on StoreKeyNotFoundException catch (_) {
       // If there is no access token, take us to the login page
@@ -38,7 +40,7 @@ class AuthGuard extends AutoRouteGuard {
       // On an unauthorized request, take us to the login page
       if (e.code == HttpStatus.unauthorized) {
         _log.warning("Unauthorized access token.");
-        unawaited(router.replaceAll([const LoginRoute()]));
+        unawaited(router.replaceAll([const LoginRoute()]).then((_) => _authService.clearLocalData()));
         return;
       }
     } catch (e) {

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -73,6 +73,7 @@ import 'package:immich_mobile/routing/auth_guard.dart';
 import 'package:immich_mobile/routing/duplicate_guard.dart';
 import 'package:immich_mobile/routing/locked_guard.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/auth.service.dart';
 import 'package:immich_mobile/services/local_auth.service.dart';
 import 'package:immich_mobile/services/secure_storage.service.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -82,6 +83,7 @@ part 'router.gr.dart';
 final appRouterProvider = Provider(
   (ref) => AppRouter(
     ref.watch(apiServiceProvider),
+    ref.watch(authServiceProvider),
     ref.watch(galleryPermissionNotifier.notifier),
     ref.watch(secureStorageServiceProvider),
     ref.watch(localAuthServiceProvider),
@@ -96,11 +98,12 @@ class AppRouter extends RootStackRouter {
 
   AppRouter(
     ApiService apiService,
+    AuthService authService,
     GalleryPermissionNotifier galleryPermissionNotifier,
     SecureStorageService secureStorageService,
     LocalAuthService localAuthService,
   ) {
-    _authGuard = AuthGuard(apiService);
+    _authGuard = AuthGuard(apiService, authService);
     _duplicateGuard = const DuplicateGuard();
     _lockedGuard = LockedGuard(apiService, secureStorageService, localAuthService);
   }


### PR DESCRIPTION
## Description

When revoking the session of a user thats currently using the app, they currently just gets moved to the login page. 
All the local data (database) is still on device and not cleared. 

Reproducing the bug:
- login into your immich account on mobile
- go to the web interface and revoke access for your mobile device
- on the mobile app click around till you get thrown back to the login page
- now all the data is still on device (which I think it shouldn't be)
- Now if you login with another user or eg. to the demo instance account you will see albums that don't belong to the current active account. 

This PR makes the AuthGuard which currently validates the session token to use the same `clearLocalData` method after moving the user back to the login page. 

## How Has This Been Tested?

- simulator

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/
