### PR TITLE
fix(server): atomic rename for encoded video output to prevent corruption on crash

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -3822,6 +3822,84 @@ describe(MediaService.name, () => {
         }),
       );
     });
+
+    it('should write ffmpeg output to a .tmp sibling and atomic-rename on success', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.multipleVideoStreams);
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.All } });
+
+      await sut.handleVideoConversion({ id: 'video-id' });
+
+      const transcodePath = mocks.media.transcode.mock.calls[0][1] as string;
+      expect(transcodePath).toMatch(/\.tmp$/);
+
+      const finalPath = transcodePath.replace(/\.tmp$/, '');
+      expect(mocks.storage.rename).toHaveBeenCalledWith(transcodePath, finalPath);
+      expect(mocks.storage.rename.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mocks.media.transcode.mock.invocationCallOrder[0],
+      );
+      expect(mocks.asset.upsertFile).toHaveBeenCalledWith(
+        expect.objectContaining({ type: AssetFileType.EncodedVideo, path: finalPath, isEdited: false }),
+      );
+      expect(mocks.asset.upsertFile.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mocks.storage.rename.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should unlink a stale .tmp file from a prior crash before transcoding', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.multipleVideoStreams);
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.All } });
+      mocks.storage.existsSync.mockReturnValue(true);
+
+      await sut.handleVideoConversion({ id: 'video-id' });
+
+      const transcodePath = mocks.media.transcode.mock.calls[0][1] as string;
+      expect(mocks.storage.existsSync).toHaveBeenCalledWith(transcodePath);
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(transcodePath);
+      expect(mocks.storage.unlink.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.media.transcode.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should not unlink if no stale .tmp file exists', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.multipleVideoStreams);
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.All } });
+      mocks.storage.existsSync.mockReturnValue(false);
+
+      await sut.handleVideoConversion({ id: 'video-id' });
+
+      expect(mocks.storage.unlink).not.toHaveBeenCalled();
+    });
+
+    it('should not rename or upsertFile when all transcode attempts fail', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.multipleVideoStreams);
+      mocks.systemMetadata.get.mockResolvedValue({
+        ffmpeg: { transcode: TranscodePolicy.All, accel: TranscodeHardwareAcceleration.Nvenc },
+      });
+      mocks.media.transcode.mockRejectedValue(new Error('Error transcoding video'));
+
+      await expect(sut.handleVideoConversion({ id: 'video-id' })).rejects.toThrowError();
+
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertFile).not.toHaveBeenCalled();
+      const transcodePath = mocks.media.transcode.mock.calls.at(-1)![1] as string;
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(transcodePath);
+    });
+
+    it('should unlink the .tmp file when transcoding fails with hw acceleration disabled', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.multipleVideoStreams);
+      mocks.systemMetadata.get.mockResolvedValue({
+        ffmpeg: { transcode: TranscodePolicy.All, accel: TranscodeHardwareAcceleration.Disabled },
+      });
+      mocks.media.transcode.mockRejectedValue(new Error('Error transcoding video'));
+
+      await expect(sut.handleVideoConversion({ id: 'video-id' })).resolves.toBe(JobStatus.Failed);
+
+      const transcodePath = mocks.media.transcode.mock.calls[0][1] as string;
+      expect(transcodePath).toMatch(/\.tmp$/);
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(transcodePath);
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertFile).not.toHaveBeenCalled();
+    });
   });
 
   describe('isSRGB', () => {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -586,7 +586,11 @@ export class MediaService extends BaseService {
 
     const input = asset.originalPath;
     const output = StorageCore.getEncodedVideoPath(asset);
+    const tmpOutput = `${output}.tmp`;
     this.storageCore.ensureFolders(output);
+    if (this.storageRepository.existsSync(tmpOutput)) {
+      await this.storageRepository.unlink(tmpOutput);
+    }
 
     const { videoStreams, audioStreams, format } = await this.mediaRepository.probe(input, {
       countFrames: this.logger.isLevelEnabled(LogLevel.Debug), // makes frame count more reliable for progress logs
@@ -627,32 +631,40 @@ export class MediaService extends BaseService {
     }
 
     try {
-      await this.mediaRepository.transcode(input, output, command);
-    } catch (error: any) {
-      this.logger.error(`Error occurred during transcoding: ${error.message}`);
-      if (ffmpeg.accel === TranscodeHardwareAcceleration.Disabled) {
-        return JobStatus.Failed;
-      }
+      try {
+        await this.mediaRepository.transcode(input, tmpOutput, command);
+      } catch (error: any) {
+        this.logger.error(`Error occurred during transcoding: ${error.message}`);
+        if (ffmpeg.accel === TranscodeHardwareAcceleration.Disabled) {
+          await this.unlinkSafe(tmpOutput);
+          return JobStatus.Failed;
+        }
 
-      let partialFallbackSuccess = false;
-      if (ffmpeg.accelDecode) {
-        try {
-          this.logger.error(`Retrying with ${ffmpeg.accel.toUpperCase()}-accelerated encoding and software decoding`);
-          ffmpeg = { ...ffmpeg, accelDecode: false };
+        let partialFallbackSuccess = false;
+        if (ffmpeg.accelDecode) {
+          try {
+            this.logger.error(`Retrying with ${ffmpeg.accel.toUpperCase()}-accelerated encoding and software decoding`);
+            ffmpeg = { ...ffmpeg, accelDecode: false };
+            const command = BaseConfig.create(ffmpeg, this.videoInterfaces).getCommand(target, videoStream, audioStream);
+            await this.mediaRepository.transcode(input, tmpOutput, command);
+            partialFallbackSuccess = true;
+          } catch (error: any) {
+            this.logger.error(`Error occurred during transcoding: ${error.message}`);
+          }
+        }
+
+        if (!partialFallbackSuccess) {
+          this.logger.error(`Retrying with ${ffmpeg.accel.toUpperCase()} acceleration disabled`);
+          ffmpeg = { ...ffmpeg, accel: TranscodeHardwareAcceleration.Disabled };
           const command = BaseConfig.create(ffmpeg, this.videoInterfaces).getCommand(target, videoStream, audioStream);
-          await this.mediaRepository.transcode(input, output, command);
-          partialFallbackSuccess = true;
-        } catch (error: any) {
-          this.logger.error(`Error occurred during transcoding: ${error.message}`);
+          await this.mediaRepository.transcode(input, tmpOutput, command);
         }
       }
 
-      if (!partialFallbackSuccess) {
-        this.logger.error(`Retrying with ${ffmpeg.accel.toUpperCase()} acceleration disabled`);
-        ffmpeg = { ...ffmpeg, accel: TranscodeHardwareAcceleration.Disabled };
-        const command = BaseConfig.create(ffmpeg, this.videoInterfaces).getCommand(target, videoStream, audioStream);
-        await this.mediaRepository.transcode(input, output, command);
-      }
+      await this.storageRepository.rename(tmpOutput, output);
+    } catch (error) {
+      await this.unlinkSafe(tmpOutput);
+      throw error;
     }
 
     this.logger.log(`Successfully encoded ${asset.id}`);
@@ -671,6 +683,14 @@ export class MediaService extends BaseService {
     return streams
       .filter((stream) => stream.codecName !== 'unknown')
       .toSorted((stream1, stream2) => stream2.bitrate - stream1.bitrate)[0];
+  }
+
+  private async unlinkSafe(path: string): Promise<void> {
+    try {
+      await this.storageRepository.unlink(path);
+    } catch {
+      // swallow — cleanup must not mask the original error
+    }
   }
 
   private getTranscodeTarget(


### PR DESCRIPTION
## Description

`handleVideoConversion` in `server/src/services/media.service.ts` points ffmpeg directly at the final encoded video path (`StorageCore.getEncodedVideoPath(asset)`). fluent-ffmpeg opens that file, streams mdat, and rewrites the header (`-movflags faststart`) only at the end. If the server process is killed mid-write — OOM, pod/container termination, or a BullMQ stalled-retry spawning a concurrent writer over the same path — the final path is left truncated (no moov atom). The DB row from a previous successful encode is not updated by the failed run, so it still points at the now-corrupt file, and the UI serves a broken video (red "!" badge, no auto-preview, unplayable).

Hit this in my own deployment: 43 files on disk were unplayable, all with "moov atom not found" when probed. Only way to recover was to manually delete the corrupt files and let the queue regenerate them.

**Fix:** write ffmpeg output to a temp sibling `<output>.tmp`, then atomically rename to the final path once ffmpeg exits successfully. On failure, unlink the temp file so it doesn't accumulate. A stale `.tmp` from a prior SIGKILL is cleaned up at the start of the next retranscode attempt — the common recovery path, since the job stays queued.

The existing ordering (ffmpeg success → DB upsert) is preserved; this only ensures the final on-disk file is never partially written. No verification step is added — ffmpeg's exit code remains the correctness signal, matching existing behavior. Reuses existing `StorageRepository.rename`, `.unlink`, and `.existsSync`. No new config. Behavior change is invisible on the happy path.

**Out of scope:** thumbnail/preview generation has the same bug class but smaller blast radius; happy to follow up in a separate PR if wanted. BullMQ job config is left as-is — the atomic-rename fix makes the writer crash-safe regardless of concurrent writers.

Fixes # (no open issue tracked for this; surfaced via field deployment)

## How Has This Been Tested?

- [x] Unit tests: five new cases in `media.service.spec.ts` — happy-path rename ordering, stale `.tmp` pre-cleanup, no-op when no stale `.tmp`, all-fallbacks-fail cleanup + rethrow, disabled-accel single-fail cleanup + `JobStatus.Failed`. All 2138 server unit tests pass.
- [x] `pnpm check` (tsc --noEmit) clean.
- [x] `pnpm lint` (eslint --max-warnings 0) clean.
- [x] Manual reasoning for the crash scenario: with the temp-file pattern, a SIGKILL mid-ffmpeg leaves `<output>.tmp` truncated and `<output>` untouched. Next queued retry unlinks the stale `.tmp` via the `existsSync` guard and starts fresh. Final `<output>` is never partially written.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — server-side bug fix, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Significant. I (the human author) diagnosed the bug in my own deployment — traced the red-"!" symptom to corrupt `encoded_video` files with missing moov atoms, confirmed via DB/disk inspection and code reading that the root cause was ffmpeg writing directly to the final output path with no atomic swap. I directed the fix design: atomic rename on ffmpeg success, no ffprobe-style post-verification (exit code is sufficient). Claude (Anthropic) drafted the code changes, unit tests, commit message, and this PR description under my direction and review. I reviewed every line, ran the test suite and typecheck/lint locally, and validated the behavior against the failure modes I had actually observed.
