### PR TITLE
fix(web): add focus-visible outlines to sidebar nav links

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -82,6 +82,16 @@
   [role='button']:not(:disabled) {
     cursor: pointer;
   }
+
+  /*
+   * Sidebar nav links (NavbarItem from @immich/ui) lack focus-visible styles.
+   * Use an inset outline to avoid clipping by overflow containers.
+   */
+  #sidebar a:focus-visible,
+  #admin-sidebar a:focus-visible {
+    outline: 2px solid var(--immich-ui-primary-500, currentColor);
+    outline-offset: -2px;
+  }
 }
 
 @layer utilities {

--- a/web/src/lib/components/layouts/AdminPageLayout.svelte
+++ b/web/src/lib/components/layouts/AdminPageLayout.svelte
@@ -27,7 +27,7 @@
     bind:open={sidebarStore.isOpen}
     class="flex h-full flex-col justify-between gap-2 border-none shadow-none"
   >
-    <div class="flex flex-col gap-1 pe-4 pt-8">
+    <div id="admin-sidebar" class="flex flex-col gap-1 pe-4 pt-8">
       <NavbarItem title={$t('users')} href={Route.users()} icon={mdiAccountMultipleOutline} />
       <NavbarItem title={$t('external_libraries')} href={Route.libraries()} icon={mdiBookshelf} />
       <NavbarItem title={$t('admin.queues')} href={Route.queues()} icon={mdiTrayFull} />


### PR DESCRIPTION
## Summary

Sidebar NavbarItem links from @immich/ui lack :focus-visible styles, making keyboard navigation invisible. This adds inset outlines scoped to #sidebar and #admin-sidebar so focus rings aren't clipped by overflow containers.

Note: the proper fix belongs in @immich/ui's NavbarItem component. This app-level workaround is scoped to avoid breaking other consumers.

## Test plan
- Manual keyboard navigation: Tab through sidebar links, verify visible focus outlines
- Existing tests pass