### PR TITLE
fix(mobile): show sync error in upload detail view instead of phantom loading state

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -682,6 +682,7 @@
   "backup_controller_page_uploading_file_info": "Uploading file info",
   "backup_err_only_album": "Cannot remove the only album",
   "backup_error_sync_failed": "Sync failed. Cannot process backup.",
+  "backup_error_sync_failed_detail": "The server metadata sync failed. Your backed-up photos are safe, but the library may be out of sync with the server.",
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_in_progress": "Upload already in progress. Try after sometime",

--- a/mobile/lib/pages/backup/drift_upload_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_upload_detail.page.dart
@@ -58,6 +58,8 @@ class _DriftUploadDetailPageState extends ConsumerState<DriftUploadDetailPage> {
   Widget build(BuildContext context) {
     final uploadItems = ref.watch(driftBackupProvider.select((state) => state.uploadItems));
     final iCloudProgress = ref.watch(driftBackupProvider.select((state) => state.iCloudDownloadProgress));
+    final isSyncing = ref.watch(driftBackupProvider.select((state) => state.isSyncing));
+    final error = ref.watch(driftBackupProvider.select((state) => state.error));
 
     for (final item in uploadItems.values) {
       if (item.isFailed == true) {
@@ -83,7 +85,7 @@ class _DriftUploadDetailPageState extends ConsumerState<DriftUploadDetailPage> {
         elevation: 0,
         scrolledUnderElevation: 1,
       ),
-      body: _buildTwoSectionLayout(context, uploadingItems, failedItems, iCloudProgress),
+      body: _buildTwoSectionLayout(context, uploadingItems, failedItems, iCloudProgress, isSyncing, error),
     );
   }
 
@@ -92,7 +94,13 @@ class _DriftUploadDetailPageState extends ConsumerState<DriftUploadDetailPage> {
     List<DriftUploadStatus> uploadingItems,
     List<DriftUploadStatus> failedItems,
     Map<String, double> iCloudProgress,
+    bool isSyncing,
+    BackupError error,
   ) {
+    final showUploadSlots = isSyncing || uploadingItems.isNotEmpty;
+    final showSyncErrorBanner =
+        error == BackupError.syncFailed && !isSyncing && uploadingItems.isEmpty && failedItems.isEmpty;
+
     return CustomScrollView(
       slivers: [
         // iCloud Downloads Section
@@ -119,30 +127,73 @@ class _DriftUploadDetailPageState extends ConsumerState<DriftUploadDetailPage> {
           ),
         ],
 
-        // Uploading Section
-        SliverToBoxAdapter(
-          child: _buildSectionHeader(
-            context,
-            title: "uploading".t(context: context),
-            count: uploadingItems.length,
-            color: context.colorScheme.primary,
+        // Sync error banner — shown when sync failed but there are no upload errors to display
+        if (showSyncErrorBanner)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: Card(
+                elevation: 0,
+                color: context.colorScheme.errorContainer,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(12)),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(Icons.sync_problem_rounded, color: context.colorScheme.error),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "backup_error_sync_failed".t(context: context),
+                              style: context.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              "backup_error_sync_failed_detail".t(context: context),
+                              style: context.textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ),
-        ),
-        SliverPadding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          sliver: SliverList(
-            delegate: SliverChildBuilderDelegate((context, index) {
-              // Use slot-based assignment to prevent items from jumping
-              final slots = _assignItemsToSlots(uploadingItems);
-              final item = slots[index];
-              if (item != null) {
-                return _buildCurrentUploadCard(context, item);
-              } else {
-                return _buildPlaceholderCard(context);
-              }
-            }, childCount: 3),
+
+        // Uploading Section — only shown when uploads are active or queued
+        if (showUploadSlots) ...[
+          SliverToBoxAdapter(
+            child: _buildSectionHeader(
+              context,
+              title: "uploading".t(context: context),
+              count: uploadingItems.length,
+              color: context.colorScheme.primary,
+            ),
           ),
-        ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate((context, index) {
+                // Use slot-based assignment to prevent items from jumping
+                final slots = _assignItemsToSlots(uploadingItems);
+                final item = slots[index];
+                if (item != null) {
+                  return _buildCurrentUploadCard(context, item);
+                } else {
+                  return _buildPlaceholderCard(context);
+                }
+              }, childCount: _maxSlots),
+            ),
+          ),
+        ],
 
         // Errors Section
         if (failedItems.isNotEmpty) ...[
@@ -499,14 +550,35 @@ class _DriftUploadDetailPageState extends ConsumerState<DriftUploadDetailPage> {
   }
 }
 
-class _CurrentUploadThumbnail extends ConsumerWidget {
+class _CurrentUploadThumbnail extends ConsumerStatefulWidget {
   final String taskId;
   const _CurrentUploadThumbnail({required this.taskId});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_CurrentUploadThumbnail> createState() => _CurrentUploadThumbnailState();
+}
+
+class _CurrentUploadThumbnailState extends ConsumerState<_CurrentUploadThumbnail> {
+  late Future<LocalAsset?> _assetFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _assetFuture = _getAsset();
+  }
+
+  Future<LocalAsset?> _getAsset() async {
+    try {
+      return await ref.read(localAssetRepository).getById(widget.taskId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return FutureBuilder<LocalAsset?>(
-      future: _getAsset(ref),
+      future: _assetFuture,
       builder: (context, snapshot) {
         return SizedBox(
           width: 48,
@@ -525,22 +597,35 @@ class _CurrentUploadThumbnail extends ConsumerWidget {
       },
     );
   }
-
-  Future<LocalAsset?> _getAsset(WidgetRef ref) async {
-    try {
-      return await ref.read(localAssetRepository).getById(taskId);
-    } catch (e) {
-      return null;
-    }
-  }
 }
 
-class FileDetailDialog extends ConsumerWidget {
+class FileDetailDialog extends ConsumerStatefulWidget {
   final DriftUploadStatus uploadStatus;
   const FileDetailDialog({super.key, required this.uploadStatus});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<FileDetailDialog> createState() => _FileDetailDialogState();
+}
+
+class _FileDetailDialogState extends ConsumerState<FileDetailDialog> {
+  late Future<LocalAsset?> _assetFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _assetFuture = _getAssetDetails();
+  }
+
+  Future<LocalAsset?> _getAssetDetails() async {
+    try {
+      return await ref.read(localAssetRepository).getById(widget.uploadStatus.taskId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return AlertDialog(
       insetPadding: const EdgeInsets.all(20),
       backgroundColor: context.colorScheme.surfaceContainerLow,
@@ -563,7 +648,7 @@ class FileDetailDialog extends ConsumerWidget {
       content: SizedBox(
         width: double.maxFinite,
         child: FutureBuilder<LocalAsset?>(
-          future: _getAssetDetails(ref, uploadStatus.taskId),
+          future: _assetFuture,
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const SizedBox(height: 200, child: Center(child: CircularProgressIndicator()));
@@ -593,12 +678,16 @@ class FileDetailDialog extends ConsumerWidget {
                   const SizedBox(height: 24),
                   if (asset != null)
                     _buildInfoSection(context, [
-                      _buildInfoRow(context, "filename".t(context: context), path.basename(uploadStatus.filename)),
+                      _buildInfoRow(
+                        context,
+                        "filename".t(context: context),
+                        path.basename(widget.uploadStatus.filename),
+                      ),
                       _buildInfoRow(context, "local_id".t(context: context), asset.id),
                       _buildInfoRow(
                         context,
                         "file_size".t(context: context),
-                        formatHumanReadableBytes(uploadStatus.fileSize, 2),
+                        formatHumanReadableBytes(widget.uploadStatus.fileSize, 2),
                       ),
                       if (asset.width != null) _buildInfoRow(context, "width".t(context: context), "${asset.width}px"),
                       if (asset.height != null)
@@ -661,13 +750,5 @@ class FileDetailDialog extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  Future<LocalAsset?> _getAssetDetails(WidgetRef ref, String localAssetId) async {
-    try {
-      return await ref.read(localAssetRepository).getById(localAssetId);
-    } catch (e) {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
## Problem

When `BackupError.syncFailed` is set (server metadata sync failure) and no photo uploads were queued, tapping **View Details** from the backup page opened a detail view that appeared permanently stuck loading — three skeleton placeholder cards under "Uploading (0)" with hourglass icons, no error info, no way to understand what failed.

Root causes:
1. **Skeleton slots always rendered**: `childCount: 3` was hardcoded, so placeholder cards showed even with zero uploads in flight.
2. **Wrong detail for the wrong error**: The sync error is a metadata sync failure, not a photo upload failure. The detail page only knew how to show upload items, so it showed nothing useful.
3. **FutureBuilder anti-pattern**: `_CurrentUploadThumbnail` and `FileDetailDialog` were `ConsumerWidget`s that called async functions inline in `build()`, creating a new `Future` on every rebuild. `FutureBuilder` restarted from waiting state on each rebuild.

## Fix

- **Upload slot cards are now hidden when backup is idle** (`!isSyncing && uploadingItems.isEmpty`). Slots only render when there are actual items in flight or a sync is actively running.
- **Sync error banner**: When `error == BackupError.syncFailed` and there are no upload-level failures, a clear card now explains that the *server metadata sync* failed (not a photo upload) and that backed-up photos are safe.
- **Stable futures**: Converted `_CurrentUploadThumbnail` and `FileDetailDialog` to `ConsumerStatefulWidget`, initializing the DB lookup future in `initState` so it never restarts on rebuild.
- **New i18n key**: `backup_error_sync_failed_detail` for the banner body text.

## Related

- Closest open issue: #28082 (different angle — sync retry blocking — but same `syncFailed` state)

## Test plan

- [ ] Trigger a sync failure (disconnect from server, force sync) → tap View Details → confirm error banner appears with explanation
- [ ] Start a photo upload → tap View Details → confirm 3 slot cards render with upload progress
- [ ] Complete all uploads → tap View Details → confirm slot cards disappear, only error section shows if any failed
- [ ] Tap a failed item → confirm detail dialog loads and stays loaded on rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)