### PR TITLE
fix(web): timeline scroll when pressing back from stacked asset

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -67,7 +67,7 @@
     preAction?: PreAction;
     onAction?: OnAction;
     onUndoDelete?: OnUndoDelete;
-    onClose?: (asset: AssetResponseDto) => void;
+    onClose?: (assetId: string) => void;
     onRemoveFromAlbum?: (assetIds: string[]) => void;
     onRandom?: () => Promise<{ id: string } | undefined>;
   }
@@ -179,7 +179,7 @@
   });
 
   const closeViewer = () => {
-    onClose?.(asset);
+    onClose?.(asset.id);
   };
 
   const closeEditor = async () => {
@@ -474,7 +474,7 @@
         onAction={handleAction}
         {onUndoDelete}
         onPlaySlideshow={() => ($slideshowState = SlideshowState.PlaySlideshow)}
-        onClose={onClose ? () => onClose(asset) : undefined}
+        onClose={onClose ? () => onClose(stack?.primaryAssetId ?? asset.id) : undefined}
         {onRemoveFromAlbum}
         {playOriginalVideo}
         {setPlayOriginalVideo}

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -96,9 +96,9 @@
     return { id: randomAsset.id };
   };
 
-  const handleClose = async (asset: { id: string }) => {
+  const handleClose = async (assetId: string) => {
     invisible = true;
-    assetViewerManager.gridScrollTarget = { at: asset.id };
+    assetViewerManager.gridScrollTarget = { at: assetId };
     await navigate({
       targetRoute: 'current',
       assetId: null,
@@ -117,7 +117,7 @@
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     (await navigateToAsset(assetCursor?.nextAsset)) ||
       (await navigateToAsset(assetCursor?.previousAsset)) ||
-      (await handleClose(assetCursor.current));
+      (await handleClose(assetCursor.current.id));
   };
 
   const handlePreAction = async (action: Action) => {
@@ -136,7 +136,7 @@
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         (await navigateToAsset(assetCursor?.nextAsset)) ||
           (await navigateToAsset(assetCursor?.previousAsset)) ||
-          (await handleClose(action.asset));
+          (await handleClose(action.asset.id));
 
         break;
       }


### PR DESCRIPTION
## Description
When viewing a non-primary asset in a stack, ensure that pressing the back button in the UI takes you to the correct place in the timeline (like View in Timeline does).

Fixes #28024

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Pressed back when viewing a primary asset in a stack
- [x] Pressed back when viewing a non-primary asset in a stack
- [x] Pressed back when viewing an asset not in a stack

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
