### PR TITLE
chore(server)!: remove libopus enum

### DIFF
--- a/mobile/openapi/lib/model/audio_codec.dart
+++ b/mobile/openapi/lib/model/audio_codec.dart
@@ -25,7 +25,6 @@ class AudioCodec {
 
   static const mp3 = AudioCodec._(r'mp3');
   static const aac = AudioCodec._(r'aac');
-  static const libopus = AudioCodec._(r'libopus');
   static const opus = AudioCodec._(r'opus');
   static const pcmS16le = AudioCodec._(r'pcm_s16le');
 
@@ -33,7 +32,6 @@ class AudioCodec {
   static const values = <AudioCodec>[
     mp3,
     aac,
-    libopus,
     opus,
     pcmS16le,
   ];
@@ -76,7 +74,6 @@ class AudioCodecTypeTransformer {
       switch (data) {
         case r'mp3': return AudioCodec.mp3;
         case r'aac': return AudioCodec.aac;
-        case r'libopus': return AudioCodec.libopus;
         case r'opus': return AudioCodec.opus;
         case r'pcm_s16le': return AudioCodec.pcmS16le;
         default:

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16929,7 +16929,6 @@
         "enum": [
           "mp3",
           "aac",
-          "libopus",
           "opus",
           "pcm_s16le"
         ],

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -7241,7 +7241,6 @@ export enum TranscodeHWAccel {
 export enum AudioCodec {
     Mp3 = "mp3",
     Aac = "aac",
-    Libopus = "libopus",
     Opus = "opus",
     PcmS16Le = "pcm_s16le"
 }

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -199,7 +199,6 @@ export const endpointTags: Record<ApiTag, string> = {
 export const AUDIO_ENCODER: Record<AudioCodec, string> = {
   [AudioCodec.Aac]: 'aac',
   [AudioCodec.Mp3]: 'mp3',
-  [AudioCodec.Libopus]: 'libopus',
   [AudioCodec.Opus]: 'libopus',
   [AudioCodec.PcmS16le]: 'pcm_s16le',
 };

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -7,7 +7,6 @@ import {
   OcrConfigSchema,
 } from 'src/dtos/model-config.dto';
 import {
-  AudioCodec,
   AudioCodecSchema,
   ColorspaceSchema,
   CQModeSchema,

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -65,10 +65,7 @@ const SystemConfigFFmpegSchema = z
     targetVideoCodec: VideoCodecSchema,
     acceptedVideoCodecs: z.array(VideoCodecSchema).describe('Accepted video codecs'),
     targetAudioCodec: AudioCodecSchema,
-    acceptedAudioCodecs: z
-      .array(AudioCodecSchema)
-      .transform((value): AudioCodec[] => value.map((v) => (v === AudioCodec.Libopus ? AudioCodec.Opus : v)))
-      .describe('Accepted audio codecs'),
+    acceptedAudioCodecs: z.array(AudioCodecSchema).describe('Accepted audio codecs'),
     acceptedContainers: z.array(VideoContainerSchema).describe('Accepted containers'),
     targetResolution: z.string().describe('Target resolution'),
     maxBitrate: z.string().describe('Max bitrate'),

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -454,8 +454,6 @@ export enum VideoSegmentCodec {
 export enum AudioCodec {
   Mp3 = 'mp3',
   Aac = 'aac',
-  /** @deprecated Use `Opus` instead */
-  Libopus = 'libopus',
   Opus = 'opus',
   PcmS16le = 'pcm_s16le',
 }


### PR DESCRIPTION
## Description

This enum was renamed to opus and "libopus" was deprecated and mapped to opus internally.