### PR TITLE
feat(mobile): add swipe-based photo curation (clean up)

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -428,7 +428,6 @@
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 					};
 					F0B57D372DF764BD00DC5BCC = {
 						CreatedOnToolsVersion = 16.4;
@@ -751,7 +750,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 240;
 				CUSTOM_GROUP_ID = group.app.immich.share;
-				DEVELOPMENT_TEAM = 2F67MQ8R79;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -895,7 +894,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 240;
 				CUSTOM_GROUP_ID = group.app.immich.share;
-				DEVELOPMENT_TEAM = 2F67MQ8R79;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -904,7 +903,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.121.0;
-				PRODUCT_BUNDLE_IDENTIFIER = app.alextran.immich.vdebug;
+				PRODUCT_BUNDLE_IDENTIFIER = app.alextran.immich;
 				PRODUCT_NAME = "Immich-Debug";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -925,7 +924,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 240;
 				CUSTOM_GROUP_ID = group.app.immich.share;
-				DEVELOPMENT_TEAM = 2F67MQ8R79;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -53,6 +53,7 @@ const int kPhotoTabIndex = 0;
 const int kSearchTabIndex = 1;
 const int kAlbumTabIndex = 2;
 const int kLibraryTabIndex = 3;
+const int kCleanUpTabIndex = 4;
 
 // Workaround for SQLite's variable limit (SQLITE_MAX_VARIABLE_NUMBER = 32766)
 const int kDriftMaxChunk = 32000;

--- a/mobile/lib/domain/models/store.model.dart
+++ b/mobile/lib/domain/models/store.model.dart
@@ -94,7 +94,11 @@ enum StoreKey<T> {
   cleanupCutoffDaysAgo<int>._(1011),
   cleanupDefaultsInitialized<bool>._(1012),
 
-  syncMigrationStatus<String>._(1013);
+  syncMigrationStatus<String>._(1013),
+
+  // Swipe curation progress
+  swipeLastReviewedId<String>._(1014),
+  swipeTotalReviewed<int>._(1015);
 
   const StoreKey._(this.id);
   final int id;

--- a/mobile/lib/pages/common/tab_shell.page.dart
+++ b/mobile/lib/pages/common/tab_shell.page.dart
@@ -56,6 +56,12 @@ class _TabShellPageState extends ConsumerState<TabShellPage> {
         selectedIcon: Icon(Icons.space_dashboard_rounded, color: context.primaryColor),
         enabled: !isReadonlyModeEnabled,
       ),
+      NavigationDestination(
+        label: 'Clean Up',
+        icon: const Icon(Icons.swipe_outlined),
+        selectedIcon: Icon(Icons.swipe_rounded, color: context.primaryColor),
+        enabled: !isReadonlyModeEnabled,
+      ),
     ];
 
     Widget navigationRail(TabsRouter tabsRouter) {
@@ -78,7 +84,7 @@ class _TabShellPageState extends ConsumerState<TabShellPage> {
     }
 
     return AutoTabsRouter(
-      routes: const [MainTimelineRoute(), DriftSearchRoute(), DriftAlbumsRoute(), DriftLibraryRoute()],
+      routes: const [MainTimelineRoute(), DriftSearchRoute(), DriftAlbumsRoute(), DriftLibraryRoute(), SwipeCurationRoute()],
       duration: const Duration(milliseconds: 600),
       transitionBuilder: (context, child, animation) => FadeTransition(opacity: animation, child: child),
       builder: (context, child) {
@@ -133,6 +139,11 @@ void _onNavigationSelected(TabsRouter router, int index, WidgetRef ref) {
   if (index == kLibraryTabIndex) {
     ref.invalidate(localAlbumProvider);
     ref.invalidate(driftGetAllPeopleProvider);
+  }
+
+  // Clean Up page
+  if (index == kCleanUpTabIndex) {
+    // The SwipeCurationPage handles its own initialization
   }
 
   ref.read(hapticFeedbackProvider.notifier).selectionClick();

--- a/mobile/lib/presentation/pages/swipe_curation.page.dart
+++ b/mobile/lib/presentation/pages/swipe_curation.page.dart
@@ -1,0 +1,452 @@
+import 'package:appinio_swiper/appinio_swiper.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/swipe/swipe_card.widget.dart';
+import 'package:immich_mobile/providers/swipe_curation.provider.dart';
+
+@RoutePage()
+class SwipeCurationPage extends ConsumerStatefulWidget {
+  const SwipeCurationPage({super.key});
+
+  @override
+  ConsumerState<SwipeCurationPage> createState() => _SwipeCurationPageState();
+}
+
+class _SwipeCurationPageState extends ConsumerState<SwipeCurationPage> {
+  final AppinioSwiperController _swiperController = AppinioSwiperController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Load assets on first frame
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(swipeCurationProvider.notifier).loadInitialBatch();
+    });
+  }
+
+  @override
+  void dispose() {
+    _swiperController.dispose();
+    super.dispose();
+  }
+
+  void _onSwipeEnd(
+      int previousIndex, int targetIndex, SwiperActivity activity) {
+    if (activity is Swipe) {
+      ref
+          .read(swipeCurationProvider.notifier)
+          .onSwipe(previousIndex, activity.direction);
+    }
+  }
+
+  void _undoSwipe() {
+    _swiperController.unswipe();
+    ref.read(swipeCurationProvider.notifier).undoSwipe();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(swipeCurationProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Progress bar
+            _buildProgressBar(context, state),
+            // Main content
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                child: state.isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : state.assets.isEmpty
+                        ? _buildEmptyState(context)
+                        : Stack(
+                            children: [
+                              if (!state.batchFinished)
+                                AppinioSwiper(
+                                  controller: _swiperController,
+                                  cardCount: state.assets.length,
+                                  swipeOptions: const SwipeOptions.only(
+                                      left: true, right: true),
+                                  onSwipeEnd: _onSwipeEnd,
+                                  onCardPositionChanged: (position) {
+                                    ref
+                                        .read(
+                                            swipeCurationProvider.notifier)
+                                        .updateSwipeOffset(position.offset);
+                                  },
+                                  onSwipeCancelled: (_) {
+                                    ref
+                                        .read(
+                                            swipeCurationProvider.notifier)
+                                        .resetSwipeOffset();
+                                  },
+                                  cardBuilder: (context, index) {
+                                    final asset = state.assets[index];
+                                    return SwipeCard(
+                                      asset: asset,
+                                      isBackground:
+                                          index != state.currentIndex,
+                                      isFavorited: state.favoritedIds
+                                              .contains(asset.id) ||
+                                          asset.isFavorite,
+                                      swipeOffset: index ==
+                                              state.currentIndex
+                                          ? state.swipeOffset
+                                          : Offset.zero,
+                                      onDoubleTap: () {
+                                        ref
+                                            .read(swipeCurationProvider
+                                                .notifier)
+                                            .favoriteAsset(asset.id);
+                                      },
+                                      onFavoriteTap: () {
+                                        ref
+                                            .read(swipeCurationProvider
+                                                .notifier)
+                                            .favoriteAsset(asset.id);
+                                      },
+                                    );
+                                  },
+                                ),
+                              if (state.batchFinished)
+                                _buildBatchEndScreen(context, state),
+                            ],
+                          ),
+              ),
+            ),
+            // Bottom actions
+            if (!state.batchFinished && state.assets.isNotEmpty)
+              _buildBottomActions(context, state),
+          ],
+        ),
+      ),
+      // Processing overlay
+      floatingActionButton: state.isProcessing
+          ? Container(
+              color: Colors.black54,
+              child: const Center(child: CircularProgressIndicator()),
+            )
+          : null,
+    );
+  }
+
+  Widget _buildProgressBar(BuildContext context, SwipeCurationState state) {
+    final batchTotal = state.assets.length;
+    final batchReviewed =
+        state.batchFinished ? batchTotal : state.keptCount + state.trashedCount;
+    final totalReviewed = state.totalReviewed + batchReviewed;
+    final total =
+        state.totalAssets > 0 ? state.totalAssets : batchTotal;
+    final progress = total > 0 ? totalReviewed / total : 0.0;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '$totalReviewed of $total reviewed',
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Row(
+                children: [
+                  Icon(Icons.check_circle_rounded,
+                      size: 14, color: Colors.green.shade400),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${state.keptCount}',
+                    style: context.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: Colors.green.shade400,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Icon(Icons.delete_rounded,
+                      size: 14,
+                      color: context.colorScheme.error),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${state.trashedCount}',
+                    style: context.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: context.colorScheme.error,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: progress.clamp(0.0, 1.0),
+              minHeight: 4,
+              backgroundColor: context.colorScheme.surfaceContainerHighest,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                  context.primaryColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.check_circle_outline_rounded,
+            size: 72,
+            color: context.colorScheme.primary.withValues(alpha: 0.5),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'All Clean!',
+            style: context.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'No photos to review right now.',
+            style: context.textTheme.bodyMedium?.copyWith(
+              color: context.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 32),
+          FilledButton.tonal(
+            onPressed: () {
+              ref.read(swipeCurationProvider.notifier).startOver();
+            },
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.refresh_rounded, size: 18),
+                SizedBox(width: 8),
+                Text('Review Again'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBatchEndScreen(
+      BuildContext context, SwipeCurationState state) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.task_alt_rounded,
+            size: 72,
+            color: Colors.green.shade400,
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Batch Complete!',
+            style: context.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'You reviewed ${state.assets.length} photos.',
+            style: context.textTheme.bodyMedium?.copyWith(
+              color: context.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 40),
+          // Empty Trash button
+          if (state.trashedIds.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: FilledButton(
+                onPressed: () {
+                  ref.read(swipeCurationProvider.notifier).emptyTrash();
+                },
+                style: FilledButton.styleFrom(
+                  backgroundColor: context.colorScheme.error,
+                  foregroundColor: context.colorScheme.onError,
+                  minimumSize: const Size(250, 52),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.delete_outline_rounded, size: 20),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Empty Trash (${state.trashedIds.length})',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          // Next batch
+          if (state.hasMorePhotos)
+            FilledButton.tonal(
+              onPressed: () {
+                ref.read(swipeCurationProvider.notifier).loadNextBatch();
+              },
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(250, 52),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              child: Text(
+                'Review Next $kSwipeBatchSize',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          if (!state.hasMorePhotos)
+            FilledButton.tonal(
+              onPressed: () {
+                ref.read(swipeCurationProvider.notifier).startOver();
+              },
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(250, 52),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.refresh_rounded, size: 18),
+                  SizedBox(width: 8),
+                  Text(
+                    'Review Again',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          const SizedBox(height: 16),
+          // Start over
+          TextButton(
+            onPressed: () {
+              _confirmStartOver(context);
+            },
+            child: const Text('Start Over From Beginning'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmStartOver(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Start Over?'),
+        content: const Text(
+          'This will reset your progress and start reviewing from the most recent photo.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.pop(context);
+              ref.read(swipeCurationProvider.notifier).startOver();
+            },
+            child: const Text('Start Over'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBottomActions(
+      BuildContext context, SwipeCurationState state) {
+    final canUndo = state.currentIndex > state.commitIndex &&
+        state.currentIndex <= state.assets.length;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          // Start over button
+          IconButton.filledTonal(
+            onPressed: () => _confirmStartOver(context),
+            icon: const Icon(Icons.refresh_rounded, size: 22),
+            tooltip: 'Start Over',
+          ),
+          // Empty Trash button
+          FilledButton(
+            onPressed: state.trashedIds.isNotEmpty
+                ? () {
+                    ref
+                        .read(swipeCurationProvider.notifier)
+                        .emptyTrash();
+                  }
+                : null,
+            style: FilledButton.styleFrom(
+              backgroundColor: state.trashedIds.isNotEmpty
+                  ? context.colorScheme.error
+                  : context.colorScheme.surfaceContainerHighest,
+              foregroundColor: state.trashedIds.isNotEmpty
+                  ? context.colorScheme.onError
+                  : context.colorScheme.onSurfaceVariant,
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(30),
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.delete_outline_rounded, size: 18),
+                const SizedBox(width: 8),
+                Text(
+                  'Trash (${state.trashedIds.length})',
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Undo button
+          IconButton.filledTonal(
+            onPressed: canUndo ? _undoSwipe : null,
+            icon: const Icon(Icons.undo_rounded, size: 22),
+            tooltip: 'Undo',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/pages/swipe_curation.page.dart
+++ b/mobile/lib/presentation/pages/swipe_curation.page.dart
@@ -17,13 +17,11 @@ class SwipeCurationPage extends ConsumerStatefulWidget {
 class _SwipeCurationPageState extends ConsumerState<SwipeCurationPage> {
   final AppinioSwiperController _swiperController = AppinioSwiperController();
 
+  Offset _swipeOffset = Offset.zero;
+
   @override
   void initState() {
     super.initState();
-    // Load assets on first frame
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(swipeCurationProvider.notifier).loadInitialBatch();
-    });
   }
 
   @override
@@ -38,6 +36,10 @@ class _SwipeCurationPageState extends ConsumerState<SwipeCurationPage> {
       ref
           .read(swipeCurationProvider.notifier)
           .onSwipe(previousIndex, activity.direction);
+          
+      setState(() {
+        _swipeOffset = Offset.zero;
+      });
     }
   }
 
@@ -66,52 +68,52 @@ class _SwipeCurationPageState extends ConsumerState<SwipeCurationPage> {
                         ? _buildEmptyState(context)
                         : Stack(
                             children: [
-                              if (!state.batchFinished)
-                                AppinioSwiper(
-                                  controller: _swiperController,
-                                  cardCount: state.assets.length,
-                                  swipeOptions: const SwipeOptions.only(
-                                      left: true, right: true),
-                                  onSwipeEnd: _onSwipeEnd,
-                                  onCardPositionChanged: (position) {
-                                    ref
-                                        .read(
-                                            swipeCurationProvider.notifier)
-                                        .updateSwipeOffset(position.offset);
-                                  },
-                                  onSwipeCancelled: (_) {
-                                    ref
-                                        .read(
-                                            swipeCurationProvider.notifier)
-                                        .resetSwipeOffset();
-                                  },
-                                  cardBuilder: (context, index) {
-                                    final asset = state.assets[index];
-                                    return SwipeCard(
-                                      asset: asset,
-                                      isBackground:
-                                          index != state.currentIndex,
-                                      isFavorited: state.favoritedIds
-                                              .contains(asset.id) ||
-                                          asset.isFavorite,
-                                      swipeOffset: index ==
-                                              state.currentIndex
-                                          ? state.swipeOffset
-                                          : Offset.zero,
-                                      onDoubleTap: () {
-                                        ref
-                                            .read(swipeCurationProvider
-                                                .notifier)
-                                            .favoriteAsset(asset.id);
-                                      },
-                                      onFavoriteTap: () {
-                                        ref
-                                            .read(swipeCurationProvider
-                                                .notifier)
-                                            .favoriteAsset(asset.id);
-                                      },
-                                    );
-                                  },
+                                Offstage(
+                                  offstage: state.batchFinished,
+                                  child: AppinioSwiper(
+                                    controller: _swiperController,
+                                    cardCount: state.assets.length,
+                                    swipeOptions: const SwipeOptions.only(
+                                        left: true, right: true),
+                                    onSwipeEnd: _onSwipeEnd,
+                                    onCardPositionChanged: (position) {
+                                      setState(() {
+                                        _swipeOffset = position.offset;
+                                      });
+                                    },
+                                    onSwipeCancelled: (_) {
+                                      setState(() {
+                                        _swipeOffset = Offset.zero;
+                                      });
+                                    },
+                                    cardBuilder: (context, index) {
+                                      final asset = state.assets[index];
+                                      return SwipeCard(
+                                        asset: asset,
+                                        isBackground:
+                                            index != state.currentIndex,
+                                        isFavorited: state.favoritedIds
+                                                .contains(asset.id) ||
+                                            asset.isFavorite,
+                                        swipeOffset: index ==
+                                                state.currentIndex
+                                            ? _swipeOffset
+                                            : Offset.zero,
+                                        onDoubleTap: () {
+                                          ref
+                                              .read(swipeCurationProvider
+                                                  .notifier)
+                                              .favoriteAsset(asset.id);
+                                        },
+                                        onFavoriteTap: () {
+                                          ref
+                                              .read(swipeCurationProvider
+                                                  .notifier)
+                                              .favoriteAsset(asset.id);
+                                        },
+                                      );
+                                    },
+                                  ),
                                 ),
                               if (state.batchFinished)
                                 _buildBatchEndScreen(context, state),

--- a/mobile/lib/presentation/widgets/swipe/swipe_card.widget.dart
+++ b/mobile/lib/presentation/widgets/swipe/swipe_card.widget.dart
@@ -1,9 +1,12 @@
 import 'dart:ui';
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/video_viewer.widget.dart';
 
 /// A card widget for the swipe curation stack.
 /// Renders a photo using Immich's Thumbnail system with
@@ -34,20 +37,37 @@ class SwipeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final double aspectRatio = 
+        (asset.width ?? 1) / math.max((asset.height ?? 1), 1);
+
     return GestureDetector(
       onDoubleTap: isBackground ? null : onDoubleTap,
       child: Center(
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(20),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              // Photo thumbnail
-              Thumbnail.fromAsset(
-                asset: asset,
-                fit: BoxFit.cover,
-                size: const Size(900, 900),
-              ),
+        child: AspectRatio(
+          aspectRatio: aspectRatio,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                // Photo thumbnail or Video Viewer
+                if (asset.isVideo && !isBackground)
+                  NativeVideoViewer(
+                    asset: asset,
+                    isCurrent: true,
+                    showControls: false,
+                    image: Thumbnail.fromAsset(
+                      asset: asset,
+                      fit: BoxFit.cover,
+                      size: const Size(900, 900),
+                    ),
+                  )
+                else
+                  Thumbnail.fromAsset(
+                    asset: asset,
+                    fit: BoxFit.cover,
+                    size: const Size(900, 900),
+                  ),
 
               // Background blur overlay for non-top cards
               if (isBackground)
@@ -216,6 +236,7 @@ class SwipeCard extends StatelessWidget {
                 ),
               ),
             ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/presentation/widgets/swipe/swipe_card.widget.dart
+++ b/mobile/lib/presentation/widgets/swipe/swipe_card.widget.dart
@@ -1,0 +1,224 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+
+/// A card widget for the swipe curation stack.
+/// Renders a photo using Immich's Thumbnail system with
+/// swipe-direction overlay, favorite icon, and video badge.
+class SwipeCard extends StatelessWidget {
+  final RemoteAsset asset;
+  final bool isBackground;
+  final bool isFavorited;
+  final Offset swipeOffset;
+  final VoidCallback? onDoubleTap;
+  final VoidCallback? onFavoriteTap;
+
+  const SwipeCard({
+    super.key,
+    required this.asset,
+    this.isBackground = false,
+    this.isFavorited = false,
+    this.swipeOffset = Offset.zero,
+    this.onDoubleTap,
+    this.onFavoriteTap,
+  });
+
+  String _formatDuration(Duration d) {
+    final mins = d.inMinutes;
+    final secs = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$mins:$secs';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onDoubleTap: isBackground ? null : onDoubleTap,
+      child: Center(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(20),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // Photo thumbnail
+              Thumbnail.fromAsset(
+                asset: asset,
+                fit: BoxFit.cover,
+                size: const Size(900, 900),
+              ),
+
+              // Background blur overlay for non-top cards
+              if (isBackground)
+                Positioned.fill(
+                  child: ClipRect(
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
+                      child: Container(
+                        color: Colors.black.withValues(alpha: 0.35),
+                      ),
+                    ),
+                  ),
+                ),
+
+              // Video duration badge
+              if (asset.isVideo)
+                Positioned(
+                  top: 12,
+                  left: 12,
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.6),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Icon(Icons.play_arrow_rounded,
+                            size: 14, color: Colors.white),
+                        const SizedBox(width: 4),
+                        Text(
+                          _formatDuration(asset.duration),
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+              // Favorite heart icon (top-right for Immich style)
+              if (!isBackground)
+                Positioned(
+                  top: asset.isVideo ? 38 : 12,
+                  right: 12,
+                  child: GestureDetector(
+                    onTap: onFavoriteTap,
+                    child: Container(
+                      padding: const EdgeInsets.all(6),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.4),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        isFavorited
+                            ? Icons.favorite_rounded
+                            : Icons.favorite_border_rounded,
+                        size: 22,
+                        color: isFavorited ? Colors.red : Colors.white,
+                      ),
+                    ),
+                  ),
+                ),
+
+              // Swipe direction overlay
+              if (!isBackground && swipeOffset.dx.abs() > 10)
+                Positioned.fill(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20),
+                      color: swipeOffset.dx > 0
+                          ? Color.fromRGBO(76, 175, 80,
+                              (swipeOffset.dx.abs() / 150).clamp(0.0, 0.55))
+                          : Color.fromRGBO(244, 67, 54,
+                              (swipeOffset.dx.abs() / 150).clamp(0.0, 0.55)),
+                    ),
+                    child: Center(
+                      child: Opacity(
+                        opacity:
+                            ((swipeOffset.dx.abs() - 30) / 80).clamp(0.0, 1.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              swipeOffset.dx > 0
+                                  ? Icons.check_circle_outline_rounded
+                                  : Icons.delete_outline_rounded,
+                              size: 48,
+                              color: Colors.white,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              swipeOffset.dx > 0 ? 'KEEP' : 'TRASH',
+                              style: const TextStyle(
+                                fontSize: 28,
+                                fontWeight: FontWeight.w900,
+                                color: Colors.white,
+                                letterSpacing: 3,
+                                shadows: [
+                                  Shadow(
+                                      blurRadius: 12,
+                                      color: Color(0x66000000)),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+
+              // Bottom hint
+              if (!isBackground)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Colors.black.withValues(alpha: 0.5),
+                          Colors.black.withValues(alpha: 0.0),
+                        ],
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.swipe_rounded,
+                            size: 14,
+                            color: Colors.white.withValues(alpha: 0.6)),
+                        const SizedBox(width: 6),
+                        Text(
+                          '← Trash  •  Keep →',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.white.withValues(alpha: 0.6),
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+              // Card border
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(
+                      color: context.colorScheme.outline.withValues(alpha: 0.1),
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/providers/swipe_curation.provider.dart
+++ b/mobile/lib/providers/swipe_curation.provider.dart
@@ -1,0 +1,374 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/providers/app_settings.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/services/action.service.dart';
+import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:logging/logging.dart';
+
+/// Batch size for loading assets at a time
+const int kSwipeBatchSize = 50;
+
+/// State for the swipe-based curation feature
+class SwipeCurationState {
+  final List<RemoteAsset> assets;
+  final int currentIndex;
+  final int keptCount;
+  final int trashedCount;
+  final List<String> trashedIds;
+  final Map<int, AxisDirection> swipeHistory;
+  final int commitIndex;
+  final bool isLoading;
+  final bool isProcessing;
+  final int totalAssets;
+  final int totalReviewed;
+  final bool hasMorePhotos;
+  final Set<String> favoritedIds;
+  final Offset swipeOffset;
+
+  const SwipeCurationState({
+    this.assets = const [],
+    this.currentIndex = 0,
+    this.keptCount = 0,
+    this.trashedCount = 0,
+    this.trashedIds = const [],
+    this.swipeHistory = const {},
+    this.commitIndex = 0,
+    this.isLoading = true,
+    this.isProcessing = false,
+    this.totalAssets = 0,
+    this.totalReviewed = 0,
+    this.hasMorePhotos = true,
+    this.favoritedIds = const {},
+    this.swipeOffset = Offset.zero,
+  });
+
+  bool get batchFinished => !isLoading && currentIndex >= assets.length;
+
+  SwipeCurationState copyWith({
+    List<RemoteAsset>? assets,
+    int? currentIndex,
+    int? keptCount,
+    int? trashedCount,
+    List<String>? trashedIds,
+    Map<int, AxisDirection>? swipeHistory,
+    int? commitIndex,
+    bool? isLoading,
+    bool? isProcessing,
+    int? totalAssets,
+    int? totalReviewed,
+    bool? hasMorePhotos,
+    Set<String>? favoritedIds,
+    Offset? swipeOffset,
+  }) {
+    return SwipeCurationState(
+      assets: assets ?? this.assets,
+      currentIndex: currentIndex ?? this.currentIndex,
+      keptCount: keptCount ?? this.keptCount,
+      trashedCount: trashedCount ?? this.trashedCount,
+      trashedIds: trashedIds ?? this.trashedIds,
+      swipeHistory: swipeHistory ?? this.swipeHistory,
+      commitIndex: commitIndex ?? this.commitIndex,
+      isLoading: isLoading ?? this.isLoading,
+      isProcessing: isProcessing ?? this.isProcessing,
+      totalAssets: totalAssets ?? this.totalAssets,
+      totalReviewed: totalReviewed ?? this.totalReviewed,
+      hasMorePhotos: hasMorePhotos ?? this.hasMorePhotos,
+      favoritedIds: favoritedIds ?? this.favoritedIds,
+      swipeOffset: swipeOffset ?? this.swipeOffset,
+    );
+  }
+}
+
+final swipeCurationProvider =
+    StateNotifierProvider<SwipeCurationNotifier, SwipeCurationState>((ref) {
+  return SwipeCurationNotifier(
+    ref.watch(actionServiceProvider),
+    ref.watch(appSettingsServiceProvider),
+    ref.watch(timelineFactoryProvider),
+    ref.watch(currentUserProvider)?.id,
+  );
+});
+
+class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
+  final ActionService _actionService;
+  final AppSettingsService _appSettings;
+  final TimelineFactory _timelineFactory;
+  final String? _userId;
+  final Logger _logger = Logger('SwipeCurationNotifier');
+
+  TimelineService? _timelineService;
+  int _loadOffset = 0;
+
+  SwipeCurationNotifier(
+    this._actionService,
+    this._appSettings,
+    this._timelineFactory,
+    this._userId,
+  ) : super(const SwipeCurationState()) {
+    _loadPersistedProgress();
+  }
+
+  void _loadPersistedProgress() {
+    final lastReviewedId =
+        _appSettings.getSetting(AppSettingsEnum.swipeLastReviewedId);
+    final totalReviewed =
+        _appSettings.getSetting(AppSettingsEnum.swipeTotalReviewed);
+
+    if (lastReviewedId.isNotEmpty || totalReviewed > 0) {
+      state = state.copyWith(totalReviewed: totalReviewed);
+      _logger.info(
+          '[SwipeCuration] Restored progress: totalReviewed=$totalReviewed, lastId=$lastReviewedId');
+    }
+  }
+
+  Future<void> _saveProgress(String assetId) async {
+    await _appSettings.setSetting(
+        AppSettingsEnum.swipeLastReviewedId, assetId);
+    await _appSettings.setSetting(
+        AppSettingsEnum.swipeTotalReviewed,
+        state.totalReviewed + state.keptCount + state.trashedCount);
+  }
+
+  /// Initialize the timeline and load the first batch
+  Future<void> loadInitialBatch() async {
+    if (_userId == null) return;
+
+    state = state.copyWith(isLoading: true);
+
+    try {
+      // Use the main timeline (all remote assets, newest first)
+      _timelineService = _timelineFactory.remoteAssets(_userId);
+
+      // Wait for the timeline to initialize with buckets
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      final totalAssets = _timelineService!.totalAssets;
+      state = state.copyWith(totalAssets: totalAssets);
+
+      // Try to resume from where user left off
+      final lastReviewedId =
+          _appSettings.getSetting(AppSettingsEnum.swipeLastReviewedId);
+
+      if (lastReviewedId.isNotEmpty) {
+        // Search for the last reviewed ID in the timeline to find
+        // the resume offset
+        await _findResumeOffset(lastReviewedId, totalAssets);
+      }
+
+      await _loadBatch();
+    } catch (e, stack) {
+      _logger.severe('Failed to load initial batch', e, stack);
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  Future<void> _findResumeOffset(String lastId, int totalAssets) async {
+    // Search through the timeline in chunks to find where we left off
+    const searchChunkSize = 200;
+    for (int offset = 0; offset < totalAssets; offset += searchChunkSize) {
+      final count =
+          (offset + searchChunkSize > totalAssets)
+              ? totalAssets - offset
+              : searchChunkSize;
+      try {
+        final assets = await _timelineService!.loadAssets(offset, count);
+        final idx = assets.indexWhere(
+          (a) => a is RemoteAsset && a.id == lastId,
+        );
+        if (idx >= 0) {
+          _loadOffset = offset + idx + 1; // Start after the last reviewed
+          _logger.info(
+              '[SwipeCuration] Found resume point at offset $_loadOffset');
+          return;
+        }
+      } catch (e) {
+        _logger.warning('[SwipeCuration] Error searching offset $offset: $e');
+        break;
+      }
+    }
+    // If not found, start from the beginning
+    _loadOffset = 0;
+  }
+
+  Future<void> _loadBatch() async {
+    if (_timelineService == null) return;
+
+    state = state.copyWith(isLoading: true);
+
+    try {
+      final totalAssets = _timelineService!.totalAssets;
+      final remaining = totalAssets - _loadOffset;
+      final count = remaining < kSwipeBatchSize ? remaining : kSwipeBatchSize;
+
+      if (count <= 0) {
+        state = state.copyWith(
+          assets: [],
+          isLoading: false,
+          hasMorePhotos: false,
+        );
+        return;
+      }
+
+      final assets = await _timelineService!.loadAssets(_loadOffset, count);
+      final remoteAssets =
+          assets.whereType<RemoteAsset>().toList(growable: false);
+
+      state = state.copyWith(
+        assets: remoteAssets,
+        currentIndex: 0,
+        commitIndex: 0,
+        keptCount: 0,
+        trashedCount: 0,
+        trashedIds: [],
+        swipeHistory: {},
+        isLoading: false,
+        hasMorePhotos: (_loadOffset + count) < totalAssets,
+        swipeOffset: Offset.zero,
+      );
+    } catch (e, stack) {
+      _logger.severe('Failed to load batch', e, stack);
+      state = state.copyWith(isLoading: false, hasMorePhotos: false);
+    }
+  }
+
+  /// Load the next batch of photos
+  Future<void> loadNextBatch() async {
+    // Accumulate total reviewed count
+    final batchPhotoCount = state.assets.length;
+    state = state.copyWith(
+      totalReviewed: state.totalReviewed + batchPhotoCount,
+    );
+
+    _loadOffset += batchPhotoCount;
+    await _loadBatch();
+  }
+
+  /// Handle a swipe event
+  void onSwipe(int previousIndex, AxisDirection direction) {
+    if (previousIndex >= state.assets.length) return;
+
+    final asset = state.assets[previousIndex];
+    final newHistory = Map<int, AxisDirection>.from(state.swipeHistory);
+    newHistory[previousIndex] = direction;
+
+    if (direction == AxisDirection.left) {
+      // Trashed
+      state = state.copyWith(
+        currentIndex: state.currentIndex + 1,
+        trashedCount: state.trashedCount + 1,
+        trashedIds: [...state.trashedIds, asset.id],
+        swipeHistory: newHistory,
+        swipeOffset: Offset.zero,
+      );
+    } else if (direction == AxisDirection.right) {
+      // Kept
+      state = state.copyWith(
+        currentIndex: state.currentIndex + 1,
+        keptCount: state.keptCount + 1,
+        swipeHistory: newHistory,
+        swipeOffset: Offset.zero,
+      );
+    }
+
+    // Persist progress
+    _saveProgress(asset.id);
+  }
+
+  /// Undo the last swipe
+  void undoSwipe() {
+    if (state.currentIndex <= state.commitIndex) return;
+
+    final prevIndex = state.currentIndex - 1;
+    final prevDirection = state.swipeHistory[prevIndex];
+    final newHistory = Map<int, AxisDirection>.from(state.swipeHistory);
+    newHistory.remove(prevIndex);
+
+    if (prevDirection == AxisDirection.left) {
+      final newTrashedIds = List<String>.from(state.trashedIds);
+      if (newTrashedIds.isNotEmpty) newTrashedIds.removeLast();
+      state = state.copyWith(
+        currentIndex: prevIndex,
+        trashedCount: state.trashedCount - 1,
+        trashedIds: newTrashedIds,
+        swipeHistory: newHistory,
+      );
+    } else if (prevDirection == AxisDirection.right) {
+      state = state.copyWith(
+        currentIndex: prevIndex,
+        keptCount: state.keptCount - 1,
+        swipeHistory: newHistory,
+      );
+    }
+  }
+
+  /// Trash all left-swiped photos on the Immich server
+  Future<void> emptyTrash() async {
+    if (state.trashedIds.isEmpty) return;
+
+    state = state.copyWith(isProcessing: true);
+
+    try {
+      await _actionService.trash(state.trashedIds);
+      _logger.info(
+          '[SwipeCuration] Trashed ${state.trashedIds.length} assets on server');
+
+      state = state.copyWith(
+        trashedIds: [],
+        commitIndex: state.currentIndex,
+        isProcessing: false,
+      );
+    } catch (e, stack) {
+      _logger.severe('Failed to empty trash', e, stack);
+      state = state.copyWith(isProcessing: false);
+    }
+  }
+
+  /// Favorite a specific asset
+  Future<void> favoriteAsset(String assetId) async {
+    try {
+      final isFavorited = state.favoritedIds.contains(assetId);
+      if (isFavorited) {
+        await _actionService.unFavorite([assetId]);
+        final newFavs = Set<String>.from(state.favoritedIds);
+        newFavs.remove(assetId);
+        state = state.copyWith(favoritedIds: newFavs);
+      } else {
+        await _actionService.favorite([assetId]);
+        final newFavs = Set<String>.from(state.favoritedIds);
+        newFavs.add(assetId);
+        state = state.copyWith(favoritedIds: newFavs);
+      }
+    } catch (e) {
+      _logger.warning('[SwipeCuration] Failed to toggle favorite: $e');
+    }
+  }
+
+  /// Update the swipe offset for UI feedback
+  void updateSwipeOffset(Offset offset) {
+    state = state.copyWith(swipeOffset: offset);
+  }
+
+  /// Reset swipe offset
+  void resetSwipeOffset() {
+    state = state.copyWith(swipeOffset: Offset.zero);
+  }
+
+  /// Start over from the beginning
+  Future<void> startOver() async {
+    _loadOffset = 0;
+    state = const SwipeCurationState();
+    await _appSettings.setSetting(AppSettingsEnum.swipeLastReviewedId, "");
+    await _appSettings.setSetting(AppSettingsEnum.swipeTotalReviewed, 0);
+    await loadInitialBatch();
+  }
+
+  @override
+  void dispose() {
+    _timelineService?.dispose();
+    super.dispose();
+  }
+}

--- a/mobile/lib/providers/swipe_curation.provider.dart
+++ b/mobile/lib/providers/swipe_curation.provider.dart
@@ -27,8 +27,6 @@ class SwipeCurationState {
   final int totalReviewed;
   final bool hasMorePhotos;
   final Set<String> favoritedIds;
-  final Offset swipeOffset;
-
   const SwipeCurationState({
     this.assets = const [],
     this.currentIndex = 0,
@@ -43,7 +41,6 @@ class SwipeCurationState {
     this.totalReviewed = 0,
     this.hasMorePhotos = true,
     this.favoritedIds = const {},
-    this.swipeOffset = Offset.zero,
   });
 
   bool get batchFinished => !isLoading && currentIndex >= assets.length;
@@ -62,7 +59,6 @@ class SwipeCurationState {
     int? totalReviewed,
     bool? hasMorePhotos,
     Set<String>? favoritedIds,
-    Offset? swipeOffset,
   }) {
     return SwipeCurationState(
       assets: assets ?? this.assets,
@@ -78,7 +74,6 @@ class SwipeCurationState {
       totalReviewed: totalReviewed ?? this.totalReviewed,
       hasMorePhotos: hasMorePhotos ?? this.hasMorePhotos,
       favoritedIds: favoritedIds ?? this.favoritedIds,
-      swipeOffset: swipeOffset ?? this.swipeOffset,
     );
   }
 }
@@ -89,7 +84,7 @@ final swipeCurationProvider =
     ref.watch(actionServiceProvider),
     ref.watch(appSettingsServiceProvider),
     ref.watch(timelineFactoryProvider),
-    ref.watch(currentUserProvider)?.id,
+    ref.watch(currentUserProvider.select((u) => u?.id)),
   );
 });
 
@@ -109,7 +104,12 @@ class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
     this._timelineFactory,
     this._userId,
   ) : super(const SwipeCurationState()) {
+    _init();
+  }
+
+  void _init() {
     _loadPersistedProgress();
+    loadInitialBatch();
   }
 
   void _loadPersistedProgress() {
@@ -227,7 +227,6 @@ class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
         swipeHistory: {},
         isLoading: false,
         hasMorePhotos: (_loadOffset + count) < totalAssets,
-        swipeOffset: Offset.zero,
       );
     } catch (e, stack) {
       _logger.severe('Failed to load batch', e, stack);
@@ -262,7 +261,6 @@ class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
         trashedCount: state.trashedCount + 1,
         trashedIds: [...state.trashedIds, asset.id],
         swipeHistory: newHistory,
-        swipeOffset: Offset.zero,
       );
     } else if (direction == AxisDirection.right) {
       // Kept
@@ -270,7 +268,6 @@ class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
         currentIndex: state.currentIndex + 1,
         keptCount: state.keptCount + 1,
         swipeHistory: newHistory,
-        swipeOffset: Offset.zero,
       );
     }
 
@@ -345,16 +342,6 @@ class SwipeCurationNotifier extends StateNotifier<SwipeCurationState> {
     } catch (e) {
       _logger.warning('[SwipeCuration] Failed to toggle favorite: $e');
     }
-  }
-
-  /// Update the swipe offset for UI feedback
-  void updateSwipeOffset(Offset offset) {
-    state = state.copyWith(swipeOffset: offset);
-  }
-
-  /// Reset swipe offset
-  void resetSwipeOffset() {
-    state = state.copyWith(swipeOffset: Offset.zero);
   }
 
   /// Start over from the beginning

--- a/mobile/lib/providers/tab.provider.dart
+++ b/mobile/lib/providers/tab.provider.dart
@@ -1,6 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-enum TabEnum { home, search, albums, library }
+enum TabEnum { home, search, albums, library, cleanUp }
 
 /// Provides the currently active tab
 final tabProvider = StateProvider<TabEnum>((ref) => TabEnum.home);

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -36,6 +36,7 @@ import 'package:immich_mobile/pages/search/map/map_location_picker.page.dart';
 import 'package:immich_mobile/pages/settings/sync_status.page.dart';
 import 'package:immich_mobile/pages/share_intent/share_intent.page.dart';
 import 'package:immich_mobile/presentation/pages/cleanup_preview.page.dart';
+import 'package:immich_mobile/presentation/pages/swipe_curation.page.dart';
 import 'package:immich_mobile/presentation/pages/dev/main_timeline.page.dart';
 import 'package:immich_mobile/presentation/pages/dev/media_stat.page.dart';
 import 'package:immich_mobile/presentation/pages/download_info.page.dart';
@@ -122,8 +123,9 @@ class AppRouter extends RootStackRouter {
       children: [
         AutoRoute(page: MainTimelineRoute.page, guards: [_authGuard, _duplicateGuard]),
         AutoRoute(page: DriftSearchRoute.page, guards: [_authGuard, _duplicateGuard], maintainState: false),
-        AutoRoute(page: DriftLibraryRoute.page, guards: [_authGuard, _duplicateGuard]),
         AutoRoute(page: DriftAlbumsRoute.page, guards: [_authGuard, _duplicateGuard]),
+        AutoRoute(page: DriftLibraryRoute.page, guards: [_authGuard, _duplicateGuard]),
+        AutoRoute(page: SwipeCurationRoute.page, guards: [_authGuard, _duplicateGuard]),
       ],
     ),
     AutoRoute(page: ProfilePictureCropRoute.page),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -1779,6 +1779,22 @@ class SplashScreenRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [SwipeCurationPage]
+class SwipeCurationRoute extends PageRouteInfo<void> {
+  const SwipeCurationRoute({List<PageRouteInfo>? children})
+    : super(SwipeCurationRoute.name, initialChildren: children);
+
+  static const String name = 'SwipeCurationRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const SwipeCurationPage();
+    },
+  );
+}
+
+/// generated route for
 /// [SyncStatusPage]
 class SyncStatusRoute extends PageRouteInfo<void> {
   const SyncStatusRoute({List<PageRouteInfo>? children})

--- a/mobile/lib/services/app_settings.service.dart
+++ b/mobile/lib/services/app_settings.service.dart
@@ -60,7 +60,10 @@ enum AppSettingsEnum<T> {
   cleanupKeepMediaType<int>(StoreKey.cleanupKeepMediaType, null, 0),
   cleanupKeepAlbumIds<String>(StoreKey.cleanupKeepAlbumIds, null, ""),
   cleanupCutoffDaysAgo<int>(StoreKey.cleanupCutoffDaysAgo, null, -1),
-  cleanupDefaultsInitialized<bool>(StoreKey.cleanupDefaultsInitialized, null, false);
+  cleanupDefaultsInitialized<bool>(StoreKey.cleanupDefaultsInitialized, null, false),
+  // Swipe curation progress persistence
+  swipeLastReviewedId<String>(StoreKey.swipeLastReviewedId, null, ""),
+  swipeTotalReviewed<int>(StoreKey.swipeTotalReviewed, null, 0);
 
   const AppSettingsEnum(this.storeKey, this.hiveKey, this.defaultValue);
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  appinio_swiper:
+    dependency: "direct main"
+    description:
+      name: appinio_swiper
+      sha256: "2e86baa65c776a93a3fdf6e973591f3e494631afd979b0e11d1137f82c3c1319"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   archive:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: 3.41.7
 
 dependencies:
+  appinio_swiper: ^2.1.1
   async: ^2.13.1
   auto_route: ^11.1.0
   background_downloader: ^9.5.4


### PR DESCRIPTION
Adds a Tinder-style swipe curation experience based on AppinioSwiper to quickly organize, favorite, and trash photos from the main library.

## Description

This PR introduces a dedicated "Clean Up" tab to the mobile app's bottom navigation bar, providing a rapid, gesture-based way for users to curate their photo libraries. 

A common pain point in photo management is the friction of individually selecting, reviewing, and deleting unwanted photos (like blurry shots or duplicates). This feature solves that by allowing users to:
* **Swipe Right:** Keep the photo.
* **Swipe Left:** Mark the photo for trash (soft delete).
* **Double Tap / Icon Tap:** Favorite the photo.

Under the hood, it leverages:
* `appinio_swiper` for smooth, Tinder-style card gestures.
* `TimelineService` for efficiently batch-loading assets (`kSwipeBatchSize = 50`).
* `ActionService` to handle the actual server-side `.trash()` operations when the user decides to "Empty Trash".
* `AppSettingsService` / `store.model.dart` to persist the ID of the last reviewed photo, ensuring the curation progress resumes exactly where the user left off across app restarts.

## How Has This Been Tested?

- [x] Tested on iOS Simulator/Physical Device.
- [x] Verified that swiping left correctly adds assets to the local trash queue and visually updates the progress bar.
- [x] Verified "Empty Trash" successfully calls `ActionService.trash()` on all queued items and clears the queue.
- [x] Verified "Undo" correctly reverses the last swipe and restores the item from the queue.
- [x] Verified that closing and reopening the app successfully resumes the swipe stack from the last reviewed `RemoteAsset` using `AppSettingsService`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-04-22 at 15 59 38" src="https://github.com/user-attachments/assets/27881fb3-b6cf-4f38-9db4-54307dae1607" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-04-22 at 15 59 56" src="https://github.com/user-attachments/assets/9dce0d27-5a94-4e27-bc04-8eac11af1425" />

https://github.com/user-attachments/assets/50b6ba4e-55bc-4c78-b2af-83c8f0277e54

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (`appinio_swiper` added for gesture handling).
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The core implementation of the swipe logic, state management (`SwipeCurationNotifier`), and integration with Immich's `TimelineService` and `AppSettingsService` was developed with the assistance of a Gemini Agentic AI coding assistant.

***