### PR TITLE
fix(web): preserve face bounding boxes during face reassignment

### DIFF
--- a/web/src/lib/components/faces-page/PersonSidePanel.svelte
+++ b/web/src/lib/components/faces-page/PersonSidePanel.svelte
@@ -145,6 +145,7 @@
       selectedPersonToCreate[editedFace.id] = newFeaturePhoto;
     }
     showSelectedFaces = false;
+    assetViewerManager.clearHighlightedFaces();
   };
 
   const handleReassignFace = (person: PersonResponseDto | null) => {
@@ -152,11 +153,13 @@
       selectedPersonToReassign[editedFace.id] = person;
     }
     showSelectedFaces = false;
+    assetViewerManager.clearHighlightedFaces();
   };
 
   const handleFacePicker = (face: AssetFaceResponseDto) => {
     editedFace = face;
     showSelectedFaces = true;
+    assetViewerManager.setHighlightedFaces([face]);
   };
 
   const deleteAssetFace = async (face: AssetFaceResponseDto) => {
@@ -246,7 +249,11 @@
               class="absolute inset-s-0 top-0 size-22.5 cursor-default"
               onfocus={() => assetViewerManager.setHighlightedFaces([peopleWithFaces[index]])}
               onpointerenter={() => assetViewerManager.setHighlightedFaces([peopleWithFaces[index]])}
-              onpointerleave={() => assetViewerManager.clearHighlightedFaces()}
+              onpointerleave={() => {
+                if (!showSelectedFaces) {
+                  assetViewerManager.clearHighlightedFaces();
+                }
+              }}
             >
               <div class="relative">
                 {#if selectedPersonToCreate[face.id]}
@@ -383,7 +390,10 @@
     {editedFace}
     {assetId}
     {assetType}
-    onClose={() => (showSelectedFaces = false)}
+    onClose={() => {
+      showSelectedFaces = false;
+      assetViewerManager.clearHighlightedFaces();
+    }}
     onCreatePerson={handleCreatePerson}
     onReassign={handleReassignFace}
   />


### PR DESCRIPTION
This is a small ux tweak. 

Currently, the face bounding boxes disappear while using the face edit side panel, even though this 'edit a specific person's face' applies to a specific person. I think it would be useful to keep that person's face bounding box active while editing that persons face. 

This PR highlights the selected face's bounding box when picking a face to reassign, and clears it when the reassignment completes or the panel closes.