### PR TITLE
fix(web): double video playback on map timeline

### DIFF
--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -86,7 +86,7 @@
     </div>
   </UserPageLayout>
   <Portal target="body">
-    {#if assetViewerManager.isViewing}
+    {#if assetViewerManager.isViewing && !isTimelinePanelVisible}
       {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
         <AssetViewer
           cursor={{ current: assetViewerManager.asset! }}


### PR DESCRIPTION
## Description

Fixes #28068

## How Has This Been Tested?

- [x] Go to a map cluster that has a video
- [x] From the map sidebar, play a video
- [x] Pause the video, it should stop playing

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Gemini was used to identify the cause
