### PR TITLE
docs(i18n): update Chinese (zh_CN) README translation

### DIFF
--- a/readme_i18n/README_zh_CN.md
+++ b/readme_i18n/README_zh_CN.md
@@ -1,17 +1,17 @@
 <p align="center"> 
-  <br/>  
+  <br/>
   <a href="https://opensource.org/license/agpl-v3"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg?color=3F51B5&style=for-the-badge&label=License&logoColor=000000&labelColor=ececec" alt="License: AGPLv3"></a>
   <a href="https://discord.immich.app">
-    <img src="https://img.shields.io/discord/979116623879368755.svg?label=Discord&logo=Discord&style=for-the-badge&logoColor=000000&labelColor=ececec" atl="Discord"/>
+    <img src="https://img.shields.io/discord/979116623879368755.svg?label=Discord&logo=Discord&style=for-the-badge&logoColor=000000&labelColor=ececec" alt="Discord"/>
   </a>
-  <br/>  
-  <br/>   
+  <br/>
+  <br/>
 </p>
 
 <p align="center">
 <img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
-<h3 align="center">高性能的照片和视频自托管解决方案</h3>
+<h3 align="center">高性能的自托管照片和视频管理方案</h3>
 <p align="center">  
 请注意: 此 README 不是由 Immich 团队维护, 而是依靠贡献者来更新的，这意味着它可能并不会被及时更新。感谢理解。
 </p>
@@ -20,8 +20,8 @@
 <img src="../design/immich-screenshots.png" title="界面截图">
 </a>
 <br/>
-<p align="center">
 
+<p align="center">
   <a href="../README.md">English</a>
   <a href="README_ca_ES.md">Català</a>
   <a href="README_es_ES.md">Español</a>
@@ -40,33 +40,28 @@
   <a href="README_ar_JO.md">العربية</a>
   <a href="README_vi_VN.md">Tiếng Việt</a>
   <a href="README_th_TH.md">ภาษาไทย</a>
-
 </p>
 
-## 免责声明
-
-- ⚠️ 本项目正在 **非常活跃** 地开发中。
-- ⚠️ 可能存在 bug 或者随时有重大变更。
-- ⚠️ **不要把本软件作为您存储照片或视频的唯一方式。**
-- ⚠️ 为了您宝贵的照片与视频，请始终遵守 [3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) 备份方案！
+> [!WARNING]
+> ⚠️ 为了您宝贵的照片与视频，请始终遵守 [3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) 备份方案！
 
 > [!NOTE]
 > 完整的项目文档以及安装教程请参见：<https://immich.app/>。
 
 ## 目录
 
