### PR TITLE
fix(docs): missing colon in config file doc

### DIFF
--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -264,4 +264,4 @@ volumes:
   - ./configuration.yml:${IMMICH_CONFIG_FILE}
 ```
 
-::
+:::


### PR DESCRIPTION
## Description

<img width="371" height="225" alt="image" src="https://github.com/user-attachments/assets/0b3cb942-aee0-413f-9f22-f0f94f255a31" />

## How Has This Been Tested?

Not at all

## API Changes
none

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none