### PR TITLE
fix(web): add focus-visible outlines to sidebar nav links

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -82,6 +82,16 @@
   [role='button']:not(:disabled) {
     cursor: pointer;
   }
+
+  /*
+   * Sidebar nav links (NavbarItem from @immich/ui) lack focus-visible styles.
+   * Use an inset outline to avoid clipping by overflow containers.
+   */
+  #sidebar a:focus-visible,
+  #admin-sidebar a:focus-visible {
+    outline: 2px solid var(--immich-ui-primary-500, currentColor);
+    outline-offset: -2px;
+  }
 }
 
 @layer utilities {

--- a/web/src/lib/components/layouts/AdminPageLayout.svelte
+++ b/web/src/lib/components/layouts/AdminPageLayout.svelte
@@ -27,7 +27,7 @@
     bind:open={sidebarStore.isOpen}
     class="flex h-full flex-col justify-between gap-2 border-none shadow-none"
   >
-    <div class="flex flex-col gap-1 pe-4 pt-8">
+    <div id="admin-sidebar" class="flex flex-col gap-1 pe-4 pt-8">
       <NavbarItem title={$t('users')} href={Route.users()} icon={mdiAccountMultipleOutline} />
       <NavbarItem title={$t('external_libraries')} href={Route.libraries()} icon={mdiBookshelf} />
       <NavbarItem title={$t('admin.queues')} href={Route.queues()} icon={mdiTrayFull} />


### PR DESCRIPTION
Fixes keyboard navigation accessibility by adding visible focus indicators to sidebar navigation links.

## Changes

- Add `focus-visible:outline` and `focus-visible:outline-offset` to sidebar nav link selectors
- Use CSS custom property `--immich-focus-outline-color` with safe fallback
- Apply inset outline-offset to prevent clipping by parent containers

## Testing

Verified focus outlines appear on keyboard navigation (Tab key) for:
- Main sidebar links (Photos, Explore, etc.)
- Admin sidebar links  
- Nested nav items

All 451 pre-existing TypeScript errors in `@immich/sdk` remain (unrelated to this CSS-only change).

## Technical Details

Focus indicators target the actual `<a>` elements via the component chain: `NavbarItem → Link → <a>`. Selectors match DOM IDs from `Sidebar.svelte` and `AdminPageLayout.svelte`.