### PR TITLE
fix(web): keep the timeline reachable on libraries past the browser scroll-box cap

### DIFF
--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -145,7 +145,10 @@
       return;
     }
 
-    const currentTop = scrollableElement?.scrollTop || 0;
+    // currentTop is DOM-scroll space; asset/visibleWindow positions are LAYOUT space.
+    // Convert scrollTop to layout space so distances are measured in the same coordinate
+    // system, then convert the chosen layout target back to scroll space for scrollTo().
+    const currentTopLayout = timelineManager.scrollToLayout(scrollableElement?.scrollTop || 0);
     const viewportHeight = visibleBottom - visibleTop;
 
     // Calculate the minimum scroll needed to bring the asset into view.
@@ -155,16 +158,16 @@
 
     // Option 1: Scroll so the top of the asset is at the top of the viewport
     const scrollToAlignTop = assetTop;
-    const distanceToAlignTop = Math.abs(scrollToAlignTop - currentTop);
+    const distanceToAlignTop = Math.abs(scrollToAlignTop - currentTopLayout);
 
     // Option 2: Scroll so the bottom of the asset is at the bottom of the viewport
     const scrollToAlignBottom = assetBottom - viewportHeight;
-    const distanceToAlignBottom = Math.abs(scrollToAlignBottom - currentTop);
+    const distanceToAlignBottom = Math.abs(scrollToAlignBottom - currentTopLayout);
 
     // Choose whichever option requires the minimum scroll distance
     const scrollTarget = distanceToAlignTop < distanceToAlignBottom ? scrollToAlignTop : scrollToAlignBottom;
 
