### PR TITLE
chore(mobile): drop deprecated deviceAssetId / deviceId from upload fields

### DIFF
--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -394,12 +394,9 @@ class BackgroundUploadService {
     final serverEndpoint = Store.get(StoreKey.serverEndpoint);
     final url = Uri.parse('$serverEndpoint/assets').toString();
     final headers = ApiService.getRequestHeaders();
-    final deviceId = Store.get(StoreKey.deviceId);
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final fieldsMap = {
       'filename': originalFileName ?? filename,
-      'deviceAssetId': deviceAssetId ?? '',
-      'deviceId': deviceId,
       'fileCreatedAt': createdAt.toUtc().toIso8601String(),
       'fileModifiedAt': modifiedAt.toUtc().toIso8601String(),
       'isFavorite': isFavorite?.toString() ?? 'false',

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -5,8 +5,6 @@ import 'dart:io';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/asset_metadata.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/extensions/network_capability_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
@@ -321,11 +319,8 @@ class ForegroundUploadService {
       }
 
       final originalFileName = entity.isLivePhoto ? p.setExtension(fileName, p.extension(file.path)) : fileName;
-      final deviceId = Store.get(StoreKey.deviceId);
 
       final fields = {
-        'deviceAssetId': asset.localId!,
-        'deviceId': deviceId,
         'fileCreatedAt': asset.createdAt.toUtc().toIso8601String(),
         'fileModifiedAt': asset.updatedAt.toUtc().toIso8601String(),
         'isFavorite': asset.isFavorite.toString(),
@@ -431,8 +426,6 @@ class ForegroundUploadService {
       final filename = p.basename(file.path);
 
       final fields = {
-        'deviceAssetId': deviceAssetId,
-        'deviceId': Store.get(StoreKey.deviceId),
         'fileCreatedAt': fileCreatedAt.toUtc().toIso8601String(),
         'fileModifiedAt': fileModifiedAt.toUtc().toIso8601String(),
         'isFavorite': 'false',


### PR DESCRIPTION
## Description

server removed the `deviceAssetId` and `deviceId` fields from `AssetMediaCreateDto` in #27818. zod silently strips unknown fields so mobile uploads still work, but we're sending dead weight on every request.

dropped both from the foreground + background upload paths and the share-intent path. `deviceAssetId` is still kept as the internal `background_downloader` taskId — just no longer in the multipart form fields.

related to #27818.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

claude code helped with tracing paths and running local repro/build commands. design, code, and review are mine.