### PR TITLE
fix(server): selectively apply metadata bitstream filter for video thumbnails

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -647,7 +647,7 @@ describe(MediaService.name, () => {
         expect.any(String),
         expect.objectContaining({
           inputOptions: expect.arrayContaining([
-            '-bsf:v',
+            '-bsf:0',
             'hevc_metadata=colour_primaries=1:matrix_coefficients=1:transfer_characteristics=1',
           ]),
           outputOptions: expect.any(Array),

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -423,14 +423,14 @@ export class ThumbnailConfig extends BaseConfig {
 
     if (metadataOverrides.length > 0) {
       // workaround for https://fftrac-bg.ffmpeg.org/ticket/11020
-      options.push('-bsf:v', `${videoStream.codecName}_metadata=${metadataOverrides.join(':')}`);
+      options.push(`-bsf:${videoStream.index}`, `${videoStream.codecName}_metadata=${metadataOverrides.join(':')}`);
     }
 
     return options;
   }
 
   getBaseOutputOptions() {
-    return ['-fps_mode', 'vfr', '-frames:v', '1', '-update', '1'];
+    return ['-map', `0:${videoStream.index}`, '-fps_mode', 'vfr', '-frames:v', '1', '-update', '1'];
   }
 
   getFilterOptions(videoStream: VideoStreamInfo): string[] {

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -430,7 +430,7 @@ export class ThumbnailConfig extends BaseConfig {
   }
 
   getBaseOutputOptions() {
-    return ['-map', `0:${videoStream.index}`, '-fps_mode', 'vfr', '-frames:v', '1', '-update', '1'];
+    return ['-fps_mode', 'vfr', '-frames:v', '1', '-update', '1'];
   }
 
   getFilterOptions(videoStream: VideoStreamInfo): string[] {


### PR DESCRIPTION
## Description

Fixes #24828

Thumbnail generation already selects a specific video stream through `VideoStreamInfo.index`, but the metadata bitstream filter was `-bsf:v`, which applies to every video stream in the input.

This can fail for valid video containers that include additional video streams. In one reproducible case, a DJI Osmo Action 6 MP4 contains a primary HEVC stream and an attached MJPEG picture stream. FFmpeg fails because `hevc_metadata` is applied to the MJPEG stream.
This change the bitstream filter to the main video stream index.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Reproduced the failure with a DJI Osmo Action 6 MP4 file.
- Confirmed the original command failed with FFmpeg applying `hevc_metadata` to the MJPEG stream.
- Applied the change locally and rebuilt the server.
- Forced thumbnail generation and confirmed that the job no longer fails with the `hevc_metadata` FFmpeg error.


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used
