### PR TITLE
feat(server): add background job to fix asset dates from filenames

### DIFF
--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -397,6 +397,7 @@ export enum ManualJobName {
   MemoryCleanup = 'memory-cleanup',
   MemoryCreate = 'memory-create',
   BackupDatabase = 'backup-database',
+  FixDateFromFilename = 'fix-date-from-filename',
 }
 
 export const ManualJobNameSchema = z.enum(ManualJobName).describe('Manual job name').meta({ id: 'ManualJobName' });
@@ -795,6 +796,8 @@ export enum JobName {
   AssetEmptyTrash = 'AssetEmptyTrash',
   AssetExtractMetadataQueueAll = 'AssetExtractMetadataQueueAll',
   AssetExtractMetadata = 'AssetExtractMetadata',
+  AssetFixDateFromFilenameQueueAll = 'AssetFixDateFromFilenameQueueAll',
+  AssetFixDateFromFilename = 'AssetFixDateFromFilename',
   AssetFileMigration = 'AssetFileMigration',
   AssetGenerateThumbnailsQueueAll = 'AssetGenerateThumbnailsQueueAll',
   AssetGenerateThumbnails = 'AssetGenerateThumbnails',

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -368,6 +368,34 @@ export class AssetJobRepository {
       .stream();
   }
 
+  @GenerateSql({ params: [false], stream: true })
+  streamForFileDateFix(force?: boolean) {
+    return this.db
+      .selectFrom('asset')
+      .select(['asset.id', 'asset.originalFileName'])
+      .where('asset.deletedAt', 'is', null)
+      .$if(!force, (qb) =>
+        qb
+          .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+          .where((eb) =>
+            eb.or([eb('asset_exif.dateTimeOriginal', 'is', null), eb('asset_exif.assetId', 'is', null)]),
+          ),
+      )
+      .stream();
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getForFileDateFixJob(id: string) {
+    return this.db
+      .selectFrom('asset')
+      .select(['asset.id', 'asset.originalFileName', 'asset.fileCreatedAt'])
+      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select(['asset_exif.dateTimeOriginal'])
+      .where('asset.id', '=', id)
+      .limit(1)
+      .executeTakeFirst();
+  }
+
   private storageTemplateAssetQuery() {
     return this.db
       .selectFrom('asset')

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -34,6 +34,10 @@ const asJobItem = (dto: JobCreateDto): JobItem => {
       return { name: JobName.DatabaseBackup };
     }
 
+    case ManualJobName.FixDateFromFilename: {
+      return { name: JobName.AssetFixDateFromFilenameQueueAll, data: { force: false } };
+    }
+
     default: {
       throw new BadRequestException('Invalid job name');
     }

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -15,7 +15,7 @@ import {
   SourceType,
 } from 'src/enum';
 import { ImmichTags } from 'src/repositories/metadata.repository';
-import { firstDateTime, MetadataService } from 'src/services/metadata.service';
+import { firstDateTime, MetadataService, parseDateFromFilename } from 'src/services/metadata.service';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { PersonFactory } from 'test/factories/person.factory';
 import { videoInfoStub } from 'test/fixtures/media.stub';
@@ -2110,6 +2110,145 @@ describe(MetadataService.name, () => {
       const result = firstDateTime(tags);
       expect(result?.tag).toBe('CreationDate');
       expect(result?.dateTime?.toDate()?.toISOString()).toBe('2025-05-24T16:26:20.000Z');
+    });
+  });
+
+  describe('parseDateFromFilename', () => {
+    it.each([
+      // WhatsApp
+      ['IMG-20230415-WA0001.jpg', '2023-04-15T00:00:00.000Z'],
+      ['VID-20230415-WA0001.mp4', '2023-04-15T00:00:00.000Z'],
+      // Android generic with time
+      ['IMG_20230415_143022.jpg', '2023-04-15T14:30:22.000Z'],
+      ['VID_20230415_143022.mp4', '2023-04-15T14:30:22.000Z'],
+      ['PANO_20230415_143022.jpg', '2023-04-15T14:30:22.000Z'],
+      // Samsung compact date+time
+      ['20230415_143022.jpg', '2023-04-15T14:30:22.000Z'],
+      ['20230415_143022_001.jpg', '2023-04-15T14:30:22.000Z'],
+      // Screenshots
+      ['Screenshot_20230415-143022.png', '2023-04-15T14:30:22.000Z'],
+      ['Screenshot_2023-04-15-14-30-22.png', '2023-04-15T14:30:22.000Z'],
+      ['Screenshot_20230415_143022.png', '2023-04-15T14:30:22.000Z'],
+      // Telegram
+      ['photo_2023-04-15_14-30-22.jpg', '2023-04-15T14:30:22.000Z'],
+      ['video_2023-04-15_14-30-22.mp4', '2023-04-15T14:30:22.000Z'],
+      // Signal
+      ['signal-2023-04-15-143022.jpg', '2023-04-15T14:30:22.000Z'],
+      // Facebook ms timestamp
+      ['FB_IMG_1681562400000.jpg', new Date(1681562400000).toISOString()],
+      // Snapchat seconds timestamp
+      ['Snapchat-1681562400.jpg', new Date(1681562400 * 1000).toISOString()],
+      // iOS RPReplay seconds timestamp
+      ['RPReplay_Final1681562400.MP4', new Date(1681562400 * 1000).toISOString()],
+      // ISO compact with T
+      ['20230415T143022.jpg', '2023-04-15T14:30:22.000Z'],
+      // General ISO hyphenated date+time
+      ['2023-04-15_14-30-22.jpg', '2023-04-15T14:30:22.000Z'],
+      // Hyphenated date only
+      ['2023-04-15 some-description.jpg', '2023-04-15T00:00:00.000Z'],
+    ] as [string, string][])(
+      'parses date from "%s" -> %s',
+      (filename, expected) => {
+        const result = parseDateFromFilename(filename);
+        expect(result).not.toBeNull();
+        expect(result!.toISOString()).toBe(expected);
+      },
+    );
+
+    it.each([
+      ['IMG_1234.jpg'],
+      ['document.pdf'],
+      ['photo.jpg'],
+      ['unnamed.jpg'],
+      // Invalid calendar dates
+      ['IMG_20231345_143022.jpg'], // month 13
+      ['IMG_20230432_143022.jpg'], // day 32
+    ])('returns null for "%s"', (filename) => {
+      expect(parseDateFromFilename(filename)).toBeNull();
+    });
+  });
+
+  describe('handleQueueFixDateFromFilename', () => {
+    it('should queue fix-date jobs for assets without exif dates', async () => {
+      const asset = AssetFactory.create({ originalFileName: 'IMG_20230415_143022.jpg' });
+      mocks.assetJob.streamForFileDateFix.mockReturnValue(makeStream([asset]));
+
+      await expect(sut.handleQueueFixDateFromFilename({ force: false })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.assetJob.streamForFileDateFix).toHaveBeenCalledWith(false);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetFixDateFromFilename, data: { id: asset.id } },
+      ]);
+    });
+
+    it('should queue all assets when force=true', async () => {
+      const asset = AssetFactory.create({ originalFileName: 'IMG_20230415_143022.jpg' });
+      mocks.assetJob.streamForFileDateFix.mockReturnValue(makeStream([asset]));
+
+      await expect(sut.handleQueueFixDateFromFilename({ force: true })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.assetJob.streamForFileDateFix).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('handleFixDateFromFilename', () => {
+    it('should return failed when asset is not found', async () => {
+      mocks.assetJob.getForFileDateFixJob.mockResolvedValue(undefined);
+
+      await expect(sut.handleFixDateFromFilename({ id: 'non-existent' })).resolves.toBe(JobStatus.Failed);
+    });
+
+    it('should skip when dateTimeOriginal is already set', async () => {
+      mocks.assetJob.getForFileDateFixJob.mockResolvedValue({
+        id: 'asset-id',
+        originalFileName: 'IMG_20230415_143022.jpg',
+        fileCreatedAt: new Date(),
+        dateTimeOriginal: new Date('2020-01-01'),
+      });
+
+      await expect(sut.handleFixDateFromFilename({ id: 'asset-id' })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.asset.update).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertExif).not.toHaveBeenCalled();
+    });
+
+    it('should skip when no date can be parsed from filename', async () => {
+      mocks.assetJob.getForFileDateFixJob.mockResolvedValue({
+        id: 'asset-id',
+        originalFileName: 'IMG_1234.jpg',
+        fileCreatedAt: new Date(),
+        dateTimeOriginal: null,
+      });
+
+      await expect(sut.handleFixDateFromFilename({ id: 'asset-id' })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.asset.update).not.toHaveBeenCalled();
+    });
+
+    it('should update asset and exif when date is parsed from filename', async () => {
+      const expectedDate = new Date('2023-04-15T14:30:22.000Z');
+      mocks.assetJob.getForFileDateFixJob.mockResolvedValue({
+        id: 'asset-id',
+        originalFileName: 'IMG_20230415_143022.jpg',
+        fileCreatedAt: new Date(),
+        dateTimeOriginal: null,
+      });
+
+      await expect(sut.handleFixDateFromFilename({ id: 'asset-id' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.asset.update).toHaveBeenCalledWith({
+        id: 'asset-id',
+        fileCreatedAt: expectedDate,
+        localDateTime: expectedDate,
+      });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith({
+        exif: {
+          assetId: 'asset-id',
+          dateTimeOriginal: expectedDate,
+          timeZone: null,
+        },
+        lockedPropertiesBehavior: 'skip',
+      });
     });
   });
 });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -83,6 +83,88 @@ export function firstDateTime(tags: ImmichTags) {
   }
 }
 
