### PR TITLE
fix(server): dedupe database backup jobs

### DIFF
--- a/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
+++ b/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
@@ -2,7 +2,7 @@ import { LoginResponseDto, ManualJobName } from '@immich/sdk';
 import { errorDto } from 'src/responses';
 import { app, utils } from 'src/utils';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 describe('/admin/database-backups', () => {
   let cookie: string | undefined;
@@ -13,6 +13,9 @@ describe('/admin/database-backups', () => {
     admin = await utils.adminSetup({
       onboarding: false,
     });
+  });
+
+  beforeEach(async () => {
     await utils.resetBackups(admin.accessToken);
   });
 

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -568,6 +568,8 @@ export const utils = {
       name: ManualJobName.BackupDatabase,
     });
 
+    await utils.waitForQueueFinish(accessToken, 'backupDatabase');
+
     return utils.poll(
       () => request(app).get('/admin/database-backups').set('Authorization', `Bearer ${accessToken}`),
       ({ status, body }) => status === 200 && body.backups.length === 1,

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -235,6 +235,9 @@ export class JobRepository {
       case JobName.VersionCheck: {
         return { jobId: JobName.VersionCheck };
       }
+      case JobName.DatabaseBackup: {
+        return { jobId: JobName.DatabaseBackup };
+      }
       default: {
         return null;
       }

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -171,8 +171,8 @@ export class JobRepository {
         options: this.getJobOptions(item) || undefined,
       } as JobItem & { data: any; options: JobsOptions | undefined };
 
-      if (job.options?.jobId) {
-        // need to use add() instead of addBulk() for jobId deduplication
+      if (job.options?.jobId || job.options?.deduplication) {
+        // need to use add() instead of addBulk() for jobId/deduplication to take effect
         promises.push(this.getQueue(queueName).add(item.name, item.data, job.options));
       } else {
         itemsByQueue[queueName] = itemsByQueue[queueName] || [];
@@ -230,13 +230,13 @@ export class JobRepository {
         return { priority: 1 };
       }
       case JobName.FacialRecognitionQueueAll: {
-        return { jobId: JobName.FacialRecognitionQueueAll };
+        return { deduplication: { id: JobName.FacialRecognitionQueueAll } };
       }
       case JobName.VersionCheck: {
-        return { jobId: JobName.VersionCheck };
+        return { deduplication: { id: JobName.VersionCheck } };
       }
       case JobName.DatabaseBackup: {
-        return { jobId: JobName.DatabaseBackup };
+        return { deduplication: { id: JobName.DatabaseBackup } };
       }
       default: {
         return null;


### PR DESCRIPTION
## Description

#27268 shows backup jobs piling up in the queue across upgrades; one pending backup is always enough.

Fixes #27268

## How Has This Been Tested?

I set a cron interval shorter than the amount of time it takes to backup on my system. Before this change (and the way I noticed this was an issue), I saw backups happening back to back. After, they happen no more frequently than the backup window.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This one's all me.