### PR TITLE
fix(web): refresh memories hourly

### DIFF
--- a/web/src/lib/managers/memory-manager.svelte.ts
+++ b/web/src/lib/managers/memory-manager.svelte.ts
@@ -33,6 +33,8 @@ class MemoryManager {
     if (authManager.authenticated) {
       void this.initialize();
     }
+
+    this.scheduleHourlyRefresh();
   }
 
   ready() {
@@ -131,6 +133,29 @@ class MemoryManager {
   private async load() {
     const memories = await searchMemories({ $for: asLocalTimeISO(DateTime.now()) });
     this.memories = memories.filter((memory) => memory.assets.length > 0);
+  }
+
+  private scheduleHourlyRefresh() {
+    const now = DateTime.utc();
+    let nextEvent = now.set({ minute: 0, second: 5 });
+
+    if (nextEvent <= now) {
+      nextEvent = nextEvent.plus({ hours: 1 });
+    }
+
+    const initialDelay = nextEvent.diff(now).as('milliseconds');
+
+    setTimeout(() => {
+      this.#loading = this.load();
+
+      // Schedule subsequent events hourly
+      setInterval(
+        () => {
+          this.#loading = this.load();
+        },
+        60 * 60 * 1000,
+      );
+    }, initialDelay);
   }
 }
 


### PR DESCRIPTION
## Description
Fix an issue with memories only being loaded on the first Immich page load. Best way to explain the issue is with the repro case:

1. Open Immich web at 23:59
2. Do whatever you want except closing the page until 00:00 or 00:01 and then go to /photos timeline
3. You'd expect the next day's memories, but the memory store is only loaded/filled on the very first web load (when the memory manager is instantiated) so we still have yesterday's memories.

Fix: at each hour at HH:00:05 (+5 sec because settimeout/interval aren't extremely reliable and user agent's local time might be off) refresh the memories store. Hourly, because the user (agent) might switch time zones between the time `setTimeout(`until 00:00`)` is called and the timeout fires, and possible other timezone issues. Does not account for time zones that aren't a full hour offset.

Fixes #24365

## How Has This Been Tested?
- Change the interval to every minute and the inital start to a time that's very soon
- Add toast in the `load` function :)
- Observe that it 'works'

I did not wait until midnight, so I can't say im 100% sure this fixes the issue. Definitely 99% sure, though.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Inspiration for the setTimeout + setInterval combination.
