### PR TITLE
fix(mobile): restore notification plugin init

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/constants/locales.dart';
@@ -163,6 +164,13 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
       }
     }
     SystemChrome.setSystemUIOverlayStyle(overlayStyle);
+
+    await FlutterLocalNotificationsPlugin().initialize(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@drawable/notification_icon'),
+        iOS: DarwinInitializationSettings(),
+      ),
+    );
   }
 
   Future<DeepLink> _deepLinkBuilder(PlatformDeepLink deepLink) async {


### PR DESCRIPTION
## Description

#27666 removed `LocalNotificationService` with the legacy stack. that was the only place calling `FlutterLocalNotificationsPlugin().initialize()`, which is what asks ios for the notification perm on first launch.

without it, fresh installs on ios never get the prompt — perm stays denied and `background_downloader` notifications get silently dropped.

putting the init back where the deleted call used to live. no `onDidReceiveNotificationResponse` callback since the only handler there cancelled the old manual upload which is also gone.

## How Has This Been Tested?

- [x] deleted the app from my iphone, fresh installed, perm prompt shows up on first launch
- [x] granted, app continues to work normally

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.