### PR TITLE
fix(mobile): show lens info without lens name

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
@@ -131,6 +131,7 @@ class TechnicalDetails extends ConsumerWidget {
     if (exifInfo == null) return null;
     final fNumber = exifInfo.fNumber.isNotEmpty ? 'ƒ/${exifInfo.fNumber}' : null;
     final focalLength = exifInfo.focalLength.isNotEmpty ? '${exifInfo.focalLength} mm' : null;
+    if (fNumber == null && focalLength == null) return null;
     return [fNumber, focalLength].where((spec) => spec != null && spec.isNotEmpty).join(_kSeparator);
   }
 }

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
@@ -22,6 +22,7 @@ class TechnicalDetails extends ConsumerWidget {
     final exifInfo = this.exifInfo;
     final cameraTitle = _getCameraInfoTitle(exifInfo);
     final lensTitle = exifInfo?.lens != null && exifInfo!.lens!.isNotEmpty ? exifInfo.lens : null;
+    final lensSubtitle = _getLensInfoSubtitle(exifInfo);
 
     return Column(
       children: [
@@ -46,8 +47,15 @@ class TechnicalDetails extends ConsumerWidget {
             title: lensTitle,
             titleStyle: context.textTheme.labelLarge,
             leading: Icon(Icons.camera_outlined, size: 24, color: context.textTheme.labelLarge?.color),
-            subtitle: _getLensInfoSubtitle(exifInfo),
+            subtitle: lensSubtitle,
             subtitleStyle: context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary),
+          ),
+        ] else if (lensSubtitle != null) ...[
+          const SizedBox(height: 16),
+          SheetTile(
+            title: lensSubtitle,
+            titleStyle: context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary),
+            leading: Icon(Icons.camera_outlined, size: 24, color: context.textTheme.labelLarge?.color),
           ),
         ],
       ],


### PR DESCRIPTION
## Description

Small test PR from learning the mobile codebase.

Fixes #28218

## How Has This Been Tested?
- [x] Provided asset (lens info and no name)
- [x] Assets with lens name and no info, both name and info, and neither name nor info

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1080" height="2424" alt="Screenshot_20260504-161255" src="https://github.com/user-attachments/assets/41c9672c-c09a-49f9-b0fc-3bcc6384f484" />
</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.
