### PR TITLE
fix: update person name after merging faces

### DIFF
--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -139,6 +139,7 @@
     await updateAssetCount();
     await handleGoBack();
 
+    personName = person.name || '';
     data = { ...data, person };
   };
 


### PR DESCRIPTION
## Description

Fixes a bug where renaming a person fails after merging faces. The `personName` variable in the component state was not being updated after a merge operation, causing the rename functionality to use stale data.

**Root cause:** When faces are merged in `handleMerge()`, the `person` object gets updated but `personName` doesn't sync, so subsequent rename attempts send the old name to the API.

**Solution:** Added `personName = person.name || '';` to synchronize state after merge.

Fixes #26019

## How Has This Been Tested?

- [x] Reproduced the bug: merged two people, tried to rename, observed it failed
- [x] Applied the fix locally
- [x] Verified rename works immediately after merge without page refresh
- [x] Checked that personName stays in sync with person.name throughout the component lifecycle

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A - This is a state synchronization fix with no visual changes

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help understand the Svelte 5 reactive state patterns in the codebase and to trace through the merge flow to identify where the state synchronization was breaking. The actual fix (adding the personName sync line) was straightforward once the root cause was identified.