### PR TITLE
fix: librknnrt permissions in machine-learning

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -112,7 +112,7 @@ ARG RKNN_TOOLKIT_VERSION="v2.3.0"
 ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2 \
     MACHINE_LEARNING_MODEL_ARENA=false
 
-ADD --checksum=sha256:73993ed4b440460825f21611731564503cc1d5a0c123746477da6cd574f34885 "https://github.com/airockchip/rknn-toolkit2/raw/refs/tags/${RKNN_TOOLKIT_VERSION}/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so" /usr/lib/
+ADD --chmod=644 --checksum=sha256:73993ed4b440460825f21611731564503cc1d5a0c123746477da6cd574f34885 "https://github.com/airockchip/rknn-toolkit2/raw/refs/tags/${RKNN_TOOLKIT_VERSION}/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so" /usr/lib/
 
 FROM prod-${DEVICE} AS prod
 


### PR DESCRIPTION
## Description

I have the super niche problem of trying to run Immich as a non-root user on a RK3588 chip. Everything seems to work except the `librknnrt.so` packaged in the official container is only readable by root:
```
-rw-------  1 root root 7259064 Jan  1  1970 librknnrt.so
```

This means the machine learning container can't initialize the RKNN runtime and is unable to use hardware acceleration:
```
immich_machine_learning  | [05/03/26 19:26:04] I        Loading visual model 'ViT-B-32__openai' to memory
immich_machine_learning  | [05/03/26 19:26:04] I        Loading RKNN model from
immich_machine_learning  |                              /cache/clip/ViT-B-32__openai/visual/rknpu/rk3588/mo
immich_machine_learning  |                              del.rknn with 1 threads.
immich_machine_learning  | E Catch exception when init runtime!
immich_machine_learning  | E Traceback (most recent call last):
immich_machine_learning  |   File "/opt/venv/lib/python3.11/site-packages/rknnlite/api/rknn_lite.py", line 148, in init_runtime
immich_machine_learning  |     self.rknn_runtime = RKNNRuntime(root_dir=self.root_dir, target=target, device_id=device_id,
immich_machine_learning  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
immich_machine_learning  |   File "rknnlite/api/rknn_runtime.py", line 363, in rknnlite.api.rknn_runtime.RKNNRuntime.__init__
immich_machine_learning  |   File "rknnlite/api/rknn_runtime.py", line 608, in rknnlite.api.rknn_runtime.RKNNRuntime._load_library
immich_machine_learning  |   File "/usr/local/lib/python3.11/ctypes/__init__.py", line 376, in __init__
immich_machine_learning  |     self._handle = _dlopen(self._name, mode)
immich_machine_learning  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
immich_machine_learning  | OSError: /usr/lib/librknnrt.so: cannot open shared object file: Permission denied
```

I fixed this locally by thin wrapper but I'd like to fix it upstream too. I didn't see any open issues so I think it's just me :laughing: 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- [ ] To reproduce, run the official images but as non-root on a RK3588 system and then upload an image. Once the ML pipeline starts you'll get an error
- [ ] I modified the permissions using a thin wrapper image and after uploading an image the ML pipeline works as expected

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I asked claude what the syntax was for the wrapper image I used while testing, otherwise those 12 additional characters were artisanal.
...
