### PR TITLE
fix(mobile): fallback to remote thumbnail when local fails

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -177,8 +177,13 @@ ImageProvider getFullImageProvider(BaseAsset asset, {Size size = const Size(1080
   return provider;
 }
 
-ImageProvider? getThumbnailImageProvider(BaseAsset asset, {Size size = kThumbnailResolution, bool edited = true}) {
-  if (_shouldUseLocalAsset(asset)) {
+ImageProvider? getThumbnailImageProvider(
+  BaseAsset asset, {
+  Size size = kThumbnailResolution,
+  bool edited = true,
+  bool localFailed = false,
+}) {
+  if (_shouldUseLocalAsset(asset) && !localFailed) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).localId!;
     return LocalThumbProvider(id: id, size: size, assetType: asset.type);
   }

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
+import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumb_hash_provider.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
@@ -18,24 +19,34 @@ class Thumbnail extends StatefulWidget {
   final ImageProvider? imageProvider;
   final ImageProvider? thumbhashProvider;
   final BoxFit fit;
+  final Size size;
+  final BaseAsset? asset;
 
-  const Thumbnail({this.imageProvider, this.fit = BoxFit.cover, this.thumbhashProvider, super.key});
+  const Thumbnail({
+    this.imageProvider,
+    this.fit = BoxFit.cover,
+    this.thumbhashProvider,
+    this.size = kThumbnailResolution,
+    this.asset,
+    super.key,
+  });
 
   Thumbnail.remote({
     required String remoteId,
     required String thumbhash,
     this.fit = BoxFit.cover,
-    Size size = kThumbnailResolution,
+    this.size = kThumbnailResolution,
     super.key,
   }) : imageProvider = RemoteImageProvider.thumbnail(assetId: remoteId, thumbhash: thumbhash),
-       thumbhashProvider = null;
+       thumbhashProvider = null,
+       asset = null;
 
   Thumbnail.fromAsset({
-    required BaseAsset? asset,
+    required this.asset,
     this.fit = BoxFit.cover,
 
     /// The logical UI size of the thumbnail. This is only used to determine the ideal image resolution and does not affect the widget size.
-    Size size = kThumbnailResolution,
+    this.size = kThumbnailResolution,
     super.key,
   }) : thumbhashProvider = switch (asset) {
          RemoteAsset() when asset.thumbHash != null && asset.localId == null => ThumbHashProvider(
@@ -105,9 +116,8 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
     thumbhashStream.addListener(thumbhashStreamListener);
   }
 
-  void _loadFromImageProvider() {
+  void _loadFromImageProvider(ImageProvider? imageProvider) {
     _stopListeningToImageStream();
-    final imageProvider = widget.imageProvider;
     if (imageProvider == null) return;
 
     final imageStream = _imageStream = imageProvider.resolve(ImageConfiguration.empty);
@@ -142,8 +152,18 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
         });
       },
       onError: (exception, stackTrace) {
-        log.severe('Error loading image: $exception', exception, stackTrace);
         _stopListeningToImageStream();
+
+        if (imageProvider is LocalThumbProvider && widget.asset != null) {
+          ImageProvider? nextProvider = getThumbnailImageProvider(widget.asset!, size: widget.size, localFailed: true);
+          if (nextProvider != null && nextProvider != imageProvider) {
+            log.fine('Error loading image, retrying with other provider: $exception', exception, stackTrace);
+            _loadFromImageProvider(nextProvider);
+            return;
+          }
+        }
+
+        log.severe('Error loading image: $exception', exception, stackTrace);
       },
     );
     imageStream.addListener(imageStreamListener);
@@ -180,7 +200,7 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
         _previousImage?.dispose();
         _previousImage = null;
       }
-      _loadFromImageProvider();
+      _loadFromImageProvider(widget.imageProvider);
     }
 
     if (_providerImage == null && oldWidget.thumbhashProvider != widget.thumbhashProvider) {
@@ -195,7 +215,7 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
   }
 
   void _loadImage() {
-    _loadFromImageProvider();
+    _loadFromImageProvider(widget.imageProvider);
     _loadFromThumbhashProvider();
   }
 


### PR DESCRIPTION
## Description

Loads an asset's remote thumbnail as a fallback if creating a thumbnail locally results in an error.

Fixes #21039

## How Has This Been Tested?

- [x] Check .mov file on Android app with no thumbnail
- [x] Upload to server
- [x] Thumbnail loads

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.
