### PR TITLE
feat(server): add MPO file type support

### DIFF
--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -18,6 +18,7 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 | `JPEG 2000` | `.jp2`                        | :white_check_mark: |                 |
 | `JPEG`      | `.jpeg` `.jpg` `.jpe` `.insp` | :white_check_mark: |                 |
 | `JPEG XL`   | `.jxl`                        | :white_check_mark: |                 |
+| `MPO`       | `.mpo`                        | :white_check_mark: | Multi-Picture (3D stereoscopic) |
 | `PNG`       | `.png`                        | :white_check_mark: |                 |
 | `PSD`       | `.psd`                        | :white_check_mark: | Adobe Photoshop |
 | `RAW`       | `.raw`                        | :white_check_mark: |                 |

--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -18,7 +18,7 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 | `JPEG 2000` | `.jp2`                        | :white_check_mark: |                 |
 | `JPEG`      | `.jpeg` `.jpg` `.jpe` `.insp` | :white_check_mark: |                 |
 | `JPEG XL`   | `.jxl`                        | :white_check_mark: |                 |
-| `MPO`       | `.mpo`                        | :white_check_mark: | Multi-Picture (3D stereoscopic) |
+| `MPO`       | `.mpo`                        | :white_check_mark: | Multi-Picture   |
 | `PNG`       | `.png`                        | :white_check_mark: |                 |
 | `PSD`       | `.psd`                        | :white_check_mark: | Adobe Photoshop |
 | `RAW`       | `.raw`                        | :white_check_mark: |                 |

--- a/e2e/src/ui/mock-network/base-network.ts
+++ b/e2e/src/ui/mock-network/base-network.ts
@@ -223,6 +223,7 @@ export const setupBaseMockApiRoutes = async (context: BrowserContext, adminUserI
           '.jp2',
           '.jpe',
           '.jxl',
+          '.mpo',
           '.svg',
           '.tif',
           '.tiff',

--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -163,6 +163,7 @@ where
           '%.jp2',
           '%.jpe',
           '%.jxl',
+          '%.mpo',
           '%.svg',
           '%.tif',
           '%.tiff'

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -80,6 +80,7 @@ const validImages = [
   '.jxl',
   '.k25',
   '.kdc',
+  '.mpo',
   '.mrw',
   '.nef',
   '.orf',

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -26,6 +26,7 @@ describe('mimeTypes', () => {
     { mimetype: 'image/jpeg', extension: '.jpe' },
     { mimetype: 'image/jpeg', extension: '.jpeg' },
     { mimetype: 'image/jpeg', extension: '.jpg' },
+    { mimetype: 'image/jpeg', extension: '.mpo' },
     { mimetype: 'image/jxl', extension: '.jxl' },
     { mimetype: 'image/k25', extension: '.k25' },
     { mimetype: 'image/kdc', extension: '.kdc' },

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -58,6 +58,7 @@ const webUnsupportedImage = {
   '.jp2': ['image/jp2'],
   '.jpe': ['image/jpeg'],
   '.jxl': ['image/jxl'],
+  '.mpo': ['image/jpeg'],
   '.svg': ['image/svg'],
   '.tif': ['image/tiff'],
   '.tiff': ['image/tiff'],


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added support for MPO file type, in accordance with the discussion at #9886.

This is a simple config change since MPO files are already natively supported for static display. There is no 3D viewer nor animation.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Manually tested with multiple MPO images in both browser and mobile app.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="1552" height="982" alt="Screenshot 2026-04-19 at 19 06 02" src="https://github.com/user-attachments/assets/3b576a92-43d1-4ae8-8441-ffe6234d6865" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used for this PR.