### PR TITLE
feat: upload assets directly to external library with move detection

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -484,6 +484,18 @@ export class AssetRepository {
       .executeTakeFirst();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.STRING] })
+  getOfflineByLibraryIdAndFilename(libraryId: string, filename: string) {
+    return this.db
+      .selectFrom('asset')
+      .selectAll('asset')
+      .where('libraryId', '=', asUuid(libraryId))
+      .where('originalFileName', '=', filename)
+      .where('isOffline', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+  }
+
   /**
    * Get assets by device's Id on the database
    * @param ownerId

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -445,13 +445,31 @@ export class AssetMediaService extends BaseService {
   }
 
   private async create(ownerId: string, dto: AssetMediaCreateDto, file: UploadFile, sidecarFile?: UploadFile) {
+
+    // ── Récupérer la librairie externe de l'utilisateur ──────────────────────
+    const libraries = await this.libraryRepository.getAll(false);
+    const externalLibrary = libraries.find((lib) => lib.ownerId === ownerId);
+    if (!externalLibrary || externalLibrary.importPaths.length === 0) {
+      throw new BadRequestException('No external library configured for user. Please create an external library first.');
+    }
+
+    // Déplacer le fichier vers la librairie externe
+    const originalFilename = dto.filename || file.originalName;
+    const externalPath = `${externalLibrary.importPaths[0]}/upload/${originalFilename}`;
+    this.storageRepository.mkdirSync(externalLibrary.importPaths[0]);
+
+    await this.storageRepository.copyFile(file.originalPath, externalPath);
+    await this.storageRepository.unlink(file.originalPath);
+
     const asset = await this.assetRepository.create({
       ownerId,
-      libraryId: null,
+      libraryId: externalLibrary.id,
+
+      isExternal: true,
 
       checksum: file.checksum,
       checksumAlgorithm: ChecksumAlgorithm.sha1File,
-      originalPath: file.originalPath,
+      originalPath: externalPath,
 
       deviceAssetId: dto.deviceAssetId,
       deviceId: dto.deviceId,
@@ -480,7 +498,7 @@ export class AssetMediaService extends BaseService {
       });
       await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
     }
-    await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
+    await this.storageRepository.utimes(externalPath, new Date(), new Date(dto.fileModifiedAt));
     await this.assetRepository.upsertExif(
       { assetId: asset.id, fileSizeInByte: file.size },
       { lockedPropertiesBehavior: 'override' },

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -248,7 +248,6 @@ export class LibraryService extends BaseService {
   @OnJob({ name: JobName.LibrarySyncFiles, queue: QueueName.Library })
   async handleSyncFiles(job: JobOf<JobName.LibrarySyncFiles>): Promise<JobStatus> {
     const library = await this.libraryRepository.get(job.libraryId);
-    // We need to check if the library still exists as it could have been deleted after the scan was queued
     if (!library) {
       this.logger.debug(`Library ${job.libraryId} not found, skipping file import`);
       return JobStatus.Failed;
@@ -258,24 +257,58 @@ export class LibraryService extends BaseService {
     }
 
     const assetImports: Insertable<AssetTable>[] = [];
+    const movedAssetIds: string[] = [];
+
     await Promise.all(
-      job.paths.map((path) =>
-        this.processEntity(path, library.ownerId, job.libraryId)
-          .then((asset) => assetImports.push(asset))
-          .catch((error: any) => this.logger.error(`Error processing ${path} for library ${job.libraryId}: ${error}`)),
-      ),
+      job.paths.map(async (filePath) => {
+        try {
+          const filename = parse(filePath).base;
+
+          // Check if an offline asset with same filename exists in this library (move detection)
+          const offlineAsset = await this.assetRepository.getByLibraryIdAndOriginalPath(
+            job.libraryId,
+            // Search by filename by querying offline assets with matching originalFileName
+            undefined as any,
+          ).catch(() => null);
+
+          // Use direct DB query for move detection
+
+          const movedAsset = await this.assetRepository.getOfflineByLibraryIdAndFilename(
+            job.libraryId,
+            filename,
+          ).catch(() => null);
+
+          if (movedAsset) {
+            // File was moved — update originalPath and restore online
+            await this.assetRepository.update({
+              id: movedAsset.id,
+              originalPath: path.normalize(filePath),
+              isOffline: false,
+              deletedAt: null,
+            });
+            movedAssetIds.push(movedAsset.id);
+            this.logger.debug(`Move detected: ${movedAsset.originalPath} → ${filePath}`);
+          } else {
+            const asset = await this.processEntity(filePath, library.ownerId, job.libraryId);
+            assetImports.push(asset);
+          }
+        } catch (error: any) {
+          this.logger.error(`Error processing ${filePath} for library ${job.libraryId}: ${error}`);
+        }
+      }),
     );
 
-    const assetIds = await this.assetRepository.createAll(assetImports);
+    const newAssetIds = await this.assetRepository.createAll(assetImports);
 
     const progressMessage =
       job.progressCounter && job.totalAssets
         ? `(${job.progressCounter} of ${job.totalAssets})`
         : `(${job.progressCounter} done so far)`;
 
-    this.logger.log(`Imported ${assetIds.length} ${progressMessage} file(s) into library ${job.libraryId}`);
+    this.logger.log(`Imported ${newAssetIds.length} ${progressMessage} file(s) into library ${job.libraryId}`);
 
-    await this.queuePostSyncJobs(assetIds);
+    // Queue post-sync jobs for both new and moved assets
+    await this.queuePostSyncJobs([...newAssetIds, ...movedAssetIds]);
 
     return JobStatus.Success;
   }
@@ -687,11 +720,13 @@ export class LibraryService extends BaseService {
   @OnJob({ name: JobName.LibraryRemoveAsset, queue: QueueName.Library })
   async handleAssetRemoval(job: JobOf<JobName.LibraryRemoveAsset>): Promise<JobStatus> {
     // This is only for handling file unlink events via the file watcher
-    this.logger.verbose(`Deleting asset(s) ${job.paths} from library ${job.libraryId}`);
+    this.logger.verbose(`File unlinked: ${job.paths} from library ${job.libraryId}`);
     for (const assetPath of job.paths) {
       const asset = await this.assetRepository.getByLibraryIdAndOriginalPath(job.libraryId, assetPath);
       if (asset) {
-        await this.assetRepository.remove(asset);
+        // Mark offline instead of removing immediately — move detection may restore it
+        await this.assetRepository.update({ id: asset.id, isOffline: true, deletedAt: new Date() });
+        this.logger.debug(`Marked asset offline (pending move detection): ${assetPath}`);
       }
     }
 


### PR DESCRIPTION
- asset-media.service.ts: copy uploaded file to external library import path under /upload/ subfolder, create asset with libraryId + isExternal=true
- library.service.ts: on file unlink, mark asset offline instead of deleting (pending move detection); on new file add, check for offline asset with same filename and update originalPath instead of creating new asset
- asset.repository.ts: add getOfflineByLibraryIdAndFilename() method

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
