### PR TITLE
fix(ml): respect time zone for logs in cuda container

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -137,7 +137,6 @@ ENV TRANSFORMERS_CACHE=/cache \
     MACHINE_LEARNING_CACHE_FOLDER=/cache \
     TZ=${TZ}
 
-
 # prevent core dumps
 RUN echo "hard core 0" >> /etc/security/limits.conf && \
     echo "fs.suid_dumpable 0" >> /etc/sysctl.conf && \

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -68,7 +68,7 @@ ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2 \
 
 RUN apt-get update && \
     # Pascal support was dropped in 9.11
-    apt-get install --no-install-recommends -yqq libcudnn9-cuda-12=9.10.2.21-1 && \
+    apt-get install --no-install-recommends -yqq libcudnn9-cuda-12=9.10.2.21-1 tzdata && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -119,14 +119,13 @@ FROM prod-${DEVICE} AS prod
 ARG DEVICE
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tini ccache libgl1 libglib2.0-0 libgomp1 tzdata $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
+    apt-get install -y --no-install-recommends tini ccache libgl1 libglib2.0-0 libgomp1 $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
     apt-get autoremove -yqq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -s "/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2" /usr/lib/libmimalloc.so.2
 
-ARG TZ=UTC
 WORKDIR /usr/src
 ENV TRANSFORMERS_CACHE=/cache \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -138,7 +137,6 @@ ENV TRANSFORMERS_CACHE=/cache \
     MACHINE_LEARNING_CACHE_FOLDER=/cache \
     TZ=${TZ}
 
-RUN cp /usr/share/zoneinfo/${TZ:-UTC} /etc/localtime
 
 # prevent core dumps
 RUN echo "hard core 0" >> /etc/security/limits.conf && \

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -119,13 +119,14 @@ FROM prod-${DEVICE} AS prod
 ARG DEVICE
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tini ccache libgl1 libglib2.0-0 libgomp1 $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
+    apt-get install -y --no-install-recommends tini ccache libgl1 libglib2.0-0 libgomp1 tzdata $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
     apt-get autoremove -yqq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -s "/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2" /usr/lib/libmimalloc.so.2
 
+ARG TZ=UTC
 WORKDIR /usr/src
 ENV TRANSFORMERS_CACHE=/cache \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -134,7 +135,10 @@ ENV TRANSFORMERS_CACHE=/cache \
     PYTHONPATH=/usr/src \
     DEVICE=${DEVICE} \
     VIRTUAL_ENV=/opt/venv \
-    MACHINE_LEARNING_CACHE_FOLDER=/cache
+    MACHINE_LEARNING_CACHE_FOLDER=/cache \
+    TZ=${TZ}
+
+RUN cp /usr/share/zoneinfo/${TZ:-UTC} /etc/localtime
 
 # prevent core dumps
 RUN echo "hard core 0" >> /etc/security/limits.conf && \

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -134,8 +134,7 @@ ENV TRANSFORMERS_CACHE=/cache \
     PYTHONPATH=/usr/src \
     DEVICE=${DEVICE} \
     VIRTUAL_ENV=/opt/venv \
-    MACHINE_LEARNING_CACHE_FOLDER=/cache \
-    TZ=${TZ}
+    MACHINE_LEARNING_CACHE_FOLDER=/cache
 
 # prevent core dumps
 RUN echo "hard core 0" >> /etc/security/limits.conf && \


### PR DESCRIPTION
## Description

Modifies the Dockerfile to add the ability to set the timezone with an environment variable in CUDA images 

Fixes #22300

## How Has This Been Tested?