-    timelineManager.scrollTo(scrollTarget);
+    timelineManager.scrollTo(timelineManager.layoutToScroll(scrollTarget));
   };
 
   const scrollAndLoadAsset = async (assetId: string) => {
@@ -282,9 +285,10 @@
     const noMonth = !scrubberMonth;
 
     if (noMonth || timelineManager.limitedScroll) {
-      // edge case - scroll limited due to size of content, must adjust - use use the overall percent instead
-      const maxScroll = timelineManager.maxScrollPercent;
-      const offset = maxScroll * overallScrollPercent * timelineManager.totalViewerHeight;
+      // Routed for two cases: small libraries (factor === 1, content barely scrolls) AND
+      // huge libraries where the cap forced a low compression factor — both want the
+      // scrubber to map overall position straight to DOM scroll range.
+      const offset = overallScrollPercent * timelineManager.maxScroll;
       timelineManager.scrollTo(offset);
     } else if (leadIn) {
       scrollToSegmentPercentage(0, timelineManager.topSectionHeight, scrubberMonthScrollPercent);
@@ -315,7 +319,8 @@
       // edge case - scroll limited due to size of content, must adjust -  use the overall percent instead
       const maxScroll = timelineManager.maxScroll;
 
-      timelineScrollPercent = Math.min(1, scrollableElement.scrollTop / maxScroll);
+      // Guard against divide-by-zero on empty libraries / content < viewport.
+      timelineScrollPercent = maxScroll > 0 ? Math.min(1, scrollableElement.scrollTop / maxScroll) : 0;
       viewportTopMonth = undefined;
       viewportTopMonthScrollPercent = 0;
     } else {
@@ -628,7 +633,7 @@
     bind:this={timelineElement}
     id="virtual-timeline"
     class:invisible
-    style:height={timelineManager.totalViewerHeight + 'px'}
+    style:height={timelineManager.renderedHeight + 'px'}
   >
     <section
       bind:clientHeight={timelineManager.topSectionHeight}
@@ -636,6 +641,7 @@
       style:position="absolute"
       style:left="0"
       style:right="0"
+      style:transform={`translate3d(0,${-timelineManager.renderOffset}px,0)`}
     >
       {@render children?.()}
       {#if isEmpty}
@@ -646,9 +652,9 @@
 
     {#each timelineManager.months as timelineMonth (timelineMonth.viewId)}
       {@const isInOrNearViewport = timelineMonth.isInOrNearViewport}
-      {@const absoluteHeight = timelineMonth.top}
+      {@const absoluteHeight = timelineMonth.top - timelineManager.renderOffset}
 
-      {#if !timelineMonth.isLoaded}
+      {#if !timelineMonth.isLoaded && isInOrNearViewport}
         <div
           style:height={timelineMonth.height + 'px'}
           style:position="absolute"
@@ -719,7 +725,7 @@
       style:position="absolute"
       style:left="0"
       style:right="0"
-      style:transform={`translate3d(0,${timelineManager.topSectionHeight + timelineManager.bodySectionHeight}px,0)`}
+      style:transform={`translate3d(0,${timelineManager.topSectionHeight + timelineManager.bodySectionHeight - timelineManager.renderOffset}px,0)`}
     ></div>
   </section>
 </section>
@@ -734,6 +740,19 @@
   #asset-grid {
     contain: strict;
     scrollbar-width: none;
+  }
+
+  /* position: relative makes #virtual-timeline the containing block for its absolutely-
+     positioned month divs (otherwise their CB is #asset-grid, which has contain: strict
+     and would expand its scrollable overflow to the largest renderY among them — up to
+     ~totalLayoutHeight on a huge library, which the browser then clamps back to the cap
+     and #asset-grid.scrollHeight flickers between rendered and ~2^24 as the user scrolls).
+     overflow: clip then keeps anything translated outside the renderedHeight box (far
+     skeleton months, lead-out spacer when scrolled up) from pushing the scroll container's
+     scrollHeight past the explicit style.height. See immich-app/immich#16788. */
+  #virtual-timeline {
+    position: relative;
+    overflow: clip;
   }
 
   .timeline-month {

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
@@ -5,16 +5,71 @@ type LayoutOptions = {
   rowHeight: number;
   gap: number;
 };
+
+// Browsers cap the rendered height of a layout/scroll box. Blink's LayoutUnit gives
+// ~33.5M device px, halved on DPR-2 displays to 2^24 = 16,777,216 CSS px; Firefox caps
+// lower (~17.9M at DPR 1). Stay safely under both so #virtual-timeline always fits inside
+// the cap. The timeline keeps a real layout coordinate space larger than the scroll box,
+// mapped to DOM scroll via a compression factor. See immich-app/immich#16788.
+function computeMaxScrollHeight(): number {
+  const dpr = Math.max(1, (globalThis.devicePixelRatio as number | undefined) || 1);
+  return Math.floor(15_000_000 / dpr);
+}
+
 export abstract class VirtualScrollManager {
   topSectionHeight = $state(0);
   bodySectionHeight = $state(0);
   bottomSectionHeight = $state(0);
   totalViewerHeight = $derived.by(() => this.topSectionHeight + this.bodySectionHeight + this.bottomSectionHeight);
 
-  visibleWindow = $derived.by(() => ({
-    top: this.#scrollTop,
-    bottom: this.#scrollTop + this.viewportHeight,
-  }));
+  // Two coordinate spaces:
+  //   Layout space: month/day/asset positions, sum to totalViewerHeight (real, uncapped).
+  //   Scroll space: what the DOM sees on #asset-grid.scrollTop, capped at renderedHeight.
+  // When the timeline fits under the cap, renderedHeight === totalViewerHeight and the
+  // compression factor maxScrollPercent === 1, reducing this to upstream's single space.
+  renderedHeight = $derived.by(() => Math.min(this.totalViewerHeight, computeMaxScrollHeight()));
+
+  // Compression factor: 1 px of DOM scroll = (1 / factor) px of layout movement.
+  // 1.0 when no compression is needed (small/medium libraries).
+  maxScrollPercent = $derived.by(() => {
+    const total = this.totalViewerHeight;
+    const vh = this.viewportHeight;
+    if (total <= vh) {
+      return 1;
+    }
+    const rendered = this.renderedHeight;
+    const numer = rendered - vh;
+    const denom = total - vh;
+    if (numer <= 0 || denom <= 0) {
+      return 1;
+    }
+    return Math.max(0.01, Math.min(1, numer / denom));
+  });
+
+  maxScroll = $derived.by(() => Math.max(0, this.renderedHeight - this.viewportHeight));
+
+  // Anchor offset that lets in-viewport months render at real (1:1) coordinates while the
+  // DOM scroll box stays under the cap. Zero when factor is 1.
+  renderOffset = $derived.by(() => {
+    const f = this.maxScrollPercent;
+    if (f >= 0.999) {
+      return 0;
+    }
+    return this.#scrollTop * (1 / f - 1);
+  });
+
+  // visibleWindow is expressed in LAYOUT space so it compares directly against
+  // month.top / position.top in intersection tests. When factor === 1 this is the
+  // upstream definition: { top: scrollTop, bottom: scrollTop + viewportHeight }.
+  visibleWindow = $derived.by(() => {
+    const f = this.maxScrollPercent;
+    const total = this.totalViewerHeight;
+    const vh = this.viewportHeight;
+    const layoutTop = f >= 0.999 ? this.#scrollTop : this.#scrollTop / f;
+    const maxLayoutTop = Math.max(0, total - vh);
+    const top = Math.max(0, Math.min(layoutTop, maxLayoutTop));
+    return { top, bottom: top + vh };
+  });
 
   #viewportHeight = $state(0);
   #viewportWidth = $state(0);
@@ -45,13 +100,16 @@ export abstract class VirtualScrollManager {
     return this.#justifiedLayoutOptions;
   }
 
-  get maxScrollPercent() {
-    const totalHeight = this.totalViewerHeight;
-    return (totalHeight - this.viewportHeight) / totalHeight;
+  // Convert a layout-space y position to the DOM scrollTop needed to place it at the
+  // viewport top. When factor is 1 this is a no-op.
+  layoutToScroll(layoutCoord: number): number {
+    return layoutCoord * this.maxScrollPercent;
   }
 
-  get maxScroll() {
-    return this.totalViewerHeight - this.viewportHeight;
+  // Convert a DOM scrollTop value to the layout-space y position at the viewport top.
+  scrollToLayout(scrollCoord: number): number {
+    const f = this.maxScrollPercent;
+    return f >= 0.999 ? scrollCoord : scrollCoord / f;
   }
 
   #setHeaderHeight(value: number) {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -73,7 +73,18 @@ export class TimelineManager extends VirtualScrollManager {
   scrubberMonths: ScrubberMonth[] = $state([]);
   scrubberTimelineHeight: number = $state(0);
   viewportTopMonthIntersection: ViewportTopMonthIntersection | undefined;
-  limitedScroll = $derived(this.maxScrollPercent < 0.5);
+  // True when scrubbing should use overall-percent rather than month-by-month positions.
+  // Triggers for tiny libraries (barely any scrollable content — original behavior) AND
+  // for huge libraries where heavy compression makes month-precision scrubbing imprecise.
+  // The 0.5 threshold can technically flip during a live viewport resize that nudges f
+  // across it — narrow scenario (mid-drag resize on ~200-300k-asset libraries); accepted.
+  limitedScroll = $derived.by(() => {
+    const vh = this.viewportHeight;
+    if (vh > 0 && this.totalViewerHeight < 2 * vh) {
+      return true;
+    }
+    return this.maxScrollPercent < 0.5;
+  });
   initTask = new CancellableTask(
     () => {
       this.isInitialized = true;

--- a/web/src/lib/managers/timeline-manager/timeline-month.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-month.svelte.ts
@@ -298,10 +298,11 @@ export class TimelineMonth {
       return;
     }
     if (index < currentIndex || monthBottomViewportRatio < 1) {
-      timelineManager.scrollBy(heightDelta);
+      // heightDelta is in LAYOUT space; scrollBy expects DOM-scroll space.
+      timelineManager.scrollBy(timelineManager.layoutToScroll(heightDelta));
     } else if (index === currentIndex) {
-      const scrollTo = this.top + height * viewportTopRatioInMonth;
-      timelineManager.scrollTo(scrollTo);
+      const scrollToLayoutY = this.top + height * viewportTopRatioInMonth;
+      timelineManager.scrollTo(timelineManager.layoutToScroll(scrollToLayoutY));
     }
   }
 


### PR DESCRIPTION
## Description

**What's wrong:** the web timeline puts its full virtual height on the scroll container with no clamp —

```svelte
<section id="virtual-timeline" ... style:height={timelineManager.totalViewerHeight + 'px'}>
```

`totalViewerHeight` is the sum of every month's height. On a large library that's tens of millions of pixels, and **browsers cap the rendered height of a layout/scroll box**: Blink's `LayoutUnit` tops out around `2^31 / 64 ≈ 33.5M` *device* px (= `2^24 = 16,777,216` CSS px on a DPR‑2/Retina display); Firefox caps lower (~17.9M at DPR 1). When the timeline asks for more, the browser silently truncates the rendered height, `scrollTop` saturates early, and the months below the cap are never laid out — **the oldest photos are unreachable by scrolling or by dragging the scrubber.**

Measured on a real instance (v2.7.4, Chrome, DPR 2, ~868 px usable width, 888,198 assets / ~289 monthly buckets back to 1999): `#virtual-timeline` `style.height` = **59,694,000 px** requested, `#asset-grid.scrollHeight` = **16,777,216 px** = 2²⁴ rendered → only **~28 %** reachable, scrolling dead‑ends around Feb 2021. Every "stops at year X" report in #16788 is a different point on the curve `(asset_count × per_asset_px / viewport_width)` vs `(cap / DPR)` — which is why it stops further back on wide/4K/non‑HiDPI monitors (higher CSS‑px cap, fewer rows), earlier on Firefox (lower cap), worse in narrow windows (more rows), why zooming the page out "fixes" it (wider CSS viewport + smaller raster), and why the native mobile app is unaffected (no giant DOM scroll box). Anyone can confirm from the DevTools console on `/photos`:

```js
const vt = document.getElementById('virtual-timeline'), ag = document.getElementById('asset-grid');
({ requested: parseFloat(vt.style.height), rendered: vt.offsetHeight, scrollHeight: ag.scrollHeight,
   reachableFraction: ag.scrollHeight / parseFloat(vt.style.height), dpr: devicePixelRatio });
// reachableFraction < 1  ⇒  hitting the cap
```

**The fix — windowed virtualization, two coordinate spaces:**

- *Layout space* (unchanged): `month.top`, `month.height`, `day.top`, `position.top`, `visibleWindow` — still sums to `totalViewerHeight`.
- *Scroll space*: `#virtual-timeline` is sized at `renderedHeight = min(totalViewerHeight, ~15M / devicePixelRatio)`, always under the cap.

A compression factor `f = (renderedHeight − viewportHeight) / (totalViewerHeight − viewportHeight)` (clamped; `=== 1` when no compression is needed) maps between them. In/near‑viewport months render at `month.top − renderOffset`, where `renderOffset = scrollTop · (1/f − 1)` — so **content at the viewport is always 1:1 (full‑size thumbnails, no shrinking)** while content far from the viewport is compressed out of the scroll box (it's offscreen anyway). `visibleWindow` is kept in *layout* space so the intersection/proximity math is untouched; the scrubber already works in ratios of layout heights, so it stays exact. `#virtual-timeline` also gets `position: relative; overflow: clip` (so its absolutely‑positioned month divs use it as their containing block — otherwise far skeleton months expand `#asset-grid`'s scrollable overflow back up to the cap and `scrollHeight` flickers as you scroll), and the unloaded‑month `<Skeleton>` placeholders are gated on `isInOrNearViewport` so a huge library doesn't mount hundreds of offscreen skeleton nodes.

**No behavior change for libraries that fit under the cap:** `renderedHeight === totalViewerHeight` ⇒ `f === 1`, `renderOffset === 0`, and `visibleWindow` plus every `layoutToScroll`/`scrollToLayout` conversion reduce to the current code exactly. (Existing `totalViewerHeight === 8337` test still passes.)

**Trade‑off:** when the cap actually bites, scrolling near the extremes is *compressed* — 1 px of scrollbar travel ≈ `1/f` px of content movement (≈7.7× for the 888k‑asset library above on DPR 2). Wheel/trackpad feels normal; clicking the scrollbar *track* jumps ~`1/f` viewports per click; the scrubber stays exact. This only happens for libraries that exceed the cap, and the alternative is the current state where most of the library is unreachable. (Shrinking thumbnails to keep 1:1 scrolling was the other option — rejected; ~80 px thumbnails for an 888k library is worse, and the layout has to stay at the configured row height for everything else.)

**Changes (`+114 / −25`, 4 files):**

| File | What |
|---|---|
| `VirtualScrollManager.svelte.ts` | adds `renderedHeight`, `renderOffset`, `layoutToScroll`/`scrollToLayout`; redefines `maxScrollPercent` as the compression factor `f` and `maxScroll = renderedHeight − vh`; `visibleWindow` now in layout space |
| `Timeline.svelte` | `#virtual-timeline` height → `renderedHeight`; lead‑in / each month / lead‑out spacer subtract `renderOffset` from `translate3d`; `scrollToAssetPosition` and `set height(h)` callers convert spaces via the helpers; `onScrub` `limitedScroll` branch simplified; gates the unloaded‑month `<Skeleton>` on `isInOrNearViewport`; adds `position: relative; overflow: clip` to `#virtual-timeline`; guards a divide‑by‑zero in the scrubber on empty libraries |
| `timeline-manager.svelte.ts` | `limitedScroll` keeps the original tiny‑library predicate (`totalViewerHeight < 2·viewportHeight`) that the redefinition of `maxScrollPercent` would otherwise drop, plus the new `f < 0.5` trigger |
| `timeline-month.svelte.ts` | `set height(h)`'s scroll‑position nudges convert layout deltas via `layoutToScroll` before `scrollBy`/`scrollTo` |

**Known limitations (narrow, left for follow‑up — happy to address if you'd prefer):** a `devicePixelRatio` change at runtime (window dragged across monitors with different DPI) doesn't re‑derive `MAX_SCROLL_HEIGHT` until the next layout pass (recovers on resize); `set height(h)`'s `scrollBy(layoutDelta · f)` rounds to sub‑pixel and could in principle accumulate a small upward drift over a very long scroll session (not observed); `limitedScroll` can flip between month‑precise and overall‑percent scrubbing if `f` crosses 0.5 during a live viewport resize on ~200–300k‑asset libraries (hysteresis would need a `$effect`).

Fixes #16788

## How Has This Been Tested?

- [x] **Live deployment** on a real instance with the symptom (Immich v2.7.4, custom `immich-server` image built from this branch, Chrome DPR 2, ~868 px usable width, 888,198 assets / ~289 monthly buckets back to 1999):

  | Metric | Before | After |
  |---|---|---|
  | `#virtual-timeline` `style.height` | 59,694,000 px | 7,500,000 px (= `MAX / DPR`) |
  | `#asset-grid.scrollHeight` | 16,777,216 px (cap hit) | 7,500,000 px (no cap hit) |
  | Reachable | ~28 % | 100 % |
  | Oldest visible | Feb 2021 | Jul 1997 |
  | Thumbnail size | 235 px row height | 235 px row height (unchanged) |
  | `scrollHeight` across the full scroll range | flickered between rendered & cap | rock‑stable single value |

  Scrollbar position → date — clean, monotonic, recency‑weighted (no saturation): `0% → today, 5% → Apr 2025, 10% → Aug 2024, 20% → Oct 2022, 30% → Aug 2020, 40% → Jan 2019, 50% → Dec 2017, 60% → Dec 2016, 70% → Jan 2016, 80% → Jan 2015, 90% → Dec 2012, 97% → Mar 2011, 100% → Jul 1997`. Asset‑viewer deep‑link (`?at=<id>`) and browser back‑navigation round‑trip verified — no regression (an earlier draft that changed the layout row height regressed there; this one never changes layout coordinates, only the scroll‑box size).

- [x] **`pnpm --filter immich-web run format`** (prettier `--check`) — clean.
- [x] **`tsc --noEmit`** in `web/` (after `pnpm --filter @immich/sdk build`) — 0 errors.
- [x] **`vitest run src/lib/managers`** — 55/55 pass, including the `timeline-manager` spec (the `totalViewerHeight === 8337` assertion still holds — confirms the `f === 1` path is unchanged).
- [ ] Dedicated unit tests for the new large‑library path (`renderedHeight === MAX`, `0 < maxScrollPercent < 1`, `layoutToScroll(scrollToLayout(x)) ≈ x`, `visibleWindow.top ≈ scrollTop / f`) — not in this PR yet; can add if you'd like them here.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Mid‑range scroll position on the 888k‑asset library after the fix — full‑size thumbnails, scrubber spanning the full 2026 → 1997 range, real day headers loading. (Screenshot available on request — captured via remote‑debugging during verification.)

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable — N/A (no user‑facing docs affected)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. — none added
- [ ] I have written tests for new code (if applicable) — not yet; existing tests pass unchanged, happy to add new‑path tests here if preferred
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. — N/A (web‑only change, no server code)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) — N/A (web‑only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. A user investigating #16788 on their own instance worked with an LLM (Claude) to diagnose the root cause, design the windowed‑virtualization approach, write the patch, review it, and verify it against the live deployment (the before/after numbers and scroll→date mapping above were measured via remote‑debugging the running instance). The diagnosis was confirmed empirically — DOM/`scrollHeight` measurements at multiple scroll positions, the asset‑viewer round‑trip, and the local `format`/`tsc`/`vitest` runs above — not just generated. Everything was human‑reviewed before submission; the author can speak to any part of it and will own the follow‑up.
