### PR TITLE
fix(mobile): asset viewer stuck on spinner after rotation

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -56,10 +56,13 @@ class _AssetPageState extends ConsumerState<AssetPage> {
   _DragIntent _dragIntent = _DragIntent.none;
   Drag? _drag;
 
+  BaseAsset? _asset;
+
   @override
   void initState() {
     super.initState();
     _eventSubscription = EventStream.shared.listen(_onEvent);
+    _asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_scrollController.hasClients) {
         return;
@@ -69,6 +72,14 @@ class _AssetPageState extends ConsumerState<AssetPage> {
         _scrollController.jumpTo(_snapOffset);
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(AssetPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.index != widget.index) {
+      _asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
+    }
   }
 
   @override
@@ -383,7 +394,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     final stackIndex = ref.watch(assetViewerProvider.select((s) => s.stackIndex));
     final isPlayingMotionVideo = ref.watch(isPlayingMotionVideoProvider);
 
-    final asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
+    final asset = _asset;
     if (asset == null) {
       return const Center(child: ImmichLoadingIndicator());
     }

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -56,10 +56,13 @@ class _AssetPageState extends ConsumerState<AssetPage> {
   _DragIntent _dragIntent = _DragIntent.none;
   Drag? _drag;
 
+  BaseAsset? _asset;
+
   @override
   void initState() {
     super.initState();
     _eventSubscription = EventStream.shared.listen(_onEvent);
+    _asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_scrollController.hasClients) return;
       _scrollController.snapPosition.snapOffset = _snapOffset;
@@ -67,6 +70,14 @@ class _AssetPageState extends ConsumerState<AssetPage> {
         _scrollController.jumpTo(_snapOffset);
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(AssetPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.index != widget.index) {
+      _asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
+    }
   }
 
   @override
@@ -357,7 +368,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     final stackIndex = ref.watch(assetViewerProvider.select((s) => s.stackIndex));
     final isPlayingMotionVideo = ref.watch(isPlayingMotionVideoProvider);
 
-    final asset = ref.read(timelineServiceProvider).getAssetSafe(widget.index);
+    final asset = _asset;
     if (asset == null) {
       return const Center(child: ImmichLoadingIndicator());
     }


### PR DESCRIPTION
## Description

Asset Viewer currently gets stuck on a loading spinner after rotating the device and rotating back. Doesn't happen all the time. 

Issue: `AssetPage` reresolves its asset from `TimelineService` shared buffer on every build via `getAssetSafe(widget.index)`. That is the same buffer thats also backing the timeline grid, which re-requests its visible rows on rotation (because column count and viewport changes I guess) and slides the buffer window away from the `widget.index`. `getAssetSafe` then returns `null` and shows the permanent spinner. 

Fix: resolve the asset once in `initState` (or in didUpdateWidget when index changes), and cache it. 

Fixes #27373

## How Has This Been Tested?

- iOS and android simulator
