### PR TITLE
fix(docs):  correct relative paths in markdown documentation

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 import { mdiAlertCircle, mdiCheckCircle } from '@mdi/js';
 import Icon from '@mdi/react';
 
-A [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) is recommended to protect your data. You should keep copies of your uploaded photos/videos as well as the Immich database for a comprehensive backup solution. This page provides an overview on how to backup the database and the location of user-uploaded pictures and videos. A template bash script that can be run as a cron job is provided [here](/guides/template-backup-script.md)
+A [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) is recommended to protect your data. You should keep copies of your uploaded photos/videos as well as the Immich database for a comprehensive backup solution. This page provides an overview on how to backup the database and the location of user-uploaded pictures and videos. A template bash script that can be run as a cron job is provided [here](../guides/template-backup-script.md)
 
 :::danger
 The instructions on this page show you how to prepare your Immich instance to be backed up, and which files to take a backup of. You still need to take care of using an actual backup tool to make a backup yourself.
@@ -62,7 +62,7 @@ Restoring a backup will wipe the current database and replace it with the backup
 
 If you're setting up Immich on a fresh installation and want to restore from an existing backup:
 
-1. Download and populate `.env` and `docker-compose.yml` as per the [installation instructions](/install/docker-compose).
+1. Download and populate `.env` and `docker-compose.yml` as per the [installation instructions](../install/docker-compose).
 2. Move the previous's instance data directories containing `backups`, `encoded-video`, `library`, `profile`, `thumbs` and `upload` into the new `UPLOAD_LOCATION`
 3. **(For external libraries)** If you used external library feature in your previous instance, make sure that the mount settings in your new `docker-compose.yml` reflect the same structure. You may need to move files accordingly.
 

--- a/docs/docs/administration/jobs-workers.md
+++ b/docs/docs/administration/jobs-workers.md
@@ -11,7 +11,7 @@ The `immich-server` container contains multiple workers:
 
 ## Split workers
 
-If you prefer to throttle or distribute the workers, you can do this using the [environment variables](/install/environment-variables) to specify which container should pick up which tasks.
+If you prefer to throttle or distribute the workers, you can do this using the [environment variables](../install/environment-variables) to specify which container should pick up which tasks.
 
 For example, for a simple setup with one container for the Web/API and one for all other microservices, you can do the following:
 

--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -29,7 +29,7 @@ Before enabling OAuth in Immich, a new client application needs to be configured
 2. Configure Redirect URIs/Origins
 
    The **Sign-in redirect URIs** should include:
-   - `app.immich:///oauth-callback` - for logging in with OAuth from the [Mobile App](/features/mobile-app.mdx)
+   - `app.immich:///oauth-callback` - for logging in with OAuth from the [Mobile App](../features/mobile-app.mdx)
    - `http://DOMAIN:PORT/auth/login` - for logging in with OAuth from the Web Client
    - `http://DOMAIN:PORT/user-settings` - for manually linking OAuth in the Web Client
 
@@ -107,7 +107,7 @@ The redirect URI for the mobile app is `app.immich:///oauth-callback`, which is 
 2. Whitelist the new endpoint as a valid redirect URI with your provider.
 3. Specify the new endpoint as the `Mobile Redirect URI Override`, in the OAuth settings.
 
-With these steps in place, you should be able to use OAuth from the [Mobile App](/features/mobile-app.mdx) without a custom scheme redirect URI.
+With these steps in place, you should be able to use OAuth from the [Mobile App](../features/mobile-app.mdx) without a custom scheme redirect URI.
 
 :::info
 Immich has a route (`/api/oauth/mobile-redirect`) that is already configured to forward requests to `app.immich:///oauth-callback`, and can be used for step 1.

