### PR TITLE
fix: update person name after merging faces

### DIFF
--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -139,6 +139,7 @@
     await updateAssetCount();
     await handleGoBack();
 
+    personName = person.name || '';
     data = { ...data, person };
   };
 


### PR DESCRIPTION
## Description

Fixes a bug where the person name is not updated in the UI after merging faces. When merging faces, the `person` object is updated but the `personName` variable (used by the rename dialog) is not synchronized, causing the rename dialog to show the old name instead of the merged person's name.

## Changes

- Added `personName` synchronization in the `handleMerge` function
- Ensures the UI reflects the correct merged person name immediately after merge

## Testing

1. Navigate to a person's page
2. Merge with another person
3. Try to rename the merged person
4. The rename dialog should now show the correct merged person's name

Fixes #26019