+function isValidDate(d: Date): boolean {
+  return !Number.isNaN(d.getTime());
+}
+
+function makeUtcDate(year: string, month: string, day: string, hour = '0', minute = '0', second = '0'): Date | null {
+  const y = Number.parseInt(year, 10);
+  const mo = Number.parseInt(month, 10);
+  const d = Number.parseInt(day, 10);
+  const h = Number.parseInt(hour, 10);
+  const mi = Number.parseInt(minute, 10);
+  const s = Number.parseInt(second, 10);
+  if (y < 1970 || y > 2100 || mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  if (h > 23 || mi > 59 || s > 59) return null;
+  const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s));
+  return isValidDate(date) && date.getUTCFullYear() === y ? date : null;
+}
+
+type FilenamePattern = { regex: RegExp; toDate: (m: RegExpMatchArray) => Date | null };
+
+const FILENAME_DATE_PATTERNS: FilenamePattern[] = [
+  // Facebook: FB_IMG_1681562400000.jpg (13-digit ms timestamp)
+  {
+    regex: /(?:^|[_-])(\d{13})(?:[_-]|$)/,
+    toDate: (m) => {
+      const d = new Date(Number.parseInt(m[1], 10));
+      return isValidDate(d) ? d : null;
+    },
+  },
+  // Snapchat / RPReplay: 10-digit Unix seconds
+  {
+    regex: /(?:^|[_-])(\d{10})(?:[_-]|$)/,
+    toDate: (m) => {
+      const sec = Number.parseInt(m[1], 10);
+      if (sec < 1_000_000_000 || sec > 2_147_483_647) return null;
+      const d = new Date(sec * 1000);
+      return isValidDate(d) ? d : null;
+    },
+  },
+  // ISO compact with T: 20230415T143022
+  {
+    regex: /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3], m[4], m[5], m[6]),
+  },
+  // Telegram / Screenshots: photo_2023-04-15_14-30-22 / Screenshot_2023-04-15-14-30-22
+  {
+    regex: /(\d{4})-(\d{2})-(\d{2})[_-](\d{2})-(\d{2})-(\d{2})(?:[_-]|$)/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3], m[4], m[5], m[6]),
+  },
+  // Signal: signal-2023-04-15-143022
+  {
+    regex: /(\d{4})-(\d{2})-(\d{2})[_-](\d{2})(\d{2})(\d{2})(?:[_-]|$)/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3], m[4], m[5], m[6]),
+  },
+  // Android / Samsung / Screenshots: 20230415_143022 / Screenshot_20230415-143022
+  {
+    regex: /(\d{4})(\d{2})(\d{2})[_-](\d{2})(\d{2})(\d{2})(?:[_-]|$)/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3], m[4], m[5], m[6]),
+  },
+  // Hyphenated date only: 2023-04-15
+  {
+    regex: /(\d{4})-(\d{2})-(\d{2})(?:[_\s-]|$)/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3]),
+  },
+  // WhatsApp / compact date only: IMG-20230415-WA, 20230415_
+  {
+    regex: /(\d{4})(\d{2})(\d{2})(?:[_-]|$)/,
+    toDate: (m) => makeUtcDate(m[1], m[2], m[3]),
+  },
+];
+
+export function parseDateFromFilename(filename: string): Date | null {
+  const stem = parse(filename).name;
+  for (const { regex, toDate } of FILENAME_DATE_PATTERNS) {
+    const match = stem.match(regex);
+    if (match) {
+      const date = toDate(match);
+      if (date) return date;
+    }
+  }
+  return null;
+}
+
 const validate = <T>(value: T): NonNullable<T> | null => {
   // handle lists of numbers
   if (Array.isArray(value)) {
@@ -413,6 +495,48 @@ export class MetadataService extends BaseService {
       userId: asset.ownerId,
       source: data.source,
     });
+  }
+
+  @OnJob({ name: JobName.AssetFixDateFromFilenameQueueAll, queue: QueueName.BackgroundTask })
+  async handleQueueFixDateFromFilename({ force }: JobOf<JobName.AssetFixDateFromFilenameQueueAll>): Promise<JobStatus> {
+    let jobs: { name: JobName.AssetFixDateFromFilename; data: { id: string } }[] = [];
+    for await (const asset of this.assetJobRepository.streamForFileDateFix(force)) {
+      jobs.push({ name: JobName.AssetFixDateFromFilename, data: { id: asset.id } });
+      if (jobs.length >= JOBS_ASSET_PAGINATION_SIZE) {
+        await this.jobRepository.queueAll(jobs);
+        jobs = [];
+      }
+    }
+    await this.jobRepository.queueAll(jobs);
+    return JobStatus.Success;
+  }
+
+  @OnJob({ name: JobName.AssetFixDateFromFilename, queue: QueueName.MetadataExtraction })
+  async handleFixDateFromFilename({ id }: JobOf<JobName.AssetFixDateFromFilename>): Promise<JobStatus> {
+    const asset = await this.assetJobRepository.getForFileDateFixJob(id);
+    if (!asset) {
+      return JobStatus.Failed;
+    }
+
+    if (asset.dateTimeOriginal) {
+      return JobStatus.Skipped;
+    }
+
+    const parsedDate = parseDateFromFilename(asset.originalFileName);
+    if (!parsedDate) {
+      this.logger.debug(`No date parsed from filename "${asset.originalFileName}" for asset ${id}`);
+      return JobStatus.Skipped;
+    }
+
+    this.logger.log(`Fixing date for asset ${id} from filename "${asset.originalFileName}": ${parsedDate.toISOString()}`);
+
+    await this.assetRepository.update({ id, fileCreatedAt: parsedDate, localDateTime: parsedDate });
+    await this.assetRepository.upsertExif({
+      exif: { assetId: id, dateTimeOriginal: parsedDate, timeZone: null },
+      lockedPropertiesBehavior: 'skip',
+    });
+
+    return JobStatus.Success;
   }
 
   @OnJob({ name: JobName.SidecarQueueAll, queue: QueueName.Sidecar })

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -347,6 +347,10 @@ export type JobItem =
   | { name: JobName.AssetExtractMetadataQueueAll; data: IBaseJob }
   | { name: JobName.AssetExtractMetadata; data: IEntityJob }
 
