### PR TITLE
fix(mobile): revert drop deprecated deviceAssetId / deviceId from upload fields (#28384)

### DIFF
--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -394,9 +394,12 @@ class BackgroundUploadService {
     final serverEndpoint = Store.get(StoreKey.serverEndpoint);
     final url = Uri.parse('$serverEndpoint/assets').toString();
     final headers = ApiService.getRequestHeaders();
+    final deviceId = Store.get(StoreKey.deviceId);
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final fieldsMap = {
       'filename': originalFileName ?? filename,
+      'deviceAssetId': deviceAssetId ?? '',
+      'deviceId': deviceId,
       'fileCreatedAt': createdAt.toUtc().toIso8601String(),
       'fileModifiedAt': modifiedAt.toUtc().toIso8601String(),
       'isFavorite': isFavorite?.toString() ?? 'false',

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -398,6 +398,7 @@ class BackgroundUploadService {
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final fieldsMap = {
       'filename': originalFileName ?? filename,
+      // deviceAssetId/deviceId required by server v2.7.5 and below (drop in v4.0 per #27818).
       'deviceAssetId': deviceAssetId ?? '',
       'deviceId': deviceId,
       'fileCreatedAt': createdAt.toUtc().toIso8601String(),

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/asset_metadata.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/extensions/network_capability_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
@@ -319,8 +321,11 @@ class ForegroundUploadService {
       }
 
       final originalFileName = entity.isLivePhoto ? p.setExtension(fileName, p.extension(file.path)) : fileName;
+      final deviceId = Store.get(StoreKey.deviceId);
 
       final fields = {
+        'deviceAssetId': asset.localId!,
+        'deviceId': deviceId,
         'fileCreatedAt': asset.createdAt.toUtc().toIso8601String(),
         'fileModifiedAt': asset.updatedAt.toUtc().toIso8601String(),
         'isFavorite': asset.isFavorite.toString(),
@@ -426,6 +431,8 @@ class ForegroundUploadService {
       final filename = p.basename(file.path);
 
       final fields = {
+        'deviceAssetId': deviceAssetId,
+        'deviceId': Store.get(StoreKey.deviceId),
         'fileCreatedAt': fileCreatedAt.toUtc().toIso8601String(),
         'fileModifiedAt': fileModifiedAt.toUtc().toIso8601String(),
         'isFavorite': 'false',

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -324,6 +324,7 @@ class ForegroundUploadService {
       final deviceId = Store.get(StoreKey.deviceId);
 
       final fields = {
+        // deviceAssetId/deviceId required by server v2.7.5 and below (drop in v4.0 per #27818).
         'deviceAssetId': asset.localId!,
         'deviceId': deviceId,
         'fileCreatedAt': asset.createdAt.toUtc().toIso8601String(),
@@ -431,6 +432,7 @@ class ForegroundUploadService {
       final filename = p.basename(file.path);
 
       final fields = {
+        // deviceAssetId/deviceId required by server v2.7.5 and below (drop in v4.0 per #27818).
         'deviceAssetId': deviceAssetId,
         'deviceId': Store.get(StoreKey.deviceId),
         'fileCreatedAt': fileCreatedAt.toUtc().toIso8601String(),


### PR DESCRIPTION
This reverts commit 571e6a8560fbf4031b30e530196e281b4858bfb4.

Revert to ensure v3.0 still be able to upload to v2.7.5 and below. Will drop these fields in v4.0
