### PR TITLE
docs: add NVIDIA CDI fallback guidance

### DIFF
--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - /lib/firmware/mali_csffw.bin:/lib/firmware/mali_csffw.bin:ro # Mali firmware for your chipset (not always required depending on the driver)
       - /usr/lib/libmali.so:/usr/lib/libmali.so:ro # Mali driver for your chipset (always required)
-  
+
   rknn:
     security_opt:
       - systempaths=unconfined
@@ -24,14 +24,10 @@ services:
   cpu: {}
 
   cuda:
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities:
-                - gpu
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
   rocm:
     group_add:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -10,16 +10,10 @@ services:
   cpu: {}
 
   nvenc:
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities:
-                - gpu
-                - compute
-                - video
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
   quicksync:
     devices:

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -113,6 +113,32 @@ immich-server:
 
 Once this is done, you can continue to step 3 of "Basic Setup".
 
+For NVIDIA NVENC, use the `nvenc` section from this file:
+
+```yaml
+runtime: nvidia
+environment:
+  - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+  - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+```
+
+You can add this to the `immich-server` service instead of extending from `hwaccel.transcoding.yml`:
+
+```yaml
+immich-server:
+  container_name: immich_server
+  image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+  # Note the lack of an `extends` section
+  runtime: nvidia
+  environment:
+    - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+    - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+  volumes:
+  ...
+```
+
+Once this is done, you can continue to step 3 of "Basic Setup".
+
 #### All-In-One - Unraid Setup
 
 ##### QSV
@@ -124,10 +150,11 @@ Once this is done, you can continue to step 3 of "Basic Setup".
 
 ##### NVENC
 
-1. In the container app, add this environmental variable: Key=`NVIDIA_VISIBLE_DEVICES` Value=`all`
-2. While still in the container app, change the container from Basic Mode to Advanced Mode and add the following parameter to the Extra Parameters field: `--runtime=nvidia`
-3. Restart the container app.
-4. Continue to step 4 of "Basic Setup".
+1. In the container app, add this environmental variable: Key=`NVIDIA_VISIBLE_DEVICES` Value=`nvidia.com/gpu=all`
+2. Add this environmental variable as well: Key=`NVIDIA_DRIVER_CAPABILITIES` Value=`compute,utility,video`
+3. While still in the container app, change the container from Basic Mode to Advanced Mode and add the following parameter to the Extra Parameters field: `--runtime=nvidia`
+4. Restart the container app.
+5. Continue to step 4 of "Basic Setup".
 
 ## Tips
 

--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -101,17 +101,15 @@ You can also check the logs of the `immich-machine-learning` container. When a S
 
 Some platforms, including Unraid and Portainer, do not support multiple Compose files as of writing. As an alternative, you can "inline" the relevant contents of the [`hwaccel.ml.yml`][hw-file] file into the `immich-machine-learning` service directly.
 
+For NVIDIA on Docker Compose, use `runtime: nvidia` with `NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all`.
+
 For example, the `cuda` section in this file is:
 
 ```yaml
-deploy:
-  resources:
-    reservations:
-      devices:
-        - driver: nvidia
-          count: 1
-          capabilities:
-            - gpu
+runtime: nvidia
+environment:
+  - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+  - NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ```
 
 You can add this to the `immich-machine-learning` service instead of extending from `hwaccel.ml.yml`:
@@ -122,14 +120,10 @@ immich-machine-learning:
   # Note the `-cuda` at the end
   image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-cuda
   # Note the lack of an `extends` section
-  deploy:
-    resources:
-      reservations:
-        devices:
-          - driver: nvidia
-            count: 1
-            capabilities:
-              - gpu
+  runtime: nvidia
+  environment:
+    - NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all
+    - NVIDIA_DRIVER_CAPABILITIES=compute,utility
   volumes:
     - model-cache:/cache
   env_file:


### PR DESCRIPTION
## Summary

- document a CDI-style NVIDIA Docker Compose alternative for machine learning when the legacy reservation path fails
- update the Unraid NVENC instructions to explain when to keep the standard example and when to switch to the CDI-style alternative
- note that the CDI-style alternative requires NVIDIA Container Toolkit `v1.12.0` or newer

## Why

Newer NVIDIA Container Toolkit setups can fail when using the legacy prestart-hook path behind `deploy.resources.reservations.devices`. This keeps the existing default examples intact for older setups and adds a CDI-style fallback for hosts where the legacy path is broken.

## Testing

- `ruby -e "require 'yaml'; %w[docker/hwaccel.ml.yml docker/hwaccel.transcoding.yml].each { |f| YAML.load_file(f); puts \"OK #{f}\" }"`
- `npx --yes prettier --check docs/docs/features/ml-hardware-acceleration.md docs/docs/features/hardware-transcoding.md docker/hwaccel.ml.yml docker/hwaccel.transcoding.yml`
