### PR TITLE
feat: add OpenEXR to supported list of image formats

### DIFF
--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -12,6 +12,7 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 | :---------- | :---------------------------- | :----------------: | :-------------- |
 | `AVIF`      | `.avif`                       | :white_check_mark: |                 |
 | `BMP`       | `.bmp`                        | :white_check_mark: |                 |
+| `OpenEXR`   | `.exr`                        | :white_check_mark: |                 |
 | `GIF`       | `.gif`                        | :white_check_mark: |                 |
 | `HEIC`      | `.heic`                       | :white_check_mark: |                 |
 | `HEIF`      | `.heif`                       | :white_check_mark: |                 |

--- a/e2e/src/ui/mock-network/base-network.ts
+++ b/e2e/src/ui/mock-network/base-network.ts
@@ -190,6 +190,7 @@ export const setupBaseMockApiRoutes = async (context: BrowserContext, adminUserI
           '.dcr',
           '.dng',
           '.erf',
+          '.exr',
           '.fff',
           '.iiq',
           '.k25',

--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -156,6 +156,7 @@ where
           '%.srf',
           '%.srw',
           '%.x3f',
+          '%.exr',
           '%.heic',
           '%.heif',
           '%.hif',

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -69,6 +69,7 @@ const validImages = [
   '.dcr',
   '.dng',
   '.erf',
+  '.exr',
   '.fff',
   '.gif',
   '.heic',

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -55,6 +55,7 @@ describe('mimeTypes', () => {
     { mimetype: 'image/x-canon-cr3', extension: '.cr3' },
     { mimetype: 'image/x-canon-crw', extension: '.crw' },
     { mimetype: 'image/x-epson-erf', extension: '.erf' },
+    { mimetype: 'image/x-exr', extension: '.exr' },
     { mimetype: 'image/x-fuji-raf', extension: '.raf' },
     { mimetype: 'image/x-hasselblad-3fr', extension: '.3fr' },
     { mimetype: 'image/x-hasselblad-fff', extension: '.fff' },
@@ -159,6 +160,7 @@ describe('mimeTypes', () => {
     for (const img of [
       'a.avif',
       'a.bmp',
+      'a.exr',
       'a.gif',
       'a.heic',
       'a.heif',

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -51,6 +51,7 @@ const webSupportedImage = {
 
 const webUnsupportedImage = {
   ...raw,
+  '.exr': ['image/x-exr'],
   '.heic': ['image/heic'],
   '.heif': ['image/heif'],
   '.hif': ['image/hif'],
@@ -81,6 +82,7 @@ const extensionOverrides: Record<string, string> = {
 const transparentCapableExtensions = new Set([
   '.avif',
   '.bmp',
+  '.exr',
   '.gif',
   '.heic',
   '.heif',


### PR DESCRIPTION
## Description

This PR adds OpenEXR to the list of supported image formats.

OpenEXR is a high–dynamic‑range, multi‑channel raster file format released as an open standard under a free software license similar to the BSD license. Using OpenEXR instead of TIFF can save disk space, especially when using lossless compression.

### How Has This Been Tested?

1. Go to openexr.com and download a [test image](https://openexr.com/en/latest/test_images/ScanLines/Cannon.html).  
2. Rename the downloaded image to an already supported file extension (e.g., `.raw`).  
3. Upload the renamed image to immich.  
4. The image is displayed correctly by immich.

Because of this, I assume the underlying tech stack already supports OpenEXR and it is only missing from the supported file formats list.
## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
Note: Could be added to `supported-formats.md`, the list already seems to be not complete by intent.
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
Note: Just as done in: https://github.com/immich-app/immich/pull/27963
Did not add a new image for end-to-end testing.
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None used. Just followed the link provided by docs  to the code.