### PR TITLE
fix(mobile): convert 10-bit HEIF/AVIF bitmaps to ARGB_8888 on Android

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/LocalImagesImpl.kt
@@ -43,23 +43,40 @@ inline fun ImageDecoder.Source.decodeBitmap(target: Size = Size(0, 0)): Bitmap {
   }
 }
 
+// Copies [this] bitmap into a native buffer in ARGB_8888 layout, matching
+// what the Dart side expects (PixelFormat.rgba8888, 4 bytes/pixel).
+//
+// Android's ImageDecoder returns wide-gamut bitmaps for 10-bit HEIF/HEIC and
+// AVIF (e.g. RGBA_1010102, RGBA_F16), and setTargetColorSpace(SRGB) does not
+// force an 8-bit output format. Writing those bits verbatim into a buffer
+// Flutter interprets as PixelFormat.rgba8888 produces correctly shaped but
+// garbled colours. Normalise via Bitmap.copy(ARGB_8888), which performs the
+// colour-space and bit-depth conversion inside Skia.
 fun Bitmap.toNativeBuffer(): Map<String, Long>  {
-  val size = width * height * 4
+  val bitmap: Bitmap = if (config == Bitmap.Config.ARGB_8888) {
+    this
+  } else {
+    val converted = copy(Bitmap.Config.ARGB_8888, false)
+      ?: throw IOException("Bitmap.copy(ARGB_8888) returned null for ${width}x${height} $config")
+    recycle()
+    converted
+  }
+  val size = bitmap.width * bitmap.height * 4
   val pointer = NativeBuffer.allocate(size)
   try {
     val buffer = NativeBuffer.wrap(pointer, size)
-    copyPixelsToBuffer(buffer)
+    bitmap.copyPixelsToBuffer(buffer)
     return mapOf(
       "pointer" to pointer,
-      "width" to width.toLong(),
-      "height" to height.toLong(),
-      "rowBytes" to (width * 4).toLong()
+      "width" to bitmap.width.toLong(),
+      "height" to bitmap.height.toLong(),
+      "rowBytes" to (bitmap.width * 4).toLong()
     )
   } catch (e: Exception) {
     NativeBuffer.free(pointer)
     throw e
   } finally {
-    recycle()
+    bitmap.recycle()
   }
 }
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -1,6 +1,8 @@
 package app.alextran.immich.images
 
 import android.content.Context
+import android.graphics.ImageDecoder
+import android.os.Build
 import android.os.CancellationSignal
 import android.os.OperationCanceledException
 import app.alextran.immich.INITIAL_BUFFER_SIZE
@@ -39,7 +41,7 @@ class RemoteImagesImpl(context: Context) : RemoteImageApi {
   override fun requestImage(
     url: String,
     requestId: Long,
-    @Suppress("UNUSED_PARAMETER") preferEncoded: Boolean, // always returns encoded; setting has no effect on Android
+    preferEncoded: Boolean,
     callback: (Result<Map<String, Long>?>) -> Unit
   ) {
     val signal = CancellationSignal()
@@ -53,6 +55,25 @@ class RemoteImagesImpl(context: Context) : RemoteImageApi {
         if (signal.isCanceled) {
           NativeBuffer.free(buffer.pointer)
           return@fetch callback(CANCELLED)
+        }
+
+        // When the caller doesn't want the raw bytes (preferEncoded=false),
+        // decode in Kotlin so toNativeBuffer can normalise to ARGB_8888.
+        // Flutter's own encoded-decode path hands the bytes to Android's
+        // ImageDecoder but then memcpys the result as if it were ARGB_8888;
+        // 10-bit HEIF/AVIF sources come back as RGBA_1010102 which produces
+        // garbled colours.
+        if (!preferEncoded && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          try {
+            val src = NativeBuffer.wrap(buffer.pointer, buffer.offset).apply { position(0) }
+            val bitmap = ImageDecoder.createSource(src).decodeBitmap()
+            NativeBuffer.free(buffer.pointer)
+            val res = bitmap.toNativeBuffer()
+            callback(Result.success(res))
+            return@fetch
+          } catch (_: Exception) {
+            // Fall through to encoded passthrough; buffer.pointer still owned.
+          }
         }
 
         callback(

--- a/mobile/lib/infrastructure/loaders/image_request.dart
+++ b/mobile/lib/infrastructure/loaders/image_request.dart
@@ -95,6 +95,27 @@ abstract class ImageRequest {
   }
 
   Future<ui.FrameInfo?> _fromDecodedPlatformImage(int address, int width, int height, int rowBytes) async {
+    final result = await _codecFromDecodedPlatformImage(address, width, height, rowBytes);
+    if (result == null) return null;
+
+    final (codec, descriptor) = result;
+    final frame = await codec.getNextFrame();
+    descriptor.dispose();
+    codec.dispose();
+    if (_isCancelled) {
+      frame.image.dispose();
+      return null;
+    }
+
+    return frame;
+  }
+
+  Future<(ui.Codec, ui.ImageDescriptor)?> _codecFromDecodedPlatformImage(
+    int address,
+    int width,
+    int height,
+    int rowBytes,
+  ) async {
     final pointer = Pointer<Uint8>.fromAddress(address);
     if (_isCancelled) {
       malloc.free(pointer);
@@ -130,14 +151,6 @@ abstract class ImageRequest {
       return null;
     }
 
-    final frame = await codec.getNextFrame();
-    descriptor.dispose();
-    codec.dispose();
-    if (_isCancelled) {
-      frame.image.dispose();
-      return null;
-    }
-
-    return frame;
+    return (codec, descriptor);
   }
 }

--- a/mobile/lib/infrastructure/loaders/local_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/local_image_request.dart
@@ -38,17 +38,37 @@ class LocalImageRequest extends ImageRequest {
       return null;
     }
 
+    // Go through the decoded path (not preferEncoded: true). Handing raw
+    // HEIF/HEIC bytes to Flutter engine's `ImageDescriptor.encoded` triggers
+    // `AndroidImageGenerator`, which calls Android `ImageDecoder.decodeBitmap`
+    // under the assumption the result is ARGB_8888. For 10-bit HEIF (e.g.
+    // Sony .HIF), Android returns `RGBA_F16` (8 bytes/pixel) and the engine's
+    // `memcpy(pixels, data, w*h*4)` silently truncates the pixel data,
+    // producing correctly shaped but garbled-colour output.
+    //
+    // `LocalImagesImpl.toNativeBuffer` on the Kotlin side normalises to
+    // ARGB_8888 before crossing the Dart boundary, so the decoded path is
+    // safe.
     final info = await localImageApi.requestImage(
       localId,
       requestId: requestId,
       width: width,
       height: height,
       isVideo: assetType == AssetType.video,
-      preferEncoded: true,
+      preferEncoded: false,
     );
     if (info == null) return null;
 
-    final (codec, _) = await _codecFromEncodedPlatformImage(info['pointer']!, info['length']!) ?? (null, null);
+    final result = await _codecFromDecodedPlatformImage(
+      info['pointer']!,
+      info['width']!,
+      info['height']!,
+      info['rowBytes']!,
+    );
+    if (result == null) return null;
+
+    final (codec, descriptor) = result;
+    descriptor.dispose();
     return codec;
   }
 


### PR DESCRIPTION
## Description

This PR converts 10 bit heic to 8 bit for display on android.

Fixes https://github.com/immich-app/immich/issues/24906

## How Has This Been Tested?

Tested on a Pixel 8 with a 10 bit HIF file from a Sony A7V. Tested with local and remote images.

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

It wrote most of this.