### PR TITLE
fix: the memcpy call at native_buffer in native_buffer.c

### DIFF
--- a/mobile/android/app/src/main/cpp/native_buffer.c
+++ b/mobile/android/app/src/main/cpp/native_buffer.c
@@ -32,7 +32,8 @@ JNIEXPORT void JNICALL
 Java_app_alextran_immich_NativeBuffer_copy(
         JNIEnv *env, jclass clazz, jobject buffer, jlong destAddress, jint offset, jint length) {
     void *src = (*env)->GetDirectBufferAddress(env, buffer);
-    if (src != NULL) {
+    jlong capacity = (*env)->GetDirectBufferCapacity(env, buffer);
+    if (src != NULL && offset >= 0 && length >= 0 && (jlong) offset + length <= capacity) {
         memcpy((void *) destAddress, (char *) src + offset, length);
     }
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `mobile/android/app/src/main/cpp/native_buffer.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `mobile/android/app/src/main/cpp/native_buffer.c:36` |
| **CWE** | CWE-120 |

**Description**: The memcpy call at native_buffer.c:36 copies 'length' bytes from 'src + offset' into 'destAddress' without validating that (1) offset + length does not exceed the source buffer size, or (2) length does not exceed the destination buffer size. Both 'length' and 'offset' are JNI parameters passed from the Java/Dart layer, meaning they can be influenced by attacker-controlled values such as crafted media file dimensions or manipulated API responses. This constitutes a classic heap buffer overflow in the Android native layer.

## Changes
- `mobile/android/app/src/main/cpp/native_buffer.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