--- a/docs/docs/administration/server-commands.md
+++ b/docs/docs/administration/server-commands.md
@@ -18,7 +18,7 @@ The `immich-server` docker image comes preinstalled with an administrative CLI (
 
 ## How to run a command
 
-To run a command, [connect](/guides/docker-help.md#attach-to-a-container) to the `immich_server` container and then execute the command via `immich-admin <command>`.
+To run a command, [connect](../guides/docker-help.md#attach-to-a-container) to the `immich_server` container and then execute the command via `immich-admin <command>`.
 
 ## Examples
 

--- a/docs/docs/administration/system-settings.md
+++ b/docs/docs/administration/system-settings.md
@@ -12,14 +12,14 @@ Manage password, OAuth, and other authentication settings
 
 ### OAuth Authentication
 
-Immich supports OAuth Authentication. Read more about this feature and its configuration [here](/administration/oauth).
+Immich supports OAuth Authentication. Read more about this feature and its configuration [here](../administration/oauth).
 
 ### Password Authentication
 
-The administrator can choose to disable login with username and password for the entire instance. This means that **no one**, including the system administrator, will be able to log using this method. If [OAuth Authentication](/administration/oauth) is also disabled, no users will be able to login using **any** method. Changing this setting does not affect existing sessions, just new login attempts.
+The administrator can choose to disable login with username and password for the entire instance. This means that **no one**, including the system administrator, will be able to log using this method. If [OAuth Authentication](../administration/oauth) is also disabled, no users will be able to login using **any** method. Changing this setting does not affect existing sessions, just new login attempts.
 
 :::tip
-You can always use the [Server CLI](/administration/server-commands) to re-enable password login.
+You can always use the [Server CLI](../administration/server-commands) to re-enable password login.
 :::
 
 ## Image Settings (thumbnails and previews)
@@ -132,7 +132,7 @@ Editable settings:
 - **Max Recognition Distance**
 - **Min Recognized Faces**
 
-You can learn more about these options on the [Facial Recognition page](/features/facial-recognition#how-face-detection-works)
+You can learn more about these options on the [Facial Recognition page](../features/facial-recognition#how-face-detection-works)
 
 :::info
 When changing the values in Min Detection Score, Max Recognition Distance, and Min Recognized Faces.
@@ -154,15 +154,15 @@ The map can be adjusted via [OpenMapTiles](https://openmaptiles.org/styles/) for
 
 ### Reverse Geocoding Settings
 
-Immich supports [Reverse Geocoding](/features/reverse-geocoding) using data from the [GeoNames](https://www.geonames.org/) geographical database.
+Immich supports [Reverse Geocoding](../features/reverse-geocoding) using data from the [GeoNames](https://www.geonames.org/) geographical database.
 
 ## Notification Settings
 
-SMTP server setup, for user creation notifications, new albums, etc. More information can be found [here](/administration/email-notification)
+SMTP server setup, for user creation notifications, new albums, etc. More information can be found [here](email-notification.mdx)
 
 ## Notification Templates
 
-Override the default notifications text with notification templates. More information can be found [here](/administration/email-notification)
+Override the default notifications text with notification templates. More information can be found [here](email-notification.mdx)
 
 ## Server Settings
 
@@ -176,7 +176,7 @@ The administrator can set a custom message on the login screen (the message will
 
 ## Storage Template
 
-Immich supports a custom [Storage Template](/administration/storage-template). Learn more about this feature and its configuration [here](/administration/storage-template).
+Immich supports a custom [Storage Template](storage-template.mdx). Learn more about this feature and its configuration [here](storage-template.mdx).
 
 ## Theme Settings
 

--- a/docs/docs/developer/devcontainers.md
+++ b/docs/docs/developer/devcontainers.md
@@ -452,7 +452,7 @@ While the Dev Container focuses on server and web development, you can connect m
    - Server URL: `http://YOUR_IP:2283/api`
    - Ensure firewall allows port 2283
 
-3. **For full mobile development**, see the [mobile development guide](/developer/setup) which covers:
+3. **For full mobile development**, see the [mobile development guide](./setup.md) which covers:
    - Flutter setup
    - Running on simulators/devices
    - Mobile-specific debugging

--- a/docs/docs/developer/pr-checklist.md
+++ b/docs/docs/developer/pr-checklist.md
@@ -53,7 +53,7 @@ You can use `dart fix --apply` and `dcm fix lib` to potentially correct some iss
 
 ## OpenAPI
 
-The OpenAPI client libraries need to be regenerated whenever there are changes to the `immich-openapi-specs.json` file. Note that you should not modify this file directly as it is auto-generated. See [OpenAPI](/api.md) for more details.
+The OpenAPI client libraries need to be regenerated whenever there are changes to the `immich-openapi-specs.json` file. Note that you should not modify this file directly as it is auto-generated. See [OpenAPI](../api.md) for more details.
 
 ## Database Migrations
 

--- a/docs/docs/features/facial-recognition.md
+++ b/docs/docs/features/facial-recognition.md
@@ -70,7 +70,7 @@ Navigating to Administration > Settings > Machine Learning Settings > Facial Rec
 :::tip
 It's better to only tweak the parameters here than to set them to something very different unless you're ready to test a variety of options. If you do need to set a parameter to a strict setting, relaxing other settings can be a good option to compensate, and vice versa.
 
-You can learn how the tune the result in this [Guide](/guides/better-facial-clusters)
+You can learn how the tune the result in this [Guide](../guides/better-facial-clusters)
 :::
 
 ### Facial recognition model

--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -35,7 +35,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
   - Where and how you can get this file depends on device and vendor, but typically, the device vendor also supplies these
   - The `hwaccel.ml.yml` file assumes the path to it is `/usr/lib/libmali.so`, so update accordingly if it is elsewhere
   - The `hwaccel.ml.yml` file assumes an additional file `/lib/firmware/mali_csffw.bin`, so update accordingly if your device's driver does not require this file
-- Optional: Configure your `.env` file, see [environment variables](/install/environment-variables) for ARM NN specific settings
+- Optional: Configure your `.env` file, see [environment variables](../install/environment-variables) for ARM NN specific settings
   - In particular, the `MACHINE_LEARNING_ANN_FP16_TURBO` can significantly improve performance at the cost of very slightly lower accuracy
 
 #### CUDA
@@ -49,7 +49,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 
 - The GPU must be supported by ROCm. If it isn't officially supported, you can attempt to use the `HSA_OVERRIDE_GFX_VERSION` environmental variable: `HSA_OVERRIDE_GFX_VERSION=<a supported version, e.g. 10.3.0>`. If this doesn't work, you might need to also set `HSA_USE_SVM=0`.
 - The ROCm image is quite large and requires at least 35GiB of free disk space. However, pulling later updates to the service through Docker will generally only amount to a few hundred megabytes as the rest will be cached.
-- This backend is new and may experience some issues. For example, GPU power consumption can be higher than usual after running inference, even if the machine learning service is idle. In this case, it will only go back to normal after being idle for 5 minutes (configurable with the [MACHINE_LEARNING_MODEL_TTL](/install/environment-variables) setting).
+- This backend is new and may experience some issues. For example, GPU power consumption can be higher than usual after running inference, even if the machine learning service is idle. In this case, it will only go back to normal after being idle for 5 minutes (configurable with the [MACHINE_LEARNING_MODEL_TTL](../install/environment-variables) setting).
 - MIGraphX is a new backend for AMD cards, which compiles models at runtime. As such, the first few inferences will be slow.
 
 #### OpenVINO
@@ -81,7 +81,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
   - This is usually pre-installed on the device vendor's Linux images
 - RKNPU driver V0.9.8 or later must be available in the host server
   - You may confirm this by running `cat /sys/kernel/debug/rknpu/version` to check the version
-- Optional: Configure your `.env` file, see [environment variables](/install/environment-variables) for RKNN specific settings
+- Optional: Configure your `.env` file, see [environment variables](../install/environment-variables) for RKNN specific settings
   - In particular, setting `MACHINE_LEARNING_RKNN_THREADS` to 2 or 3 can _dramatically_ improve performance for RK3576 and RK3588 compared to the default of 1, at the expense of multiplying the amount of RAM each model uses by that amount.
 
 ## Setup

--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -68,7 +68,7 @@ After bringing down the containers with `docker compose down` and back up with `
 :::note
 To see exactly what metrics are made available, you can additionally add `8081:8081` (API metrics) and `8082:8082` (microservices metrics) to the immich_server container's ports.
 Visiting the `/metrics` endpoint for these services will show the same raw data that Prometheus collects.
-To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](/install/environment-variables/#general).
+To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](../install/environment-variables#general).
 :::
 
 ### Usage
@@ -146,6 +146,6 @@ This format includes:
 - `message`: Log message
 - `context`: Service or component that generated the log
 
-For more information on log formats, see [`IMMICH_LOG_FORMAT`](/install/environment-variables.md#general).
+For more information on log formats, see [`IMMICH_LOG_FORMAT`](../install/environment-variables.md#general).
 
 [prom-file]: https://github.com/immich-app/immich/releases/latest/download/prometheus.yml

--- a/docs/docs/features/partner-sharing.md
+++ b/docs/docs/features/partner-sharing.md
@@ -1,6 +1,6 @@
 # Partner Sharing
 
-Immich allows you to share your library with other users. They can then view your library and download the assets. You can manage Partner Sharing from the [User Settings](docs/features/user-settings.md) page on the web.
+Immich allows you to share your library with other users. They can then view your library and download the assets. You can manage Partner Sharing from the [User Settings](user-settings.md) page on the web.
 
 Partner sharing includes:
 

--- a/docs/docs/features/reverse-geocoding.md
+++ b/docs/docs/features/reverse-geocoding.md
@@ -8,7 +8,7 @@ During Exif Extraction, assets with latitudes and longitudes are reverse geocode
 
 ## Usage
 
-Data from a reverse geocode is displayed in the image details, and used in [Smart Search](/features/searching.md).
+Data from a reverse geocode is displayed in the image details, and used in [Smart Search](searching.md).
 
 <img src={require('./img/reverse-geocoding-mobile3.webp').default} width='33%' title='Reverse Geocoding' />
 <img src={require('./img/reverse-geocoding-mobile1.webp').default} width='33%' title='Reverse Geocoding' />

--- a/docs/docs/features/sharing.md
+++ b/docs/docs/features/sharing.md
@@ -24,7 +24,7 @@ After creating an album, you can access the sharing options by clicking on the s
 
 Partner sharing allows you to share your _entire_ library with other users of your choice. They can then view your library and download the assets.
 
-You can read this guide to learn more about [partner sharing](/features/partner-sharing).
+You can read this guide to learn more about [partner sharing](partner-sharing.md).
 
 ## Public sharing
 

--- a/docs/docs/features/tags.md
+++ b/docs/docs/features/tags.md
@@ -1,6 +1,6 @@
 # Tags
 
-Immich supports hierarchical tags, with the ability to read existing tags from the XMP `TagsList` field and IPTC `Keywords` field. Any changes to tags made through Immich are also written back to a [sidecar](/features/xmp-sidecars) file. You can re-run the metadata extraction jobs for all assets to import your existing tags.
+Immich supports hierarchical tags, with the ability to read existing tags from the XMP `TagsList` field and IPTC `Keywords` field. Any changes to tags made through Immich are also written back to a [sidecar](xmp-sidecars.md) file. You can re-run the metadata extraction jobs for all assets to import your existing tags.
 
 ## Enable tags feature
 

--- a/docs/docs/features/user-settings.md
+++ b/docs/docs/features/user-settings.md
@@ -15,9 +15,9 @@ You can access the [user settings](https://my.immich.app/user-settings) by click
 ---
 
 :::tip Reset Password
-The admin can reset a user password through the [User Management](/administration/user-management.mdx) screen.
+The admin can reset a user password through the [User Management](../administration/user-management.mdx) screen.
 :::
 
 :::tip Reset Admin Password
-The admin password can be reset using a [Server Command](/administration/server-commands.md)
+The admin password can be reset using a [Server Command](../administration/server-commands.md)
 :::

--- a/docs/docs/guides/better-facial-clusters.md
+++ b/docs/docs/guides/better-facial-clusters.md
@@ -10,7 +10,7 @@ This guide explains how to optimize facial recognition in systems with large ima
 
 - **Best Suited For:** Large image libraries after importing a significant number of images.
 - **Warning:** This method deletes all previously assigned names.
-- **Tip:** **Always take a [backup](/administration/backup-and-restore#database) before proceeding!**
+- **Tip:** **Always take a [backup](../administration/backup-and-restore#database) before proceeding!**
 
 ---
 

--- a/docs/docs/guides/database-queries.md
+++ b/docs/docs/guides/database-queries.md
@@ -7,7 +7,7 @@ Keep in mind that mucking around in the database might set the Moon on fire. Avo
 :::tip
 Run `docker exec -it immich_postgres psql --dbname=<DB_DATABASE_NAME> --username=<DB_USERNAME>` to connect to the database via the container directly.
 
-(Replace `<DB_DATABASE_NAME>` and `<DB_USERNAME>` with the values from your [`.env` file](/install/environment-variables#database)).
+(Replace `<DB_DATABASE_NAME>` and `<DB_USERNAME>` with the values from your [`.env` file](../install/environment-variables#database)).
 :::
 
 ## Assets
@@ -142,7 +142,7 @@ DELETE FROM "person" WHERE "name" = 'PersonNameHere';
 SELECT "key", "value" FROM "system_metadata" WHERE "key" = 'system-config';
 ```
 
-(Only used when not using the [config file](/install/config-file))
+(Only used when not using the [config file](../install/config-file.md))
 
 ### File properties
 

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -7,7 +7,7 @@ in a directory on the same machine.
 # Mount the directory into the containers.
 
 Edit `docker-compose.yml` to add one or more new mount points in the section `immich-server:` under `volumes:`.
-If you want Immich to be able to delete the images in the external library or add metadata ([XMP sidecars](/features/xmp-sidecars)), remove `:ro` from the end of the mount point.
+If you want Immich to be able to delete the images in the external library or add metadata ([XMP sidecars](../features/xmp-sidecars.md)), remove `:ro` from the end of the mount point.
 
 ```diff
 immich-server:

--- a/docs/docs/guides/remote-access.md
+++ b/docs/docs/guides/remote-access.md
@@ -46,7 +46,7 @@ You can learn how to set up Tailscale together with Immich with the [tutorial vi
 
 A reverse proxy is a service that sits between web servers and clients. A reverse proxy can either be hosted on the server itself or remotely. Clients can connect to the reverse proxy via https, and the proxy relays data to Immich. This setup makes most sense if you have your own domain and want to access your Immich instance just like any other website, from outside your LAN. You can also use a DDNS provider like DuckDNS or no-ip if you don't have a domain. This configuration allows the Immich Android and iphone apps to connect to your server without a VPN or tailscale app on the client side.
 
-If you're hosting your own reverse proxy, [Nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) is a great option. An example configuration for Nginx is provided [here](/administration/reverse-proxy.md).
+If you're hosting your own reverse proxy, [Nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) is a great option. An example configuration for Nginx is provided [here](../administration/reverse-proxy.md).
 
 You'll also need your own certificate to authenticate https connections. If you're making Immich publicly accessible, [Let's Encrypt](https://letsencrypt.org/) can provide a free certificate for your domain and is the recommended option. Alternatively, a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate) allows you to encrypt your connection to Immich, but it raises a security warning on the client's browser.
 

--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -1,6 +1,6 @@
 # Remote Machine Learning
 
-To alleviate [performance issues on low-memory systems](/FAQ.mdx#why-is-immich-slow-on-low-memory-systems-like-the-raspberry-pi) like the Raspberry Pi, you may also host Immich's machine learning container on a more powerful system, such as your laptop or desktop computer. The server container will send requests containing the image preview to the remote machine learning container for processing. The machine learning container does not persist this data or associate it with a particular user.
+To alleviate [performance issues on low-memory systems](../FAQ.mdx#why-is-immich-slow-on-low-memory-systems-like-the-raspberry-pi) like the Raspberry Pi, you may also host Immich's machine learning container on a more powerful system, such as your laptop or desktop computer. The server container will send requests containing the image preview to the remote machine learning container for processing. The machine learning container does not persist this data or associate it with a particular user.
 
 :::info
 Smart Search and Face Detection will use this feature, but Facial Recognition will not. This is because Facial Recognition uses the _outputs_ of these models that have already been saved to the database. As such, its processing is between the server container and the database.
@@ -14,7 +14,7 @@ Image previews are sent to the remote machine learning container. Use this optio
 2. Copy the following `docker-compose.yml` to the remote server
 
 :::info
-If using hardware acceleration, the [hwaccel.ml.yml](https://github.com/immich-app/immich/releases/latest/download/hwaccel.ml.yml) file also needs to be added and the `docker-compose.yml` needs to be configured as described in the [hardware acceleration documentation](/features/ml-hardware-acceleration)
+If using hardware acceleration, the [hwaccel.ml.yml](https://github.com/immich-app/immich/releases/latest/download/hwaccel.ml.yml) file also needs to be added and the `docker-compose.yml` needs to be configured as described in the [hardware acceleration documentation](../features/ml-hardware-acceleration.md)
 :::
 
 ```yaml

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -7,7 +7,7 @@ This script assumes you have a second hard drive connected to your server for on
 The database is saved to your Immich upload folder in the `database-backup` subdirectory. The database is then backed up and versioned with your assets by Borg. This ensures that the database backup is in sync with your assets in every snapshot.
 
 :::info
-This script makes backups of your database along with your photo/video library. This is redundant with the [automatic database backup tool](/administration/backup-and-restore#automatic-database-dumps) built into Immich. Using this script to backup your database has two advantages over the built-in backup tool:
+This script makes backups of your database along with your photo/video library. This is redundant with the [automatic database backup tool](../administration/backup-and-restore.md#automatic-database-dumps) built into Immich. Using this script to backup your database has two advantages over the built-in backup tool:
 
 - This script uses storage more efficiently by versioning your backups instead of making multiple copies.
 - The database backups are performed at the same time as the library backup, ensuring that the backups of your database and the library are always in sync.

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -251,7 +251,7 @@ So you can just grab it from there, paste it into a file and you're pretty much 
 ### Step 2 - Specify the file location
 
 In your `.env` file, set the variable `IMMICH_CONFIG_FILE` to the path of your config.
-For more information, refer to the [Environment Variables](/install/environment-variables.md) section.
+For more information, refer to the [Environment Variables](environment-variables.md) section.
 
 :::info Docker Compose
 In your `.env` file, the variables `UPLOAD_LOCATION` and `DB_DATA_LOCATION` concern the location on the host.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -44,7 +44,7 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | `IMMICH_MICROSERVICES_METRICS_PORT` | Port for the OTEL metrics                                                                                                                              |            `8082`            | server                   | microservices      |
 | `IMMICH_PROCESS_INVALID_IMAGES`     | When `true`, generate thumbnails for invalid images                                                                                                    |                              | server                   | microservices      |
 | `IMMICH_TRUSTED_PROXIES`            | List of comma-separated IPs set as trusted proxies                                                                                                     |                              | server                   | api                |
-| `IMMICH_IGNORE_MOUNT_CHECK_ERRORS`  | See [System Integrity](/administration/system-integrity)                                                                                               |                              | server                   | api, microservices |
+| `IMMICH_IGNORE_MOUNT_CHECK_ERRORS`  | See [System Integrity](../administration/system-integrity)                                                                                               |                              | server                   | api, microservices |
 | `IMMICH_ALLOW_SETUP`                | When `false` disables the `/auth/admin-sign-up` endpoint                                                                                               |            `true`            | server                   | api                |
 
 \*1: `TZ` should be set to a `TZ identifier` from [this list][tz-list]. For example, `TZ="Etc/UTC"`.
@@ -60,7 +60,7 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | `IMMICH_WORKERS_EXCLUDE` | Do not run these workers. Matches against default workers, or `IMMICH_WORKERS_INCLUDE` if specified. |         | server     |
 
 :::info
-Information on the current workers can be found [here](/administration/jobs-workers).
+Information on the current workers can be found [here](../administration/jobs-workers).
 :::
 
 ## Ports

--- a/docs/docs/install/portainer.md
+++ b/docs/docs/install/portainer.md
@@ -45,5 +45,5 @@ alt="Dot Env Example"
 11. Click on "**Deploy the stack**".
 
 :::tip
-For more information on how to use the application, please refer to the [Post Installation](/install/post-install.mdx) guide.
+For more information on how to use the application, please refer to the [Post Installation](../install/post-install.mdx) guide.
 :::

--- a/docs/docs/install/script.md
+++ b/docs/docs/install/script.md
@@ -5,12 +5,12 @@ sidebar_position: 20
 # Install script [Experimental]
 
 :::caution
-This method is experimental and not currently recommended for production use. For production, please refer to installing with [Docker Compose](/install/docker-compose.mdx).
+This method is experimental and not currently recommended for production use. For production, please refer to installing with [Docker Compose](../install/docker-compose.mdx).
 :::
 
 ## Requirements
 
-Follow the [requirements page](/install/requirements) to get started.
+Follow the [requirements page](../install/requirements.md) to get started.
 
 The install script only supports Linux operating systems and requires Docker to be already installed on the system.
 
@@ -32,5 +32,5 @@ The web application and mobile app will be available at `http://<machine-ip-addr
 The directory which is used to store the library files is `./immich-app` relative to the current directory.
 
 :::tip
-For common next steps, see [Post Install Steps](/install/post-install.mdx).
+For common next steps, see [Post Install Steps](../install/post-install.mdx).
 :::

--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -27,7 +27,7 @@ Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/la
 
 ## Step 2 - Populate the .env file with custom values
 
-Follow [Step 2 in Docker Compose](/install/docker-compose#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
+Follow [Step 2 in Docker Compose](../install/docker-compose.mdx#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
 
 ## Step 3 - Create a new project in Container Manager
 
@@ -70,7 +70,7 @@ Click "**Edit Rules**" and add the following firewall rules:
 
 ## Next Steps
 
-Read the [Post Installation](/install/post-install.mdx) steps and [upgrade instructions](/install/upgrading.md).
+Read the [Post Installation](../install/post-install.mdx) steps and [upgrade instructions](../install/upgrading.md).
 
 <details>
   <summary>Updating Immich using Container Manager</summary>

--- a/docs/docs/install/truenas.md
+++ b/docs/docs/install/truenas.md
@@ -66,7 +66,7 @@ Thumbnails can also be stored on the SSDs for faster access. This is an advanced
 :::warning
 If you just created the datasets using the **Apps** preset, you can skip this warning section.
 
-If the **data** dataset uses ACL it must have [ACL mode](https://www.truenas.com/docs/scale/scaletutorials/datasets/permissionsscale/) set to `Passthrough` if you plan on using a [storage template](/administration/storage-template.mdx) and the dataset is configured for network sharing (its ACL type is set to `SMB/NFSv4`). When the template is applied and files need to be moved from **upload** to **library** (internal folder created by Immich within the **data** dataset), Immich performs `chmod` internally and must be allowed to execute the command. [More info.](https://github.com/immich-app/immich/pull/13017)
+If the **data** dataset uses ACL it must have [ACL mode](https://www.truenas.com/docs/scale/scaletutorials/datasets/permissionsscale/) set to `Passthrough` if you plan on using a [storage template](../administration/storage-template.mdx) and the dataset is configured for network sharing (its ACL type is set to `SMB/NFSv4`). When the template is applied and files need to be moved from **upload** to **library** (internal folder created by Immich within the **data** dataset), Immich performs `chmod` internally and must be allowed to execute the command. [More info.](https://github.com/immich-app/immich/pull/13017)
 
 To change or verify the ACL mode, go to the **Datasets** screen, select the **library** dataset, click on the **Edit** button next to **Dataset Details**, then click on the **Advanced Options** tab, scroll down to the **ACL Mode** section, and select `Passthrough` from the dropdown menu. Click **Save** to apply the changes. If the option is greyed out, set the **ACL Type** to `SMB/NFSv4` first, then you can change the **ACL Mode** to `Passthrough`.
 :::
@@ -129,7 +129,7 @@ The **Timezone** is set to the system default, which usually matches your local 
 
 **Enable Machine Learning** is enabled by default. It allows Immich to use machine learning features such as face recognition, image search, and smart duplicate detection. Untick this option if you do not want to use these features.
 
-Select the **Machine Learning Image Type** based on the hardware you have. More details here: [Hardware-Accelerated Machine Learning](/features/ml-hardware-acceleration.md)
+Select the **Machine Learning Image Type** based on the hardware you have. More details here: [Hardware-Accelerated Machine Learning](../features/ml-hardware-acceleration.md)
 
 **Database Password** should be set to a custom value using only the characters `A-Za-z0-9`. This password is used to secure the Postgres database.
 
@@ -156,7 +156,7 @@ className="border rounded-xl"
 />
 
 These are used to add custom configuration options or to enable specific features.
-More information on available environment variables can be found in the **[environment variables documentation](/install/environment-variables/)**.
+More information on available environment variables can be found in the **[environment variables documentation](../install/environment-variables.md)**.
 
 :::info
 Some environment variables are not available for the TrueNAS Community Edition app as they can be configured through GUI options in the [Edit Immich screen](#edit-app-settings).
@@ -309,7 +309,7 @@ className="border rounded-xl"
 
 Both **CPU** and **Memory** are limits, not reservations. This means that Immich can use up to the specified amount of CPU threads and RAM, but it will not reserve that amount of resources at all times. The system will allocate resources as needed, and Immich will use less than the specified amount most of the time.
 
-- Enable **GPU Configuration** options if you have a GPU or CPU with integrated graphics that you will use for [Hardware Transcoding](/features/hardware-transcoding) and/or [Hardware-Accelerated Machine Learning](/features/ml-hardware-acceleration.md).
+- Enable **GPU Configuration** options if you have a GPU or CPU with integrated graphics that you will use for [Hardware Transcoding](../features/hardware-transcoding.md) and/or [Hardware-Accelerated Machine Learning](../features/ml-hardware-acceleration.md).
 
 The process for NVIDIA GPU passthrough requires additional steps.
 More details here: [GPU Passthrough Docs for TrueNAS Apps](https://apps.truenas.com/managing-apps/installing-apps/#gpu-passthrough)
@@ -332,7 +332,7 @@ Click **Web Portal** on the **Application Info** widget, or go to the URL `http:
 After that, you can start using Immich to upload and manage your photos and videos.
 
 :::tip
-For more information on how to use the application once installed, please refer to the [Post Install](/install/post-install.mdx) guide.
+For more information on how to use the application once installed, please refer to the [Post Install](../install/post-install.mdx) guide.
 :::
 
 ## Edit App Settings
@@ -347,7 +347,7 @@ For more information on how to use the application once installed, please refer 
 ## Updating the App
 
 :::danger
-Make sure to read the general [upgrade instructions](/install/upgrading.md).
+Make sure to read the general [upgrade instructions](../install/upgrading.md).
 :::
 
 When updates become available, TrueNAS alerts and provides easy updates.

--- a/docs/docs/install/unraid.md
+++ b/docs/docs/install/unraid.md
@@ -125,7 +125,7 @@ alt="Go to Docker Tab and visit the address listed next to immich-web"
 </details>
 
 :::tip
-For more information on how to use the application once installed, please refer to the [Post Install](/install/post-install.mdx) guide.
+For more information on how to use the application once installed, please refer to the [Post Install](../install/post-install.mdx) guide.
 :::
 
 ## Updating Steps

--- a/docs/docs/overview/support-the-project.md
+++ b/docs/docs/overview/support-the-project.md
@@ -10,11 +10,11 @@ By far the easiest way to help make Immich better it to use it and report issues
 
 ## Translations
 
-Support the project by localizing on [Weblate](https://hosted.weblate.org/projects/immich/immich/). For more information, see the [Translations](/developer/translations) section.
+Support the project by localizing on [Weblate](https://hosted.weblate.org/projects/immich/immich/). For more information, see the [Translations](../developer/translations.md) section.
 
 ## Development
 
-If you are a programmer or developer, take a look at Immich's [technology stack](/developer/architecture.mdx) and consider fixing bugs or building new features. The team and I are always looking for new contributors. For information about how to contribute as a developer, see the [Developer](/developer/architecture.mdx) section.
+If you are a programmer or developer, take a look at Immich's [technology stack](../developer/architecture.mdx#Architecture) and consider fixing bugs or building new features. The team and I are always looking for new contributors. For information about how to contribute as a developer, see the [Developer](../developer/architecture.mdx) section.
 
 ## Purchase Immich
 

--- a/docs/docs/partials/_mobile-app-backup.md
+++ b/docs/docs/partials/_mobile-app-backup.md
@@ -9,5 +9,5 @@
 3. Scroll down to the bottom and press "**Enable Backup**" to start the backup process. This will upload all the assets in the selected albums.
 
 :::info
-You can read more about backup options [here](/features/mobile-backup.md).
+You can read more about backup options [here](../features/mobile-backup.md).
 :::

--- a/docs/docs/partials/_storage-template.md
+++ b/docs/docs/partials/_storage-template.md
@@ -1,7 +1,7 @@
 Immich allows the admin user to set the uploaded filename pattern at the directory and filename level as well as the [storage label for a user](/administration/user-management/#set-storage-label-for-user).
 
 :::tip
-You can read more about the differences between storage template engine on and off [here](/administration/backup-and-restore#asset-types-and-storage-locations)
+You can read more about the differences between storage template engine on and off [here](../administration/backup-and-restore.md#asset-types-and-storage-locations)
 :::
 
 The admin user can set the template by using the template builder in the `Administration -> Settings -> Storage Template`. Immich provides a set of variables that you can use in constructing the template, along with additional custom text. If the template produces [multiple files with the same filename, they won't be overwritten](https://github.com/immich-app/immich/discussions/3324) as a sequence number is appended to the filename.


### PR DESCRIPTION
## Description

Fix relative paths in /docs/docs/*.md files. Many links returned an "Error Loading Page", because they were using absolute paths with a leading slash.

## How Has This Been Tested?

- Manually clicking links to confirm correct redirection to the intended pages.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


</details>


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs have been used
