### PR TITLE
feat(web): add richer ML model selectors

### DIFF
--- a/web/src/lib/components/shared-components/Combobox.svelte
+++ b/web/src/lib/components/shared-components/Combobox.svelte
@@ -5,6 +5,8 @@
     id?: string;
     label: string;
     value: string;
+    description?: string;
+    keywords?: string[];
   };
 
   export const asComboboxOptions = (values: string[]) =>
@@ -130,8 +132,31 @@
     openDropdown();
   };
 
+  const normalizeQuery = (value: string) => value.trim().toLowerCase();
+
+  const findMatchingOption = (value: string): ComboBoxOption | undefined => {
+    const normalizedValue = normalizeQuery(value);
+    if (!normalizedValue) {
+      return undefined;
+    }
+
+    return options.find((option) => {
+      return [option.label, option.value].some((candidate) => normalizeQuery(candidate) === normalizedValue);
+    });
+  };
+
   const deactivate = () => {
-    searchQuery = selectedOption ? selectedOption.label : '';
+    const trimmedQuery = searchQuery.trim();
+    const matchingOption = findMatchingOption(trimmedQuery);
+
+    if (allowCreate && trimmedQuery !== '' && (!selectedOption || normalizeQuery(selectedOption.label) !== normalizeQuery(trimmedQuery))) {
+      const nextOption = matchingOption ?? { label: trimmedQuery, value: trimmedQuery };
+      selectedOption = nextOption;
+      onSelect(nextOption);
+      searchQuery = nextOption.label;
+    } else {
+      searchQuery = selectedOption ? selectedOption.label : '';
+    }
     isActive = false;
     closeDropdown();
   };
