### PR TITLE
fix(ml): update CUDA base image to 12.8.1 for Blackwell GPU support

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
     apt-get remove wget -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04@sha256:94c1577b2cd9dd6c0312dc04dff9cb2fdce2b268018abc3d7c2dbcacf1155000 AS prod-cuda
+FROM nvidia/cuda:12.8.1-runtime-ubuntu22.04 AS prod-cuda
 
 ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2 \
     MACHINE_LEARNING_MODEL_ARENA=false

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
     apt-get remove wget -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-FROM nvidia/cuda:12.8.1-runtime-ubuntu22.04 AS prod-cuda
+FROM nvidia/cuda:12.8.1-runtime-ubuntu22.04@sha256:4a801ef9232d2b05e69df4eb8aa054dbbe2824e5499e1e6e857320bb01ac41a9 AS prod-cuda
 
 ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2 \
     MACHINE_LEARNING_MODEL_ARENA=false


### PR DESCRIPTION
## Description

Update the `prod-cuda` stage base image from `nvidia/cuda:12.2.2-runtime-ubuntu22.04` to `nvidia/cuda:12.8.1-runtime-ubuntu22.04`.

**Why:** CUDA 12.2 does not support NVIDIA Blackwell GPUs (compute capability sm_120 — RTX 5060 Ti, 5070, 5080, 5090). Blackwell support was added in CUDA 12.8 (released February 2025). With the current 12.2 base image, ONNX Runtime fails to initialize `CUDAExecutionProvider` on Blackwell hardware with:

```
CUDA failure 35: CUDA driver version is insufficient for CUDA runtime version
```

This failure is silent from the user's perspective — Immich starts normally, but ML (face detection, CLIP) runs on CPU. The `libcudnn9-cuda-12` package pinned on line 71 (`9.10.2.21-1`) is compatible with CUDA 12.8.

Fixes #28031

## How Has This Been Tested?

Tested on a homelab machine with an RTX 5060 Ti (Blackwell, sm_120, driver 580.126.18) running the `release-cuda` image inside a privileged LXC container (Incus/NixOS host).

- Before: ONNX Runtime log shows `CPUExecutionProvider`; `nvidia-smi` shows 0% GPU utilization during face detection
- After (built locally with `nvidia/cuda:12.8.1-runtime-ubuntu22.04`): ONNX Runtime log shows `CUDAExecutionProvider`; GPU utilization is non-zero during face detection jobs

- [x] Test A: verified `CUDAExecutionProvider` initializes on Blackwell (RTX 5060 Ti, sm_120)
- [x] Test B: verified `libcudnn9-cuda-12=9.10.2.21-1` installs cleanly on 12.8.1 base

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code was used to help draft the PR description and identify the root cause. The fix itself (one-line base image version bump) was determined by testing on hardware and reading NVIDIA CUDA release notes.