### PR TITLE
fix(web): convert shared link expiry to UTC before serialising

### DIFF
--- a/web/src/lib/components/SharedLinkExpiration.svelte
+++ b/web/src/lib/components/SharedLinkExpiration.svelte
@@ -35,7 +35,7 @@
 
   const setSelectedDate = (value: DateTime | undefined) => {
     selectedPresetValue = null; // Clear preset when manually setting date
-    expiresAt = value ? value.toISO() : null;
+    expiresAt = value ? value.toUTC().toISO() : null;
   };
 
   const selectPreset = (value: number) => {
@@ -44,8 +44,8 @@
       expiresAt = null;
       return;
     }
-    const newDate = DateTime.now().plus(value);
-    expiresAt = newDate.toISO();
+    const newDate = DateTime.now().plus({ milliseconds: value });
+    expiresAt = newDate.toUTC().toISO();
   };
 
   const isSelected = (value: number) => {


### PR DESCRIPTION
fixes https://github.com/dnplkndll/immich/issues/10 by porting/implementing https://github.com/dnplkndll/immich/issues/9

- `DateTime#toISO()` emits a local-offset string (e.g. `2026-05-23T09:12:08.227-04:00`) which is rejected by the server's `isoDatetimeToDate` codec in `server/src/validation.ts` — it wraps `z.iso.datetime()`, which only accepts UTC (`Z`-suffix) strings.
- Replace `.toISO()` with `.toUTC().toISO()` in both the manual date picker path and the preset selection path.
- Enhance readability in `DateTime.now().plus(value)` ([Luxon Docs](https://moment.github.io/luxon/api-docs/index.html#datetimeplus))