@@ -255,10 +280,16 @@
   const getInputPosition = () => input?.getBoundingClientRect();
 
   let filteredOptions = $derived.by(() => {
-    const _options = options.filter((option) => option.label.toLowerCase().includes(searchQuery.toLowerCase()));
+    const trimmedQuery = searchQuery.trim();
+    const normalizedQuery = trimmedQuery.toLowerCase();
+    const _options = options.filter((option) => {
+      const haystacks = [option.label, option.value, option.description ?? '', ...(option.keywords ?? [])]
+        .map((value) => value.toLowerCase());
+      return haystacks.some((value) => value.includes(normalizedQuery));
+    });
 
-    if (allowCreate && searchQuery !== '' && _options.filter((option) => option.label === searchQuery).length === 0) {
-      _options.unshift({ label: searchQuery, value: searchQuery });
+    if (allowCreate && trimmedQuery !== '' && !findMatchingOption(trimmedQuery)) {
+      _options.unshift({ label: trimmedQuery, value: trimmedQuery });
     }
 
     return _options;
@@ -415,7 +446,12 @@
           onclick={() => handleSelect(option)}
           role="option"
         >
-          {option.label}
+          <div class="flex flex-col gap-0.5">
+            <span>{option.label}</span>
+            {#if option.description}
+              <span class="text-xs text-gray-500 dark:text-gray-400">{option.description}</span>
+            {/if}
+          </div>
         </li>
       {/each}
     {/if}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -42,6 +42,98 @@ export const dateFormats = {
   } satisfies Intl.DateTimeFormatOptions,
 };
 
+type MachineLearningModelOption = {
+  label: string;
+  value: string;
+  description: string;
+  keywords?: string[];
+};
+
+// Frontend snapshot of the supported ML model catalog.
+// Model identifiers were taken from machine-learning/immich_ml/models/constants.py,
+// CLIP embedding dimensions were taken from server/src/constants.ts, and the release
+// dates were copied from the corresponding immich-app Hugging Face model listings/cards.
+export const machineLearningClipModelOptions: MachineLearningModelOption[] = [
+    { label: 'ViT-gopt-16-SigLIP2-256__webli', value: 'ViT-gopt-16-SigLIP2-256__webli', description: '1536d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-gopt-16-SigLIP2-384__webli', value: 'ViT-gopt-16-SigLIP2-384__webli', description: '1536d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-SO400M-14-SigLIP-384__webli', value: 'ViT-SO400M-14-SigLIP-384__webli', description: '1152d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-SO400M-14-SigLIP2-378__webli', value: 'ViT-SO400M-14-SigLIP2-378__webli', description: '1152d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-SO400M-14-SigLIP2__webli', value: 'ViT-SO400M-14-SigLIP2__webli', description: '1152d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-SO400M-16-SigLIP2-256__webli', value: 'ViT-SO400M-16-SigLIP2-256__webli', description: '1152d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-SO400M-16-SigLIP2-384__webli', value: 'ViT-SO400M-16-SigLIP2-384__webli', description: '1152d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-SO400M-16-SigLIP2-512__webli', value: 'ViT-SO400M-16-SigLIP2-512__webli', description: '1152d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'nllb-clip-large-siglip__mrl', value: 'nllb-clip-large-siglip__mrl', description: '1152d embeddings. Multilingual search model. Released Jul 2024.' },
+    { label: 'nllb-clip-large-siglip__v1', value: 'nllb-clip-large-siglip__v1', description: '1152d embeddings. Multilingual search model. Released Dec 2023.' },
+    { label: 'RN50__cc12m', value: 'RN50__cc12m', description: '1024d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'RN50__openai', value: 'RN50__openai', description: '1024d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'RN50__yfcc15m', value: 'RN50__yfcc15m', description: '1024d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'RN50x64__openai', value: 'RN50x64__openai', description: '1024d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'ViT-H-14-378-quickgelu__dfn5b', value: 'ViT-H-14-378-quickgelu__dfn5b', description: '1024d embeddings. General-purpose CLIP model. Released Dec 2023.' },
+    { label: 'ViT-H-14-quickgelu__dfn5b', value: 'ViT-H-14-quickgelu__dfn5b', description: '1024d embeddings. General-purpose CLIP model. Released Dec 2023.' },
+    { label: 'ViT-H-14__laion2b-s32b-b79k', value: 'ViT-H-14__laion2b-s32b-b79k', description: '1024d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-L-16-SigLIP-256__webli', value: 'ViT-L-16-SigLIP-256__webli', description: '1024d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-L-16-SigLIP-384__webli', value: 'ViT-L-16-SigLIP-384__webli', description: '1024d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-L-16-SigLIP2-256__webli', value: 'ViT-L-16-SigLIP2-256__webli', description: '1024d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-L-16-SigLIP2-384__webli', value: 'ViT-L-16-SigLIP2-384__webli', description: '1024d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-L-16-SigLIP2-512__webli', value: 'ViT-L-16-SigLIP2-512__webli', description: '1024d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-g-14__laion2b-s12b-b42k', value: 'ViT-g-14__laion2b-s12b-b42k', description: '1024d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k', value: 'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k', description: '1024d embeddings. Multilingual search model. Released Dec 2023.' },
+    { label: 'LABSE-Vit-L-14', value: 'LABSE-Vit-L-14', description: '768d embeddings. Multilingual search model. Released Oct 2023.' },
+    { label: 'RN50x16__openai', value: 'RN50x16__openai', description: '768d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'ViT-B-16-SigLIP-256__webli', value: 'ViT-B-16-SigLIP-256__webli', description: '768d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-B-16-SigLIP-384__webli', value: 'ViT-B-16-SigLIP-384__webli', description: '768d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-B-16-SigLIP-512__webli', value: 'ViT-B-16-SigLIP-512__webli', description: '768d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-B-16-SigLIP-i18n-256__webli', value: 'ViT-B-16-SigLIP-i18n-256__webli', description: '768d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-B-16-SigLIP2__webli', value: 'ViT-B-16-SigLIP2__webli', description: '768d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-B-16-SigLIP__webli', value: 'ViT-B-16-SigLIP__webli', description: '768d embeddings. Fast and accurate semantic search model. Released Jul 2024.' },
+    { label: 'ViT-B-32-SigLIP2-256__webli', value: 'ViT-B-32-SigLIP2-256__webli', description: '768d embeddings. Newest generation embedding family. Released Mar 2025.' },
+    { label: 'ViT-L-14-336__openai', value: 'ViT-L-14-336__openai', description: '768d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-L-14-quickgelu__dfn2b', value: 'ViT-L-14-quickgelu__dfn2b', description: '768d embeddings. General-purpose CLIP model. Released Dec 2023.' },
+    { label: 'ViT-L-14__laion2b-s32b-b82k', value: 'ViT-L-14__laion2b-s32b-b82k', description: '768d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-L-14__laion400m_e31', value: 'ViT-L-14__laion400m_e31', description: '768d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-L-14__laion400m_e32', value: 'ViT-L-14__laion400m_e32', description: '768d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-L-14__openai', value: 'ViT-L-14__openai', description: '768d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'XLM-Roberta-Large-Vit-L-14', value: 'XLM-Roberta-Large-Vit-L-14', description: '768d embeddings. Multilingual search model. Released Oct 2023.' },
+    { label: 'nllb-clip-base-siglip__mrl', value: 'nllb-clip-base-siglip__mrl', description: '768d embeddings. Multilingual search model. Released Jul 2024.' },
+    { label: 'nllb-clip-base-siglip__v1', value: 'nllb-clip-base-siglip__v1', description: '768d embeddings. Multilingual search model. Released Dec 2023.' },
+    { label: 'RN50x4__openai', value: 'RN50x4__openai', description: '640d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'ViT-B-16-plus-240__laion400m_e31', value: 'ViT-B-16-plus-240__laion400m_e31', description: '640d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-16-plus-240__laion400m_e32', value: 'ViT-B-16-plus-240__laion400m_e32', description: '640d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'XLM-Roberta-Large-Vit-B-16Plus', value: 'XLM-Roberta-Large-Vit-B-16Plus', description: '640d embeddings. Multilingual search model. Released Oct 2023.' },
+    { label: 'RN101__openai', value: 'RN101__openai', description: '512d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'RN101__yfcc15m', value: 'RN101__yfcc15m', description: '512d embeddings. Legacy baseline with broad compatibility. Released Oct 2023.' },
+    { label: 'ViT-B-16__laion400m_e31', value: 'ViT-B-16__laion400m_e31', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-16__laion400m_e32', value: 'ViT-B-16__laion400m_e32', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-16__openai', value: 'ViT-B-16__openai', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-32__laion2b-s34b-b79k', value: 'ViT-B-32__laion2b-s34b-b79k', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-32__laion2b_e16', value: 'ViT-B-32__laion2b_e16', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-32__laion400m_e31', value: 'ViT-B-32__laion400m_e31', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-32__laion400m_e32', value: 'ViT-B-32__laion400m_e32', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'ViT-B-32__openai', value: 'ViT-B-32__openai', description: '512d embeddings. General-purpose CLIP model. Released Oct 2023.' },
+    { label: 'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k', value: 'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k', description: '512d embeddings. Multilingual search model. Released Jul 2024.' },
+    { label: 'XLM-Roberta-Large-Vit-B-32', value: 'XLM-Roberta-Large-Vit-B-32', description: '512d embeddings. Multilingual search model. Released Oct 2023.' },
+  ];
+
+export const machineLearningFacialRecognitionModelOptions: MachineLearningModelOption[] = [
+    { label: 'antelopev2', value: 'antelopev2', description: 'Largest face model with the strongest matching quality. Released Nov 2023.' },
+    { label: 'buffalo_l', value: 'buffalo_l', description: 'Large face model with balanced speed and recognition accuracy. Released Nov 2023.' },
+    { label: 'buffalo_m', value: 'buffalo_m', description: 'Medium face model for modest hardware. Released Nov 2023.' },
+    { label: 'buffalo_s', value: 'buffalo_s', description: 'Smallest face model with the lightest runtime footprint. Released Nov 2023.' },
+  ];
+
+export const machineLearningOcrModelOptions: MachineLearningModelOption[] = [
+    { label: 'CH__PP-OCRv5_server', value: 'CH__PP-OCRv5_server', description: 'Largest OCR model for Chinese-heavy workloads.' },
+    { label: 'PP-OCRv5_server', value: 'PP-OCRv5_server', description: 'Large OCR model tuned for highest quality text extraction.' },
+    { label: 'CH__PP-OCRv5_mobile', value: 'CH__PP-OCRv5_mobile', description: 'Medium OCR model for Chinese-heavy workloads.' },
+    { label: 'PP-OCRv5_mobile', value: 'PP-OCRv5_mobile', description: 'Medium OCR model and the default general-purpose choice.' },
+    { label: 'EL__PP-OCRv5_mobile', value: 'EL__PP-OCRv5_mobile', description: 'Compact Greek and English OCR model.' },
+    { label: 'EN__PP-OCRv5_mobile', value: 'EN__PP-OCRv5_mobile', description: 'Compact English OCR model.' },
+    { label: 'ESLAV__PP-OCRv5_mobile', value: 'ESLAV__PP-OCRv5_mobile', description: 'Compact East Slavic OCR model.' },
+    { label: 'KOREAN__PP-OCRv5_mobile', value: 'KOREAN__PP-OCRv5_mobile', description: 'Compact Korean and English OCR model.' },
+    { label: 'LATIN__PP-OCRv5_mobile', value: 'LATIN__PP-OCRv5_mobile', description: 'Compact Latin-script OCR model for broad European language coverage.' },
+    { label: 'TH__PP-OCRv5_mobile', value: 'TH__PP-OCRv5_mobile', description: 'Compact Thai and English OCR model.' },
+  ];
+
 export enum QueryParameter {
   ACTION = 'action',
   ID = 'id',

--- a/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
+++ b/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
@@ -5,495 +5,32 @@
   import SettingSwitch from '$lib/components/shared-components/settings/SettingSwitch.svelte';
   import SettingButtonsRow from '$lib/components/shared-components/settings/SystemConfigButtonRow.svelte';
   import type { ComboBoxOption } from '$lib/components/shared-components/Combobox.svelte';
-  import { SettingInputFieldType } from '$lib/constants';
+  import {
+    machineLearningClipModelOptions,
+    machineLearningFacialRecognitionModelOptions,
+    machineLearningOcrModelOptions,
+    SettingInputFieldType,
+  } from '$lib/constants';
   import FormatMessage from '$lib/elements/FormatMessage.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { systemConfigManager } from '$lib/managers/system-config-manager.svelte';
   import { Button, IconButton } from '@immich/ui';
   import { mdiPlus, mdiTrashCanOutline } from '@mdi/js';
   import { isEqual } from 'lodash-es';
-  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
-
-  type HuggingFaceModel = {
-    id?: string;
-    modelId?: string;
-    createdAt?: string;
-    lastModified?: string;
-    downloads?: number;
-  };
 
   const disabled = $derived(featureFlagsManager.value.configFile);
   const config = $derived(systemConfigManager.value);
   let configToEdit = $state(systemConfigManager.cloneValue());
-  let isRefreshingModelOptions = $state(false);
-  let isHfConnected = $state(false);
 
-  let clipModelOptions = $state<ComboBoxOption[]>([]);
-  let facialRecognitionModelOptions = $state<ComboBoxOption[]>([]);
-  let ocrModelOptions = $state<ComboBoxOption[]>([]);
-
-  const CLIP_MODEL_DIMENSIONS: Record<string, number> = {
-    RN101__openai: 512,
-    RN101__yfcc15m: 512,
-    'ViT-B-16__laion400m_e31': 512,
-    'ViT-B-16__laion400m_e32': 512,
-    'ViT-B-16__openai': 512,
-    'ViT-B-32__laion2b-s34b-b79k': 512,
-    'ViT-B-32__laion2b_e16': 512,
-    'ViT-B-32__laion400m_e31': 512,
-    'ViT-B-32__laion400m_e32': 512,
-    'ViT-B-32__openai': 512,
-    'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': 512,
-    'XLM-Roberta-Large-Vit-B-32': 512,
-    RN50x4__openai: 640,
-    'ViT-B-16-plus-240__laion400m_e31': 640,
-    'ViT-B-16-plus-240__laion400m_e32': 640,
-    'XLM-Roberta-Large-Vit-B-16Plus': 640,
-    'LABSE-Vit-L-14': 768,
-    RN50x16__openai: 768,
-    'ViT-B-16-SigLIP-256__webli': 768,
-    'ViT-B-16-SigLIP-384__webli': 768,
-    'ViT-B-16-SigLIP-512__webli': 768,
-    'ViT-B-16-SigLIP-i18n-256__webli': 768,
-    'ViT-B-16-SigLIP__webli': 768,
-    'ViT-L-14-336__openai': 768,
-    'ViT-L-14-quickgelu__dfn2b': 768,
-    'ViT-L-14__laion2b-s32b-b82k': 768,
-    'ViT-L-14__laion400m_e31': 768,
-    'ViT-L-14__laion400m_e32': 768,
-    'ViT-L-14__openai': 768,
-    'XLM-Roberta-Large-Vit-L-14': 768,
-    'nllb-clip-base-siglip__mrl': 768,
-    'nllb-clip-base-siglip__v1': 768,
-    RN50__cc12m: 1024,
-    RN50__openai: 1024,
-    RN50__yfcc15m: 1024,
-    RN50x64__openai: 1024,
-    'ViT-H-14-378-quickgelu__dfn5b': 1024,
-    'ViT-H-14-quickgelu__dfn5b': 1024,
-    'ViT-H-14__laion2b-s32b-b79k': 1024,
-    'ViT-L-16-SigLIP-256__webli': 1024,
-    'ViT-L-16-SigLIP-384__webli': 1024,
-    'ViT-g-14__laion2b-s12b-b42k': 1024,
-    'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': 1024,
-    'ViT-SO400M-14-SigLIP-384__webli': 1152,
-    'nllb-clip-large-siglip__mrl': 1152,
-    'nllb-clip-large-siglip__v1': 1152,
-    'ViT-B-16-SigLIP2__webli': 768,
-    'ViT-B-32-SigLIP2-256__webli': 768,
-    'ViT-L-16-SigLIP2-256__webli': 1024,
-    'ViT-L-16-SigLIP2-384__webli': 1024,
-    'ViT-L-16-SigLIP2-512__webli': 1024,
-    'ViT-SO400M-14-SigLIP2__webli': 1152,
-    'ViT-SO400M-14-SigLIP2-378__webli': 1152,
-    'ViT-SO400M-16-SigLIP2-256__webli': 1152,
-    'ViT-SO400M-16-SigLIP2-384__webli': 1152,
-    'ViT-SO400M-16-SigLIP2-512__webli': 1152,
-    'ViT-gopt-16-SigLIP2-256__webli': 1536,
-    'ViT-gopt-16-SigLIP2-384__webli': 1536,
-  };
-
-  const MODEL_RELEASE_DATES: Record<string, string> = {
-    antelopev2: '2023-11-10',
-    buffalo_l: '2023-11-10',
-    buffalo_l_batch: '2024-06-10',
-    buffalo_m: '2023-11-10',
-    buffalo_s: '2023-11-10',
-    'LABSE-Vit-L-14': '2023-10-28',
-    'nllb-clip-base-siglip__mrl': '2024-07-22',
-    'nllb-clip-base-siglip__v1': '2023-12-11',
-    'nllb-clip-large-siglip__mrl': '2024-07-22',
-    'nllb-clip-large-siglip__v1': '2023-12-11',
-    'RN101__openai': '2023-10-28',
-    'RN101__yfcc15m': '2023-10-28',
-    'RN50__cc12m': '2023-10-28',
-    'RN50__openai': '2023-10-28',
-    'RN50__yfcc15m': '2023-10-28',
-    'RN50x16__openai': '2023-10-28',
-    'RN50x4__openai': '2023-10-28',
-    'RN50x64__openai': '2023-10-28',
-    'ViT-B-16__laion400m_e31': '2023-10-28',
-    'ViT-B-16__laion400m_e32': '2023-10-28',
-    'ViT-B-16__openai': '2023-10-28',
-    'ViT-B-16-plus-240__laion400m_e31': '2023-10-28',
-    'ViT-B-16-plus-240__laion400m_e32': '2023-10-28',
-    'ViT-B-16-SigLIP__webli': '2024-07-22',
-    'ViT-B-16-SigLIP-256__webli': '2024-07-22',
-    'ViT-B-16-SigLIP-384__webli': '2024-07-22',
-    'ViT-B-16-SigLIP-512__webli': '2024-07-22',
-    'ViT-B-16-SigLIP-i18n-256__webli': '2024-07-22',
-    'ViT-B-16-SigLIP2__webli': '2025-03-12',
-    'ViT-B-32__laion2b_e16': '2023-10-28',
-    'ViT-B-32__laion2b-s34b-b79k': '2023-10-28',
-    'ViT-B-32__laion400m_e31': '2023-10-28',
-    'ViT-B-32__laion400m_e32': '2023-10-28',
-    'ViT-B-32__openai': '2023-10-28',
-    'ViT-B-32-SigLIP2-256__webli': '2025-03-12',
-    'ViT-g-14__laion2b-s12b-b42k': '2023-10-28',
-    'ViT-gopt-16-SigLIP2-256__webli': '2025-03-13',
-    'ViT-gopt-16-SigLIP2-384__webli': '2025-03-13',
-    'ViT-H-14__laion2b-s32b-b79k': '2023-10-28',
-    'ViT-H-14-378-quickgelu__dfn5b': '2023-12-11',
-    'ViT-H-14-quickgelu__dfn5b': '2023-12-11',
-    'ViT-L-14__laion2b-s32b-b82k': '2023-10-28',
-    'ViT-L-14__laion400m_e31': '2023-10-28',
-    'ViT-L-14__laion400m_e32': '2023-10-28',
-    'ViT-L-14__openai': '2023-10-28',
-    'ViT-L-14-336__openai': '2023-10-28',
-    'ViT-L-14-quickgelu__dfn2b': '2023-12-11',
-    'ViT-L-16-SigLIP-256__webli': '2024-07-22',
-    'ViT-L-16-SigLIP-384__webli': '2024-07-22',
-    'ViT-L-16-SigLIP2-256__webli': '2025-03-12',
-    'ViT-L-16-SigLIP2-384__webli': '2025-03-13',
-    'ViT-L-16-SigLIP2-512__webli': '2025-03-13',
-    'ViT-SO400M-14-SigLIP-384__webli': '2024-07-22',
-    'ViT-SO400M-14-SigLIP2__webli': '2025-03-13',
-    'ViT-SO400M-14-SigLIP2-378__webli': '2025-03-13',
-    'ViT-SO400M-16-SigLIP2-256__webli': '2025-03-13',
-    'ViT-SO400M-16-SigLIP2-384__webli': '2025-03-13',
-    'ViT-SO400M-16-SigLIP2-512__webli': '2025-03-13',
-    'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': '2024-07-22',
-    'XLM-Roberta-Large-Vit-B-16Plus': '2023-10-28',
-    'XLM-Roberta-Large-Vit-B-32': '2023-10-28',
-    'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': '2023-12-11',
-    'XLM-Roberta-Large-Vit-L-14': '2023-10-28',
-  };
-
-  const formatReleaseDate = (date?: string): string => {
-    if (!date) {
-      return 'Release date unavailable';
-    }
-
-    const parsedDate = new Date(date);
-    if (Number.isNaN(parsedDate.getTime())) {
-      return 'Release date unavailable';
-    }
-
-    return `Released ${new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric' }).format(parsedDate)}`;
-  };
-
-  const getModelReleaseDate = (modelName: string, model?: HuggingFaceModel): string => {
-    return model?.createdAt ?? MODEL_RELEASE_DATES[modelName] ?? '';
-  };
-
-  const getReleaseSortKey = (date?: string): string => {
-    if (!date) {
-      return '';
-    }
-
-    const parsedDate = new Date(date);
-    if (Number.isNaN(parsedDate.getTime())) {
-      return '';
-    }
-
-    return parsedDate.toISOString().slice(0, 10);
-  };
-
-  const compareModelReleaseDateDesc = (
-    left: { modelName: string; model?: HuggingFaceModel },
-    right: { modelName: string; model?: HuggingFaceModel },
-  ): number => {
-    const leftReleaseKey = getReleaseSortKey(getModelReleaseDate(left.modelName, left.model));
-    const rightReleaseKey = getReleaseSortKey(getModelReleaseDate(right.modelName, right.model));
-
-    if (leftReleaseKey !== rightReleaseKey) {
-      return rightReleaseKey.localeCompare(leftReleaseKey);
-    }
-
-    return left.modelName.localeCompare(right.modelName);
-  };
-
-  const joinDescriptionParts = (...parts: Array<string | undefined>): string => {
-    return parts.filter((part) => Boolean(part)).join(' ');
-  };
-
-  const getClipModelValueDescription = (modelName: string, dimSize: number): string => {
-    if (modelName.includes('SigLIP2')) {
-      return `${dimSize}d, newest generation`;
-    }
-
-    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
-      return `${dimSize}d, multilingual search`;
-    }
-
-    if (modelName.includes('SigLIP')) {
-      return `${dimSize}d, fast and accurate`;
-    }
-
-    return `${dimSize}d, stable baseline`;
-  };
-
-  const getClipModelRecommendation = (modelName: string): string => {
-    if (modelName.includes('SigLIP2')) {
-      return 'Best for new deployments that want the strongest search quality and the most modern embedding family.';
-    }
-
-    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
-      return 'Best for multilingual libraries where captions and search terms span multiple languages.';
-    }
-
-    if (modelName.includes('SigLIP')) {
-      return 'Strong default when you want fast indexing with better semantic search quality than the older CLIP baselines.';
-    }
-
-    if (modelName.includes('RN')) {
-      return 'Legacy baseline with broad compatibility, useful when you want predictable behavior over newest quality gains.';
-    }
-
-    if (modelName.includes('ViT-H') || modelName.includes('ViT-g')) {
-      return 'Higher-capacity model family aimed at quality-first search on stronger hardware.';
-    }
-
-    return 'Balanced CLIP baseline for semantic search and duplicate detection embeddings.';
-  };
-
-  const buildClipDescription = (modelName: string, dimSize: number, model?: HuggingFaceModel): string => {
-    return joinDescriptionParts(
-      getClipModelValueDescription(modelName, dimSize) + '.',
-      getClipModelRecommendation(modelName),
-      formatReleaseDate(getModelReleaseDate(modelName, model)) + '.',
-    );
-  };
-
-  const getClipModelKeywords = (modelName: string): string[] => {
-    const keywords = ['clip', 'smart search', 'semantic search'];
-    if (modelName.includes('SigLIP2')) {
-      keywords.push('siglip2', 'newest');
-    }
-    if (modelName.includes('SigLIP')) {
-      keywords.push('siglip');
-    }
-    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
-      keywords.push('multilingual');
-    }
-    if (modelName.includes('ViT-H') || modelName.includes('ViT-g')) {
-      keywords.push('high accuracy');
-    }
-    return keywords;
-  };
-
-  const CLIP_MODEL_FALLBACK_OPTIONS: ComboBoxOption[] = Object.entries(CLIP_MODEL_DIMENSIONS)
-    .map(([modelName, dimSize]) => ({ modelName, model: undefined as HuggingFaceModel | undefined, dimSize }))
-    .sort(compareModelReleaseDateDesc)
-    .map(({ modelName, dimSize }) => ({
-      value: modelName,
-      label: modelName,
-      description: buildClipDescription(modelName, dimSize),
-      keywords: getClipModelKeywords(modelName),
-    }));
-
-  const FACIAL_RECOGNITION_FALLBACK_OPTIONS: ComboBoxOption[] = [
-    {
-      value: 'antelopev2',
-      label: 'antelopev2',
-      description: joinDescriptionParts(
-        'Best face recognition quality with the highest memory use, suited to large libraries and quality-first matching.',
-        formatReleaseDate(getModelReleaseDate('antelopev2')) + '.',
-      ),
-      keywords: ['face', 'recognition', 'highest quality', 'memory'],
-    },
-    {
-      value: 'buffalo_l',
-      label: 'buffalo_l',
-      description: joinDescriptionParts(
-        'High recognition quality with balanced speed. A strong default if you want reliable matching without the heaviest footprint.',
-        formatReleaseDate(getModelReleaseDate('buffalo_l')) + '.',
-      ),
-      keywords: ['face', 'recognition', 'balanced', 'quality'],
-    },
-    {
-      value: 'buffalo_m',
-      label: 'buffalo_m',
-      description: joinDescriptionParts(
-        'Balanced quality and memory footprint. Best for modest hardware that still needs useful face grouping and recognition.',
-        formatReleaseDate(getModelReleaseDate('buffalo_m')) + '.',
-      ),
-      keywords: ['face', 'recognition', 'memory', 'balanced'],
-    },
-    {
-      value: 'buffalo_s',
-      label: 'buffalo_s',
-      description: joinDescriptionParts(
-        'Lowest memory usage and fastest startup, with the biggest tradeoff in recognition quality and matching recall.',
-        formatReleaseDate(getModelReleaseDate('buffalo_s')) + '.',
-      ),
-      keywords: ['face', 'recognition', 'fastest', 'lightweight'],
-    },
-  ].sort((left, right) => compareModelReleaseDateDesc({ modelName: left.value }, { modelName: right.value }));
-
-  const OCR_MODEL_FALLBACK_OPTIONS: ComboBoxOption[] = [
-    {
-      value: 'PP-OCRv5_server',
-      label: 'PP-OCRv5_server',
-      description: joinDescriptionParts(
-        'Best OCR quality and layout handling, but also the heaviest compute option. Use when text extraction accuracy matters more than throughput.',
-        formatReleaseDate(getModelReleaseDate('PP-OCRv5_server')) + '.',
-      ),
-      keywords: ['ocr', 'server', 'highest quality'],
-    },
-    {
-      value: 'PP-OCRv5_mobile',
-      label: 'PP-OCRv5_mobile',
-      description: joinDescriptionParts(
-        'Balanced OCR quality and speed. The best default for mixed workloads and general-purpose photo libraries.',
-        formatReleaseDate(getModelReleaseDate('PP-OCRv5_mobile')) + '.',
-      ),
-      keywords: ['ocr', 'mobile', 'balanced'],
-    },
-    {
-      value: 'EN__PP-OCRv5_mobile',
-      label: 'EN__PP-OCRv5_mobile',
-      description: joinDescriptionParts(
-        'English-only OCR and the fastest option when you do not need multilingual text extraction.',
-        formatReleaseDate(getModelReleaseDate('EN__PP-OCRv5_mobile')) + '.',
-      ),
-      keywords: ['ocr', 'english', 'fastest'],
-    },
-    {
-      value: 'EL__PP-OCRv5_mobile',
-      label: 'EL__PP-OCRv5_mobile',
-      description: joinDescriptionParts('Greek and English OCR model for libraries that mainly need Greek script support.', formatReleaseDate(getModelReleaseDate('EL__PP-OCRv5_mobile')) + '.'),
-      keywords: ['ocr', 'greek', 'english'],
-    },
-    {
-      value: 'KOREAN__PP-OCRv5_mobile',
-      label: 'KOREAN__PP-OCRv5_mobile',
-      description: joinDescriptionParts('Korean and English OCR model for mixed Korean-language collections.', formatReleaseDate(getModelReleaseDate('KOREAN__PP-OCRv5_mobile')) + '.'),
-      keywords: ['ocr', 'korean', 'english'],
-    },
-    {
-      value: 'LATIN__PP-OCRv5_mobile',
-      label: 'LATIN__PP-OCRv5_mobile',
-      description: joinDescriptionParts('Latin-script OCR model for broad European language coverage without the full multilingual overhead.', formatReleaseDate(getModelReleaseDate('LATIN__PP-OCRv5_mobile')) + '.'),
-      keywords: ['ocr', 'latin', 'multilingual'],
-    },
-    {
-      value: 'ESLAV__PP-OCRv5_mobile',
-      label: 'ESLAV__PP-OCRv5_mobile',
-      description: joinDescriptionParts('East Slavic and English OCR model for Cyrillic-heavy libraries.', formatReleaseDate(getModelReleaseDate('ESLAV__PP-OCRv5_mobile')) + '.'),
-      keywords: ['ocr', 'slavic', 'english'],
-    },
-    {
-      value: 'TH__PP-OCRv5_mobile',
-      label: 'TH__PP-OCRv5_mobile',
-      description: joinDescriptionParts('Thai and English OCR model for mixed Thai-language collections.', formatReleaseDate(getModelReleaseDate('TH__PP-OCRv5_mobile')) + '.'),
-      keywords: ['ocr', 'thai', 'english'],
-    },
-  ].sort((left, right) => compareModelReleaseDateDesc({ modelName: left.value }, { modelName: right.value }));
+  let clipModelOptions = $state<ComboBoxOption[]>(machineLearningClipModelOptions);
+  let facialRecognitionModelOptions = $state<ComboBoxOption[]>(machineLearningFacialRecognitionModelOptions);
+  let ocrModelOptions = $state<ComboBoxOption[]>(machineLearningOcrModelOptions);
 
   const getSelectedModelOption = (options: ComboBoxOption[], value: string): ComboBoxOption | undefined => {
     return options.find((option) => option.value === value) ?? (value ? { label: value, value } : undefined);
   };
-
-  const getModelIdentifier = (model: HuggingFaceModel): string | undefined => {
-    return model.modelId || model.id;
-  };
-
-  const buildClipModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
-    return models
-      .map((model) => ({ modelName: getModelIdentifier(model)?.replace(/^immich-app\//, ''), model }))
-      .filter((entry): entry is { modelName: string; model: HuggingFaceModel } => Boolean(entry.modelName))
-      .filter(({ modelName }) => modelName in CLIP_MODEL_DIMENSIONS)
-      .sort(compareModelReleaseDateDesc)
-      .map(({ modelName, model }) => {
-        const dimSize = CLIP_MODEL_DIMENSIONS[modelName] ?? 0;
-        return {
-          value: modelName,
-          label: modelName,
-          description: joinDescriptionParts(
-            buildClipDescription(modelName, dimSize, model),
-            typeof model.downloads === 'number' && model.downloads > 0 ? `${model.downloads.toLocaleString()} downloads on Hugging Face.` : undefined,
-          ),
-          keywords: getClipModelKeywords(modelName),
-        };
-      });
-  };
-
-  const buildFaceModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
-    const releaseDates = new Map(
-      models
-        .map((model) => [getModelIdentifier(model)?.replace(/^immich-app\//, ''), model.createdAt] as const)
-        .filter(([value]) => Boolean(value)),
-    );
-
-    return FACIAL_RECOGNITION_FALLBACK_OPTIONS.filter((option) => releaseDates.has(option.value))
-      .map((option) => ({
-        ...option,
-        description: option.description.replace(/Released [A-Za-z]{3} \d{4}|Release date unavailable/, formatReleaseDate(releaseDates.get(option.value) ?? MODEL_RELEASE_DATES[option.value])),
-      }))
-      .sort((left, right) =>
-        compareModelReleaseDateDesc(
-          { modelName: left.value, model: { createdAt: releaseDates.get(left.value) } },
-          { modelName: right.value, model: { createdAt: releaseDates.get(right.value) } },
-        ),
-      );
-  };
-
-  const buildOcrModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
-    const releaseDates = new Map(
-      models
-        .map((model) => [getModelIdentifier(model)?.replace(/^immich-app\//, ''), model.createdAt] as const)
-        .filter(([value]) => Boolean(value)),
-    );
-
-    return OCR_MODEL_FALLBACK_OPTIONS.filter((option) => releaseDates.has(option.value))
-      .map((option) => ({
-        ...option,
-        description: option.description.replace(/Released [A-Za-z]{3} \d{4}|Release date unavailable/, formatReleaseDate(releaseDates.get(option.value) ?? MODEL_RELEASE_DATES[option.value])),
-      }))
-      .sort((left, right) =>
-        compareModelReleaseDateDesc(
-          { modelName: left.value, model: { createdAt: releaseDates.get(left.value) } },
-          { modelName: right.value, model: { createdAt: releaseDates.get(right.value) } },
-        ),
-      );
-  };
-
-  const refreshModelOptionsFromHf = async () => {
-    isRefreshingModelOptions = true;
-
-    try {
-      const response = await fetch('https://huggingface.co/api/models?author=immich-app&limit=200&full=false');
-      if (!response.ok) {
-        throw new Error(`Failed to fetch Hugging Face models: ${response.status}`);
-      }
-
-      const models = (await response.json()) as HuggingFaceModel[];
-      const uniqueModels = Object.values(
-        Object.fromEntries(
-          models
-            .map((model) => [getModelIdentifier(model), model] as const)
-            .filter(([identifier]) => Boolean(identifier)),
-        ),
-      );
-
-      const dynamicClipOptions = buildClipModelOptionsFromHf(uniqueModels);
-      const dynamicFaceOptions = buildFaceModelOptionsFromHf(uniqueModels);
-      const dynamicOcrOptions = buildOcrModelOptionsFromHf(uniqueModels);
-
-      clipModelOptions = dynamicClipOptions.length > 0 ? dynamicClipOptions : CLIP_MODEL_FALLBACK_OPTIONS;
-      facialRecognitionModelOptions =
-        dynamicFaceOptions.length > 0 ? dynamicFaceOptions : FACIAL_RECOGNITION_FALLBACK_OPTIONS;
-      ocrModelOptions = dynamicOcrOptions.length > 0 ? dynamicOcrOptions : OCR_MODEL_FALLBACK_OPTIONS;
-      isHfConnected = true;
-    } catch {
-      clipModelOptions = CLIP_MODEL_FALLBACK_OPTIONS;
-      facialRecognitionModelOptions = FACIAL_RECOGNITION_FALLBACK_OPTIONS;
-      ocrModelOptions = OCR_MODEL_FALLBACK_OPTIONS;
-      isHfConnected = false;
-    } finally {
-      isRefreshingModelOptions = false;
-    }
-  };
-
-  onMount(() => {
-    clipModelOptions = CLIP_MODEL_FALLBACK_OPTIONS;
-    facialRecognitionModelOptions = FACIAL_RECOGNITION_FALLBACK_OPTIONS;
-    ocrModelOptions = OCR_MODEL_FALLBACK_OPTIONS;
-    void refreshModelOptionsFromHf();
-  });
 </script>
 
 <div class="mt-2">
@@ -603,15 +140,13 @@
 
           <SettingCombobox
             title={$t('admin.machine_learning_clip_model')}
-            subtitle={isHfConnected
-              ? 'Search compatible models by name, dimension, capability, or script. You can also type any custom model name.'
-              : 'Hugging Face suggestions are unavailable right now. You can still type any compatible model name manually.'}
-            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter a CLIP model name'}
+            subtitle={'Search the supported CLIP models by name, size, or capability. You can also type any custom model name.'}
+            comboboxPlaceholder={'Search or enter a CLIP model name'}
             selectedOption={getSelectedModelOption(clipModelOptions, configToEdit.machineLearning.clip.modelName)}
             options={clipModelOptions}
             allowCreate={true}
             defaultFirstOption={true}
-            disabled={disabled || isRefreshingModelOptions || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+            disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
             onSelect={(option) => {
               configToEdit.machineLearning.clip.modelName = option?.value ?? '';
             }}
@@ -675,10 +210,8 @@
 
           <SettingCombobox
             title={$t('admin.machine_learning_facial_recognition_model')}
-            subtitle={isHfConnected
-              ? 'Search by model family, speed, memory footprint, or quality profile. Manual values are still allowed.'
-              : 'Suggested face models are unavailable right now. You can still type a compatible model name manually.'}
-            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter a face model name'}
+            subtitle={'Search the supported face models by name or size tier. Manual values are still allowed.'}
+            comboboxPlaceholder={'Search or enter a face model name'}
             selectedOption={getSelectedModelOption(
               facialRecognitionModelOptions,
               configToEdit.machineLearning.facialRecognition.modelName,
@@ -687,7 +220,6 @@
             allowCreate={true}
             defaultFirstOption={true}
             disabled={disabled ||
-              isRefreshingModelOptions ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.facialRecognition.enabled}
             onSelect={(option) => {
@@ -760,16 +292,13 @@
 
           <SettingCombobox
             title={$t('admin.machine_learning_ocr_model')}
-            subtitle={isHfConnected
-              ? 'Search OCR models by language coverage, speed, or quality. Manual values are also allowed.'
-              : 'Suggested OCR models are unavailable right now. You can still type a compatible model name manually.'}
-            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter an OCR model name'}
+            subtitle={'Search the supported OCR models by name, language pack, or size tier. Manual values are also allowed.'}
+            comboboxPlaceholder={'Search or enter an OCR model name'}
             selectedOption={getSelectedModelOption(ocrModelOptions, configToEdit.machineLearning.ocr.modelName)}
             options={ocrModelOptions}
             allowCreate={true}
             defaultFirstOption={true}
             disabled={disabled ||
-              isRefreshingModelOptions ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.ocr.enabled}
             onSelect={(option) => {

--- a/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
+++ b/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
@@ -11,12 +11,193 @@
   import { Button, IconButton } from '@immich/ui';
   import { mdiPlus, mdiTrashCanOutline } from '@mdi/js';
   import { isEqual } from 'lodash-es';
+  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
+
+  type SelectOption = { value: string; text: string };
+  type HuggingFaceModel = { id?: string; modelId?: string };
 
   const disabled = $derived(featureFlagsManager.value.configFile);
   const config = $derived(systemConfigManager.value);
   let configToEdit = $state(systemConfigManager.cloneValue());
+  let isRefreshingModelOptions = $state(false);
+  let isHfConnected = $state(false);
+
+  let clipModelOptions = $state<SelectOption[]>([]);
+  let facialRecognitionModelOptions = $state<SelectOption[]>([]);
+  let ocrModelOptions = $state<SelectOption[]>([]);
+
+  const CLIP_MODEL_DIMENSIONS: Record<string, number> = {
+    RN101__openai: 512,
+    RN101__yfcc15m: 512,
+    'ViT-B-16__laion400m_e31': 512,
+    'ViT-B-16__laion400m_e32': 512,
+    'ViT-B-16__openai': 512,
+    'ViT-B-32__laion2b-s34b-b79k': 512,
+    'ViT-B-32__laion2b_e16': 512,
+    'ViT-B-32__laion400m_e31': 512,
+    'ViT-B-32__laion400m_e32': 512,
+    'ViT-B-32__openai': 512,
+    'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': 512,
+    'XLM-Roberta-Large-Vit-B-32': 512,
+    RN50x4__openai: 640,
+    'ViT-B-16-plus-240__laion400m_e31': 640,
+    'ViT-B-16-plus-240__laion400m_e32': 640,
+    'XLM-Roberta-Large-Vit-B-16Plus': 640,
+    'LABSE-Vit-L-14': 768,
+    RN50x16__openai: 768,
+    'ViT-B-16-SigLIP-256__webli': 768,
+    'ViT-B-16-SigLIP-384__webli': 768,
+    'ViT-B-16-SigLIP-512__webli': 768,
+    'ViT-B-16-SigLIP-i18n-256__webli': 768,
+    'ViT-B-16-SigLIP__webli': 768,
+    'ViT-L-14-336__openai': 768,
+    'ViT-L-14-quickgelu__dfn2b': 768,
+    'ViT-L-14__laion2b-s32b-b82k': 768,
+    'ViT-L-14__laion400m_e31': 768,
+    'ViT-L-14__laion400m_e32': 768,
+    'ViT-L-14__openai': 768,
+    'XLM-Roberta-Large-Vit-L-14': 768,
+    'nllb-clip-base-siglip__mrl': 768,
+    'nllb-clip-base-siglip__v1': 768,
+    RN50__cc12m: 1024,
+    RN50__openai: 1024,
+    RN50__yfcc15m: 1024,
+    RN50x64__openai: 1024,
+    'ViT-H-14-378-quickgelu__dfn5b': 1024,
+    'ViT-H-14-quickgelu__dfn5b': 1024,
+    'ViT-H-14__laion2b-s32b-b79k': 1024,
+    'ViT-L-16-SigLIP-256__webli': 1024,
+    'ViT-L-16-SigLIP-384__webli': 1024,
+    'ViT-g-14__laion2b-s12b-b42k': 1024,
+    'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': 1024,
+    'ViT-SO400M-14-SigLIP-384__webli': 1152,
+    'nllb-clip-large-siglip__mrl': 1152,
+    'nllb-clip-large-siglip__v1': 1152,
+    'ViT-B-16-SigLIP2__webli': 768,
+    'ViT-B-32-SigLIP2-256__webli': 768,
+    'ViT-L-16-SigLIP2-256__webli': 1024,
+    'ViT-L-16-SigLIP2-384__webli': 1024,
+    'ViT-L-16-SigLIP2-512__webli': 1024,
+    'ViT-SO400M-14-SigLIP2__webli': 1152,
+    'ViT-SO400M-14-SigLIP2-378__webli': 1152,
+    'ViT-SO400M-16-SigLIP2-256__webli': 1152,
+    'ViT-SO400M-16-SigLIP2-384__webli': 1152,
+    'ViT-SO400M-16-SigLIP2-512__webli': 1152,
+    'ViT-gopt-16-SigLIP2-256__webli': 1536,
+    'ViT-gopt-16-SigLIP2-384__webli': 1536,
+  };
+
+  const getClipModelValueDescription = (modelName: string, dimSize: number): string => {
+    if (modelName.includes('SigLIP2')) {
+      return `${dimSize}d, newest generation`;
+    }
+
+    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
+      return `${dimSize}d, multilingual search`;
+    }
+
+    if (modelName.includes('SigLIP')) {
+      return `${dimSize}d, fast and accurate`;
+    }
+
+    return `${dimSize}d, stable baseline`;
+  };
+
+  const CLIP_MODEL_FALLBACK_OPTIONS: SelectOption[] = Object.entries(CLIP_MODEL_DIMENSIONS).map(([modelName, dimSize]) => ({
+    value: modelName,
+    text: `${modelName} (${getClipModelValueDescription(modelName, dimSize)})`,
+  }));
+
+  const FACIAL_RECOGNITION_FALLBACK_OPTIONS: SelectOption[] = [
+    { value: 'antelopev2', text: 'antelopev2 (best quality, highest memory)' },
+    { value: 'buffalo_l', text: 'buffalo_l (high quality, balanced speed)' },
+    { value: 'buffalo_m', text: 'buffalo_m (balanced quality and memory)' },
+    { value: 'buffalo_s', text: 'buffalo_s (lowest memory, fastest startup)' },
+  ];
+
+  const OCR_MODEL_FALLBACK_OPTIONS: SelectOption[] = [
+    { value: 'PP-OCRv5_server', text: 'PP-OCRv5_server (best OCR quality, highest compute)' },
+    { value: 'PP-OCRv5_mobile', text: 'PP-OCRv5_mobile (balanced quality and speed)' },
+    { value: 'EN__PP-OCRv5_mobile', text: 'EN__PP-OCRv5_mobile (English-only, fastest option)' },
+    { value: 'EL__PP-OCRv5_mobile', text: 'EL__PP-OCRv5_mobile (Greek and English)' },
+    { value: 'KOREAN__PP-OCRv5_mobile', text: 'KOREAN__PP-OCRv5_mobile (Korean and English)' },
+    { value: 'LATIN__PP-OCRv5_mobile', text: 'LATIN__PP-OCRv5_mobile (Latin script languages)' },
+    {
+      value: 'ESLAV__PP-OCRv5_mobile',
+      text: 'ESLAV__PP-OCRv5_mobile (East Slavic and English)',
+    },
+    { value: 'TH__PP-OCRv5_mobile', text: 'TH__PP-OCRv5_mobile (Thai and English)' },
+  ];
+
+  const getModelIdentifier = (model: HuggingFaceModel): string | undefined => {
+    return model.modelId || model.id;
+  };
+
+  const buildClipModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
+    return modelIds
+      .filter((id) => id in CLIP_MODEL_DIMENSIONS)
+      .sort((left, right) => left.localeCompare(right))
+      .map((modelName) => {
+        const dimSize = CLIP_MODEL_DIMENSIONS[modelName] ?? 0;
+        return {
+          value: modelName,
+          text: `${modelName} (${getClipModelValueDescription(modelName, dimSize)})`,
+        };
+      });
+  };
+
+  const buildFaceModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
+    return FACIAL_RECOGNITION_FALLBACK_OPTIONS.filter((option) => modelIds.includes(option.value));
+  };
+
+  const buildOcrModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
+    return OCR_MODEL_FALLBACK_OPTIONS.filter((option) => modelIds.includes(option.value));
+  };
+
+  const refreshModelOptionsFromHf = async () => {
+    isRefreshingModelOptions = true;
+
+    try {
+      const response = await fetch('https://huggingface.co/api/models?author=immich-app&limit=200&full=false');
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Hugging Face models: ${response.status}`);
+      }
+
+      const models = (await response.json()) as HuggingFaceModel[];
+      const modelIds = models
+        .map(getModelIdentifier)
+        .filter((id): id is string => Boolean(id))
+        .map((id) => id.replace(/^immich-app\//, ''));
+
+      const uniqueModelIds = [...new Set(modelIds)];
+
+      const dynamicClipOptions = buildClipModelOptionsFromHf(uniqueModelIds);
+      const dynamicFaceOptions = buildFaceModelOptionsFromHf(uniqueModelIds);
+      const dynamicOcrOptions = buildOcrModelOptionsFromHf(uniqueModelIds);
+
+      clipModelOptions = dynamicClipOptions.length > 0 ? dynamicClipOptions : CLIP_MODEL_FALLBACK_OPTIONS;
+      facialRecognitionModelOptions =
+        dynamicFaceOptions.length > 0 ? dynamicFaceOptions : FACIAL_RECOGNITION_FALLBACK_OPTIONS;
+      ocrModelOptions = dynamicOcrOptions.length > 0 ? dynamicOcrOptions : OCR_MODEL_FALLBACK_OPTIONS;
+      isHfConnected = true;
+    } catch {
+      clipModelOptions = CLIP_MODEL_FALLBACK_OPTIONS;
+      facialRecognitionModelOptions = FACIAL_RECOGNITION_FALLBACK_OPTIONS;
+      ocrModelOptions = OCR_MODEL_FALLBACK_OPTIONS;
+      isHfConnected = false;
+    } finally {
+      isRefreshingModelOptions = false;
+    }
+  };
+
+  onMount(() => {
+    clipModelOptions = CLIP_MODEL_FALLBACK_OPTIONS;
+    facialRecognitionModelOptions = FACIAL_RECOGNITION_FALLBACK_OPTIONS;
+    ocrModelOptions = OCR_MODEL_FALLBACK_OPTIONS;
+    void refreshModelOptionsFromHf();
+  });
 </script>
 
 <div class="mt-2">
@@ -128,20 +309,35 @@
             inputType={SettingInputFieldType.TEXT}
             label={$t('admin.machine_learning_clip_model')}
             bind:value={configToEdit.machineLearning.clip.modelName}
-            required={true}
+            description={$t('admin.machine_learning_clip_model_description')}
             disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
             isEdited={configToEdit.machineLearning.clip.modelName !== config.machineLearning.clip.modelName}
-          >
-            {#snippet descriptionSnippet()}
-              <p class="pb-2 text-sm immich-form-label">
-                <FormatMessage key="admin.machine_learning_clip_model_description">
-                  {#snippet children({ message })}
-                    <a target="_blank" href="https://huggingface.co/immich-app"><u>{message}</u></a>
-                  {/snippet}
-                </FormatMessage>
-              </p>
-            {/snippet}
-          </SettingInputField>
+          />
+
+          {#if isHfConnected}
+            <SettingSelect
+              label={$t('admin.machine_learning_clip_model')}
+              desc={''}
+              name="clip-model-select"
+              value={configToEdit.machineLearning.clip.modelName}
+              options={clipModelOptions}
+              disabled={disabled || isRefreshingModelOptions || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+              onSelect={(value) => {
+                if (typeof value === 'string') {
+                  configToEdit.machineLearning.clip.modelName = value;
+                }
+              }}
+              isEdited={configToEdit.machineLearning.clip.modelName !== config.machineLearning.clip.modelName}
+            />
+          {/if}
+
+          <p class="pb-2 text-sm immich-form-label">
+            <FormatMessage key="admin.machine_learning_clip_model_description">
+              {#snippet children({ message })}
+                <a target="_blank" href="https://huggingface.co/immich-app"><u>{message}</u></a>
+              {/snippet}
+            </FormatMessage>
+          </p>
         </div>
       </SettingAccordion>
 
@@ -190,23 +386,38 @@
 
           <hr />
 
-          <SettingSelect
+          <SettingInputField
+            inputType={SettingInputFieldType.TEXT}
             label={$t('admin.machine_learning_facial_recognition_model')}
-            desc={$t('admin.machine_learning_facial_recognition_model_description')}
-            name="facial-recognition-model"
+            description={$t('admin.machine_learning_facial_recognition_model_description')}
             bind:value={configToEdit.machineLearning.facialRecognition.modelName}
-            options={[
-              { value: 'antelopev2', text: 'antelopev2' },
-              { value: 'buffalo_l', text: 'buffalo_l' },
-              { value: 'buffalo_m', text: 'buffalo_m' },
-              { value: 'buffalo_s', text: 'buffalo_s' },
-            ]}
             disabled={disabled ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.facialRecognition.enabled}
             isEdited={configToEdit.machineLearning.facialRecognition.modelName !==
               config.machineLearning.facialRecognition.modelName}
           />
+
+          {#if isHfConnected}
+            <SettingSelect
+              label={$t('admin.machine_learning_facial_recognition_model')}
+              desc={''}
+              name="facial-recognition-model-select"
+              value={configToEdit.machineLearning.facialRecognition.modelName}
+              options={facialRecognitionModelOptions}
+              disabled={disabled ||
+                isRefreshingModelOptions ||
+                !configToEdit.machineLearning.enabled ||
+                !configToEdit.machineLearning.facialRecognition.enabled}
+              onSelect={(value) => {
+                if (typeof value === 'string') {
+                  configToEdit.machineLearning.facialRecognition.modelName = value;
+                }
+              }}
+              isEdited={configToEdit.machineLearning.facialRecognition.modelName !==
+                config.machineLearning.facialRecognition.modelName}
+            />
+          {/if}
 
           <SettingInputField
             inputType={SettingInputFieldType.NUMBER}
@@ -269,24 +480,34 @@
 
           <hr />
 
-          <SettingSelect
+          <SettingInputField
+            inputType={SettingInputFieldType.TEXT}
             label={$t('admin.machine_learning_ocr_model')}
-            desc={$t('admin.machine_learning_ocr_model_description')}
-            name="ocr-model"
+            description={$t('admin.machine_learning_ocr_model_description')}
             bind:value={configToEdit.machineLearning.ocr.modelName}
-            options={[
-              { text: 'PP-OCRv5_server (Chinese, Japanese and English)', value: 'PP-OCRv5_server' },
-              { text: 'PP-OCRv5_mobile (Chinese, Japanese and English)', value: 'PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (English-only)', value: 'EN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Greek and English)', value: 'EL__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Korean and English)', value: 'KOREAN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Latin script languages)', value: 'LATIN__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Russian, Belarusian, Ukrainian and English)', value: 'ESLAV__PP-OCRv5_mobile' },
-              { text: 'PP-OCRv5_mobile (Thai and English)', value: 'TH__PP-OCRv5_mobile' },
-            ]}
             disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.ocr.enabled}
             isEdited={configToEdit.machineLearning.ocr.modelName !== config.machineLearning.ocr.modelName}
           />
+
+          {#if isHfConnected}
+            <SettingSelect
+              label={$t('admin.machine_learning_ocr_model')}
+              desc={''}
+              name="ocr-model-select"
+              value={configToEdit.machineLearning.ocr.modelName}
+              options={ocrModelOptions}
+              disabled={disabled ||
+                isRefreshingModelOptions ||
+                !configToEdit.machineLearning.enabled ||
+                !configToEdit.machineLearning.ocr.enabled}
+              onSelect={(value) => {
+                if (typeof value === 'string') {
+                  configToEdit.machineLearning.ocr.modelName = value;
+                }
+              }}
+              isEdited={configToEdit.machineLearning.ocr.modelName !== config.machineLearning.ocr.modelName}
+            />
+          {/if}
 
           <SettingInputField
             inputType={SettingInputFieldType.NUMBER}

--- a/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
+++ b/web/src/routes/admin/system-settings/MachineLearningSettings.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import SettingAccordion from '$lib/components/shared-components/settings/SettingAccordion.svelte';
   import SettingInputField from '$lib/components/shared-components/settings/SettingInputField.svelte';
-  import SettingSelect from './SettingSelect.svelte';
+  import SettingCombobox from './SettingCombobox.svelte';
   import SettingSwitch from '$lib/components/shared-components/settings/SettingSwitch.svelte';
   import SettingButtonsRow from '$lib/components/shared-components/settings/SystemConfigButtonRow.svelte';
+  import type { ComboBoxOption } from '$lib/components/shared-components/Combobox.svelte';
   import { SettingInputFieldType } from '$lib/constants';
   import FormatMessage from '$lib/elements/FormatMessage.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
@@ -15,8 +16,13 @@
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
 
-  type SelectOption = { value: string; text: string };
-  type HuggingFaceModel = { id?: string; modelId?: string };
+  type HuggingFaceModel = {
+    id?: string;
+    modelId?: string;
+    createdAt?: string;
+    lastModified?: string;
+    downloads?: number;
+  };
 
   const disabled = $derived(featureFlagsManager.value.configFile);
   const config = $derived(systemConfigManager.value);
@@ -24,9 +30,9 @@
   let isRefreshingModelOptions = $state(false);
   let isHfConnected = $state(false);
 
-  let clipModelOptions = $state<SelectOption[]>([]);
-  let facialRecognitionModelOptions = $state<SelectOption[]>([]);
-  let ocrModelOptions = $state<SelectOption[]>([]);
+  let clipModelOptions = $state<ComboBoxOption[]>([]);
+  let facialRecognitionModelOptions = $state<ComboBoxOption[]>([]);
+  let ocrModelOptions = $state<ComboBoxOption[]>([]);
 
   const CLIP_MODEL_DIMENSIONS: Record<string, number> = {
     RN101__openai: 512,
@@ -89,6 +95,120 @@
     'ViT-gopt-16-SigLIP2-384__webli': 1536,
   };
 
+  const MODEL_RELEASE_DATES: Record<string, string> = {
+    antelopev2: '2023-11-10',
+    buffalo_l: '2023-11-10',
+    buffalo_l_batch: '2024-06-10',
+    buffalo_m: '2023-11-10',
+    buffalo_s: '2023-11-10',
+    'LABSE-Vit-L-14': '2023-10-28',
+    'nllb-clip-base-siglip__mrl': '2024-07-22',
+    'nllb-clip-base-siglip__v1': '2023-12-11',
+    'nllb-clip-large-siglip__mrl': '2024-07-22',
+    'nllb-clip-large-siglip__v1': '2023-12-11',
+    'RN101__openai': '2023-10-28',
+    'RN101__yfcc15m': '2023-10-28',
+    'RN50__cc12m': '2023-10-28',
+    'RN50__openai': '2023-10-28',
+    'RN50__yfcc15m': '2023-10-28',
+    'RN50x16__openai': '2023-10-28',
+    'RN50x4__openai': '2023-10-28',
+    'RN50x64__openai': '2023-10-28',
+    'ViT-B-16__laion400m_e31': '2023-10-28',
+    'ViT-B-16__laion400m_e32': '2023-10-28',
+    'ViT-B-16__openai': '2023-10-28',
+    'ViT-B-16-plus-240__laion400m_e31': '2023-10-28',
+    'ViT-B-16-plus-240__laion400m_e32': '2023-10-28',
+    'ViT-B-16-SigLIP__webli': '2024-07-22',
+    'ViT-B-16-SigLIP-256__webli': '2024-07-22',
+    'ViT-B-16-SigLIP-384__webli': '2024-07-22',
+    'ViT-B-16-SigLIP-512__webli': '2024-07-22',
+    'ViT-B-16-SigLIP-i18n-256__webli': '2024-07-22',
+    'ViT-B-16-SigLIP2__webli': '2025-03-12',
+    'ViT-B-32__laion2b_e16': '2023-10-28',
+    'ViT-B-32__laion2b-s34b-b79k': '2023-10-28',
+    'ViT-B-32__laion400m_e31': '2023-10-28',
+    'ViT-B-32__laion400m_e32': '2023-10-28',
+    'ViT-B-32__openai': '2023-10-28',
+    'ViT-B-32-SigLIP2-256__webli': '2025-03-12',
+    'ViT-g-14__laion2b-s12b-b42k': '2023-10-28',
+    'ViT-gopt-16-SigLIP2-256__webli': '2025-03-13',
+    'ViT-gopt-16-SigLIP2-384__webli': '2025-03-13',
+    'ViT-H-14__laion2b-s32b-b79k': '2023-10-28',
+    'ViT-H-14-378-quickgelu__dfn5b': '2023-12-11',
+    'ViT-H-14-quickgelu__dfn5b': '2023-12-11',
+    'ViT-L-14__laion2b-s32b-b82k': '2023-10-28',
+    'ViT-L-14__laion400m_e31': '2023-10-28',
+    'ViT-L-14__laion400m_e32': '2023-10-28',
+    'ViT-L-14__openai': '2023-10-28',
+    'ViT-L-14-336__openai': '2023-10-28',
+    'ViT-L-14-quickgelu__dfn2b': '2023-12-11',
+    'ViT-L-16-SigLIP-256__webli': '2024-07-22',
+    'ViT-L-16-SigLIP-384__webli': '2024-07-22',
+    'ViT-L-16-SigLIP2-256__webli': '2025-03-12',
+    'ViT-L-16-SigLIP2-384__webli': '2025-03-13',
+    'ViT-L-16-SigLIP2-512__webli': '2025-03-13',
+    'ViT-SO400M-14-SigLIP-384__webli': '2024-07-22',
+    'ViT-SO400M-14-SigLIP2__webli': '2025-03-13',
+    'ViT-SO400M-14-SigLIP2-378__webli': '2025-03-13',
+    'ViT-SO400M-16-SigLIP2-256__webli': '2025-03-13',
+    'ViT-SO400M-16-SigLIP2-384__webli': '2025-03-13',
+    'ViT-SO400M-16-SigLIP2-512__webli': '2025-03-13',
+    'XLM-Roberta-Base-ViT-B-32__laion5b_s13b_b90k': '2024-07-22',
+    'XLM-Roberta-Large-Vit-B-16Plus': '2023-10-28',
+    'XLM-Roberta-Large-Vit-B-32': '2023-10-28',
+    'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': '2023-12-11',
+    'XLM-Roberta-Large-Vit-L-14': '2023-10-28',
+  };
+
+  const formatReleaseDate = (date?: string): string => {
+    if (!date) {
+      return 'Release date unavailable';
+    }
+
+    const parsedDate = new Date(date);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return 'Release date unavailable';
+    }
+
+    return `Released ${new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric' }).format(parsedDate)}`;
+  };
+
+  const getModelReleaseDate = (modelName: string, model?: HuggingFaceModel): string => {
+    return model?.createdAt ?? MODEL_RELEASE_DATES[modelName] ?? '';
+  };
+
+  const getReleaseSortKey = (date?: string): string => {
+    if (!date) {
+      return '';
+    }
+
+    const parsedDate = new Date(date);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return '';
+    }
+
+    return parsedDate.toISOString().slice(0, 10);
+  };
+
+  const compareModelReleaseDateDesc = (
+    left: { modelName: string; model?: HuggingFaceModel },
+    right: { modelName: string; model?: HuggingFaceModel },
+  ): number => {
+    const leftReleaseKey = getReleaseSortKey(getModelReleaseDate(left.modelName, left.model));
+    const rightReleaseKey = getReleaseSortKey(getModelReleaseDate(right.modelName, right.model));
+
+    if (leftReleaseKey !== rightReleaseKey) {
+      return rightReleaseKey.localeCompare(leftReleaseKey);
+    }
+
+    return left.modelName.localeCompare(right.modelName);
+  };
+
+  const joinDescriptionParts = (...parts: Array<string | undefined>): string => {
+    return parts.filter((part) => Boolean(part)).join(' ');
+  };
+
   const getClipModelValueDescription = (modelName: string, dimSize: number): string => {
     if (modelName.includes('SigLIP2')) {
       return `${dimSize}d, newest generation`;
@@ -105,55 +225,230 @@
     return `${dimSize}d, stable baseline`;
   };
 
-  const CLIP_MODEL_FALLBACK_OPTIONS: SelectOption[] = Object.entries(CLIP_MODEL_DIMENSIONS).map(([modelName, dimSize]) => ({
-    value: modelName,
-    text: `${modelName} (${getClipModelValueDescription(modelName, dimSize)})`,
-  }));
+  const getClipModelRecommendation = (modelName: string): string => {
+    if (modelName.includes('SigLIP2')) {
+      return 'Best for new deployments that want the strongest search quality and the most modern embedding family.';
+    }
 
-  const FACIAL_RECOGNITION_FALLBACK_OPTIONS: SelectOption[] = [
-    { value: 'antelopev2', text: 'antelopev2 (best quality, highest memory)' },
-    { value: 'buffalo_l', text: 'buffalo_l (high quality, balanced speed)' },
-    { value: 'buffalo_m', text: 'buffalo_m (balanced quality and memory)' },
-    { value: 'buffalo_s', text: 'buffalo_s (lowest memory, fastest startup)' },
-  ];
+    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
+      return 'Best for multilingual libraries where captions and search terms span multiple languages.';
+    }
 
-  const OCR_MODEL_FALLBACK_OPTIONS: SelectOption[] = [
-    { value: 'PP-OCRv5_server', text: 'PP-OCRv5_server (best OCR quality, highest compute)' },
-    { value: 'PP-OCRv5_mobile', text: 'PP-OCRv5_mobile (balanced quality and speed)' },
-    { value: 'EN__PP-OCRv5_mobile', text: 'EN__PP-OCRv5_mobile (English-only, fastest option)' },
-    { value: 'EL__PP-OCRv5_mobile', text: 'EL__PP-OCRv5_mobile (Greek and English)' },
-    { value: 'KOREAN__PP-OCRv5_mobile', text: 'KOREAN__PP-OCRv5_mobile (Korean and English)' },
-    { value: 'LATIN__PP-OCRv5_mobile', text: 'LATIN__PP-OCRv5_mobile (Latin script languages)' },
+    if (modelName.includes('SigLIP')) {
+      return 'Strong default when you want fast indexing with better semantic search quality than the older CLIP baselines.';
+    }
+
+    if (modelName.includes('RN')) {
+      return 'Legacy baseline with broad compatibility, useful when you want predictable behavior over newest quality gains.';
+    }
+
+    if (modelName.includes('ViT-H') || modelName.includes('ViT-g')) {
+      return 'Higher-capacity model family aimed at quality-first search on stronger hardware.';
+    }
+
+    return 'Balanced CLIP baseline for semantic search and duplicate detection embeddings.';
+  };
+
+  const buildClipDescription = (modelName: string, dimSize: number, model?: HuggingFaceModel): string => {
+    return joinDescriptionParts(
+      getClipModelValueDescription(modelName, dimSize) + '.',
+      getClipModelRecommendation(modelName),
+      formatReleaseDate(getModelReleaseDate(modelName, model)) + '.',
+    );
+  };
+
+  const getClipModelKeywords = (modelName: string): string[] => {
+    const keywords = ['clip', 'smart search', 'semantic search'];
+    if (modelName.includes('SigLIP2')) {
+      keywords.push('siglip2', 'newest');
+    }
+    if (modelName.includes('SigLIP')) {
+      keywords.push('siglip');
+    }
+    if (modelName.includes('XLM') || modelName.includes('nllb') || modelName.includes('LABSE')) {
+      keywords.push('multilingual');
+    }
+    if (modelName.includes('ViT-H') || modelName.includes('ViT-g')) {
+      keywords.push('high accuracy');
+    }
+    return keywords;
+  };
+
+  const CLIP_MODEL_FALLBACK_OPTIONS: ComboBoxOption[] = Object.entries(CLIP_MODEL_DIMENSIONS)
+    .map(([modelName, dimSize]) => ({ modelName, model: undefined as HuggingFaceModel | undefined, dimSize }))
+    .sort(compareModelReleaseDateDesc)
+    .map(({ modelName, dimSize }) => ({
+      value: modelName,
+      label: modelName,
+      description: buildClipDescription(modelName, dimSize),
+      keywords: getClipModelKeywords(modelName),
+    }));
+
+  const FACIAL_RECOGNITION_FALLBACK_OPTIONS: ComboBoxOption[] = [
+    {
+      value: 'antelopev2',
+      label: 'antelopev2',
+      description: joinDescriptionParts(
+        'Best face recognition quality with the highest memory use, suited to large libraries and quality-first matching.',
+        formatReleaseDate(getModelReleaseDate('antelopev2')) + '.',
+      ),
+      keywords: ['face', 'recognition', 'highest quality', 'memory'],
+    },
+    {
+      value: 'buffalo_l',
+      label: 'buffalo_l',
+      description: joinDescriptionParts(
+        'High recognition quality with balanced speed. A strong default if you want reliable matching without the heaviest footprint.',
+        formatReleaseDate(getModelReleaseDate('buffalo_l')) + '.',
+      ),
+      keywords: ['face', 'recognition', 'balanced', 'quality'],
+    },
+    {
+      value: 'buffalo_m',
+      label: 'buffalo_m',
+      description: joinDescriptionParts(
+        'Balanced quality and memory footprint. Best for modest hardware that still needs useful face grouping and recognition.',
+        formatReleaseDate(getModelReleaseDate('buffalo_m')) + '.',
+      ),
+      keywords: ['face', 'recognition', 'memory', 'balanced'],
+    },
+    {
+      value: 'buffalo_s',
+      label: 'buffalo_s',
+      description: joinDescriptionParts(
+        'Lowest memory usage and fastest startup, with the biggest tradeoff in recognition quality and matching recall.',
+        formatReleaseDate(getModelReleaseDate('buffalo_s')) + '.',
+      ),
+      keywords: ['face', 'recognition', 'fastest', 'lightweight'],
+    },
+  ].sort((left, right) => compareModelReleaseDateDesc({ modelName: left.value }, { modelName: right.value }));
+
+  const OCR_MODEL_FALLBACK_OPTIONS: ComboBoxOption[] = [
+    {
+      value: 'PP-OCRv5_server',
+      label: 'PP-OCRv5_server',
+      description: joinDescriptionParts(
+        'Best OCR quality and layout handling, but also the heaviest compute option. Use when text extraction accuracy matters more than throughput.',
+        formatReleaseDate(getModelReleaseDate('PP-OCRv5_server')) + '.',
+      ),
+      keywords: ['ocr', 'server', 'highest quality'],
+    },
+    {
+      value: 'PP-OCRv5_mobile',
+      label: 'PP-OCRv5_mobile',
+      description: joinDescriptionParts(
+        'Balanced OCR quality and speed. The best default for mixed workloads and general-purpose photo libraries.',
+        formatReleaseDate(getModelReleaseDate('PP-OCRv5_mobile')) + '.',
+      ),
+      keywords: ['ocr', 'mobile', 'balanced'],
+    },
+    {
+      value: 'EN__PP-OCRv5_mobile',
+      label: 'EN__PP-OCRv5_mobile',
+      description: joinDescriptionParts(
+        'English-only OCR and the fastest option when you do not need multilingual text extraction.',
+        formatReleaseDate(getModelReleaseDate('EN__PP-OCRv5_mobile')) + '.',
+      ),
+      keywords: ['ocr', 'english', 'fastest'],
+    },
+    {
+      value: 'EL__PP-OCRv5_mobile',
+      label: 'EL__PP-OCRv5_mobile',
+      description: joinDescriptionParts('Greek and English OCR model for libraries that mainly need Greek script support.', formatReleaseDate(getModelReleaseDate('EL__PP-OCRv5_mobile')) + '.'),
+      keywords: ['ocr', 'greek', 'english'],
+    },
+    {
+      value: 'KOREAN__PP-OCRv5_mobile',
+      label: 'KOREAN__PP-OCRv5_mobile',
+      description: joinDescriptionParts('Korean and English OCR model for mixed Korean-language collections.', formatReleaseDate(getModelReleaseDate('KOREAN__PP-OCRv5_mobile')) + '.'),
+      keywords: ['ocr', 'korean', 'english'],
+    },
+    {
+      value: 'LATIN__PP-OCRv5_mobile',
+      label: 'LATIN__PP-OCRv5_mobile',
+      description: joinDescriptionParts('Latin-script OCR model for broad European language coverage without the full multilingual overhead.', formatReleaseDate(getModelReleaseDate('LATIN__PP-OCRv5_mobile')) + '.'),
+      keywords: ['ocr', 'latin', 'multilingual'],
+    },
     {
       value: 'ESLAV__PP-OCRv5_mobile',
-      text: 'ESLAV__PP-OCRv5_mobile (East Slavic and English)',
+      label: 'ESLAV__PP-OCRv5_mobile',
+      description: joinDescriptionParts('East Slavic and English OCR model for Cyrillic-heavy libraries.', formatReleaseDate(getModelReleaseDate('ESLAV__PP-OCRv5_mobile')) + '.'),
+      keywords: ['ocr', 'slavic', 'english'],
     },
-    { value: 'TH__PP-OCRv5_mobile', text: 'TH__PP-OCRv5_mobile (Thai and English)' },
-  ];
+    {
+      value: 'TH__PP-OCRv5_mobile',
+      label: 'TH__PP-OCRv5_mobile',
+      description: joinDescriptionParts('Thai and English OCR model for mixed Thai-language collections.', formatReleaseDate(getModelReleaseDate('TH__PP-OCRv5_mobile')) + '.'),
+      keywords: ['ocr', 'thai', 'english'],
+    },
+  ].sort((left, right) => compareModelReleaseDateDesc({ modelName: left.value }, { modelName: right.value }));
+
+  const getSelectedModelOption = (options: ComboBoxOption[], value: string): ComboBoxOption | undefined => {
+    return options.find((option) => option.value === value) ?? (value ? { label: value, value } : undefined);
+  };
 
   const getModelIdentifier = (model: HuggingFaceModel): string | undefined => {
     return model.modelId || model.id;
   };
 
-  const buildClipModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
-    return modelIds
-      .filter((id) => id in CLIP_MODEL_DIMENSIONS)
-      .sort((left, right) => left.localeCompare(right))
-      .map((modelName) => {
+  const buildClipModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
+    return models
+      .map((model) => ({ modelName: getModelIdentifier(model)?.replace(/^immich-app\//, ''), model }))
+      .filter((entry): entry is { modelName: string; model: HuggingFaceModel } => Boolean(entry.modelName))
+      .filter(({ modelName }) => modelName in CLIP_MODEL_DIMENSIONS)
+      .sort(compareModelReleaseDateDesc)
+      .map(({ modelName, model }) => {
         const dimSize = CLIP_MODEL_DIMENSIONS[modelName] ?? 0;
         return {
           value: modelName,
-          text: `${modelName} (${getClipModelValueDescription(modelName, dimSize)})`,
+          label: modelName,
+          description: joinDescriptionParts(
+            buildClipDescription(modelName, dimSize, model),
+            typeof model.downloads === 'number' && model.downloads > 0 ? `${model.downloads.toLocaleString()} downloads on Hugging Face.` : undefined,
+          ),
+          keywords: getClipModelKeywords(modelName),
         };
       });
   };
 
-  const buildFaceModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
-    return FACIAL_RECOGNITION_FALLBACK_OPTIONS.filter((option) => modelIds.includes(option.value));
+  const buildFaceModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
+    const releaseDates = new Map(
+      models
+        .map((model) => [getModelIdentifier(model)?.replace(/^immich-app\//, ''), model.createdAt] as const)
+        .filter(([value]) => Boolean(value)),
+    );
+
+    return FACIAL_RECOGNITION_FALLBACK_OPTIONS.filter((option) => releaseDates.has(option.value))
+      .map((option) => ({
+        ...option,
+        description: option.description.replace(/Released [A-Za-z]{3} \d{4}|Release date unavailable/, formatReleaseDate(releaseDates.get(option.value) ?? MODEL_RELEASE_DATES[option.value])),
+      }))
+      .sort((left, right) =>
+        compareModelReleaseDateDesc(
+          { modelName: left.value, model: { createdAt: releaseDates.get(left.value) } },
+          { modelName: right.value, model: { createdAt: releaseDates.get(right.value) } },
+        ),
+      );
   };
 
-  const buildOcrModelOptionsFromHf = (modelIds: string[]): SelectOption[] => {
-    return OCR_MODEL_FALLBACK_OPTIONS.filter((option) => modelIds.includes(option.value));
+  const buildOcrModelOptionsFromHf = (models: HuggingFaceModel[]): ComboBoxOption[] => {
+    const releaseDates = new Map(
+      models
+        .map((model) => [getModelIdentifier(model)?.replace(/^immich-app\//, ''), model.createdAt] as const)
+        .filter(([value]) => Boolean(value)),
+    );
+
+    return OCR_MODEL_FALLBACK_OPTIONS.filter((option) => releaseDates.has(option.value))
+      .map((option) => ({
+        ...option,
+        description: option.description.replace(/Released [A-Za-z]{3} \d{4}|Release date unavailable/, formatReleaseDate(releaseDates.get(option.value) ?? MODEL_RELEASE_DATES[option.value])),
+      }))
+      .sort((left, right) =>
+        compareModelReleaseDateDesc(
+          { modelName: left.value, model: { createdAt: releaseDates.get(left.value) } },
+          { modelName: right.value, model: { createdAt: releaseDates.get(right.value) } },
+        ),
+      );
   };
 
   const refreshModelOptionsFromHf = async () => {
@@ -166,16 +461,17 @@
       }
 
       const models = (await response.json()) as HuggingFaceModel[];
-      const modelIds = models
-        .map(getModelIdentifier)
-        .filter((id): id is string => Boolean(id))
-        .map((id) => id.replace(/^immich-app\//, ''));
+      const uniqueModels = Object.values(
+        Object.fromEntries(
+          models
+            .map((model) => [getModelIdentifier(model), model] as const)
+            .filter(([identifier]) => Boolean(identifier)),
+        ),
+      );
 
-      const uniqueModelIds = [...new Set(modelIds)];
-
-      const dynamicClipOptions = buildClipModelOptionsFromHf(uniqueModelIds);
-      const dynamicFaceOptions = buildFaceModelOptionsFromHf(uniqueModelIds);
-      const dynamicOcrOptions = buildOcrModelOptionsFromHf(uniqueModelIds);
+      const dynamicClipOptions = buildClipModelOptionsFromHf(uniqueModels);
+      const dynamicFaceOptions = buildFaceModelOptionsFromHf(uniqueModels);
+      const dynamicOcrOptions = buildOcrModelOptionsFromHf(uniqueModels);
 
       clipModelOptions = dynamicClipOptions.length > 0 ? dynamicClipOptions : CLIP_MODEL_FALLBACK_OPTIONS;
       facialRecognitionModelOptions =
@@ -305,31 +601,22 @@
 
           <hr />
 
-          <SettingInputField
-            inputType={SettingInputFieldType.TEXT}
-            label={$t('admin.machine_learning_clip_model')}
-            bind:value={configToEdit.machineLearning.clip.modelName}
-            description={$t('admin.machine_learning_clip_model_description')}
-            disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+          <SettingCombobox
+            title={$t('admin.machine_learning_clip_model')}
+            subtitle={isHfConnected
+              ? 'Search compatible models by name, dimension, capability, or script. You can also type any custom model name.'
+              : 'Hugging Face suggestions are unavailable right now. You can still type any compatible model name manually.'}
+            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter a CLIP model name'}
+            selectedOption={getSelectedModelOption(clipModelOptions, configToEdit.machineLearning.clip.modelName)}
+            options={clipModelOptions}
+            allowCreate={true}
+            defaultFirstOption={true}
+            disabled={disabled || isRefreshingModelOptions || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+            onSelect={(option) => {
+              configToEdit.machineLearning.clip.modelName = option?.value ?? '';
+            }}
             isEdited={configToEdit.machineLearning.clip.modelName !== config.machineLearning.clip.modelName}
           />
-
-          {#if isHfConnected}
-            <SettingSelect
-              label={$t('admin.machine_learning_clip_model')}
-              desc={''}
-              name="clip-model-select"
-              value={configToEdit.machineLearning.clip.modelName}
-              options={clipModelOptions}
-              disabled={disabled || isRefreshingModelOptions || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
-              onSelect={(value) => {
-                if (typeof value === 'string') {
-                  configToEdit.machineLearning.clip.modelName = value;
-                }
-              }}
-              isEdited={configToEdit.machineLearning.clip.modelName !== config.machineLearning.clip.modelName}
-            />
-          {/if}
 
           <p class="pb-2 text-sm immich-form-label">
             <FormatMessage key="admin.machine_learning_clip_model_description">
@@ -386,38 +673,29 @@
 
           <hr />
 
-          <SettingInputField
-            inputType={SettingInputFieldType.TEXT}
-            label={$t('admin.machine_learning_facial_recognition_model')}
-            description={$t('admin.machine_learning_facial_recognition_model_description')}
-            bind:value={configToEdit.machineLearning.facialRecognition.modelName}
+          <SettingCombobox
+            title={$t('admin.machine_learning_facial_recognition_model')}
+            subtitle={isHfConnected
+              ? 'Search by model family, speed, memory footprint, or quality profile. Manual values are still allowed.'
+              : 'Suggested face models are unavailable right now. You can still type a compatible model name manually.'}
+            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter a face model name'}
+            selectedOption={getSelectedModelOption(
+              facialRecognitionModelOptions,
+              configToEdit.machineLearning.facialRecognition.modelName,
+            )}
+            options={facialRecognitionModelOptions}
+            allowCreate={true}
+            defaultFirstOption={true}
             disabled={disabled ||
+              isRefreshingModelOptions ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.facialRecognition.enabled}
+            onSelect={(option) => {
+              configToEdit.machineLearning.facialRecognition.modelName = option?.value ?? '';
+            }}
             isEdited={configToEdit.machineLearning.facialRecognition.modelName !==
               config.machineLearning.facialRecognition.modelName}
           />
-
-          {#if isHfConnected}
-            <SettingSelect
-              label={$t('admin.machine_learning_facial_recognition_model')}
-              desc={''}
-              name="facial-recognition-model-select"
-              value={configToEdit.machineLearning.facialRecognition.modelName}
-              options={facialRecognitionModelOptions}
-              disabled={disabled ||
-                isRefreshingModelOptions ||
-                !configToEdit.machineLearning.enabled ||
-                !configToEdit.machineLearning.facialRecognition.enabled}
-              onSelect={(value) => {
-                if (typeof value === 'string') {
-                  configToEdit.machineLearning.facialRecognition.modelName = value;
-                }
-              }}
-              isEdited={configToEdit.machineLearning.facialRecognition.modelName !==
-                config.machineLearning.facialRecognition.modelName}
-            />
-          {/if}
 
           <SettingInputField
             inputType={SettingInputFieldType.NUMBER}
@@ -480,34 +758,25 @@
 
           <hr />
 
-          <SettingInputField
-            inputType={SettingInputFieldType.TEXT}
-            label={$t('admin.machine_learning_ocr_model')}
-            description={$t('admin.machine_learning_ocr_model_description')}
-            bind:value={configToEdit.machineLearning.ocr.modelName}
-            disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.ocr.enabled}
+          <SettingCombobox
+            title={$t('admin.machine_learning_ocr_model')}
+            subtitle={isHfConnected
+              ? 'Search OCR models by language coverage, speed, or quality. Manual values are also allowed.'
+              : 'Suggested OCR models are unavailable right now. You can still type a compatible model name manually.'}
+            comboboxPlaceholder={isRefreshingModelOptions ? 'Refreshing model list...' : 'Search or enter an OCR model name'}
+            selectedOption={getSelectedModelOption(ocrModelOptions, configToEdit.machineLearning.ocr.modelName)}
+            options={ocrModelOptions}
+            allowCreate={true}
+            defaultFirstOption={true}
+            disabled={disabled ||
+              isRefreshingModelOptions ||
+              !configToEdit.machineLearning.enabled ||
+              !configToEdit.machineLearning.ocr.enabled}
+            onSelect={(option) => {
+              configToEdit.machineLearning.ocr.modelName = option?.value ?? '';
+            }}
             isEdited={configToEdit.machineLearning.ocr.modelName !== config.machineLearning.ocr.modelName}
           />
-
-          {#if isHfConnected}
-            <SettingSelect
-              label={$t('admin.machine_learning_ocr_model')}
-              desc={''}
-              name="ocr-model-select"
-              value={configToEdit.machineLearning.ocr.modelName}
-              options={ocrModelOptions}
-              disabled={disabled ||
-                isRefreshingModelOptions ||
-                !configToEdit.machineLearning.enabled ||
-                !configToEdit.machineLearning.ocr.enabled}
-              onSelect={(value) => {
-                if (typeof value === 'string') {
-                  configToEdit.machineLearning.ocr.modelName = value;
-                }
-              }}
-              isEdited={configToEdit.machineLearning.ocr.modelName !== config.machineLearning.ocr.modelName}
-            />
-          {/if}
 
           <SettingInputField
             inputType={SettingInputFieldType.NUMBER}

--- a/web/src/routes/admin/system-settings/SettingCombobox.svelte
+++ b/web/src/routes/admin/system-settings/SettingCombobox.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import Combobox, { type ComboBoxOption } from '$lib/components/shared-components/Combobox.svelte';
+  import { t } from 'svelte-i18n';
+  import { quintOut } from 'svelte/easing';
+  import { fly } from 'svelte/transition';
+
+  interface Props {
+    title: string;
+    subtitle?: string;
+    comboboxPlaceholder: string;
+    disabled?: boolean;
+    isEdited?: boolean;
+    options: ComboBoxOption[];
+    selectedOption: ComboBoxOption | undefined;
+    allowCreate?: boolean;
+    defaultFirstOption?: boolean;
+    onSelect: (combobox: ComboBoxOption | undefined) => void;
+  }
+
+  let {
+    title,
+    subtitle = '',
+    comboboxPlaceholder,
+    disabled = false,
+    isEdited = false,
+    options,
+    selectedOption,
+    allowCreate = false,
+    defaultFirstOption = false,
+    onSelect,
+  }: Props = $props();
+</script>
+
+<div class="mb-4 w-full">
+  <div class="flex h-6.5 place-items-center gap-1">
+    <label class="text-sm font-medium text-primary">{title}</label>
+    {#if isEdited}
+      <div
+        transition:fly={{ x: 10, duration: 200, easing: quintOut }}
+        class="rounded-full bg-orange-100 px-2 text-[10px] text-orange-900"
+      >
+        {$t('unsaved_change')}
+      </div>
+    {/if}
+  </div>
+
+  {#if subtitle}
+    <p class="pb-2 text-sm immich-form-label">{subtitle}</p>
+  {/if}
+
+  <div class="max-w-full md:max-w-[38rem]">
+    <Combobox
+      label={title}
+      hideLabel={true}
+      {selectedOption}
+      {options}
+      placeholder={comboboxPlaceholder}
+      {disabled}
+      {allowCreate}
+      {defaultFirstOption}
+      {onSelect}
+    />
+  </div>
+</div>


### PR DESCRIPTION
## Description

Simplifies the admin machine learning model selectors by switching to curated frontend lists for CLIP, facial recognition, and OCR. Each dropdown now uses its own static supported-model list with richer descriptions, while still allowing manual model names when a custom value is needed.

Fixes N/A

## How Has This Been Tested?

- [x] `pnpm --filter @immich/sdk --filter immich-web build`
- [x] Manual validation of the admin Machine Learning settings UI against a local test deployment

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not included.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

GitHub Copilot was used to help implement the UI changes, simplify the selector data flow, review the resulting diff, and validate the web build. The final changes were reviewed and tested locally before updating the PR.