### PR TITLE
feat(server)!: add isOwned filter to albums API

### DIFF
--- a/e2e/src/specs/server/api/album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/album.e2e-spec.ts
@@ -146,7 +146,7 @@ describe('/albums', () => {
 
     it('should not return shared albums with a deleted owner', async () => {
       const { status, body } = await request(app)
-        .get('/albums?shared=true')
+        .get('/albums?isShared=true')
         .set('Authorization', `Bearer ${user1.accessToken}`);
 
       expect(status).toBe(200);
@@ -230,9 +230,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return the album collection filtered by shared', async () => {
+    it('should return the album collection filtered by isShared', async () => {
       const { status, body } = await request(app)
-        .get('/albums?shared=true')
+        .get('/albums?isShared=true')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(4);
@@ -270,9 +270,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return the album collection filtered by NOT shared', async () => {
+    it('should return the album collection filtered by NOT isShared', async () => {
       const { status, body } = await request(app)
-        .get('/albums?shared=false')
+        .get('/albums?isShared=false')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(1);
@@ -289,9 +289,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return only owned albums when filtered by owned=true', async () => {
+    it('should return only owned albums when filtered by isOwned=true', async () => {
       const { status, body } = await request(app)
-        .get('/albums?owned=true')
+        .get('/albums?isOwned=true')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(4);
@@ -305,9 +305,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return only shared-with-me albums when filtered by owned=false', async () => {
+    it('should return only shared-with-me albums when filtered by isOwned=false', async () => {
       const { status, body } = await request(app)
-        .get('/albums?owned=false')
+        .get('/albums?isOwned=false')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(1);
@@ -323,9 +323,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return owned shared-out albums when filtered by owned=true&shared=true', async () => {
+    it('should return owned shared-out albums when filtered by isOwned=true&ishared=true', async () => {
       const { status, body } = await request(app)
-        .get('/albums?owned=true&shared=true')
+        .get('/albums?isOwned=true&isShared=true')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(3);
@@ -338,9 +338,9 @@ describe('/albums', () => {
       );
     });
 
-    it('should return empty list when filtered by owned=false&shared=false', async () => {
+    it('should return empty list when filtered by isOwned=false&isShared=false', async () => {
       const { status, body } = await request(app)
-        .get('/albums?owned=false&shared=false')
+        .get('/albums?isOwned=false&isShared=false')
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(0);
@@ -354,17 +354,17 @@ describe('/albums', () => {
       expect(body).toHaveLength(2);
     });
 
-    it('should return the album collection filtered by assetId and ignores shared=true', async () => {
+    it('should return the album collection filtered by assetId and ignores isShared=true', async () => {
       const { status, body } = await request(app)
-        .get(`/albums?shared=true&assetId=${user1Asset1.id}`)
+        .get(`/albums?isShared=true&assetId=${user1Asset1.id}`)
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(5);
     });
 
-    it('should return the album collection filtered by assetId and ignores shared=false', async () => {
+    it('should return the album collection filtered by assetId and ignores isShared=false', async () => {
       const { status, body } = await request(app)
-        .get(`/albums?shared=false&assetId=${user1Asset1.id}`)
+        .get(`/albums?isShared=false&assetId=${user1Asset1.id}`)
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
       expect(body).toHaveLength(5);

--- a/e2e/src/specs/server/api/album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/album.e2e-spec.ts
@@ -188,7 +188,7 @@ describe('/albums', () => {
     it('should return the album collection including owned and shared', async () => {
       const { status, body } = await request(app).get('/albums').set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toBe(200);
-      expect(body).toHaveLength(4);
+      expect(body).toHaveLength(5);
       expect(body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -218,6 +218,13 @@ describe('/albums', () => {
               { role: AlbumUserRole.Owner, user: expect.objectContaining({ id: user1.userId }) },
             ]),
             shared: false,
+          }),
+          expect.objectContaining({
+            albumName: user2SharedUser,
+            albumUsers: expect.arrayContaining([
+              { role: AlbumUserRole.Owner, user: expect.objectContaining({ id: user2.userId }) },
+            ]),
+            shared: true,
           }),
         ]),
       );
@@ -280,6 +287,63 @@ describe('/albums', () => {
           }),
         ]),
       );
+    });
+
+    it('should return only owned albums when filtered by owned=true', async () => {
+      const { status, body } = await request(app)
+        .get('/albums?owned=true')
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+      expect(status).toBe(200);
+      expect(body).toHaveLength(4);
+      expect(body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ albumName: user1SharedEditorUser }),
+          expect.objectContaining({ albumName: user1SharedViewerUser }),
+          expect.objectContaining({ albumName: user1SharedLink }),
+          expect.objectContaining({ albumName: user1NotShared }),
+        ]),
+      );
+    });
+
+    it('should return only shared-with-me albums when filtered by owned=false', async () => {
+      const { status, body } = await request(app)
+        .get('/albums?owned=false')
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+      expect(status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            albumName: user2SharedUser,
+            albumUsers: expect.arrayContaining([
+              { role: AlbumUserRole.Owner, user: expect.objectContaining({ id: user2.userId }) },
+            ]),
+          }),
+        ]),
+      );
+    });
+
+    it('should return owned shared-out albums when filtered by owned=true&shared=true', async () => {
+      const { status, body } = await request(app)
+        .get('/albums?owned=true&shared=true')
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+      expect(status).toBe(200);
+      expect(body).toHaveLength(3);
+      expect(body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ albumName: user1SharedEditorUser }),
+          expect.objectContaining({ albumName: user1SharedViewerUser }),
+          expect.objectContaining({ albumName: user1SharedLink }),
+        ]),
+      );
+    });
+
+    it('should return empty list when filtered by owned=false&shared=false', async () => {
+      const { status, body } = await request(app)
+        .get('/albums?owned=false&shared=false')
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+      expect(status).toBe(200);
+      expect(body).toHaveLength(0);
     });
 
     it('should return the album collection filtered by assetId', async () => {

--- a/e2e/src/ui/mock-network/base-network.ts
+++ b/e2e/src/ui/mock-network/base-network.ts
@@ -240,7 +240,8 @@ export const setupBaseMockApiRoutes = async (context: BrowserContext, adminUserI
     });
   });
   await context.route('**/api/albums*', async (route, request) => {
-    if (request.url().endsWith('albums?isShared=true') || request.url().endsWith('albums')) {
+    const url = request.url();
+    if (url.endsWith('albums?isShared=true') || url.endsWith('albums?isOwned=true') || url.endsWith('albums')) {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/e2e/src/ui/mock-network/base-network.ts
+++ b/e2e/src/ui/mock-network/base-network.ts
@@ -240,7 +240,7 @@ export const setupBaseMockApiRoutes = async (context: BrowserContext, adminUserI
     });
   });
   await context.route('**/api/albums*', async (route, request) => {
-    if (request.url().endsWith('albums?shared=true') || request.url().endsWith('albums')) {
+    if (request.url().endsWith('albums?isShared=true') || request.url().endsWith('albums')) {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/mobile/openapi/lib/api/albums_api.dart
+++ b/mobile/openapi/lib/api/albums_api.dart
@@ -506,11 +506,14 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [String] assetId:
-  ///   Filter albums containing this asset ID (ignores shared parameter)
+  ///   Filter albums containing this asset ID (ignores other parameters)
+  ///
+  /// * [bool] owned:
+  ///   Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter
   ///
   /// * [bool] shared:
-  ///   Filter by shared status: true = only shared, false = not shared, undefined = all owned albums
-  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, bool? shared, }) async {
+  ///   Filter by shared status: true = only shared, false = not shared, undefined = no filter
+  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, bool? owned, bool? shared, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums';
 
@@ -523,6 +526,9 @@ class AlbumsApi {
 
     if (assetId != null) {
       queryParams.addAll(_queryParams('', 'assetId', assetId));
+    }
+    if (owned != null) {
+      queryParams.addAll(_queryParams('', 'owned', owned));
     }
     if (shared != null) {
       queryParams.addAll(_queryParams('', 'shared', shared));
@@ -549,12 +555,15 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [String] assetId:
-  ///   Filter albums containing this asset ID (ignores shared parameter)
+  ///   Filter albums containing this asset ID (ignores other parameters)
+  ///
+  /// * [bool] owned:
+  ///   Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter
   ///
   /// * [bool] shared:
-  ///   Filter by shared status: true = only shared, false = not shared, undefined = all owned albums
-  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, bool? shared, }) async {
-    final response = await getAllAlbumsWithHttpInfo( assetId: assetId, shared: shared, );
+  ///   Filter by shared status: true = only shared, false = not shared, undefined = no filter
+  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, bool? owned, bool? shared, }) async {
+    final response = await getAllAlbumsWithHttpInfo( assetId: assetId, owned: owned, shared: shared, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/albums_api.dart
+++ b/mobile/openapi/lib/api/albums_api.dart
@@ -499,7 +499,7 @@ class AlbumsApi {
 
   /// List all albums
   ///
-  /// Retrieve a list of albums available to the authenticated user. Results are filtered by the `owned` and `shared` query parameters:  | `owned` | `shared` | Result | |---------|----------|--------| | — | — | All accessible albums (owned + shared-with-me) | | `true` | — | Only albums owned by the user | | `false` | — | Only albums shared with the user (not owned) | | `true` | `true` | Owned albums that have been shared out | | `true` | `false` | Owned private albums (not shared) | | — | `true` | Owned albums shared out, plus all albums shared with the user | | — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) | | `false` | `true` | Albums shared with the user (same as `owned=false`) | | `false` | `false` | Empty (logically impossible combination) |
+  /// Retrieve a list of albums available to the authenticated user.
   ///
   /// Note: This method returns the HTTP [Response].
   ///
@@ -550,7 +550,7 @@ class AlbumsApi {
 
   /// List all albums
   ///
-  /// Retrieve a list of albums available to the authenticated user. Results are filtered by the `owned` and `shared` query parameters:  | `owned` | `shared` | Result | |---------|----------|--------| | — | — | All accessible albums (owned + shared-with-me) | | `true` | — | Only albums owned by the user | | `false` | — | Only albums shared with the user (not owned) | | `true` | `true` | Owned albums that have been shared out | | `true` | `false` | Owned private albums (not shared) | | — | `true` | Owned albums shared out, plus all albums shared with the user | | — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) | | `false` | `true` | Albums shared with the user (same as `owned=false`) | | `false` | `false` | Empty (logically impossible combination) |
+  /// Retrieve a list of albums available to the authenticated user.
   ///
   /// Parameters:
   ///

--- a/mobile/openapi/lib/api/albums_api.dart
+++ b/mobile/openapi/lib/api/albums_api.dart
@@ -508,12 +508,12 @@ class AlbumsApi {
   /// * [String] assetId:
   ///   Filter albums containing this asset ID (ignores other parameters)
   ///
-  /// * [bool] owned:
+  /// * [bool] isOwned:
   ///   Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter
   ///
-  /// * [bool] shared:
+  /// * [bool] isShared:
   ///   Filter by shared status: true = only shared, false = not shared, undefined = no filter
-  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, bool? owned, bool? shared, }) async {
+  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, bool? isOwned, bool? isShared, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums';
 
@@ -527,11 +527,11 @@ class AlbumsApi {
     if (assetId != null) {
       queryParams.addAll(_queryParams('', 'assetId', assetId));
     }
-    if (owned != null) {
-      queryParams.addAll(_queryParams('', 'owned', owned));
+    if (isOwned != null) {
+      queryParams.addAll(_queryParams('', 'isOwned', isOwned));
     }
-    if (shared != null) {
-      queryParams.addAll(_queryParams('', 'shared', shared));
+    if (isShared != null) {
+      queryParams.addAll(_queryParams('', 'isShared', isShared));
     }
 
     const contentTypes = <String>[];
@@ -557,13 +557,13 @@ class AlbumsApi {
   /// * [String] assetId:
   ///   Filter albums containing this asset ID (ignores other parameters)
   ///
-  /// * [bool] owned:
+  /// * [bool] isOwned:
   ///   Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter
   ///
-  /// * [bool] shared:
+  /// * [bool] isShared:
   ///   Filter by shared status: true = only shared, false = not shared, undefined = no filter
-  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, bool? owned, bool? shared, }) async {
-    final response = await getAllAlbumsWithHttpInfo( assetId: assetId, owned: owned, shared: shared, );
+  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, bool? isOwned, bool? isShared, }) async {
+    final response = await getAllAlbumsWithHttpInfo( assetId: assetId, isOwned: isOwned, isShared: isShared, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/albums_api.dart
+++ b/mobile/openapi/lib/api/albums_api.dart
@@ -499,7 +499,7 @@ class AlbumsApi {
 
   /// List all albums
   ///
-  /// Retrieve a list of albums available to the authenticated user.
+  /// Retrieve a list of albums available to the authenticated user. Results are filtered by the `owned` and `shared` query parameters:  | `owned` | `shared` | Result | |---------|----------|--------| | — | — | All accessible albums (owned + shared-with-me) | | `true` | — | Only albums owned by the user | | `false` | — | Only albums shared with the user (not owned) | | `true` | `true` | Owned albums that have been shared out | | `true` | `false` | Owned private albums (not shared) | | — | `true` | Owned albums shared out, plus all albums shared with the user | | — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) | | `false` | `true` | Albums shared with the user (same as `owned=false`) | | `false` | `false` | Empty (logically impossible combination) |
   ///
   /// Note: This method returns the HTTP [Response].
   ///
@@ -550,7 +550,7 @@ class AlbumsApi {
 
   /// List all albums
   ///
-  /// Retrieve a list of albums available to the authenticated user.
+  /// Retrieve a list of albums available to the authenticated user. Results are filtered by the `owned` and `shared` query parameters:  | `owned` | `shared` | Result | |---------|----------|--------| | — | — | All accessible albums (owned + shared-with-me) | | `true` | — | Only albums owned by the user | | `false` | — | Only albums shared with the user (not owned) | | `true` | `true` | Owned albums that have been shared out | | `true` | `false` | Owned private albums (not shared) | | — | `true` | Owned albums shared out, plus all albums shared with the user | | — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) | | `false` | `true` | Albums shared with the user (same as `owned=false`) | | `false` | `false` | Empty (logically impossible combination) |
   ///
   /// Parameters:
   ///

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1641,7 +1641,7 @@
             "name": "assetId",
             "required": false,
             "in": "query",
-            "description": "Filter albums containing this asset ID (ignores shared parameter)",
+            "description": "Filter albums containing this asset ID (ignores other parameters)",
             "schema": {
               "format": "uuid",
               "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
@@ -1649,10 +1649,19 @@
             }
           },
           {
+            "name": "owned",
+            "required": false,
+            "in": "query",
+            "description": "Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "shared",
             "required": false,
             "in": "query",
-            "description": "Filter by shared status: true = only shared, false = not shared, undefined = all owned albums",
+            "description": "Filter by shared status: true = only shared, false = not shared, undefined = no filter",
             "schema": {
               "type": "boolean"
             }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1649,7 +1649,7 @@
             }
           },
           {
-            "name": "owned",
+            "name": "isOwned",
             "required": false,
             "in": "query",
             "description": "Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter",
@@ -1658,7 +1658,7 @@
             }
           },
           {
-            "name": "shared",
+            "name": "isShared",
             "required": false,
             "in": "query",
             "description": "Filter by shared status: true = only shared, false = not shared, undefined = no filter",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1634,7 +1634,7 @@
     },
     "/albums": {
       "get": {
-        "description": "Retrieve a list of albums available to the authenticated user.\nResults are filtered by the `owned` and `shared` query parameters:\n\n| `owned` | `shared` | Result |\n|---------|----------|--------|\n| — | — | All accessible albums (owned + shared-with-me) |\n| `true` | — | Only albums owned by the user |\n| `false` | — | Only albums shared with the user (not owned) |\n| `true` | `true` | Owned albums that have been shared out |\n| `true` | `false` | Owned private albums (not shared) |\n| — | `true` | Owned albums shared out, plus all albums shared with the user |\n| — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) |\n| `false` | `true` | Albums shared with the user (same as `owned=false`) |\n| `false` | `false` | Empty (logically impossible combination) |",
+        "description": "Retrieve a list of albums available to the authenticated user.",
         "operationId": "getAllAlbums",
         "parameters": [
           {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1634,7 +1634,7 @@
     },
     "/albums": {
       "get": {
-        "description": "Retrieve a list of albums available to the authenticated user.",
+        "description": "Retrieve a list of albums available to the authenticated user.\nResults are filtered by the `owned` and `shared` query parameters:\n\n| `owned` | `shared` | Result |\n|---------|----------|--------|\n| — | — | All accessible albums (owned + shared-with-me) |\n| `true` | — | Only albums owned by the user |\n| `false` | — | Only albums shared with the user (not owned) |\n| `true` | `true` | Owned albums that have been shared out |\n| `true` | `false` | Owned private albums (not shared) |\n| — | `true` | Owned albums shared out, plus all albums shared with the user |\n| — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) |\n| `false` | `true` | Albums shared with the user (same as `owned=false`) |\n| `false` | `false` | Empty (logically impossible combination) |",
         "operationId": "getAllAlbums",
         "parameters": [
           {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3657,8 +3657,9 @@ export function getUserStatisticsAdmin({ id, isFavorite, isTrashed, visibility }
 /**
  * List all albums
  */
-export function getAllAlbums({ assetId, shared }: {
+export function getAllAlbums({ assetId, owned, shared }: {
     assetId?: string;
+    owned?: boolean;
     shared?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
@@ -3666,6 +3667,7 @@ export function getAllAlbums({ assetId, shared }: {
         data: AlbumResponseDto[];
     }>(`/albums${QS.query(QS.explode({
         assetId,
+        owned,
         shared
     }))}`, {
         ...opts

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3657,18 +3657,18 @@ export function getUserStatisticsAdmin({ id, isFavorite, isTrashed, visibility }
 /**
  * List all albums
  */
-export function getAllAlbums({ assetId, owned, shared }: {
+export function getAllAlbums({ assetId, isOwned, isShared }: {
     assetId?: string;
-    owned?: boolean;
-    shared?: boolean;
+    isOwned?: boolean;
+    isShared?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: AlbumResponseDto[];
     }>(`/albums${QS.query(QS.explode({
         assetId,
-        owned,
-        shared
+        isOwned,
+        isShared
     }))}`, {
         ...opts
     }));

--- a/server/src/controllers/album.controller.spec.ts
+++ b/server/src/controllers/album.controller.spec.ts
@@ -25,11 +25,11 @@ describe(AlbumController.name, () => {
     });
 
     it('should reject an invalid shared param', async () => {
-      const { status, body } = await request(ctx.getHttpServer()).get('/albums?shared=invalid');
+      const { status, body } = await request(ctx.getHttpServer()).get('/albums?isShared=invalid');
       expect(status).toEqual(400);
       expect(body).toEqual(
         factory.responses.validationError([
-          { path: ['shared'], message: 'Invalid option: expected one of "true"|"false"' },
+          { path: ['isShared'], message: 'Invalid option: expected one of "true"|"false"' },
         ]),
       );
     });

--- a/server/src/controllers/album.controller.ts
+++ b/server/src/controllers/album.controller.ts
@@ -29,22 +29,7 @@ export class AlbumController {
   @Authenticated({ permission: Permission.AlbumRead })
   @Endpoint({
     summary: 'List all albums',
-    description: [
-      'Retrieve a list of albums available to the authenticated user.',
-      'Results are filtered by the `owned` and `shared` query parameters:',
-      '',
-      '| `owned` | `shared` | Result |',
-      '|---------|----------|--------|',
-      '| — | — | All accessible albums (owned + shared-with-me) |',
-      '| `true` | — | Only albums owned by the user |',
-      '| `false` | — | Only albums shared with the user (not owned) |',
-      '| `true` | `true` | Owned albums that have been shared out |',
-      '| `true` | `false` | Owned private albums (not shared) |',
-      '| — | `true` | Owned albums shared out, plus all albums shared with the user |',
-      '| — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) |',
-      '| `false` | `true` | Albums shared with the user (same as `owned=false`) |',
-      '| `false` | `false` | Empty (logically impossible combination) |',
-    ].join('\n'),
+    description: 'Retrieve a list of albums available to the authenticated user.',
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
   getAllAlbums(@Auth() auth: AuthDto, @Query() query: GetAlbumsDto): Promise<AlbumResponseDto[]> {

--- a/server/src/controllers/album.controller.ts
+++ b/server/src/controllers/album.controller.ts
@@ -29,7 +29,22 @@ export class AlbumController {
   @Authenticated({ permission: Permission.AlbumRead })
   @Endpoint({
     summary: 'List all albums',
-    description: 'Retrieve a list of albums available to the authenticated user.',
+    description: [
+      'Retrieve a list of albums available to the authenticated user.',
+      'Results are filtered by the `owned` and `shared` query parameters:',
+      '',
+      '| `owned` | `shared` | Result |',
+      '|---------|----------|--------|',
+      '| — | — | All accessible albums (owned + shared-with-me) |',
+      '| `true` | — | Only albums owned by the user |',
+      '| `false` | — | Only albums shared with the user (not owned) |',
+      '| `true` | `true` | Owned albums that have been shared out |',
+      '| `true` | `false` | Owned private albums (not shared) |',
+      '| — | `true` | Owned albums shared out, plus all albums shared with the user |',
+      '| — | `false` | Owned private albums only (albums shared with the user are always excluded because the user is a non-owner member) |',
+      '| `false` | `true` | Albums shared with the user (same as `owned=false`) |',
+      '| `false` | `false` | Empty (logically impossible combination) |',
+    ].join('\n'),
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
   getAllAlbums(@Auth() auth: AuthDto, @Query() query: GetAlbumsDto): Promise<AlbumResponseDto[]> {

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -65,10 +65,13 @@ const UpdateAlbumSchema = z
 
 const GetAlbumsSchema = z
   .object({
+    owned: stringToBool
+      .optional()
+      .describe('Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter'),
     shared: stringToBool
       .optional()
-      .describe('Filter by shared status: true = only shared, false = not shared, undefined = all owned albums'),
-    assetId: z.uuidv4().optional().describe('Filter albums containing this asset ID (ignores shared parameter)'),
+      .describe('Filter by shared status: true = only shared, false = not shared, undefined = no filter'),
+    assetId: z.uuidv4().optional().describe('Filter albums containing this asset ID (ignores other parameters)'),
   })
   .meta({ id: 'GetAlbumsDto' });
 

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -65,10 +65,10 @@ const UpdateAlbumSchema = z
 
 const GetAlbumsSchema = z
   .object({
-    owned: stringToBool
+    isOwned: stringToBool
       .optional()
       .describe('Filter by ownership: true = only owned, false = only shared-with-me, undefined = no filter'),
-    shared: stringToBool
+    isShared: stringToBool
       .optional()
       .describe('Filter by shared status: true = only shared, false = not shared, undefined = no filter'),
     assetId: z.uuidv4().optional().describe('Filter albums containing this asset ID (ignores other parameters)'),

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -244,18 +244,10 @@ from
   and "album_user"."userId" = $2
 where
   "album"."deletedAt" is null
-  and exists (
-    select
-    from
-      "album_user" as "au"
-    where
-      "au"."albumId" = "album"."id"
-      and "au"."role" = 'owner'
-  )
 order by
   "album"."createdAt" desc
 
--- AlbumRepository.getAll
+-- AlbumRepository.getAllIds
 select
   "album"."id"
 from
@@ -264,14 +256,6 @@ from
   and "album_user"."userId" = $1
 where
   "album"."deletedAt" is null
-  and exists (
-    select
-    from
-      "album_user" as "au"
-    where
-      "au"."albumId" = "album"."id"
-      and "au"."role" = 'owner'
-  )
 order by
   "album"."createdAt" desc
 

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -244,6 +244,24 @@ from
   and "album_user"."userId" = $2
 where
   "album"."deletedAt" is null
+  and "album_user"."role" = 'owner'
+  and (
+    exists (
+      select
+      from
+        "album_user" as "au"
+      where
+        "au"."albumId" = "album"."id"
+        and "au"."role" != 'owner'
+    )
+    or exists (
+      select
+      from
+        "shared_link"
+      where
+        "shared_link"."albumId" = "album"."id"
+    )
+  )
 order by
   "album"."createdAt" desc
 
@@ -256,6 +274,24 @@ from
   and "album_user"."userId" = $1
 where
   "album"."deletedAt" is null
+  and "album_user"."role" = 'owner'
+  and (
+    exists (
+      select
+      from
+        "album_user" as "au"
+      where
+        "au"."albumId" = "album"."id"
+        and "au"."role" != 'owner'
+    )
+    or exists (
+      select
+      from
+        "shared_link"
+      where
+        "shared_link"."albumId" = "album"."id"
+    )
+  )
 order by
   "album"."createdAt" desc
 

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -185,7 +185,7 @@ where
 group by
   "album_asset"."albumId"
 
--- AlbumRepository.getOwned
+-- AlbumRepository.getAll
 select
   "album".*,
   (
@@ -242,172 +242,35 @@ from
   "album"
   inner join "album_user" on "album_user"."albumId" = "album"."id"
   and "album_user"."userId" = $2
-  and "album_user"."role" = 'owner'
 where
   "album"."deletedAt" is null
-order by
-  "album"."createdAt" desc
-
--- AlbumRepository.getShared
-select
-  "album".*,
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "album_user"."role",
-          (
-            select
-              to_json(obj)
-            from
-              (
-                select
-                  "id",
-                  "name",
-                  "email",
-                  "avatarColor",
-                  "profileImagePath",
-                  "profileChangedAt"
-                from
-                  (
-                    select
-                      1
-                  ) as "dummy"
-              ) as obj
-          ) as "user"
-        from
-          "album_user"
-          inner join "user" on "user"."id" = "album_user"."userId"
-        where
-          "album_user"."albumId" = "album"."id"
-        order by
-          "album_user"."role",
-          "album_user"."userId" = $1 desc,
-          "user"."name" asc
-      ) as agg
-  ) as "albumUsers",
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "shared_link".*
-        from
-          "shared_link"
-        where
-          "shared_link"."albumId" = "album"."id"
-      ) as agg
-  ) as "sharedLinks"
-from
-  "album"
-  inner join (
-    select
-      "album_user"."albumId" as "id"
-    from
-      "album_user"
-    where
-      "album_user"."userId" = $2
-      and "album_user"."albumId" in (
-        select
-          "album_user"."albumId"
-        from
-          "album_user"
-        where
-          "album_user"."role" != 'owner'
-      )
-    union
-    select
-      "shared_link"."albumId" as "id"
-    from
-      "shared_link"
-    where
-      "shared_link"."userId" = $3
-      and "shared_link"."albumId" is not null
-  ) as "matching" on "matching"."id" = "album"."id"
-  inner join "album_user" on "album_user"."albumId" = "album"."id"
-  and "album_user"."role" = 'owner'
-where
-  "album"."deletedAt" is null
-order by
-  "album"."createdAt" desc
-
--- AlbumRepository.getNotShared
-select
-  "album".*,
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "shared_link".*
-        from
-          "shared_link"
-        where
-          "shared_link"."albumId" = "album"."id"
-      ) as agg
-  ) as "sharedLinks",
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "album_user"."role",
-          (
-            select
-              to_json(obj)
-            from
-              (
-                select
-                  "id",
-                  "name",
-                  "email",
-                  "avatarColor",
-                  "profileImagePath",
-                  "profileChangedAt"
-                from
-                  (
-                    select
-                      1
-                  ) as "dummy"
-              ) as obj
-          ) as "user"
-        from
-          "album_user"
-          inner join "user" on "user"."id" = "album_user"."userId"
-        where
-          "album_user"."albumId" = "album"."id"
-        order by
-          "album_user"."role",
-          "album_user"."userId" = $1 desc,
-          "user"."name" asc
-      ) as agg
-  ) as "albumUsers"
-from
-  "album"
-  inner join "album_user" on "album_user"."albumId" = "album"."id"
-  and "album_user"."userId" = $2
-  and "album_user"."role" = 'owner'
-where
-  "album"."deletedAt" is null
-  and not exists (
+  and exists (
     select
     from
       "album_user" as "au"
     where
       "au"."albumId" = "album"."id"
-      and "au"."role" != 'owner'
+      and "au"."role" = 'owner'
   )
-  and not exists (
+order by
+  "album"."createdAt" desc
+
+-- AlbumRepository.getAll
+select
+  "album"."id"
+from
+  "album"
+  inner join "album_user" on "album_user"."albumId" = "album"."id"
+  and "album_user"."userId" = $1
+where
+  "album"."deletedAt" is null
+  and exists (
     select
     from
-      "shared_link"
+      "album_user" as "au"
     where
-      "shared_link"."albumId" = "album"."id"
+      "au"."albumId" = "album"."id"
+      and "au"."role" = 'owner'
   )
 order by
   "album"."createdAt" desc

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -214,7 +214,10 @@ export class AlbumRepository {
       .$if(shared === false, (qb) => qb.where((eb) => eb.not(hasAlbumSharedStatus(eb))));
   }
 
-  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean; select: ['id'] }): Promise<Pick<Selectable<AlbumTable>, 'id'>[]>;
+  getAll(
+    ownerId: string,
+    options: { owned?: boolean; shared?: boolean; select: ['id'] },
+  ): Promise<Pick<Selectable<AlbumTable>, 'id'>[]>;
   getAll(ownerId: string, options: { owned?: boolean; shared?: boolean }): Promise<MapAlbumDto[]>;
   @GenerateSql({ params: [DummyValue.UUID, {}] }, { params: [DummyValue.UUID, { select: ['id'] }] })
   getAll(ownerId: string, { owned, shared, select }: { owned?: boolean; shared?: boolean; select?: string[] }) {

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -208,7 +208,7 @@ export class AlbumRepository {
       );
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, {}] })
+  @GenerateSql({ params: [DummyValue.UUID, { isOwned: true, isShared: true }] })
   getAll(ownerId: string, options: { isOwned?: boolean; isShared?: boolean } = {}): Promise<MapAlbumDto[]> {
     return this.buildAlbumBaseQuery(ownerId, options)
       .selectAll('album')
@@ -218,7 +218,7 @@ export class AlbumRepository {
       .execute();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, {}] })
+  @GenerateSql({ params: [DummyValue.UUID, { isOwned: true, isShared: true }] })
   async getAllIds(ownerId: string, options: { isOwned?: boolean; isShared?: boolean } = {}): Promise<string[]> {
     const rows = await this.buildAlbumBaseQuery(ownerId, options)
       .select('album.id')

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -184,17 +184,6 @@ export class AlbumRepository {
   }
 
   private buildAlbumBaseQuery(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
-    const isShared = (eb: ExpressionBuilder<DB, 'album' | 'album_user'>) =>
-      eb.or([
-        eb.exists(
-          eb
-            .selectFrom('album_user as au')
-            .whereRef('au.albumId', '=', 'album.id')
-            .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
-        ),
-        eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
-      ]);
-
     return this.db
       .selectFrom('album')
       .innerJoin('album_user', (join) =>
@@ -203,8 +192,20 @@ export class AlbumRepository {
       .where('album.deletedAt', 'is', null)
       .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
       .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
-      .$if(shared === true, (qb) => qb.where(isShared))
-      .$if(shared === false, (qb) => qb.where((eb) => eb.not(isShared(eb))));
+      .$if(shared !== undefined, (qb) =>
+        qb.where((eb) => {
+          const isShared = eb.or([
+            eb.exists(
+              eb
+                .selectFrom('album_user as au')
+                .whereRef('au.albumId', '=', 'album.id')
+                .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+            ),
+            eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+          ]);
+          return shared ? isShared : eb.not(isShared);
+        }),
+      );
   }
 
   @GenerateSql({ params: [DummyValue.UUID, {}] })

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -82,6 +82,17 @@ const isAlbumOwned = (ownerId: string) => (eb: ExpressionBuilder<DB, 'album'>) =
       .where('album_user.userId', '=', ownerId),
   );
 
+const hasAlbumSharedStatus = (eb: ExpressionBuilder<DB, 'album'>) =>
+  eb.or([
+    eb.exists(
+      eb
+        .selectFrom('album_user as au')
+        .whereRef('au.albumId', '=', 'album.id')
+        .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+    ),
+    eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+  ]);
+
 @Injectable()
 export class AlbumRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
@@ -201,32 +212,8 @@ export class AlbumRepository {
       )
       .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
       .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
-      .$if(shared === true, (qb) =>
-        qb.where(({ or, exists, selectFrom }) =>
-          or([
-            exists(
-              selectFrom('album_user as au')
-                .whereRef('au.albumId', '=', 'album.id')
-                .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
-            ),
-            exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
-          ]),
-        ),
-      )
-      .$if(shared === false, (qb) =>
-        qb.where(({ not, or, exists, selectFrom }) =>
-          not(
-            or([
-              exists(
-                selectFrom('album_user as au')
-                  .whereRef('au.albumId', '=', 'album.id')
-                  .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
-              ),
-              exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
-            ]),
-          ),
-        ),
-      )
+      .$if(shared === true, (qb) => qb.where(hasAlbumSharedStatus))
+      .$if(shared === false, (qb) => qb.where((eb) => eb.not(hasAlbumSharedStatus(eb))))
       .select(withAlbumUsers(ownerId))
       .select(withSharedLink)
       .orderBy('album.createdAt', 'desc')

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -183,18 +183,18 @@ export class AlbumRepository {
     );
   }
 
-  private buildAlbumBaseQuery(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
+  private buildAlbumBaseQuery(ownerId: string, { isOwned, isShared }: { isOwned?: boolean; isShared?: boolean }) {
     return this.db
       .selectFrom('album')
       .innerJoin('album_user', (join) =>
         join.onRef('album_user.albumId', '=', 'album.id').on('album_user.userId', '=', ownerId),
       )
       .where('album.deletedAt', 'is', null)
-      .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
-      .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
-      .$if(shared !== undefined, (qb) =>
+      .$if(isOwned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
+      .$if(isOwned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
+      .$if(isShared !== undefined, (qb) =>
         qb.where((eb) => {
-          const isShared = eb.or([
+          const isSharedAlbum = eb.or([
             eb.exists(
               eb
                 .selectFrom('album_user as au')
@@ -203,13 +203,13 @@ export class AlbumRepository {
             ),
             eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
           ]);
-          return shared ? isShared : eb.not(isShared);
+          return isShared ? isSharedAlbum : eb.not(isSharedAlbum);
         }),
       );
   }
 
   @GenerateSql({ params: [DummyValue.UUID, {}] })
-  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean } = {}): Promise<MapAlbumDto[]> {
+  getAll(ownerId: string, options: { isOwned?: boolean; isShared?: boolean } = {}): Promise<MapAlbumDto[]> {
     return this.buildAlbumBaseQuery(ownerId, options)
       .selectAll('album')
       .select(withAlbumUsers(ownerId))
@@ -219,7 +219,7 @@ export class AlbumRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID, {}] })
-  async getAllIds(ownerId: string, options: { owned?: boolean; shared?: boolean } = {}): Promise<string[]> {
+  async getAllIds(ownerId: string, options: { isOwned?: boolean; isShared?: boolean } = {}): Promise<string[]> {
     const rows = await this.buildAlbumBaseQuery(ownerId, options)
       .select('album.id')
       .orderBy('album.createdAt', 'desc')

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -13,7 +13,7 @@ import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
 import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { Chunked, ChunkedArray, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
-import { AlbumUserCreateDto } from 'src/dtos/album.dto';
+import { AlbumUserCreateDto, MapAlbumDto } from 'src/dtos/album.dto';
 import { AlbumUserRole } from 'src/enum';
 import { DB } from 'src/schema';
 import { AlbumTable } from 'src/schema/tables/album.table';
@@ -194,11 +194,9 @@ export class AlbumRepository {
     );
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, {}] })
-  getAll(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
+  private buildAlbumBaseQuery(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
     return this.db
       .selectFrom('album')
-      .selectAll('album')
       .innerJoin('album_user', (join) =>
         join.onRef('album_user.albumId', '=', 'album.id').on('album_user.userId', '=', ownerId),
       )
@@ -213,7 +211,21 @@ export class AlbumRepository {
       .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
       .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
       .$if(shared === true, (qb) => qb.where(hasAlbumSharedStatus))
-      .$if(shared === false, (qb) => qb.where((eb) => eb.not(hasAlbumSharedStatus(eb))))
+      .$if(shared === false, (qb) => qb.where((eb) => eb.not(hasAlbumSharedStatus(eb))));
+  }
+
+  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean; select: ['id'] }): Promise<Pick<Selectable<AlbumTable>, 'id'>[]>;
+  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean }): Promise<MapAlbumDto[]>;
+  @GenerateSql({ params: [DummyValue.UUID, {}] }, { params: [DummyValue.UUID, { select: ['id'] }] })
+  getAll(ownerId: string, { owned, shared, select }: { owned?: boolean; shared?: boolean; select?: string[] }) {
+    if (select) {
+      return this.buildAlbumBaseQuery(ownerId, { owned, shared })
+        .select('album.id')
+        .orderBy('album.createdAt', 'desc')
+        .execute();
+    }
+    return this.buildAlbumBaseQuery(ownerId, { owned, shared })
+      .selectAll('album')
       .select(withAlbumUsers(ownerId))
       .select(withSharedLink)
       .orderBy('album.createdAt', 'desc')

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -201,6 +201,81 @@ export class AlbumRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getAllAccessible(ownerId: string) {
+    return this.db
+      .selectFrom('album')
+      .selectAll('album')
+      .innerJoin('album_user', (join) =>
+        join.onRef('album_user.albumId', '=', 'album.id').on('album_user.userId', '=', ownerId),
+      )
+      .where('album.deletedAt', 'is', null)
+      .where(({ exists, selectFrom }) =>
+        exists(
+          selectFrom('album_user as au')
+            .whereRef('au.albumId', '=', 'album.id')
+            .where('au.role', '=', sql.lit(AlbumUserRole.Owner)),
+        ),
+      )
+      .select(withAlbumUsers(ownerId))
+      .select(withSharedLink)
+      .orderBy('album.createdAt', 'desc')
+      .execute();
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getSharedWithMe(ownerId: string) {
+    return this.db
+      .selectFrom('album')
+      .selectAll('album')
+      .innerJoin('album_user', (join) =>
+        join
+          .onRef('album_user.albumId', '=', 'album.id')
+          .on('album_user.userId', '=', ownerId)
+          .on('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)),
+      )
+      .where('album.deletedAt', 'is', null)
+      .where(({ exists, selectFrom }) =>
+        exists(
+          selectFrom('album_user as au')
+            .whereRef('au.albumId', '=', 'album.id')
+            .where('au.role', '=', sql.lit(AlbumUserRole.Owner)),
+        ),
+      )
+      .select(withAlbumUsers(ownerId))
+      .select(withSharedLink)
+      .orderBy('album.createdAt', 'desc')
+      .execute();
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getOwnedAndShared(ownerId: string) {
+    return this.db
+      .selectFrom('album')
+      .selectAll('album')
+      .innerJoin('album_user', (join) =>
+        join
+          .onRef('album_user.albumId', '=', 'album.id')
+          .on('album_user.userId', '=', ownerId)
+          .on('album_user.role', '=', sql.lit(AlbumUserRole.Owner)),
+      )
+      .where('album.deletedAt', 'is', null)
+      .where(({ or, exists, selectFrom }) =>
+        or([
+          exists(
+            selectFrom('album_user as au')
+              .whereRef('au.albumId', '=', 'album.id')
+              .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+          ),
+          exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+        ]),
+      )
+      .select(withAlbumUsers(ownerId))
+      .select(withSharedLink)
+      .orderBy('album.createdAt', 'desc')
+      .execute();
+  }
+
   /**
    * Get albums shared with and shared by owner.
    */

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -183,26 +183,8 @@ export class AlbumRepository {
     );
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getOwned(ownerId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin('album_user', (join) =>
-        join
-          .onRef('album_user.albumId', '=', 'album.id')
-          .on('album_user.userId', '=', ownerId)
-          .on('album_user.role', '=', sql.lit(AlbumUserRole.Owner)),
-      )
-      .where('album.deletedAt', 'is', null)
-      .select(withAlbumUsers(ownerId))
-      .select(withSharedLink)
-      .orderBy('album.createdAt', 'desc')
-      .execute();
-  }
-
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getAllAccessible(ownerId: string) {
+  @GenerateSql({ params: [DummyValue.UUID, {}] })
+  getAll(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
     return this.db
       .selectFrom('album')
       .selectAll('album')
@@ -217,137 +199,36 @@ export class AlbumRepository {
             .where('au.role', '=', sql.lit(AlbumUserRole.Owner)),
         ),
       )
-      .select(withAlbumUsers(ownerId))
-      .select(withSharedLink)
-      .orderBy('album.createdAt', 'desc')
-      .execute();
-  }
-
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getSharedWithMe(ownerId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin('album_user', (join) =>
-        join
-          .onRef('album_user.albumId', '=', 'album.id')
-          .on('album_user.userId', '=', ownerId)
-          .on('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)),
-      )
-      .where('album.deletedAt', 'is', null)
-      .where(({ exists, selectFrom }) =>
-        exists(
-          selectFrom('album_user as au')
-            .whereRef('au.albumId', '=', 'album.id')
-            .where('au.role', '=', sql.lit(AlbumUserRole.Owner)),
+      .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
+      .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
+      .$if(shared === true, (qb) =>
+        qb.where(({ or, exists, selectFrom }) =>
+          or([
+            exists(
+              selectFrom('album_user as au')
+                .whereRef('au.albumId', '=', 'album.id')
+                .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+            ),
+            exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+          ]),
         ),
       )
-      .select(withAlbumUsers(ownerId))
-      .select(withSharedLink)
-      .orderBy('album.createdAt', 'desc')
-      .execute();
-  }
-
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getOwnedAndShared(ownerId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin('album_user', (join) =>
-        join
-          .onRef('album_user.albumId', '=', 'album.id')
-          .on('album_user.userId', '=', ownerId)
-          .on('album_user.role', '=', sql.lit(AlbumUserRole.Owner)),
-      )
-      .where('album.deletedAt', 'is', null)
-      .where(({ or, exists, selectFrom }) =>
-        or([
-          exists(
-            selectFrom('album_user as au')
-              .whereRef('au.albumId', '=', 'album.id')
-              .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
-          ),
-          exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
-        ]),
-      )
-      .select(withAlbumUsers(ownerId))
-      .select(withSharedLink)
-      .orderBy('album.createdAt', 'desc')
-      .execute();
-  }
-
-  /**
-   * Get albums shared with and shared by owner.
-   */
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getShared(ownerId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin(
-        (eb) =>
-          eb
-            .selectFrom('album_user')
-            .select('album_user.albumId as id')
-            .where('album_user.userId', '=', ownerId)
-            .where(
-              'album_user.albumId',
-              'in',
-              eb
-                .selectFrom('album_user')
-                .select('album_user.albumId')
-                .where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)),
-            )
-            .union(
-              eb
-                .selectFrom('shared_link')
-                .where('shared_link.userId', '=', ownerId)
-                .where('shared_link.albumId', 'is not', null)
-                .select('shared_link.albumId as id')
-                .$narrowType<{ id: NotNull }>(),
-            )
-            .as('matching'),
-        (join) => join.onRef('matching.id', '=', 'album.id'),
-      )
-      .innerJoin('album_user', (join) =>
-        join.onRef('album_user.albumId', '=', 'album.id').on('album_user.role', '=', sql.lit(AlbumUserRole.Owner)),
-      )
-      .where('album.deletedAt', 'is', null)
-      .select(withAlbumUsers(ownerId))
-      .select(withSharedLink)
-      .orderBy('album.createdAt', 'desc')
-      .execute();
-  }
-
-  /**
-   * Get albums of owner that are _not_ shared
-   */
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getNotShared(ownerId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin('album_user', (join) =>
-        join
-          .onRef('album_user.albumId', '=', 'album.id')
-          .on('album_user.userId', '=', ownerId)
-          .on('album_user.role', '=', sql.lit(AlbumUserRole.Owner)),
-      )
-      .where('album.deletedAt', 'is', null)
-      .where(({ not, exists, selectFrom }) =>
-        not(
-          exists(
-            selectFrom('album_user as au')
-              .whereRef('au.albumId', '=', 'album.id')
-              .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+      .$if(shared === false, (qb) =>
+        qb.where(({ not, or, exists, selectFrom }) =>
+          not(
+            or([
+              exists(
+                selectFrom('album_user as au')
+                  .whereRef('au.albumId', '=', 'album.id')
+                  .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+              ),
+              exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+            ]),
           ),
         ),
       )
-      .where(({ not, exists, selectFrom }) =>
-        not(exists(selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id'))),
-      )
-      .select(withSharedLink)
       .select(withAlbumUsers(ownerId))
+      .select(withSharedLink)
       .orderBy('album.createdAt', 'desc')
       .execute();
   }

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -82,17 +82,6 @@ const isAlbumOwned = (ownerId: string) => (eb: ExpressionBuilder<DB, 'album'>) =
       .where('album_user.userId', '=', ownerId),
   );
 
-const hasAlbumSharedStatus = (eb: ExpressionBuilder<DB, 'album'>) =>
-  eb.or([
-    eb.exists(
-      eb
-        .selectFrom('album_user as au')
-        .whereRef('au.albumId', '=', 'album.id')
-        .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
-    ),
-    eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
-  ]);
-
 @Injectable()
 export class AlbumRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
@@ -195,44 +184,46 @@ export class AlbumRepository {
   }
 
   private buildAlbumBaseQuery(ownerId: string, { owned, shared }: { owned?: boolean; shared?: boolean }) {
+    const isShared = (eb: ExpressionBuilder<DB, 'album' | 'album_user'>) =>
+      eb.or([
+        eb.exists(
+          eb
+            .selectFrom('album_user as au')
+            .whereRef('au.albumId', '=', 'album.id')
+            .where('au.role', '!=', sql.lit(AlbumUserRole.Owner)),
+        ),
+        eb.exists(eb.selectFrom('shared_link').whereRef('shared_link.albumId', '=', 'album.id')),
+      ]);
+
     return this.db
       .selectFrom('album')
       .innerJoin('album_user', (join) =>
         join.onRef('album_user.albumId', '=', 'album.id').on('album_user.userId', '=', ownerId),
       )
       .where('album.deletedAt', 'is', null)
-      .where(({ exists, selectFrom }) =>
-        exists(
-          selectFrom('album_user as au')
-            .whereRef('au.albumId', '=', 'album.id')
-            .where('au.role', '=', sql.lit(AlbumUserRole.Owner)),
-        ),
-      )
       .$if(owned === true, (qb) => qb.where('album_user.role', '=', sql.lit(AlbumUserRole.Owner)))
       .$if(owned === false, (qb) => qb.where('album_user.role', '!=', sql.lit(AlbumUserRole.Owner)))
-      .$if(shared === true, (qb) => qb.where(hasAlbumSharedStatus))
-      .$if(shared === false, (qb) => qb.where((eb) => eb.not(hasAlbumSharedStatus(eb))));
+      .$if(shared === true, (qb) => qb.where(isShared))
+      .$if(shared === false, (qb) => qb.where((eb) => eb.not(isShared(eb))));
   }
 
-  getAll(
-    ownerId: string,
-    options: { owned?: boolean; shared?: boolean; select: ['id'] },
-  ): Promise<Pick<Selectable<AlbumTable>, 'id'>[]>;
-  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean }): Promise<MapAlbumDto[]>;
-  @GenerateSql({ params: [DummyValue.UUID, {}] }, { params: [DummyValue.UUID, { select: ['id'] }] })
-  getAll(ownerId: string, { owned, shared, select }: { owned?: boolean; shared?: boolean; select?: string[] }) {
-    if (select) {
-      return this.buildAlbumBaseQuery(ownerId, { owned, shared })
-        .select('album.id')
-        .orderBy('album.createdAt', 'desc')
-        .execute();
-    }
-    return this.buildAlbumBaseQuery(ownerId, { owned, shared })
+  @GenerateSql({ params: [DummyValue.UUID, {}] })
+  getAll(ownerId: string, options: { owned?: boolean; shared?: boolean } = {}): Promise<MapAlbumDto[]> {
+    return this.buildAlbumBaseQuery(ownerId, options)
       .selectAll('album')
       .select(withAlbumUsers(ownerId))
       .select(withSharedLink)
       .orderBy('album.createdAt', 'desc')
       .execute();
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID, {}] })
+  async getAllIds(ownerId: string, options: { owned?: boolean; shared?: boolean } = {}): Promise<string[]> {
+    const rows = await this.buildAlbumBaseQuery(ownerId, options)
+      .select('album.id')
+      .orderBy('album.createdAt', 'desc')
+      .execute();
+    return rows.map((r) => r.id);
   }
 
   async restoreAll(userId: string): Promise<void> {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -26,18 +26,16 @@ describe(AlbumService.name, () => {
 
   describe('getStatistics', () => {
     it('should get the album count', async () => {
-      mocks.album.getOwned.mockResolvedValue([]);
-      mocks.album.getShared.mockResolvedValue([]);
-      mocks.album.getNotShared.mockResolvedValue([]);
+      mocks.album.getAll.mockResolvedValue([]);
       await expect(sut.getStatistics(authStub.admin)).resolves.toEqual({
         owned: 0,
         shared: 0,
         notShared: 0,
       });
 
-      expect(mocks.album.getOwned).toHaveBeenCalledWith(authStub.admin.user.id);
-      expect(mocks.album.getShared).toHaveBeenCalledWith(authStub.admin.user.id);
-      expect(mocks.album.getNotShared).toHaveBeenCalledWith(authStub.admin.user.id);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { shared: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true, shared: false });
     });
   });
 
@@ -46,7 +44,7 @@ describe(AlbumService.name, () => {
       const album = AlbumFactory.from().albumUser().build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       const sharedWithUserAlbum = AlbumFactory.from().owner(owner).albumUser().build();
-      mocks.album.getAllAccessible.mockResolvedValue([getForAlbum(album), getForAlbum(sharedWithUserAlbum)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album), getForAlbum(sharedWithUserAlbum)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         {
           albumId: album.id,
@@ -68,6 +66,7 @@ describe(AlbumService.name, () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toEqual(album.id);
       expect(result[1].id).toEqual(sharedWithUserAlbum.id);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: undefined });
     });
 
     it('gets list of albums that have a specific asset', async () => {
@@ -98,7 +97,7 @@ describe(AlbumService.name, () => {
     it('gets list of albums that are shared', async () => {
       const album = AlbumFactory.from().albumUser().build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.album.getShared.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         {
           albumId: album.id,
@@ -112,13 +111,13 @@ describe(AlbumService.name, () => {
       const result = await sut.getAll(AuthFactory.create(owner), { shared: true });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getShared).toHaveBeenCalledTimes(1);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: true });
     });
 
     it('gets list of albums that are NOT shared', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.album.getNotShared.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         {
           albumId: album.id,
@@ -132,62 +131,63 @@ describe(AlbumService.name, () => {
       const result = await sut.getAll(AuthFactory.create(owner), { shared: false });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getNotShared).toHaveBeenCalledTimes(1);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: false });
     });
 
     it('gets only owned albums when owned=true', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.album.getOwned.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: true });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getOwned).toHaveBeenCalledTimes(1);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: true, shared: undefined });
     });
 
     it('gets only shared-with-me albums when owned=false', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.album.getSharedWithMe.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: false });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getSharedWithMe).toHaveBeenCalledTimes(1);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: false, shared: undefined });
     });
 
     it('gets owned shared-out albums when owned=true and shared=true', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.album.getOwnedAndShared.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: true, shared: true });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getOwnedAndShared).toHaveBeenCalledTimes(1);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: true, shared: true });
     });
 
     it('returns empty list when owned=false and shared=false', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      mocks.album.getAll.mockResolvedValue([]);
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: false, shared: false });
       expect(result).toHaveLength(0);
-      expect(mocks.album.getMetadataForIds).not.toHaveBeenCalled();
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: false, shared: false });
     });
   });
 
   it('counts assets correctly', async () => {
     const album = AlbumFactory.create();
     const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-    mocks.album.getAllAccessible.mockResolvedValue([getForAlbum(album)]);
+    mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
     mocks.album.getMetadataForIds.mockResolvedValue([
       {
         albumId: album.id,
@@ -201,7 +201,7 @@ describe(AlbumService.name, () => {
     const result = await sut.getAll(AuthFactory.create(owner), {});
     expect(result).toHaveLength(1);
     expect(result[0].assetCount).toEqual(1);
-    expect(mocks.album.getAllAccessible).toHaveBeenCalledTimes(1);
+    expect(mocks.album.getAll).toHaveBeenCalledTimes(1);
   });
 
   describe('create', () => {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -37,23 +37,6 @@ describe(AlbumService.name, () => {
       expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { shared: true });
       expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true, shared: false });
     });
-
-    it('should count each category independently', async () => {
-      const ownedAlbums = [AlbumFactory.create(), AlbumFactory.create(), AlbumFactory.create()];
-      const sharedAlbums = [AlbumFactory.create(), AlbumFactory.create()];
-      const notSharedAlbums = [AlbumFactory.create()];
-
-      mocks.album.getAll
-        .mockResolvedValueOnce(ownedAlbums.map(getForAlbum))
-        .mockResolvedValueOnce(sharedAlbums.map(getForAlbum))
-        .mockResolvedValueOnce(notSharedAlbums.map(getForAlbum));
-
-      await expect(sut.getStatistics(authStub.admin)).resolves.toEqual({
-        owned: 3,
-        shared: 2,
-        notShared: 1,
-      });
-    });
   });
 
   describe('getAll', () => {
@@ -83,7 +66,7 @@ describe(AlbumService.name, () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toEqual(album.id);
       expect(result[1].id).toEqual(sharedWithUserAlbum.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, {});
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: undefined });
     });
 
     it('gets list of albums that have a specific asset', async () => {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -37,6 +37,23 @@ describe(AlbumService.name, () => {
       expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { shared: true });
       expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true, shared: false });
     });
+
+    it('should count each category independently', async () => {
+      const ownedAlbums = [AlbumFactory.create(), AlbumFactory.create(), AlbumFactory.create()];
+      const sharedAlbums = [AlbumFactory.create(), AlbumFactory.create()];
+      const notSharedAlbums = [AlbumFactory.create()];
+
+      mocks.album.getAll
+        .mockResolvedValueOnce(ownedAlbums.map(getForAlbum))
+        .mockResolvedValueOnce(sharedAlbums.map(getForAlbum))
+        .mockResolvedValueOnce(notSharedAlbums.map(getForAlbum));
+
+      await expect(sut.getStatistics(authStub.admin)).resolves.toEqual({
+        owned: 3,
+        shared: 2,
+        notShared: 1,
+      });
+    });
   });
 
   describe('getAll', () => {
@@ -66,7 +83,7 @@ describe(AlbumService.name, () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toEqual(album.id);
       expect(result[1].id).toEqual(sharedWithUserAlbum.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: undefined });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, {});
     });
 
     it('gets list of albums that have a specific asset', async () => {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -46,7 +46,7 @@ describe(AlbumService.name, () => {
       const album = AlbumFactory.from().albumUser().build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       const sharedWithUserAlbum = AlbumFactory.from().owner(owner).albumUser().build();
-      mocks.album.getOwned.mockResolvedValue([getForAlbum(album), getForAlbum(sharedWithUserAlbum)]);
+      mocks.album.getAllAccessible.mockResolvedValue([getForAlbum(album), getForAlbum(sharedWithUserAlbum)]);
       mocks.album.getMetadataForIds.mockResolvedValue([
         {
           albumId: album.id,
@@ -134,12 +134,60 @@ describe(AlbumService.name, () => {
       expect(result[0].id).toEqual(album.id);
       expect(mocks.album.getNotShared).toHaveBeenCalledTimes(1);
     });
+
+    it('gets only owned albums when owned=true', async () => {
+      const album = AlbumFactory.create();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      mocks.album.getOwned.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
+      ]);
+
+      const result = await sut.getAll(AuthFactory.create(owner), { owned: true });
+      expect(result).toHaveLength(1);
+      expect(mocks.album.getOwned).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets only shared-with-me albums when owned=false', async () => {
+      const album = AlbumFactory.create();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      mocks.album.getSharedWithMe.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
+      ]);
+
+      const result = await sut.getAll(AuthFactory.create(owner), { owned: false });
+      expect(result).toHaveLength(1);
+      expect(mocks.album.getSharedWithMe).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets owned shared-out albums when owned=true and shared=true', async () => {
+      const album = AlbumFactory.create();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      mocks.album.getOwnedAndShared.mockResolvedValue([getForAlbum(album)]);
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
+      ]);
+
+      const result = await sut.getAll(AuthFactory.create(owner), { owned: true, shared: true });
+      expect(result).toHaveLength(1);
+      expect(mocks.album.getOwnedAndShared).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty list when owned=false and shared=false', async () => {
+      const album = AlbumFactory.create();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+
+      const result = await sut.getAll(AuthFactory.create(owner), { owned: false, shared: false });
+      expect(result).toHaveLength(0);
+      expect(mocks.album.getMetadataForIds).not.toHaveBeenCalled();
+    });
   });
 
   it('counts assets correctly', async () => {
     const album = AlbumFactory.create();
     const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-    mocks.album.getOwned.mockResolvedValue([getForAlbum(album)]);
+    mocks.album.getAllAccessible.mockResolvedValue([getForAlbum(album)]);
     mocks.album.getMetadataForIds.mockResolvedValue([
       {
         albumId: album.id,
@@ -153,7 +201,7 @@ describe(AlbumService.name, () => {
     const result = await sut.getAll(AuthFactory.create(owner), {});
     expect(result).toHaveLength(1);
     expect(result[0].assetCount).toEqual(1);
-    expect(mocks.album.getOwned).toHaveBeenCalledTimes(1);
+    expect(mocks.album.getAllAccessible).toHaveBeenCalledTimes(1);
   });
 
   describe('create', () => {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -128,7 +128,7 @@ describe(AlbumService.name, () => {
       const result = await sut.getAll(AuthFactory.create(owner), { shared: true });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ shared: true }));
     });
 
     it('gets list of albums that are NOT shared', async () => {
@@ -148,7 +148,7 @@ describe(AlbumService.name, () => {
       const result = await sut.getAll(AuthFactory.create(owner), { shared: false });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: false });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ shared: false }));
     });
 
     it('gets only owned albums when owned=true', async () => {
@@ -161,7 +161,7 @@ describe(AlbumService.name, () => {
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: true });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: true, shared: undefined });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ owned: true }));
     });
 
     it('gets only shared-with-me albums when owned=false', async () => {
@@ -174,7 +174,7 @@ describe(AlbumService.name, () => {
 
       const result = await sut.getAll(AuthFactory.create(owner), { owned: false });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: false, shared: undefined });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ owned: false }));
     });
 
     it('gets owned shared-out albums when owned=true and shared=true', async () => {

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -33,9 +33,9 @@ describe(AlbumService.name, () => {
         notShared: 0,
       });
 
-      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true });
-      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { shared: true });
-      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { owned: true, shared: false });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { isOwned: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { isShared: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(authStub.admin.user.id, { isOwned: true, isShared: false });
     });
   });
 
@@ -66,7 +66,7 @@ describe(AlbumService.name, () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toEqual(album.id);
       expect(result[1].id).toEqual(sharedWithUserAlbum.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: undefined, shared: undefined });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { isOwned: undefined, isShared: undefined });
     });
 
     it('gets list of albums that have a specific asset', async () => {
@@ -108,10 +108,10 @@ describe(AlbumService.name, () => {
         },
       ]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { shared: true });
+      const result = await sut.getAll(AuthFactory.create(owner), { isShared: true });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ shared: true }));
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ isShared: true }));
     });
 
     it('gets list of albums that are NOT shared', async () => {
@@ -128,13 +128,13 @@ describe(AlbumService.name, () => {
         },
       ]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { shared: false });
+      const result = await sut.getAll(AuthFactory.create(owner), { isShared: false });
       expect(result).toHaveLength(1);
       expect(result[0].id).toEqual(album.id);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ shared: false }));
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ isShared: false }));
     });
 
