### PR TITLE
fix(mobile): enable autoplay for motion photos in video viewer

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -148,7 +148,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
     if (ref.read(assetViewerProvider).showingDetails) return;
 
     final autoPlayVideo = AppSetting.get(Setting.autoPlayVideo);
-    if (autoPlayVideo) await _notifier.play();
+    if (autoPlayVideo || widget.asset.isMotionPhoto) await _notifier.play();
   }
 
   void _onPlaybackEnded() {


### PR DESCRIPTION
## Description

Currently when playing a motion photo we just create a native video viewer, and do nothing else. We rely on the video viewer automatically starting the video playback upon creation. 

Issue: if someone disables `autoPlayVideo` in the settings we don't start playing on creation. So if that setting is disabled, motion photos that should play, are stuck on the first frame. 

Fix: rather simple, next to checking `autoPlayVideo` we also check `widget.asset.isMotionPhoto` in `_onPlaybackReady` and in both cases we call `play()

Fixes #27121

## How Has This Been Tested?

- simulator with autoPlayVideo setting disabled.   

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/