### PR TITLE
fix(mobile): cronet buffer overflow on compressed thumbnails

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -23,6 +23,8 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 
+private const val MAX_PREALLOC_BYTES = 128 * 1024 * 1024
+
 private class RemoteRequest(val cancellationSignal: CancellationSignal)
 
 class RemoteImagesImpl(context: Context) : RemoteImageApi {
@@ -228,7 +230,6 @@ private class CronetImageFetcher : ImageFetcher {
     private val onComplete: () -> Unit,
   ) : UrlRequest.Callback() {
     private var buffer: NativeByteBuffer? = null
-    private var wrapped: ByteBuffer? = null
     private var error: Exception? = null
 
     override fun onRedirectReceived(request: UrlRequest, info: UrlResponseInfo, newUrl: String) {
@@ -242,15 +243,16 @@ private class CronetImageFetcher : ImageFetcher {
       }
 
       try {
+        // Content-Length is a size hint only. With Content-Encoding (gzip/br/...),
+        // Cronet auto-decompresses and writes decompressed bytes to our buffer, which
+        // may exceed the wire/compressed Content-Length. Always use the growable
+        // buffer path so we can't overflow.
         val contentLength = info.allHeaders["content-length"]?.firstOrNull()?.toIntOrNull() ?: 0
-        if (contentLength > 0) {
-          buffer = NativeByteBuffer(contentLength + 1)
-          wrapped = NativeBuffer.wrap(buffer!!.pointer, contentLength + 1)
-          request.read(wrapped)
-        } else {
-          buffer = NativeByteBuffer(INITIAL_BUFFER_SIZE)
-          request.read(buffer!!.wrapRemaining())
-        }
+        // Cap the up-front alloc: Content-Length is untrusted and can be huge or near
+        // Int.MAX_VALUE (overflowing `+1`). For larger responses the grow path takes over.
+        val initialSize = if (contentLength in 1..MAX_PREALLOC_BYTES) contentLength + 1 else INITIAL_BUFFER_SIZE
+        buffer = NativeByteBuffer(initialSize)
+        request.read(buffer!!.wrapRemaining())
       } catch (e: Exception) {
         error = e
         return request.cancel()
@@ -263,14 +265,18 @@ private class CronetImageFetcher : ImageFetcher {
       byteBuffer: ByteBuffer
     ) {
       try {
-        val buf = if (wrapped == null) {
-          buffer!!.run {
-            advance(byteBuffer.position())
-            ensureHeadroom()
-            wrapRemaining()
-          }
+        val b = buffer!!
+        b.advance(byteBuffer.position())
+        // Reuse the caller-supplied ByteBuffer as long as we don't need to grow.
+        // It already points at our native memory with position advanced past the
+        // written bytes — Cronet can keep writing into the remaining tail.
+        // Only when the buffer is full do we grow (which may realloc + move the
+        // native pointer) and need a fresh wrap.
+        val buf = if (b.offset == b.capacity) {
+          b.ensureHeadroom()
+          b.wrapRemaining()
         } else {
-          wrapped
+          byteBuffer
         }
         request.read(buf)
       } catch (e: Exception) {
@@ -280,7 +286,6 @@ private class CronetImageFetcher : ImageFetcher {
     }
 
     override fun onSucceeded(request: UrlRequest, info: UrlResponseInfo) {
-      wrapped?.let { buffer!!.advance(it.position()) }
       onSuccess(buffer!!)
       onComplete()
     }


### PR DESCRIPTION
## Description

Cronet auto-decompresses gzip/br responses, writing decompressed bytes into our buffer. We were sizing it from `Content-Length` which is the compressed wire size — so decompressed bytes can overflow it. The next `request.read(buf)` call throws `IllegalArgumentException: ByteBuffer is already full.`

`CronetImageFetcher` now uses the growable path with Content-Length as a hint for the initial allocation, capped at 128 MB so an untrusted server can't overflow `Int.MAX_VALUE` or OOM upfront. Cronet's `ByteBuffer` is still reused between reads when no grow is needed — only a buffer-full triggers a realloc + fresh wrap. `OkHttpImageFetcher` unaffected — OkHttp's `body.contentLength()` is already the decoded size.

Closes #28419.

Repro'd on a Pixel 9a against a local node proxy that forces gzip with fixed Content-Length on thumbnail responses (matches what a Sophos WAF / similar layer does to the reporter). Before fix: 2/5 compressed thumbnails fired the exception. After fix: 0/13. Same scroll session, same proxy.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

claude helped trace the cronet read loop and set up the local repro proxy. fix and verification mine.