-    it('gets only owned albums when owned=true', async () => {
+    it('gets only owned albums when isOwned=true', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
@@ -142,12 +142,12 @@ describe(AlbumService.name, () => {
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { owned: true });
+      const result = await sut.getAll(AuthFactory.create(owner), { isOwned: true });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ owned: true }));
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ isOwned: true }));
     });
 
-    it('gets only shared-with-me albums when owned=false', async () => {
+    it('gets only shared-with-me albums when isOwned=false', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
@@ -155,12 +155,12 @@ describe(AlbumService.name, () => {
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { owned: false });
+      const result = await sut.getAll(AuthFactory.create(owner), { isOwned: false });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ owned: false }));
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, expect.objectContaining({ isOwned: false }));
     });
 
-    it('gets owned shared-out albums when owned=true and shared=true', async () => {
+    it('gets owned shared-out albums when isOwned=true and isShared=true', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.album.getAll.mockResolvedValue([getForAlbum(album)]);
@@ -168,19 +168,19 @@ describe(AlbumService.name, () => {
         { albumId: album.id, assetCount: 0, startDate: null, endDate: null, lastModifiedAssetTimestamp: null },
       ]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { owned: true, shared: true });
+      const result = await sut.getAll(AuthFactory.create(owner), { isOwned: true, isShared: true });
       expect(result).toHaveLength(1);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: true, shared: true });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { isOwned: true, isShared: true });
     });
 
