### PR TITLE
fix(web): add back button to single-asset share view

### DIFF
--- a/web/src/lib/components/share-page/individual-shared-viewer.svelte
+++ b/web/src/lib/components/share-page/individual-shared-viewer.svelte
@@ -131,9 +131,20 @@
     {/if}
   </header>
 {:else if assets.length === 1}
-  {#await getAssetInfo({ ...authManager.params, id: assets[0].id }) then asset}
-    {#await import('$lib/components/asset-viewer/asset-viewer.svelte') then { default: AssetViewer }}
-      <AssetViewer cursor={{ current: asset }} onAction={handleAction} />
+  <header class="fixed top-0 inset-s-0 w-full">
+    <ControlAppBar onClose={() => goto(Route.photos())} backIcon={mdiArrowLeft} showBackButton={true}>
+      {#snippet leading()}
+        <a data-sveltekit-preload-data="hover" class="ms-4" href="/">
+          <Logo variant={mediaQueryManager.maxMd ? 'icon' : 'inline'} class="min-w-10" />
+        </a>
+      {/snippet}
+    </ControlAppBar>
+  </header>
+  <div class="mt-16">
+    {#await getAssetInfo({ ...authManager.params, id: assets[0].id }) then asset}
+      {#await import('$lib/components/asset-viewer/asset-viewer.svelte') then { default: AssetViewer }}
+        <AssetViewer cursor={{ current: asset }} onAction={handleAction} />
+      {/await}
     {/await}
-  {/await}
+  </div>
 {/if}


### PR DESCRIPTION
## Summary

Closes #25689

### Problem

When a user navigates to a shared link with a single asset (e.g., from a deeplink), they become stuck in the asset viewer. There is no navigation available to return to the album or timeline view, forcing a full page reload to exit.

### Fix

This commit resolves the issue by wrapping the single-asset viewer component in the standard . This provides a consistent UI and, most importantly, a back button that allows the user to navigate away from the single-asset view and back to the main photo gallery.

This improves the user experience for shared links and makes navigation more intuitive.