### PR TITLE
feat(mobile): add per-video original/transcoded playback toggle to three-dot menu

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/play_original_video_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/play_original_video_action_button.widget.dart
@@ -1,0 +1,27 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/providers/asset_viewer/play_original_video_provider.dart';
+
+class PlayOriginalVideoActionButton extends ConsumerWidget {
+  const PlayOriginalVideoActionButton({super.key, required this.asset, this.iconOnly = false, this.menuItem = false});
+
+  final BaseAsset asset;
+  final bool iconOnly;
+  final bool menuItem;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final playOriginalVideo = ref.watch(effectivePlayOriginalVideoProvider(asset.heroTag));
+
+    return BaseActionButton(
+      label: playOriginalVideo ? 'play_transcoded_video'.tr() : 'play_original_video'.tr(),
+      iconData: Icons.video_file_outlined,
+      iconOnly: iconOnly,
+      menuItem: menuItem,
+      onPressed: () => ref.read(playOriginalVideoOverrideProvider(asset.heroTag).notifier).state = !playOriginalVideo,
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -64,6 +64,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   @override
   void didUpdateWidget(NativeVideoViewer oldWidget) {
     super.didUpdateWidget(oldWidget);
+
     if (widget.isCurrent == oldWidget.isCurrent || _controller == null) return;
 
     if (!widget.isCurrent) {
@@ -71,6 +72,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
       _notifier.pause();
       return;
     }
+
     // Prevent unnecessary loading when swiping between assets.
     _loadTimer = Timer(const Duration(milliseconds: 200), _loadVideo);
   }
@@ -97,16 +99,20 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
 
   Future<VideoSource?> _createSource({bool? playOriginalOverride}) async {
     if (!mounted) return null;
+
     final videoAsset = await ref.read(assetServiceProvider).getAsset(widget.asset) ?? widget.asset;
     if (!mounted) return null;
+
     try {
       if (videoAsset.hasLocal && videoAsset.livePhotoVideoId == null) {
         final id = videoAsset is LocalAsset ? videoAsset.id : (videoAsset as RemoteAsset).localId!;
         final file = await StorageRepository().getFileForAsset(id);
         if (!mounted) return null;
+
         if (file == null) {
           throw Exception('No file found for the video');
         }
+
         // Pass a file:// URI so Android's Uri.parse doesn't
         // interpret characters like '#' as fragment identifiers.
         return VideoSource.init(
@@ -116,6 +122,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
       }
 
       final remoteId = (videoAsset as RemoteAsset).id;
+
       final serverEndpoint = Store.get(StoreKey.serverEndpoint);
       final bool isOriginalVideo = playOriginalOverride ?? ref.read(effectivePlayOriginalVideoProvider(widget.asset.heroTag));
       final String postfixUrl = isOriginalVideo ? 'original' : 'video/playback';
@@ -132,17 +139,27 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
 
   void _onPlaybackReady() async {
     if (!mounted || !widget.isCurrent) return;
+
     _notifier.onNativePlaybackReady();
+
+    // onPlaybackReady may be called multiple times, usually when more data
+    // loads. If this is not the first time that the player has become ready, we
+    // should not autoplay.
     if (_isVideoReady) return;
+
     setState(() => _isVideoReady = true);
+
     if (ref.read(assetViewerProvider).showingDetails) return;
+
     final autoPlayVideo = AppSetting.get(Setting.autoPlayVideo);
     if (autoPlayVideo || widget.asset.isMotionPhoto) await _notifier.play();
   }
 
   void _onPlaybackEnded() {
     if (!mounted) return;
+
     _notifier.onNativePlaybackEnded();
+
     if (_controller?.playbackInfo?.status == PlaybackStatus.stopped) {
       ref.read(isPlayingMotionVideoProvider.notifier).playing = false;
     }
@@ -168,6 +185,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   void _loadVideo({bool forceReload = false}) async {
     final nc = _controller;
     if (nc == null || nc.videoSource != null || !mounted) return;
+
     if (forceReload) {
       await _notifier.pause();
       setState(() => _isVideoReady = false);
@@ -176,6 +194,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
       playOriginalOverride: ref.read(playOriginalVideoOverrideProvider(widget.asset.heroTag)),
     );
     if (source == null || !mounted) return;
+
     await _notifier.load(source);
     final loopVideo = ref.read(appSettingsServiceProvider).getSetting<bool>(AppSettingsEnum.loopVideo);
     await _notifier.setLoop(!widget.asset.isMotionPhoto && loopVideo);
@@ -184,12 +203,16 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
 
   void _initController(NativeVideoPlayerController nc) {
     if (_controller != null || !mounted) return;
+
     _notifier.attachController(nc);
+
     nc.onPlaybackPositionChanged.addListener(_onPlaybackPositionChanged);
     nc.onPlaybackStatusChanged.addListener(_onPlaybackStatusChanged);
     nc.onPlaybackReady.addListener(_onPlaybackReady);
     nc.onPlaybackEnded.addListener(_onPlaybackEnded);
+
     _controller = nc;
+
     if (widget.isCurrent) _loadVideo();
   }
 
@@ -197,6 +220,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   Widget build(BuildContext context) {
     final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
     final status = ref.watch(videoPlayerProvider(widget.asset.heroTag).select((v) => v.status));
+
     return IgnorePointer(
       child: Stack(
         children: [

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -20,6 +20,7 @@ import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:logging/logging.dart';
 import 'package:native_video_player/native_video_player.dart';
+import 'package:immich_mobile/providers/asset_viewer/play_original_video_provider.dart'; // <--- new import
 
 class NativeVideoViewer extends ConsumerStatefulWidget {
   final BaseAsset asset;
@@ -43,7 +44,6 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   static final _log = Logger('NativeVideoViewer');
 
   NativeVideoPlayerController? _controller;
-  late final Future<VideoSource?> _videoSource;
   Timer? _loadTimer;
   bool _isVideoReady = false;
   bool _shouldPlayOnForeground = true;
@@ -54,13 +54,16 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _videoSource = _createSource();
+    ref.listenManual(playOriginalVideoOverrideProvider(widget.asset.heroTag), (previous, next) {
+      if (previous != null && previous != next) {
+        _loadVideo(forceReload: true);
+      }
+    });
   }
 
   @override
   void didUpdateWidget(NativeVideoViewer oldWidget) {
     super.didUpdateWidget(oldWidget);
-
     if (widget.isCurrent == oldWidget.isCurrent || _controller == null) return;
 
     if (!widget.isCurrent) {
@@ -68,7 +71,6 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
       _notifier.pause();
       return;
     }
-
     // Prevent unnecessary loading when swiping between assets.
     _loadTimer = Timer(const Duration(milliseconds: 200), _loadVideo);
   }
@@ -93,22 +95,18 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
     }
   }
 
-  Future<VideoSource?> _createSource() async {
+  Future<VideoSource?> _createSource({bool? playOriginalOverride}) async {
     if (!mounted) return null;
-
     final videoAsset = await ref.read(assetServiceProvider).getAsset(widget.asset) ?? widget.asset;
     if (!mounted) return null;
-
     try {
       if (videoAsset.hasLocal && videoAsset.livePhotoVideoId == null) {
         final id = videoAsset is LocalAsset ? videoAsset.id : (videoAsset as RemoteAsset).localId!;
         final file = await StorageRepository().getFileForAsset(id);
         if (!mounted) return null;
-
         if (file == null) {
           throw Exception('No file found for the video');
         }
-
         // Pass a file:// URI so Android's Uri.parse doesn't
         // interpret characters like '#' as fragment identifiers.
         return VideoSource.init(
@@ -118,9 +116,8 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
       }
 
       final remoteId = (videoAsset as RemoteAsset).id;
-
       final serverEndpoint = Store.get(StoreKey.serverEndpoint);
-      final isOriginalVideo = ref.read(settingsProvider).get<bool>(Setting.loadOriginalVideo);
+      final bool isOriginalVideo = playOriginalOverride ?? ref.read(effectivePlayOriginalVideoProvider(widget.asset.heroTag));
       final String postfixUrl = isOriginalVideo ? 'original' : 'video/playback';
       final String videoUrl = videoAsset.livePhotoVideoId != null
           ? '$serverEndpoint/assets/${videoAsset.livePhotoVideoId}/$postfixUrl'
@@ -135,27 +132,17 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
 
   void _onPlaybackReady() async {
     if (!mounted || !widget.isCurrent) return;
-
     _notifier.onNativePlaybackReady();
-
-    // onPlaybackReady may be called multiple times, usually when more data
-    // loads. If this is not the first time that the player has become ready, we
-    // should not autoplay.
     if (_isVideoReady) return;
-
     setState(() => _isVideoReady = true);
-
     if (ref.read(assetViewerProvider).showingDetails) return;
-
     final autoPlayVideo = AppSetting.get(Setting.autoPlayVideo);
     if (autoPlayVideo || widget.asset.isMotionPhoto) await _notifier.play();
   }
 
   void _onPlaybackEnded() {
     if (!mounted) return;
-
     _notifier.onNativePlaybackEnded();
-
     if (_controller?.playbackInfo?.status == PlaybackStatus.stopped) {
       ref.read(isPlayingMotionVideoProvider.notifier).playing = false;
     }
@@ -178,13 +165,17 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
     _controller?.onPlaybackEnded.removeListener(_onPlaybackEnded);
   }
 
-  void _loadVideo() async {
+  void _loadVideo({bool forceReload = false}) async {
     final nc = _controller;
     if (nc == null || nc.videoSource != null || !mounted) return;
-
-    final source = await _videoSource;
+    if (forceReload) {
+      await _notifier.pause();
+      setState(() => _isVideoReady = false);
+    }
+    final source = await _createSource(
+      playOriginalOverride: ref.read(playOriginalVideoOverrideProvider(widget.asset.heroTag)),
+    );
     if (source == null || !mounted) return;
-
     await _notifier.load(source);
     final loopVideo = ref.read(appSettingsServiceProvider).getSetting<bool>(AppSettingsEnum.loopVideo);
     await _notifier.setLoop(!widget.asset.isMotionPhoto && loopVideo);
@@ -193,16 +184,12 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
 
   void _initController(NativeVideoPlayerController nc) {
     if (_controller != null || !mounted) return;
-
     _notifier.attachController(nc);
-
     nc.onPlaybackPositionChanged.addListener(_onPlaybackPositionChanged);
     nc.onPlaybackStatusChanged.addListener(_onPlaybackStatusChanged);
     nc.onPlaybackReady.addListener(_onPlaybackReady);
     nc.onPlaybackEnded.addListener(_onPlaybackEnded);
-
     _controller = nc;
-
     if (widget.isCurrent) _loadVideo();
   }
 
@@ -210,7 +197,6 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
   Widget build(BuildContext context) {
     final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
     final status = ref.watch(videoPlayerProvider(widget.asset.heroTag).select((v) => v.status));
-
     return IgnorePointer(
       child: Stack(
         children: [

--- a/mobile/lib/providers/asset_viewer/play_original_video_provider.dart
+++ b/mobile/lib/providers/asset_viewer/play_original_video_provider.dart
@@ -1,0 +1,13 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
+
+final playOriginalVideoOverrideProvider = StateProvider.autoDispose.family<bool?, String>((ref, assetId) => null);
+
+final effectivePlayOriginalVideoProvider = Provider.autoDispose.family<bool, String>((ref, assetId) {
+  final override = ref.watch(playOriginalVideoOverrideProvider(assetId));
+  if (override != null) {
+    return override;
+  }
+  return ref.watch(settingsProvider.notifier).get<bool>(Setting.loadOriginalVideo);
+});


### PR DESCRIPTION
## Description

Adds mobile support for choosing original video playback per video:

- The video viewer kebab (three-dot) menu now includes an action to toggle the current remote video between original and transcoded playback, regardless of network.
- The toggle is specific to each video asset and switches playback immediately in the viewer.

The motivation is video quality. Transcoded videos play reliably, but for some videos the **SDR** transcode quality is **noticeably worse** than the original, especially in dark scenes where blacks can look washed out or blocky. 

Users should be able to keep transcodes for bandwidth-constrained playback while still choosing the original when quality matters, such as when watching at home. The app already has a force-original option; this adds fine-grained flexibility on mobile without mandating original playback everywhere.

## How Has This Been Tested?

- [x] git diff --check
- [x] dart analyze lib --fatal-infos
- [x] Flutter dependencies installed and app launched on Android 15 / API 35 emulator
- [x] Manual tests run on iOS and Android Device (see screenshots section below)

Manual test plan (for reviewers):

- Configure the server to transcode videos and upload a video that has a generated transcoded playback stream.
- With Force original video **disabled**, open the remote video and confirm playback uses the transcoded endpoint.
- Enable Force original video, reopen the same remote video, and confirm playback uses the original endpoint.
- Disable Force original video, open a remote video, and use the three-dot viewer menu to tap "Play original video". Confirm playback switches to the original endpoint.
- Tap "Play transcoded video" from the same menu and confirm playback switches back to the transcoded endpoint.
- Confirm locally available videos continue to play from the local file and do not show the original/transcoded menu action.

<details><summary><h2>Screenshots</h2></summary>

https://github.com/user-attachments/assets/5a3b95af-d1df-40fd-8ed3-8ccb4eff4de6

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in src/repositories/ is pretty basic/simple and does not have any immich specific logic (that belongs in src/services/)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The PR description and wording were assisted by an LLM. All code changes, logic, and testing were implemented and verified manually.