### PR TITLE
fix: periodically execute pragma optimize

### DIFF
--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -176,15 +176,8 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       final backgroundSyncManager = _ref?.read(backgroundSyncProvider);
       final nativeSyncApi = _ref?.read(nativeSyncApiProvider);
 
-      await _drift.close();
-      await _driftLogger.close();
-
-      _ref?.dispose();
-      _ref = null;
-
-      _cancellationToken.complete();
       _logger.info("Cleaning up background worker");
-
+      _cancellationToken.complete();
       final cleanupFutures = [
         nativeSyncApi?.cancelHashing(),
         workerManagerPatch.dispose().catchError((_) async {
@@ -195,10 +188,15 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         Store.dispose(),
 
         backgroundSyncManager?.cancel(),
+        _drift.optimize(allTables: true),
       ];
 
       await Future.wait(cleanupFutures.nonNulls);
-      _logger.info("Background worker resources cleaned up");
+      await _drift.close();
+      await _driftLogger.close();
+
+      _ref?.dispose();
+      _ref = null;
     } catch (error, stack) {
       dPrint(() => 'Failed to cleanup background worker: $error with stack: $stack');
     }

--- a/mobile/lib/infrastructure/repositories/db.repository.dart
+++ b/mobile/lib/infrastructure/repositories/db.repository.dart
@@ -29,6 +29,7 @@ import 'package:immich_mobile/infrastructure/entities/user.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/user_metadata.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.steps.dart';
+import 'package:logging/logging.dart';
 
 @DriftDatabase(
   tables: [
@@ -81,6 +82,17 @@ class Drift extends $Drift {
       // Refresh all stream queries
       notifyUpdates({for (final table in allTables) TableUpdate.onTable(table)});
     });
+  }
+
+  Future<void> optimize({bool allTables = false}) async {
+    try {
+      if (allTables) {
+        await customStatement('PRAGMA optimize=0x10002');
+      }
+      await customStatement('PRAGMA optimize');
+    } catch (error) {
+      Logger('Drift').fine('Failed to optimize database', error);
+    }
   }
 
   @override
@@ -260,6 +272,7 @@ class Drift extends $Drift {
       }
 
       await customStatement('PRAGMA foreign_keys = ON;');
+      await optimize();
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');

--- a/mobile/lib/infrastructure/repositories/db.repository.dart
+++ b/mobile/lib/infrastructure/repositories/db.repository.dart
@@ -83,6 +83,17 @@ class Drift extends $Drift {
     });
   }
 
+  Future<void> optimize({bool allTables = false}) async {
+    try {
+      if (allTables) {
+        await customStatement('PRAGMA optimize=0x10002');
+      }
+      await customStatement('PRAGMA optimize');
+    } catch (_) {
+      // Ignore optimize errors
+    }
+  }
+
   @override
   int get schemaVersion => 24;
 
@@ -260,6 +271,7 @@ class Drift extends $Drift {
       }
 
       await customStatement('PRAGMA foreign_keys = ON;');
+      await optimize();
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');


### PR DESCRIPTION
## Description

Periodically runs `PRAGMA optimize` on the connection:
  	- On cold start (Runs across all tables)
  	- After each remote sync (Runs only on tables that have been read within the connection)
  	- After migrations (Runs only on tables that have modified)

Tested this on a large SQLite dump from the mobile database (~950mb) and since we haven't been running ANALYZE / OPTIMIZE at all, the initial run of the full optimize command took 10 seconds. Subsequent run of the same completed in under few milliseconds. Also confirmed that executing the command populates the `sqlite_stat1` and `sqlite_stat4` tables which were empty so far