### PR TITLE
fix(mobile): avoid duplicate assets in album view

### DIFF
--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -244,15 +244,19 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
 
     final isAscending = albumData.order == AlbumAssetOrder.asc;
 
-    final query = _db.remoteAssetEntity.select().addColumns([_db.localAssetEntity.id]).join([
+    // Correlated subquery picks the first matching local asset by checksum,
+    // avoiding fan-out when the same photo exists in multiple device albums (#23273).
+    final localId = subqueryExpression<String>(
+      _db.localAssetEntity.selectOnly()
+        ..addColumns([_db.localAssetEntity.id])
+        ..where(_db.localAssetEntity.checksum.equalsExp(_db.remoteAssetEntity.checksum))
+        ..limit(1),
+    );
+
+    final query = _db.remoteAssetEntity.select().addColumns([localId]).join([
       innerJoin(
         _db.remoteAlbumAssetEntity,
         _db.remoteAlbumAssetEntity.assetId.equalsExp(_db.remoteAssetEntity.id),
-        useColumns: false,
-      ),
-      leftOuterJoin(
-        _db.localAssetEntity,
-        _db.remoteAssetEntity.checksum.equalsExp(_db.localAssetEntity.checksum),
         useColumns: false,
       ),
     ])..where(_db.remoteAssetEntity.deletedAt.isNull() & _db.remoteAlbumAssetEntity.albumId.equals(albumId));
@@ -265,9 +269,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
 
     query.limit(count, offset: offset);
 
-    return query
-        .map((row) => row.readTable(_db.remoteAssetEntity).toDto(localId: row.read(_db.localAssetEntity.id)))
-        .get();
+    return query.map((row) => row.readTable(_db.remoteAssetEntity).toDto(localId: row.read(localId))).get();
   }
 
   TimelineQuery fromAssets(List<BaseAsset> assets, TimelineOrigin origin) => (

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/timeline.repository.dart';
+
+import '../repository_context.dart';
+
+void main() {
+  late MediumRepositoryContext ctx;
+  late DriftTimelineRepository sut;
+
+  setUp(() {
+    ctx = MediumRepositoryContext();
+    sut = DriftTimelineRepository(ctx.db);
+  });
+
+  tearDown(() async {
+    await ctx.dispose();
+  });
+
+  group('remoteAlbum assets', () {
+    test('no duplicate assets when identical checksum appears in multiple local asset rows', () async {
+      // Regression check for #23273: a LEFT OUTER JOIN on checksum would fan out and create duplicates
+      // happens when same photo exists in multiple albums on device
+      final user = await ctx.newUser();
+      final checksum = 'yolo';
+      final album = await ctx.newRemoteAlbum(ownerId: user.id);
+      final remoteAsset = await ctx.newRemoteAsset(ownerId: user.id, checksum: checksum);
+      await ctx.insertRemoteAlbumAsset(albumId: album.id, assetId: remoteAsset.id);
+
+      final localAsset1 = await ctx.newLocalAsset(checksum: checksum);
+      final localAsset2 = await ctx.newLocalAsset(checksum: checksum);
+
+      final assets = await sut.remoteAlbum(album.id, GroupAssetsBy.day).assetSource(0, 10);
+
+      expect(assets, hasLength(1));
+      expect((assets.first as RemoteAsset).id, remoteAsset.id);
+      expect([localAsset1.id, localAsset2.id], contains((assets.first as RemoteAsset).localId));
+    });
+  });
+}


### PR DESCRIPTION
## Description

As outlined in the descriptions on issue #23273, when the same photo is added to multiple albums on Android devices, this results in multiple localAssetEntity rows with the same checksum. The previous LEFT OUTER JOIN on the checksum caused fanning out into multiple duplicate rows, which caused photos to be shown multiple times in the album view (e.g. Shared Albums). Because only the asset query seems to fan out, it also causes offsets to drift, so assets will be rendered with the wrong date.

The most likely root cause for this issue to appear in the first place is probably people receiving photos via various apps and saving them to Camera Roll and defaulting to synching all albums. Ultimately, how many copies of identical photos people want to maintain is a personal choice and the offset drift is still unpleasant.

Fixed by joining against a pre-deduplicated subquery (GROUP BY checksum) instead of the raw table, so each remote asset should only match one local row. Subquery would probably also work, but would be slower on larger albums in particular. Resolves described issue successfully on a Pixel 9 Pro.

Fixes #23273

## How Has This Been Tested?

To reproduce the underlying issue, an Android device needs an identical photo to exist in multiple device albums (e.g. Camera and WhatsApp Images).

1. Take a photo
2. Create a new album "Test"
3. Add photo to album "Test". (some applications e.g. Samsung's Gallery suggest moving the file vs. copying, which is sensible, but not helpful here - pick copy)
4. In Immich, select both the Camera and the Test folder for sync
5. Add the photo to a Shared Album
6. When the Shared Album is viewed on the device where the photo/albums are present, the picture will be shown n times, n being the number of albums it exists in and with drifting metadata.

- [x] Manually verified on a Pixel 9 Pro (via flutter run over ADB) side-to-side with current Play Store version. Duplicate assets are no longer shown in Shared Album view.
- [x] `flutter test` - All 668 tests pass (with 1 skipped)

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (N/A, no new deps)
- [x] I have written tests for new code (if applicable) (N/A - bug fix, covered by existing suite)
- [x] I have followed naming conventions/patterns in the surrounding code
- ~~[ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~ N/A, change effects /mobile only
- ~~[ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~ N/A, change effects /mobile only

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