-    it('returns empty list when owned=false and shared=false', async () => {
+    it('returns empty list when isOwned=false and isShared=false', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.album.getAll.mockResolvedValue([]);
 
-      const result = await sut.getAll(AuthFactory.create(owner), { owned: false, shared: false });
+      const result = await sut.getAll(AuthFactory.create(owner), { isOwned: false, isShared: false });
       expect(result).toHaveLength(0);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { owned: false, shared: false });
+      expect(mocks.album.getAll).toHaveBeenCalledWith(owner.id, { isOwned: false, isShared: false });
     });
   });
 

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -38,18 +38,35 @@ export class AlbumService extends BaseService {
     };
   }
 
-  async getAll({ user: { id: ownerId } }: AuthDto, { assetId, shared }: GetAlbumsDto): Promise<AlbumResponseDto[]> {
+  async getAll(
+    { user: { id: ownerId } }: AuthDto,
+    { assetId, owned, shared }: GetAlbumsDto,
+  ): Promise<AlbumResponseDto[]> {
     await this.albumRepository.updateThumbnails();
 
     let albums: MapAlbumDto[];
     if (assetId) {
       albums = await this.albumRepository.getByAssetId(ownerId, assetId);
+    } else if (owned === false && shared === false) {
+      albums = [];
+    } else if (owned === false) {
+      albums = await this.albumRepository.getSharedWithMe(ownerId);
     } else if (shared === true) {
-      albums = await this.albumRepository.getShared(ownerId);
+      albums =
+        owned === true
+          ? await this.albumRepository.getOwnedAndShared(ownerId)
+          : await this.albumRepository.getShared(ownerId);
     } else if (shared === false) {
       albums = await this.albumRepository.getNotShared(ownerId);
     } else {
-      albums = await this.albumRepository.getOwned(ownerId);
+      albums =
+        owned === true
+          ? await this.albumRepository.getOwned(ownerId)
+          : await this.albumRepository.getAllAccessible(ownerId);
+    }
+
+    if (albums.length === 0) {
+      return [];
     }
 
     // Get asset count for each album. Then map the result to an object:

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -25,9 +25,9 @@ import { getPreferences } from 'src/utils/preferences';
 export class AlbumService extends BaseService {
   async getStatistics(auth: AuthDto): Promise<AlbumStatisticsResponseDto> {
     const [owned, shared, notShared] = await Promise.all([
-      this.albumRepository.getAll(auth.user.id, { owned: true }),
-      this.albumRepository.getAll(auth.user.id, { shared: true }),
-      this.albumRepository.getAll(auth.user.id, { owned: true, shared: false }),
+      this.albumRepository.getAll(auth.user.id, { isOwned: true }),
+      this.albumRepository.getAll(auth.user.id, { isShared: true }),
+      this.albumRepository.getAll(auth.user.id, { isOwned: true, isShared: false }),
     ]);
 
     return {
@@ -39,13 +39,13 @@ export class AlbumService extends BaseService {
 
   async getAll(
     { user: { id: ownerId } }: AuthDto,
-    { assetId, owned, shared }: GetAlbumsDto,
+    { assetId, isOwned, isShared }: GetAlbumsDto,
   ): Promise<AlbumResponseDto[]> {
     await this.albumRepository.updateThumbnails();
 
     const albums = assetId
       ? await this.albumRepository.getByAssetId(ownerId, assetId)
-      : await this.albumRepository.getAll(ownerId, { owned, shared });
+      : await this.albumRepository.getAll(ownerId, { isOwned, isShared });
 
     if (albums.length === 0) {
       return [];

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -8,7 +8,6 @@ import {
   CreateAlbumDto,
   GetAlbumsDto,
   mapAlbum,
-  MapAlbumDto,
   UpdateAlbumDto,
   UpdateAlbumUserDto,
 } from 'src/dtos/album.dto';
@@ -26,9 +25,9 @@ import { getPreferences } from 'src/utils/preferences';
 export class AlbumService extends BaseService {
   async getStatistics(auth: AuthDto): Promise<AlbumStatisticsResponseDto> {
     const [owned, shared, notShared] = await Promise.all([
-      this.albumRepository.getOwned(auth.user.id),
-      this.albumRepository.getShared(auth.user.id),
-      this.albumRepository.getNotShared(auth.user.id),
+      this.albumRepository.getAll(auth.user.id, { owned: true }),
+      this.albumRepository.getAll(auth.user.id, { shared: true }),
+      this.albumRepository.getAll(auth.user.id, { owned: true, shared: false }),
     ]);
 
     return {
@@ -44,26 +43,9 @@ export class AlbumService extends BaseService {
   ): Promise<AlbumResponseDto[]> {
     await this.albumRepository.updateThumbnails();
 
-    let albums: MapAlbumDto[];
-    if (assetId) {
-      albums = await this.albumRepository.getByAssetId(ownerId, assetId);
-    } else if (owned === false && shared === false) {
-      albums = [];
-    } else if (owned === false) {
-      albums = await this.albumRepository.getSharedWithMe(ownerId);
-    } else if (shared === true) {
-      albums =
-        owned === true
-          ? await this.albumRepository.getOwnedAndShared(ownerId)
-          : await this.albumRepository.getShared(ownerId);
-    } else if (shared === false) {
-      albums = await this.albumRepository.getNotShared(ownerId);
-    } else {
-      albums =
-        owned === true
-          ? await this.albumRepository.getOwned(ownerId)
-          : await this.albumRepository.getAllAccessible(ownerId);
-    }
+    const albums = assetId
+      ? await this.albumRepository.getByAssetId(ownerId, assetId)
+      : await this.albumRepository.getAll(ownerId, { owned, shared });
 
     if (albums.length === 0) {
       return [];

--- a/server/src/services/map.service.spec.ts
+++ b/server/src/services/map.service.spec.ts
@@ -4,7 +4,7 @@ import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
 import { PartnerFactory } from 'test/factories/partner.factory';
 import { userStub } from 'test/fixtures/user.stub';
-import { getForAlbum, getForPartner } from 'test/mappers';
+import { getForPartner } from 'test/mappers';
 import { newTestService, ServiceMocks } from 'test/utils';
 
 describe(MapService.name, () => {
@@ -84,13 +84,13 @@ describe(MapService.name, () => {
       mocks.map.getMapMarkers.mockResolvedValue([marker]);
       const album1 = AlbumFactory.create();
       const album2 = AlbumFactory.from().albumUser({ userId: userStub.user1.id }).build();
-      mocks.album.getAll.mockResolvedValue([getForAlbum(album1), getForAlbum(album2)]);
+      mocks.album.getAllIds.mockResolvedValue([album1.id, album2.id]);
 
       const markers = await sut.getMapMarkers(auth, { withSharedAlbums: true });
 
       expect(markers).toHaveLength(1);
       expect(markers[0]).toEqual(marker);
-      expect(mocks.album.getAll).toHaveBeenCalledWith(auth.user.id, { select: ['id'] });
+      expect(mocks.album.getAllIds).toHaveBeenCalledWith(auth.user.id);
     });
   });
 

--- a/server/src/services/map.service.spec.ts
+++ b/server/src/services/map.service.spec.ts
@@ -82,8 +82,8 @@ describe(MapService.name, () => {
       };
       mocks.partner.getAll.mockResolvedValue([]);
       mocks.map.getMapMarkers.mockResolvedValue([marker]);
-      mocks.album.getOwned.mockResolvedValue([getForAlbum(AlbumFactory.create())]);
-      mocks.album.getShared.mockResolvedValue([
+      mocks.album.getAll.mockResolvedValue([
+        getForAlbum(AlbumFactory.create()),
         getForAlbum(AlbumFactory.from().albumUser({ userId: userStub.user1.id }).build()),
       ]);
 

--- a/server/src/services/map.service.spec.ts
+++ b/server/src/services/map.service.spec.ts
@@ -82,15 +82,15 @@ describe(MapService.name, () => {
       };
       mocks.partner.getAll.mockResolvedValue([]);
       mocks.map.getMapMarkers.mockResolvedValue([marker]);
-      mocks.album.getAll.mockResolvedValue([
-        getForAlbum(AlbumFactory.create()),
-        getForAlbum(AlbumFactory.from().albumUser({ userId: userStub.user1.id }).build()),
-      ]);
+      const album1 = AlbumFactory.create();
+      const album2 = AlbumFactory.from().albumUser({ userId: userStub.user1.id }).build();
+      mocks.album.getAll.mockResolvedValue([getForAlbum(album1), getForAlbum(album2)]);
 
       const markers = await sut.getMapMarkers(auth, { withSharedAlbums: true });
 
       expect(markers).toHaveLength(1);
       expect(markers[0]).toEqual(marker);
+      expect(mocks.album.getAll).toHaveBeenCalledWith(auth.user.id, { select: ['id'] });
     });
   });
 

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -13,14 +13,10 @@ export class MapService extends BaseService {
       userIds.push(...partnerIds);
     }
 
-    // TODO convert to SQL join
     const albumIds: string[] = [];
     if (options.withSharedAlbums) {
-      const [ownedAlbums, sharedAlbums] = await Promise.all([
-        this.albumRepository.getOwned(auth.user.id),
-        this.albumRepository.getShared(auth.user.id),
-      ]);
-      albumIds.push(...ownedAlbums.map((album) => album.id), ...sharedAlbums.map((album) => album.id));
+      const albums = await this.albumRepository.getAll(auth.user.id, {});
+      albumIds.push(...albums.map((album) => album.id));
     }
 
     return this.mapRepository.getMapMarkers(userIds, albumIds, options);

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -15,7 +15,7 @@ export class MapService extends BaseService {
 
     const albumIds: string[] = [];
     if (options.withSharedAlbums) {
-      const albums = await this.albumRepository.getAll(auth.user.id, {});
+      const albums = await this.albumRepository.getAll(auth.user.id, { select: ['id'] });
       albumIds.push(...albums.map((album) => album.id));
     }
 

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -13,11 +13,7 @@ export class MapService extends BaseService {
       userIds.push(...partnerIds);
     }
 
-    const albumIds: string[] = [];
-    if (options.withSharedAlbums) {
-      const albums = await this.albumRepository.getAll(auth.user.id, { select: ['id'] });
-      albumIds.push(...albums.map((album) => album.id));
-    }
+    const albumIds = options.withSharedAlbums ? await this.albumRepository.getAllIds(auth.user.id) : [];
 
     return this.mapRepository.getMapMarkers(userIds, albumIds, options);
   }

--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -28,11 +28,8 @@
   let { onClose }: Props = $props();
 
   onMount(async () => {
-    // TODO the server should *really* just return all albums (paginated ideally)
-    const ownedAlbums = await getAllAlbums({ shared: false });
-    ownedAlbums.push.apply(ownedAlbums, await getAllAlbums({ shared: true }));
-    albums = ownedAlbums;
-    recentAlbums = albums.sort((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
+    albums = await getAllAlbums({});
+    recentAlbums = [...albums].sort((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
     loading = false;
   });
 

--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -29,7 +29,7 @@
 
   onMount(async () => {
     albums = await getAllAlbums({});
-    recentAlbums = [...albums].sort((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
+    recentAlbums = albums.toSorted((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
     loading = false;
   });
 

--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -29,7 +29,7 @@
 
   onMount(async () => {
     albums = await getAllAlbums({});
-    recentAlbums = albums.toSorted((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
+    recentAlbums = [...albums].sort((a, b) => (new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1)).slice(0, 3);
     loading = false;
   });
 

--- a/web/src/routes/(user)/albums/+page.ts
+++ b/web/src/routes/(user)/albums/+page.ts
@@ -5,8 +5,8 @@ import type { PageLoad } from './$types';
 
 export const load = (async ({ url }) => {
   await authenticate(url);
-  const sharedAlbums = await getAllAlbums({ shared: true });
-  const albums = await getAllAlbums({ owned: true });
+  const sharedAlbums = await getAllAlbums({ isShared: true });
+  const albums = await getAllAlbums({ isOwned: true });
   const $t = await getFormatter();
 
   return {

--- a/web/src/routes/(user)/albums/+page.ts
+++ b/web/src/routes/(user)/albums/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load = (async ({ url }) => {
   await authenticate(url);
   const sharedAlbums = await getAllAlbums({ shared: true });
-  const albums = await getAllAlbums({});
+  const albums = await getAllAlbums({ owned: true });
   const $t = await getFormatter();
 
   return {

--- a/web/src/routes/(user)/sharing/+page.ts
+++ b/web/src/routes/(user)/sharing/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 
 export const load = (async ({ url }) => {
   await authenticate(url);
-  const sharedAlbums = await getAllAlbums({ shared: true });
+  const sharedAlbums = await getAllAlbums({ isShared: true });
   const partners = await getPartners({ direction: PartnerDirection.SharedWith });
   const $t = await getFormatter();
 


### PR DESCRIPTION
## Description

Adds an `isOwned` tri-state query parameter to `GET /albums` and changes the default (no parameters) to return all albums accessible to the user instead of only owned albums. This has been discussed at the beginning of march on discord.

> [!CAUTION]
>  **Breaking Change**
> `GET /albums` (no params) previously returned only owned albums. It now returns all accessible albums. Web/mobile clients that relied on the default returning only owned albums should pass `isOwned=true` explicitly to restore the old behavior.
> The `shared` param has been renamed to `isShared`

This PR addresses these breaking changes by updating the web client implementation accordingly.

supersedes #28181 (repository changes adopted)

### New query parameter: `isOwned`

`isOwned` and `isShared` are now two independent axes:

| `isOwned` | `isShared` | Result |
|---------|----------|--------|
| — | — | All accessible albums (owned + shared-with-me) |
| `true` | — | Only albums owned by the user |
| `false` | — | Only albums shared with the user |
| `true` | `true` | Owned albums that have been shared out |
| `true` | `false` | Owned private albums |
| — | `true` | All albums involving sharing |
| — | `false` | Private albums only |
| `false` | `true` | Albums shared with the user (same as `isOwned=false`) |
| `false` | `false` | Empty (logically impossible) |

## How Has This Been Tested?

- Updated all existing unit tests
- Added new unit and e2e tests for all new parameter combinations

## API Changes

`GET /albums` gains an `isOwned` boolean query parameter. Default behavior changes from owned-only to all-accessible. `shared` is renamed to `isShared`

## Screenshots

<details><summary>Details</summary>
<p>

<img width="1039" height="481" alt="Screenshot 2026-05-03 at 16 46 45" src="https://github.com/user-attachments/assets/ab7098f2-4aa9-40e3-88e0-69a8f9694063" />
<img width="959" height="451" alt="Screenshot 2026-05-03 at 16 46 49" src="https://github.com/user-attachments/assets/5434c32e-265f-4678-9064-8dc13cf68778" />
<img width="963" height="449" alt="Screenshot 2026-05-03 at 16 46 54" src="https://github.com/user-attachments/assets/0ff7d694-aabf-44b8-847d-f2e0f4797669" />
<img width="1366" height="829" alt="Screenshot 2026-05-03 at 16 47 34" src="https://github.com/user-attachments/assets/8caa1b20-9163-41a0-9690-2e52e8b0e73a" />


</p>
</details> 

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Planning the implementation