+  // Fix Date From Filename
+  | { name: JobName.AssetFixDateFromFilenameQueueAll; data: IBaseJob }
+  | { name: JobName.AssetFixDateFromFilename; data: IEntityJob }
+
   // Notifications
   | { name: JobName.NotificationsCleanup; data?: IBaseJob }
 


### PR DESCRIPTION
## Summary

- Adds a new manual background job (`fix-date-from-filename`) that backfills `fileCreatedAt`, `localDateTime`, and `exif.dateTimeOriginal` for assets where EXIF date is missing
- Parses the capture date from the original filename instead of falling back to upload/mtime
- Supports the most common app filename conventions: WhatsApp, Android/Samsung, Telegram, Signal, Facebook (13-digit ms timestamp), Snapchat/RPReplay (10-digit Unix seconds), iOS Screenshots, and ISO-like formats
- No DB schema changes — only existing columns are written
- Job is idempotent: skips assets that already have `dateTimeOriginal` set; `force=true` reprocesses all

## Filename patterns supported

| Source | Example |
|--------|---------|
| WhatsApp | `IMG-20230415-WA0001.jpg` |
| Android generic | `IMG_20230415_143022.jpg` |
| Samsung | `20230415_143022.jpg` |
| Screenshots | `Screenshot_20230415-143022.png`, `Screenshot_2023-04-15-14-30-22.png` |
| Telegram | `photo_2023-04-15_14-30-22.jpg` |
| Signal | `signal-2023-04-15-143022.jpg` |
| Facebook | `FB_IMG_1681562400000.jpg` (ms timestamp) |
| Snapchat | `Snapchat-1681562400.jpg` (Unix seconds) |
| iOS RPReplay | `RPReplay_Final1681562400.MP4` (Unix seconds) |
| ISO compact | `20230415T143022.jpg` |
| General ISO | `2023-04-15_14-30-22.jpg` |

## Test plan

- [ ] Unit tests pass: `cd server && pnpm test src/services/metadata.service.spec.ts`
- [ ] `parseDateFromFilename` tests cover all 11 format families + invalid/null cases
- [ ] `handleQueueFixDateFromFilename` tests verify force=false and force=true streaming behaviour
- [ ] `handleFixDateFromFilename` tests verify: not-found → Failed, already-has-date → Skipped, no-parse → Skipped, valid parse → Success with correct field updates
- [ ] Trigger job via admin API: `POST /api/jobs` `{"name": "fix-date-from-filename"}` and confirm assets missing EXIF dates are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)