### PR TITLE
fix: mobile upload duration type

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16271,7 +16271,7 @@
           },
           "duration": {
             "description": "Duration in milliseconds (for videos)",
-            "maximum": 2147483647,
+            "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
           },

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -38,7 +38,7 @@ export enum UploadFieldName {
 const AssetMediaBaseSchema = z.object({
   fileCreatedAt: isoDatetimeToDate.describe('File creation date'),
   fileModifiedAt: isoDatetimeToDate.describe('File modification date'),
-  duration: z.int32().min(0).optional().describe('Duration in milliseconds (for videos)'),
+  duration: z.coerce.number().int().min(0).optional().describe('Duration in milliseconds (for videos)'),
   filename: z.string().optional().describe('Filename'),
   /** The properties below are added to correctly generate the API docs and client SDKs. Validation should be handled in the controller. */
   [UploadFieldName.ASSET_DATA]: z.any().describe('Asset file data').meta({ type: 'string', format: 'binary' }),


### PR DESCRIPTION
Mobile uses multipart form fields and the duration always arrive as string. Make sure to convcert duration to number instead