-- [官方文档](https://docs.immich.app)
+- [官方文档](https://docs.immich.app/)
 - [项目总览](https://docs.immich.app/overview/introduction)
 - [安装教程](https://docs.immich.app/install/requirements)
 - [路线图](https://immich.app/roadmap)
-- [在线演示](#示例)
+- [在线演示](#在线演示)
 - [功能特性](#功能特性)
 - [多语言](https://docs.immich.app/developer/translations)
-- [贡献者](https://docs.immich.app/overview/support-the-project)
+- [参与贡献](https://docs.immich.app/overview/support-the-project)
 
-## 示例
+## 在线演示
 
-您可以在[此处](https://demo.immich.app)访问在线演示网站。在移动端，您可以使用 `https://demo.immich.app` 作为 `服务终端链接`
+您可以在[此处](https://demo.immich.app)访问在线演示网站。在移动端，您可以使用 `https://demo.immich.app` 作为 `Server Endpoint URL`。
 
 ### 登录认证信息
 
@@ -76,38 +71,38 @@
 
 ## 功能特性
 
-| 功能特性                                    | 移动端 | 网页端 |
-| :------------------------------------------ | ------ | ------ |
-| 上传并查看照片和视频                        | 是     | 是     |
-| 软件运行时自动备份                          | 是     | N/A    |
-| 忽略重复的项目                              | 是     | 是     |
-| 选择需要备份的相册                          | 是     | N/A    |
-| 下载照片和视频到本地                        | 是     | 是     |
-| 多用户支持                                  | 是     | 是     |
-| 相册与共享相册                              | 是     | 是     |
-| 可拖动的快速滚动条                          | 是     | 是     |
-| 支持RAW格式                                 | 是     | 是     |
-| 元数据视图（EXIF、地图）                    | 是     | 是     |
-| 通过元数据、对象、人脸和标签进行搜索        | 是     | 是     |
-| 管理功能（用户管理）                        | 否     | 是     |
-| 后台备份                                    | 是     | N/A    |
-| 虚拟滚动                                    | 是     | 是     |
-| OAuth 支持                                  | 是     | 是     |
-| API Keys                                    | N/A    | 是     |
-| 实况照片备份和查看                          | 是     | 是     |
-| 支持360度全景图显示                         | 否     | 是     |
-| 用户自定义存储结构                          | 是     | 是     |
-| 公共分享                                    | 是     | 是     |
-| 归档与收藏功能                              | 是     | 是     |
-| 足迹地图                                    | 是     | 是     |
-| 好友分享                                    | 是     | 是     |
-| 人脸识别与分组                              | 是     | 是     |
-| 回忆（那年今日）                            | 是     | 是     |
-| 离线支持                                    | 是     | 否     |
-| 只读相册                                    | 是     | 是     |
-| 照片堆叠                                    | 是     | 是     |
-| 标签                                        | 否     | 是     |
-| 文件夹浏览                                  | 否     | 是     |
+| 功能特性                                     | 移动端 | 网页端 |
+| :------------------------------------------- | ------ | ------ |
+| 上传并查看照片和视频                         | ✅     | ✅     |
+| 软件运行时自动备份                           | ✅     | N/A    |
+| 防止资产重复                                 | ✅     | ✅     |
+| 选择需要备份的相册                           | ✅     | N/A    |
+| 下载照片和视频到本地设备                     | ✅     | ✅     |
+| 多用户支持                                   | ✅     | ✅     |
+| 相册与共享相册                               | ✅     | ✅     |
+| 可拖动的快速滚动条                           | ✅     | ✅     |
+| 支持 RAW 格式                                | ✅     | ✅     |
+| 元数据视图（EXIF、地图）                     | ✅     | ✅     |
+| 通过元数据、对象、人脸和 CLIP 进行搜索       | ✅     | ✅     |
+| 管理功能（用户管理）                         | ❌     | ✅     |
+| 后台备份                                     | ✅     | N/A    |
+| 虚拟滚动                                     | ✅     | ✅     |
+| OAuth 支持                                   | ✅     | ✅     |
+| API 密钥                                     | N/A    | ✅     |
+| 实况照片/动态照片备份和播放                  | ✅     | ✅     |
+| 支持 360 度全景图显示                        | ❌     | ✅     |
+| 用户自定义存储结构                           | ✅     | ✅     |
+| 公开分享                                     | ✅     | ✅     |
+| 归档与收藏                                   | ✅     | ✅     |
+| 全局地图                                     | ✅     | ✅     |
+| 伙伴分享                                     | ✅     | ✅     |
+| 人脸识别与分组                               | ✅     | ✅     |
+| 回忆（那年今日）                             | ✅     | ✅     |
+| 离线支持                                     | ✅     | ❌     |
+| 只读图库                                     | ✅     | ✅     |
+| 照片堆叠                                     | ✅     | ✅     |
+| 标签                                         | ❌     | ✅     |
+| 文件夹浏览                                   | ✅     | ✅     |
 
 ## 多语言
 
@@ -117,22 +112,22 @@
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="翻译进度" />
 </a>
 
-## 活跃度
+## 仓库活跃度
 
 ![活跃度](https://repobeats.axiom.co/api/embed/9e86d9dc3ddd137161f2f6d2e758d7863b1789cb.svg "Repobeats analytics image")
 
-## Star增长曲线
+## Star 增长历史
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.com/#immich-app/immich&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=date" width="100%" />
  </picture>
 </a>
 
 ## 贡献者
 
-<a href="https://github.com/alextran1502/immich/graphs/contributors">
+<a href="https://github.com/immich-app/immich/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=immich-app/immich" width="100%"/>
 </a>


### PR DESCRIPTION
## Changes

This PR updates the existing Chinese (zh_CN) README translation to sync with the current English README.

Changes include:

- **Fixed typo**: \ changed to \n- **Synced warning section**: Updated to match the current English README [!WARNING] format
- **Fixed Folder View support**: Updated from No to Yes to match the English README
- **Fixed contributors link**: Updated from old alextran1502/immich to immich-app/immich
- **Updated Star history URL**: Synced with English README URL format
- **Used checkbox icons**: Replaced plain text with visual icons in the features table for better readability
- **Minor translation improvements**: Polished various Chinese translations for clarity and consistency