### PR TITLE
fix: The memory generation job does not work correctly

### DIFF
--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -12,21 +12,16 @@ import { IBulkAsset } from 'src/types';
 
 @Injectable()
 export class MemoryRepository implements IBulkAsset {
-  constructor(@InjectKysely() private db: Kysely<DB>) {}
+  constructor(@InjectKysely() private db: Kysely<DB>) { }
 
   async cleanup() {
-    await this.db
-      .deleteFrom('memory_asset')
-      .using('asset')
-      .whereRef('memory_asset.assetId', '=', 'asset.id')
-      .where('asset.visibility', '!=', AssetVisibility.Timeline)
-      .execute();
+    await this.db.transaction().execute(async (trx) => {
+      await trx.deleteFrom('memory_asset').execute();
+    });
 
-    return this.db
-      .deleteFrom('memory')
-      .where('createdAt', '<', DateTime.now().minus({ days: 30 }).toJSDate())
-      .where('isSaved', '=', false)
-      .execute();
+    return await this.db.transaction().execute(async (trx) => {
+      await trx.deleteFrom('memory').execute();
+    });
   }
 
   searchBuilder(ownerId: string, dto: MemorySearchDto) {

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -19,6 +19,13 @@ export class MemoryService extends BaseService {
     await this.databaseRepository.withLock(DatabaseLock.MemoryCreation, async () => {
       const state = await this.systemMetadataRepository.get(SystemMetadataKey.MemoriesState);
       const start = DateTime.utc().startOf('day').minus({ days: DAYS });
+      const systemConfig = await this.systemMetadataRepository.get(SystemMetadataKey.SystemConfig)
+      const isManualGenerate = DateTime.now().toFormat('HH:mm') !== systemConfig?.nightlyTasks?.startTime
+      if (isManualGenerate && state) {
+        state["lastOnThisDayDate"] = start.toISO();
+        // if not cleanup, record will duplicates
+        this.onMemoriesCleanup();
+      }
       const lastOnThisDayDate = state?.lastOnThisDayDate ? DateTime.fromISO(state.lastOnThisDayDate) : start;
 
       // generate a memory +/- X days from today


### PR DESCRIPTION
## Description
1. The memory generation job fails to run correctly due to a database field issue. For details, see [discuss#25906.](https://github.com/immich-app/immich/discussions/25906)

2. Modify the job's execution condition: if the execution time does not match the nightly tasks settings, it should be considered a manually triggered job.

3. Since the memory and memory_asset tables lack unique constraints, manually running the memory generation job multiple times results in duplicate records. Therefore, the cleanup logic needs to be adjusted. The solution is to clear all existing records and regenerate them.
