### PR TITLE
fix(mobile): mounted check before setState in album sync action

### DIFF
--- a/mobile/lib/widgets/settings/backup_settings/drift_backup_settings.dart
+++ b/mobile/lib/widgets/settings/backup_settings/drift_backup_settings.dart
@@ -74,6 +74,7 @@ class _AlbumSyncActionButtonState extends ConsumerState<_AlbumSyncActionButton> 
     } catch (_) {
     } finally {
       Future.delayed(const Duration(seconds: 1), () {
+        if (!mounted) return;
         setState(() {
           isAlbumSyncInProgress = false;
         });


### PR DESCRIPTION
## Description

_AlbumSyncActionButtonState._manualSyncAlbums schedules a setState 1s after sync via Future.delayed without a mounted check. if the user navigates away in that second, the State is disposed and setState throws null check operator on State._element. global error logger picks it up as severe — not user-visible but a real crash.

one line fix: `if (!mounted) return;` before setState.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

minimal — single guard line.