```
root@docker:~/.config/immich_ml_testing# cat docker-compose.yml 
services:
  immich-machine-learning:
    container_name: immich_machine_learning
    build:
      context: ./
      args:
        DEVICE: cuda
        TZ: America/New_York
    restart: always
    ports:
      - "3003:3003"
    volumes:
      - model-cache:/cache
    gpus: all
    runtime: nvidia
volumes:
  model-cache:
root@docker:~/.config/immich_ml_testing# docker compose up 
[+] Building 382.2s (27/27) FINISHED                                                                                                  
 => [internal] load local bake definitions                                                                                       0.0s
 => => reading from stdin 686B                                                                                                   0.0s
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 7.06kB                                                                                           0.0s
 => [internal] load metadata for ghcr.io/astral-sh/uv:0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c5428  0.0s
 => [internal] load metadata for docker.io/library/python:3.11-bookworm@sha256:970c99f886b839fc8829289040c1845dadaf2cae46b37acc  0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:12.2.2-runtime-ubuntu22.04@sha256:94c1577b2cd9dd6c0312dc04dff9cb2fdce2b2  0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                  0.0s
 => [internal] load build context                                                                                                0.0s
 => => transferring context: 1.69kB                                                                                              0.0s
 => [builder-cpu 1/1] FROM docker.io/library/python:3.11-bookworm@sha256:970c99f886b839fc8829289040c1845dadaf2cae46b37acc77103  29.9s
 => => resolve docker.io/library/python:3.11-bookworm@sha256:970c99f886b839fc8829289040c1845dadaf2cae46b37acc7710333158ec29b4    0.0s
 => => sha256:0e1e360c8563edc0c545822fe240295395f5a8d076d3ac4bf59e637296b61b44 24.07MB / 24.07MB                                14.2s
 => => sha256:fb20672b53862671eb032e39d4519f21bb2b34856ff38adaa59d8c9f75281d67 6.16MB / 6.16MB                                   2.6s
 => => sha256:b267853a2602be02c651d45a79ece242837985d07267fe166ad1109a4b3baa39 211.53MB / 211.53MB                              24.9s
 => => sha256:de73ef470b7b271fede6f98a4c8376971bd059ce04ebc13b9f86e34e534b89ae 64.40MB / 64.40MB                                 8.3s
 => => sha256:c2c3414b1d6b49c54c305584faac46aad75c67644cf4f8495e8145206d28e416 24.04MB / 24.04MB                                12.5s
 => => sha256:c150dd3f5fc91eabd1818cc30298a4a956782621583cadfd369c4d327584008e 48.49MB / 48.49MB                                 7.1s
 => => extracting sha256:c150dd3f5fc91eabd1818cc30298a4a956782621583cadfd369c4d327584008e                                        1.0s
 => => extracting sha256:c2c3414b1d6b49c54c305584faac46aad75c67644cf4f8495e8145206d28e416                                        0.6s
 => => extracting sha256:de73ef470b7b271fede6f98a4c8376971bd059ce04ebc13b9f86e34e534b89ae                                        1.6s
 => => extracting sha256:b267853a2602be02c651d45a79ece242837985d07267fe166ad1109a4b3baa39                                        4.0s
 => => extracting sha256:fb20672b53862671eb032e39d4519f21bb2b34856ff38adaa59d8c9f75281d67                                        0.2s
 => => extracting sha256:0e1e360c8563edc0c545822fe240295395f5a8d076d3ac4bf59e637296b61b44                                        0.7s
 => => extracting sha256:859c709f45fb4da613bf83caa96ec6c59af7aa13d10914eff36355a9bb45d28d                                        0.0s
 => CACHED [prod-cuda 1/5] FROM docker.io/nvidia/cuda:12.2.2-runtime-ubuntu22.04@sha256:94c1577b2cd9dd6c0312dc04dff9cb2fdce2b26  0.0s
 => => resolve docker.io/nvidia/cuda:12.2.2-runtime-ubuntu22.04@sha256:94c1577b2cd9dd6c0312dc04dff9cb2fdce2b268018abc3d7c2dbcac  0.0s
 => FROM ghcr.io/astral-sh/uv:0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c54289ced0                    11.2s
 => => resolve ghcr.io/astral-sh/uv:0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c54289ced0               0.0s
 => => sha256:b5c1d8a02beb46ee3f43053f7563d00d605bb930f63bfbcececd04a7455f5b80 21.39MB / 21.39MB                                10.8s
 => => extracting sha256:b5c1d8a02beb46ee3f43053f7563d00d605bb930f63bfbcececd04a7455f5b80                                        0.2s
 => => extracting sha256:62e48a8cb359f6e3f4375bbaac58fc12a40797b94590ce447f61d2f3f190c493                                        0.1s
 => [prod-cuda 2/5] RUN apt-get update &&     apt-get install --no-install-recommends -yqq libcudnn9-cuda-12=9.10.2.21-1 &&    289.7s
 => [builder 1/3] RUN apt-get update && apt-get install -y --no-install-recommends g++                                           2.9s
 => [builder 2/3] COPY --from=ghcr.io/astral-sh/uv:0.8.15@sha256:a5727064a0de127bdb7c9d3c1383f3a9ac307d9f2d8a391edc7896c54289ce  0.1s
 => [builder 3/3] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,source=uv.lock,target=uv.lock     --moun  39.2s
 => [prod-cuda 3/5] COPY --from=builder-cuda /usr/local/bin/python3 /usr/local/bin/python3                                       0.0s
 => [prod-cuda 4/5] COPY --from=builder-cuda /usr/local/lib/python3.11 /usr/local/lib/python3.11                                 0.2s
 => [prod-cuda 5/5] COPY --from=builder-cuda /usr/local/lib/libpython3.11.so /usr/local/lib/libpython3.11.so                     0.1s
 => [prod 1/8] RUN apt-get update &&     apt-get install -y --no-install-recommends tini ccache libgl1 libglib2.0-0 libgomp1 t  19.3s
 => [prod 2/8] RUN ln -s "/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2" /usr/lib/libmimalloc.so.2                                 0.1s
 => [prod 3/8] WORKDIR /usr/src                                                                                                  0.0s
 => [prod 4/8] RUN cp /usr/share/zoneinfo/America/New_York /etc/localtime                                                        0.1s
 => [prod 5/8] RUN echo "hard core 0" >> /etc/security/limits.conf &&     echo "fs.suid_dumpable 0" >> /etc/sysctl.conf &&       0.1s
 => [prod 6/8] COPY --from=builder /opt/venv /opt/venv                                                                           3.8s
 => [prod 7/8] COPY scripts/healthcheck.py .                                                                                     0.3s
 => [prod 8/8] COPY immich_ml immich_ml                                                                                          0.0s
 => exporting to image                                                                                                          68.2s
 => => exporting layers                                                                                                         50.4s
 => => exporting manifest sha256:58f77f7c9eed3314a6ec23db8b8258ab42066a1241726e033576092e07c22330                                0.0s
 => => exporting config sha256:d92bd55e300be37d2fa9194cd59408a6854f4ff351ec79897db037828c6ee94a                                  0.0s
 => => exporting attestation manifest sha256:bc10b4d2a75d26787b19b9cd0740f2d11aaab7e3f04cdfbd2902341da575e3f8                    0.0s
 => => exporting manifest list sha256:423c50b82ef095ba00a12e6df682a3149d88083d62ff0a908a9fe2cbdbfff1c1                           0.0s
 => => naming to docker.io/library/immich_ml_testing-immich-machine-learning:latest                                              0.0s
 => => unpacking to docker.io/library/immich_ml_testing-immich-machine-learning:latest                                          17.7s
 => resolving provenance for metadata file                                                                                       0.0s
[+] up 4/4
 ✔ Image immich_ml_testing-immich-machine-learning Built                                                                        382.2s ✔ Network immich_ml_testing_default               Created                                                                        0.0s ✔ Volume immich_ml_testing_model-cache            Created                                                                        0.0s ✔ Container immich_machine_learning               Created                                                                        0.0sAttaching to immich_machine_learning
immich_machine_learning  | [04/29/26 09:26:19] INFO     Starting gunicorn 25.3.0                           
immich_machine_learning  | [04/29/26 09:26:19] INFO     Listening at: http://[::]:3003 (61)                
immich_machine_learning  | [04/29/26 09:26:19] INFO     Using worker: immich_ml.config.CustomUvicornWorker 
immich_machine_learning  | [04/29/26 09:26:19] INFO     Booting worker with pid: 77                        
immich_machine_learning  | [04/29/26 09:26:19] INFO     Control socket listening at                        
immich_machine_learning  |                              /root/.gunicorn/gunicorn.ctl                       
immich_machine_learning  | [04/29/26 09:26:21] INFO     Started server process [77]                        
immich_machine_learning  | [04/29/26 09:26:21] INFO     Waiting for application startup.                   
immich_machine_learning  | [04/29/26 09:26:21] INFO     Created in-memory cache with unloading after 300s  
immich_machine_learning  |                              of inactivity.                                     
immich_machine_learning  | [04/29/26 09:26:21] INFO     Initialized request thread pool with 16 threads.   
immich_machine_learning  | [04/29/26 09:26:21] INFO     Application startup complete.                      
root@docker:~/.config/immich_ml_testing# docker exec immich_machine_learning date
Wed Apr 29 09:27:30 EDT 2026
```

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
