### PR TITLE
fix(server): correct asset dimensions for cropped RAW + ignore IFD1 thumbnail orientation

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -89,7 +89,20 @@ export class MetadataRepository {
     geoTz: (lat, lon) => geotz.find(lat, lon)[0],
     geolocation: true,
     // Enable exiftool LFS to parse metadata for files larger than 2GB.
-    readArgs: ['-api', 'largefilesupport=1'],
+    // Exclude IFD1 (embedded thumbnail) Orientation/ImageWidth/ImageHeight tags so they
+    // never leak into the main image's metadata. Without these excludes, ExifTool can
+    // attribute IFD1:Orientation (e.g. 6) to the main image and the server then swaps
+    // the asset's stored width/height. See immich-app/immich#27966.
+    readArgs: [
+      '-api',
+      'largefilesupport=1',
+      '-x',
+      'IFD1:Orientation',
+      '-x',
+      'IFD1:ImageWidth',
+      '-x',
+      'IFD1:ImageHeight',
+    ],
     writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
     taskTimeoutMillis: 2 * 60 * 1000,
   });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1820,6 +1820,48 @@ describe(MetadataService.name, () => {
       );
     });
 
+    it('should prefer ExifImageWidth/Height over ImageSize (Sony ARW crop case)', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      // Sony A7R V in 4:3 crop mode: ImageSize reports the full sensor (3:2),
+      // but ExifImageWidth/Height describes the rendered/cropped image (4:3).
+      mockReadTags({
+        ExifImageWidth: 8448,
+        ExifImageHeight: 6336,
+        ImageSize: '9600x6376',
+        ImageWidth: 9600,
+        ImageHeight: 6376,
+      });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: 8448,
+          height: 6336,
+        }),
+      );
+    });
+
+    it('should fall back to ImageSize when ExifImageWidth is missing (CR2/RAF)', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      // Canon CR2 / Fuji RAF: ImageWidth is the small embedded preview, ImageSize
+      // (Composite) holds the real sensor image dims. See immich-app/immich#13377.
+      mockReadTags({
+        ImageSize: '6000x4000',
+        ImageWidth: 1620,
+        ImageHeight: 1080,
+      });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: 6000,
+          height: 4000,
+        }),
+      );
+    });
+
     it('should overwrite existing width/height for unedited assets', async () => {
       const asset = AssetFactory.create({ width: 1920, height: 1080, isEdited: false });
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -564,13 +564,24 @@ export class MetadataService extends BaseService {
   private getImageDimensions(exifTags: ImmichTags): { width?: number; height?: number } {
     /*
      * The "true" values for width and height are a bit hidden, depending on the camera model and file format.
-     * For RAW images in the CR2 or RAF format, the "ImageSize" value seems to be correct,
-     * but ImageWidth and ImageHeight are not correct (they contain the dimensions of the preview image).
+     *
+     * Priority:
+     *   1. ExifIFD's ExifImageWidth/Height — describes the *rendered* image (post-crop, post-process).
+     *      This is what Sharp uses to generate thumbnails/previews from the embedded JPEG. Matching
+     *      these here keeps the layout aspect ratio in sync with what the user actually sees.
+     *      Required for Sony ARW shot in 4:3 crop mode (where ImageSize = full sensor 3:2 but
+     *      ExifImageWidth = the cropped 4:3 capture).
+     *   2. Composite ImageSize — fallback for CR2/RAF where ungrouped ImageWidth gives the embedded
+     *      thumbnail's small dims (see immich-app/immich#13377).
+     *   3. ungrouped ImageWidth/ImageHeight — last resort for files without the above.
      */
-    let [width, height] =
-      exifTags.ImageSize?.toString()
-        ?.split('x')
-        ?.map((dim) => Number.parseInt(dim) || undefined) ?? [];
+    let [width, height] = [exifTags.ExifImageWidth, exifTags.ExifImageHeight];
+    if (!width || !height) {
+      [width, height] =
+        exifTags.ImageSize?.toString()
+          ?.split('x')
+          ?.map((dim) => Number.parseInt(dim) || undefined) ?? [];
+    }
     if (!width || !height) {
       [width, height] = [exifTags.ImageWidth, exifTags.ImageHeight];
     }


### PR DESCRIPTION
## Description

Two related metadata-extraction bugs that result in `asset.width` / `asset.height` being stored with the wrong aspect ratio for some images. The frontend then uses those dimensions to size timeline cells (`getAssetRatio` → justified-layout) and the asset viewer (`AdaptiveImage.svelte`), so affected images render cropped or stretched even though the file on disk is fine. The mobile app and the editor read `HTMLImageElement.naturalWidth/naturalHeight` directly so they remain correct, which is why this is a server-side root cause that surfaces only in the web UI.

### 1. Sony ARW shot in 4:3 crop mode → dims stored as 3:2 full sensor

`getImageDimensions` previously preferred the Composite `ImageSize` tag. For Sony A7R V (and similar bodies) RAWs shot in a 4:3 crop, the file contains:

| Tag (group) | Value | Meaning |
|---|---|---|
| `Composite ImageSize` | `9600×6376` | Full sensor area (3:2) |
| `SubIFD ImageWidth/Height` | `9600×6376` | Same |
| `ExifIFD ExifImageWidth/Height` | `8448×6336` | **The rendered (cropped) image** |
| `Sony FullImageSize` | `8448×6336` | Same |
| `PreviewImageSize` | `1440×1080` (4:3) | Embedded preview JPEG |

Sharp generates thumbnails/previews from the embedded preview JPEG (4:3) while the layout consumed `9600×6376` (3:2) — visible distortion in the timeline + viewer.

This is a regression: pre-#13377 (v1.119 and earlier) the code used `ImageWidth/ImageHeight` directly, which on Sony ARW happened to resolve to `8448` from the ExifIFD group — i.e. the right value. After #13377 stored dimensions silently flipped to 3:2 for these files, but #27220 (v2.7.0) only made it visible by then refreshing dims on every extraction. Users who imported before v1.120 saw their previously-correct values overwritten on first re-extraction after the v2.7 upgrade.

Switching the priority to `ExifImageWidth/Height` (which describes the rendered image across JPG / HEIC / PNG / Sony ARW) resolves this. `ImageSize` is kept as a fallback for the original CR2/RAF case from #13377 where the ungrouped `ImageWidth` is the small preview's dims.

### 2. IFD1 (thumbnail) Orientation polluting the main image

ExifTool's ungrouped `Orientation` can resolve to `IFD1:Orientation` for some files (e.g. portrait JPGs whose embedded thumbnail has its own Orientation tag) — see #27966 for the maintainer's diagnosis. The server then swaps the asset's stored width/height based on the thumbnail's orientation rather than the main image's.

Fix: pass `-x IFD1:Orientation -x IFD1:ImageWidth -x IFD1:ImageHeight` to ExifTool's `readArgs` so those IFD1 fields can never leak into the main image's metadata read.

### Files changed

- `server/src/repositories/metadata.repository.ts` — exclude `IFD1:Orientation/ImageWidth/ImageHeight` in default `readArgs`.
- `server/src/services/metadata.service.ts` — `getImageDimensions` precedence: `ExifImageWidth/Height` → `ImageSize` → `ImageWidth/Height`.
- `server/src/services/metadata.service.spec.ts` — two new unit tests covering the precedence.

Fixes #27966

## How Has This Been Tested?

- [x] Existing `metadata.service.spec.ts` test suite still passes (the original four width/height test cases are unchanged because `ExifImageWidth` is unset in those mocks, so the precedence falls through to the legacy behavior).
- [x] Two new unit tests in `metadata.service.spec.ts`:
  - "should prefer ExifImageWidth/Height over ImageSize (Sony ARW crop case)" — verifies the new primary source.
  - "should fall back to ImageSize when ExifImageWidth is missing (CR2/RAF)" — verifies #13377's case is preserved.
- [x] End-to-end on a v2.7.5 cluster: built a patched `immich-server` image, deployed it, and triggered `POST /api/assets/jobs name=refresh-metadata` over a real library:
  - `R5_00026.ARW` (Sony A7R V, 4:3 crop): stored `9600×6376` (3:2) → `8448×6336` (4:3, matches the rendered preview).
  - All other ARWs in the library: same correction.
  - HEIC `Orientation=6` portraits remain correctly stored as portrait (`3024×4032`); HEICs with `Orientation=1` unchanged. The IFD1 patch does not regress JPGs/HEICs that were correct before.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — server-only fix; visible only as correctly proportioned thumbnails/viewer once metadata is re-extracted.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Heavily — the diagnosis (git archeology to identify #13377 and #27220 as the regression points), the patch design, the test cases, and this PR description were all produced with the assistance of an LLM (Claude). The author reviewed the diff, manually verified the fix on a live v2.7.5 cluster (see the end-to-end results above), and confirmed both unit tests run against the changed code.