### PR TITLE
fix(web): exclude PWA manifest from public share routes

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -236,7 +236,9 @@
 
 <svelte:head>
   <title>{page.data.meta?.title || 'Web'} - Immich</title>
-  <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+  {#if !page.url.pathname.startsWith('/share/') && !page.url.pathname.startsWith('/s/')}
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+  {/if}
   <meta name="theme-color" content="white" media="(prefers-color-scheme: light)" />
   <meta name="theme-color" content="black" media="(prefers-color-scheme: dark)" />
 


### PR DESCRIPTION
## Description

Safari on iOS uses the web app manifest’s `start_url` for “Add to Home Screen” shortcuts instead of the page you’re viewing. The global manifest points at /, so visitors on a public share (/share/... or /s/...) got a shortcut to the root and were redirected to login instead of the public page.

### Change

Do not emit <link rel="manifest"> on public share routes so iOS falls back to bookmarking the current URL; the shortcut then opens the shared album directly.

## How Has This Been Tested?
Not tested - sorry I am a 100% noob about web apps and related stuff.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Opus 4.7 received my description of the problem and proposed this solution. 