### PR TITLE
fix(web): toggle person visibility without persisting hidden state

### DIFF
--- a/web/src/routes/(user)/people/ManagePeopleVisibility.svelte
+++ b/web/src/routes/(user)/people/ManagePeopleVisibility.svelte
@@ -37,22 +37,22 @@
     }
   };
 
+  const isPersonVisible = (person: PersonResponseDto) => {
+    const isHidden = overrides.get(person.id) ?? person.isHidden;
+    if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
+      return false;
+    } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
+      return false;
+    }
+    return !isHidden;
+  };
+
+  let filteredPeople = $derived(
+    toggleVisibility === ToggleVisibility.SHOW_ALL ? people : people.filter((person) => isPersonVisible(person)),
+  );
+
   const handleToggleVisibility = () => {
     toggleVisibility = getNextVisibility(toggleVisibility);
-
-    for (const person of people) {
-      let isHidden = overrides.get(person.id) ?? person.isHidden;
-
-      if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
-        isHidden = true;
-      } else if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
-        isHidden = false;
-      } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
-        isHidden = true;
-      }
-
-      setHiddenOverride(person, isHidden);
-    }
   };
 
   const handleSaveVisibility = async () => {
@@ -147,7 +147,7 @@
   </div>
 
   <div class="flex flex-wrap gap-1 p-2 pb-8 md:px-8">
-    <PeopleInfiniteScroll {people} hasNextPage={true} {loadNextPage}>
+    <PeopleInfiniteScroll people={filteredPeople} hasNextPage={true} {loadNextPage}>
       {#snippet children({ person })}
         {@const hidden = overrides.get(person.id) ?? person.isHidden}
         <button


### PR DESCRIPTION
## Description

Fix the toggle person visibility button on the /people page. The eye icon that cycles through Show All / Hide Unnamed / Hide All was incorrectly persisting changes to each person's `isHidden` state in the database via the overrides map. Now it only filters the view without modifying the underlying data.

Fixes #19956

## How Has This Been Tested?

- [x] Verified toggle cycles through Show All / Hide Unnamed / Hide All without modifying the overrides map
- [x] Verified individual person clicks still correctly update the overrides map
- [x] Verified clicking Done only persists intentional individual changes, not toggle-based changes

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No visual changes - the toggle buttons look the same, they just no longer persist unintended state changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code