### PR TITLE
fix(jobs): Use bullmq's deduplication to simplify album update and migration workers

### DIFF
--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -219,12 +219,12 @@ export class JobRepository {
     switch (item.name) {
       case JobName.NotifyAlbumUpdate: {
         return {
-          jobId: `${item.data.id}/${item.data.recipientId}`,
+          deduplication: { id: `${item.data.id}/${item.data.recipientId}`, replace: true },
           delay: item.data?.delay,
         };
       }
       case JobName.StorageTemplateMigrationSingle: {
-        return { jobId: item.data.id };
+        return { deduplication: { id: item.data.id } };
       }
       case JobName.PersonGenerateThumbnail: {
         return { priority: 1 };
@@ -246,14 +246,5 @@ export class JobRepository {
 
   private getQueue(queue: QueueName): Queue {
     return this.moduleRef.get<Queue>(getQueueToken(queue), { strict: false });
-  }
-
-  /** @deprecated */
-  // todo: remove this when asset notifications no longer need it.
-  public async removeJob(name: JobName, jobID: string): Promise<void> {
-    const existingJob = await this.getQueue(this.getQueueName(name)).getJob(jobID);
-    if (existingJob) {
-      await existingJob.remove();
-    }
   }
 }

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -523,7 +523,6 @@ describe(NotificationService.name, () => {
 
     it('should add new recipients for new images if job is already queued', async () => {
       await sut.onAlbumUpdate({ id: '1', recipientId: '2' } as INotifyAlbumUpdateJob);
-      expect(mocks.job.removeJob).toHaveBeenCalledWith(JobName.NotifyAlbumUpdate, '1/2');
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.NotifyAlbumUpdate,
         data: {

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -218,7 +218,6 @@ export class NotificationService extends BaseService {
 
   @OnEvent({ name: 'AlbumUpdate' })
   async onAlbumUpdate({ id, recipientId }: ArgOf<'AlbumUpdate'>) {
-    await this.jobRepository.removeJob(JobName.NotifyAlbumUpdate, `${id}/${recipientId}`);
     await this.jobRepository.queue({
       name: JobName.NotifyAlbumUpdate,
       data: { id, recipientId, delay: NotificationService.albumUpdateEmailDelayMs },

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -19,6 +19,5 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     getJobCounts: vitest.fn(),
     clear: vitest.fn(),
     waitForQueueCompletion: vitest.fn(),
-    removeJob: vitest.fn(),
   };
 };


### PR DESCRIPTION
## Description

Following up from https://github.com/immich-app/immich/pull/28341#issuecomment-4451902348 , this uses the better bullmq dedupe primitive to simplify worker logic.

## How Has This Been Tested?

Stuck with the test suites for this one.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
N/A