### PR TITLE
feat(mobile): add 360° panorama viewer for equirectangular photos

### DIFF
--- a/mobile/lib/domain/models/exif.model.dart
+++ b/mobile/lib/domain/models/exif.model.dart
@@ -26,6 +26,11 @@ class ExifInfo {
   final int? iso;
   final double? exposureSeconds;
 
+  // Spherical
+  final String? projectionType;
+
+  bool get isPanorama => projectionType?.toUpperCase() == 'EQUIRECTANGULAR';
+
   bool get hasCoordinates => latitude != null && longitude != null && latitude != 0 && longitude != 0;
 
   String get exposureTime {
@@ -65,6 +70,7 @@ class ExifInfo {
     this.mm,
     this.iso,
     this.exposureSeconds,
+    this.projectionType,
   });
 
   @override
@@ -94,7 +100,8 @@ class ExifInfo {
         other.mm == mm &&
         other.iso == iso &&
         other.exposureSeconds == exposureSeconds &&
-        other.assetId == assetId;
+        other.assetId == assetId &&
+        other.projectionType == projectionType;
   }
 
   @override
@@ -120,7 +127,8 @@ class ExifInfo {
         mm.hashCode ^
         iso.hashCode ^
         exposureSeconds.hashCode ^
-        assetId.hashCode;
+        assetId.hashCode ^
+        projectionType.hashCode;
   }
 
   @override
@@ -147,6 +155,7 @@ f: ${f ?? 'NA'},
 mm: ${mm ?? '<NA>'},
 iso: ${iso ?? 'NA'},
 exposureSeconds: ${exposureSeconds ?? 'NA'},
+projectionType: ${projectionType ?? 'NA'},
 }''';
   }
 
@@ -173,6 +182,7 @@ exposureSeconds: ${exposureSeconds ?? 'NA'},
     double? mm,
     int? iso,
     double? exposureSeconds,
+    String? projectionType,
   }) {
     return ExifInfo(
       assetId: assetId ?? this.assetId,
@@ -197,6 +207,7 @@ exposureSeconds: ${exposureSeconds ?? 'NA'},
       mm: mm ?? this.mm,
       iso: iso ?? this.iso,
       exposureSeconds: exposureSeconds ?? this.exposureSeconds,
+      projectionType: projectionType ?? this.projectionType,
     );
   }
 }

--- a/mobile/lib/infrastructure/entities/exif.entity.dart
+++ b/mobile/lib/infrastructure/entities/exif.entity.dart
@@ -84,5 +84,6 @@ extension RemoteExifEntityDataDomainEx on RemoteExifEntityData {
     lens: lens,
     isFlipped: ExifDtoConverter.isOrientationFlipped(orientation),
     exposureSeconds: ExifDtoConverter.exposureTimeToSeconds(exposureTime),
+    projectionType: projectionType,
   );
 }

--- a/mobile/lib/infrastructure/utils/exif.converter.dart
+++ b/mobile/lib/infrastructure/utils/exif.converter.dart
@@ -23,6 +23,7 @@ abstract final class ExifDtoConverter {
       mm: dto.focalLength?.toDouble(),
       iso: dto.iso?.toInt(),
       exposureSeconds: exposureTimeToSeconds(dto.exposureTime),
+      projectionType: dto.projectionType,
     );
   }
 

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -17,6 +17,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/download_statu
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_page.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_preloader.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/panorama360_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_bottom_app_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
@@ -323,6 +324,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
                 height: context.padding.top,
               ),
             ),
+          const Panorama360Button(),
         ],
       ),
     );

--- a/mobile/lib/presentation/widgets/asset_viewer/panorama360_button.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/panorama360_button.widget.dart
@@ -1,0 +1,88 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/panorama.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
+
+class Panorama360Button extends ConsumerWidget {
+  const Panorama360Button({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asset = ref.watch(assetViewerProvider.select((s) => s.currentAsset));
+    if (asset == null || !asset.isImage) {
+      return const SizedBox.shrink();
+    }
+
+    final showingDetails = ref.watch(assetViewerProvider.select((s) => s.showingDetails));
+    if (showingDetails) {
+      return const SizedBox.shrink();
+    }
+
+    final showControls = ref.watch(assetViewerProvider.select((s) => s.showingControls));
+
+    final isPanoramaAsync = ref.watch(isPanoramaProvider(asset));
+    final isPanorama = isPanoramaAsync.valueOrNull ?? false;
+    if (!isPanorama) {
+      return const SizedBox.shrink();
+    }
+
+    return IgnorePointer(
+      ignoring: !showControls,
+      child: AnimatedOpacity(
+        opacity: showControls ? 1.0 : 0.0,
+        duration: Durations.short2,
+        child: SafeArea(
+          child: Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              // Sits above the bottom app bar.
+              padding: const EdgeInsets.only(left: 16, bottom: 88),
+              child: _PanoramaChip(
+                onTap: () => context.pushRoute(PanoramaViewerRoute(asset: asset)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PanoramaChip extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _PanoramaChip({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.grey[900]!.withValues(alpha: 0.55),
+      borderRadius: const BorderRadius.all(Radius.circular(24)),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(24)),
+        child: const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.threesixty, color: Colors.white, size: 18),
+              SizedBox(width: 6),
+              Text(
+                '360°',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/panorama_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/panorama_viewer.page.dart
@@ -1,0 +1,195 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
+import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:immich_mobile/utils/panorama_xmp.dart';
+import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
+import 'package:openapi/api.dart';
+import 'package:panorama_viewer/panorama_viewer.dart';
+
+// One request: preview bytes are used for both XMP parsing and sphere rendering.
+final _panoramaDataProvider = FutureProvider.autoDispose
+    .family<({PanoramaXmpCrop? crop, Uint8List bytes}), BaseAsset>(
+  (ref, asset) async {
+    final String? remoteId = asset.remoteId;
+    if (remoteId == null) {
+      return (crop: null, bytes: Uint8List(0));
+    }
+
+    final url = Uri.parse(
+      getThumbnailUrlForRemoteId(remoteId, type: AssetMediaSize.preview),
+    );
+    final response = await NetworkRepository.client.get(url);
+    if (response.statusCode != 200 && response.statusCode != 206) {
+      return (crop: null, bytes: Uint8List(0));
+    }
+    final bytes = response.bodyBytes;
+    final crop = readPanoramaXmpFromBytes(bytes);
+    return (crop: crop, bytes: bytes);
+  },
+);
+
+@RoutePage()
+class PanoramaViewerPage extends ConsumerStatefulWidget {
+  final BaseAsset asset;
+
+  const PanoramaViewerPage({super.key, required this.asset});
+
+  @override
+  ConsumerState<PanoramaViewerPage> createState() => _PanoramaViewerPageState();
+}
+
+class _PanoramaViewerPageState extends ConsumerState<PanoramaViewerPage> {
+  SensorControl _sensorControl = SensorControl.none;
+  bool _imageLoaded = false;
+
+  void _toggleSensor() {
+    setState(() {
+      _sensorControl = _sensorControl == SensorControl.none
+          ? SensorControl.orientation
+          : SensorControl.none;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+  }
+
+  @override
+  void dispose() {
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dataAsync = ref.watch(_panoramaDataProvider(widget.asset));
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          dataAsync.when(
+            loading: () => const Center(child: ImmichLoadingIndicator()),
+            error: (_, __) => _buildViewer(crop: null, bytes: null),
+            data: (d) => _buildViewer(crop: d.crop, bytes: d.bytes),
+          ),
+          if (dataAsync.hasValue && !_imageLoaded) const Center(child: ImmichLoadingIndicator()),
+          _Overlay(
+            sensorActive: _sensorControl != SensorControl.none,
+            onBack: () => Navigator.of(context).pop(),
+            onToggleSensor: _toggleSensor,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildViewer({required PanoramaXmpCrop? crop, required Uint8List? bytes}) {
+    final ImageProvider imageProvider = bytes != null && bytes.isNotEmpty
+        ? MemoryImage(bytes)
+        : getFullImageProvider(widget.asset);
+
+    final Rect area = crop?.croppedArea ?? const Rect.fromLTWH(0.0, 0.0, 1.0, 1.0);
+    // GPano heading is clockwise; panorama_viewer longitude is counter-clockwise.
+    final double initialLongitude = crop?.initialHeadingDegrees != null
+        ? -crop!.initialHeadingDegrees!
+        : (area.left + area.width / 2.0 - 0.5) * 360.0;
+    final double initialLatitude = crop?.initialPitchDegrees ?? -5.0;
+
+    final double top = area.top;
+    final double height = area.height;
+    final double latCap = crop != null ? 75.0 : 50.0;
+    final double maxLat = (90.0 - top * 180.0).clamp(-90.0, latCap);
+    final double minLat = (90.0 - (top + height) * 180.0).clamp(-latCap, 90.0);
+
+    return PanoramaViewer(
+      sensorControl: _sensorControl,
+      latitude: initialLatitude,
+      longitude: initialLongitude,
+      sensitivity: 1.5, // default 1.0 is too slow for phone screens
+      minLatitude: minLat,
+      maxLatitude: maxLat,
+      croppedArea: area,
+      croppedFullWidth: 1.0,
+      croppedFullHeight: 1.0,
+      onImageLoad: () {
+        if (!_imageLoaded) {
+          setState(() => _imageLoaded = true);
+        }
+      },
+      child: Image(image: imageProvider, fit: BoxFit.cover),
+    );
+  }
+}
+
+class _Overlay extends StatelessWidget {
+  final bool sensorActive;
+  final VoidCallback onBack;
+  final VoidCallback onToggleSensor;
+
+  const _Overlay({
+    required this.sensorActive,
+    required this.onBack,
+    required this.onToggleSensor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Stack(
+        children: [
+          Positioned(
+            top: 8,
+            left: 8,
+            child: _OverlayButton(
+              onTap: onBack,
+              child: const Icon(Icons.arrow_back_rounded, color: Colors.white, size: 22),
+            ),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: _OverlayButton(
+              onTap: onToggleSensor,
+              child: Icon(
+                sensorActive ? Icons.screen_rotation_outlined : Icons.screen_rotation_alt_outlined,
+                color: sensorActive ? Colors.white : Colors.white54,
+                size: 22,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OverlayButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final Widget child;
+
+  const _OverlayButton({required this.onTap, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black54,
+      shape: const CircleBorder(),
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const CircleBorder(),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/panorama.provider.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/metadata.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -290,15 +291,16 @@ class _TileOverlayIcon extends StatelessWidget {
   }
 }
 
-class _AssetTypeIcons extends StatelessWidget {
+class _AssetTypeIcons extends ConsumerWidget {
   final BaseAsset asset;
 
   const _AssetTypeIcons({required this.asset});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final remoteAsset = asset is RemoteAsset ? asset as RemoteAsset : null;
     final isLivePhoto = remoteAsset?.livePhotoVideoId != null;
+    final isPanorama = ref.watch(isPanoramaProvider(asset)).valueOrNull ?? false;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -313,6 +315,11 @@ class _AssetTypeIcons extends StatelessWidget {
           ),
         if (asset.isAnimatedImage)
           const Padding(padding: EdgeInsets.only(right: 10.0, top: 6.0), child: _TileOverlayIcon(Icons.gif_rounded)),
+        if (isPanorama)
+          const Padding(
+            padding: EdgeInsets.only(right: 10.0, top: 6.0),
+            child: _TileOverlayIcon(Icons.threesixty),
+          ),
       ],
     );
   }

--- a/mobile/lib/providers/asset_viewer/panorama.provider.dart
+++ b/mobile/lib/providers/asset_viewer/panorama.provider.dart
@@ -1,0 +1,12 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
+
+final isPanoramaProvider = FutureProvider.autoDispose.family<bool, BaseAsset>((ref, asset) async {
+  if (!asset.isImage || !asset.hasRemote) {
+    return false;
+  }
+
+  final exif = await ref.watch(assetExifProvider(asset).future);
+  return exif?.isPanorama ?? false;
+});

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -69,6 +69,7 @@ import 'package:immich_mobile/presentation/pages/local_timeline.page.dart';
 import 'package:immich_mobile/presentation/pages/profile/profile_picture_crop.page.dart';
 import 'package:immich_mobile/presentation/pages/search/drift_search.page.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/panorama_viewer.page.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/routing/auth_guard.dart';
@@ -191,6 +192,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: DownloadInfoRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: CleanupPreviewRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftSlideshowRoute.page, guards: [_authGuard, _duplicateGuard]),
+    AutoRoute(page: PanoramaViewerRoute.page, guards: [_authGuard, _duplicateGuard], fullscreenDialog: true),
     // required to handle all deeplinks in deep_link.service.dart
     // auto_route_library#1722
     RedirectRoute(path: '*', redirectTo: '/'),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -1457,6 +1457,53 @@ class MapLocationPickerRouteArgs {
 }
 
 /// generated route for
+/// [PanoramaViewerPage]
+class PanoramaViewerRoute extends PageRouteInfo<PanoramaViewerRouteArgs> {
+  PanoramaViewerRoute({
+    Key? key,
+    required BaseAsset asset,
+    List<PageRouteInfo>? children,
+  }) : super(
+         PanoramaViewerRoute.name,
+         args: PanoramaViewerRouteArgs(key: key, asset: asset),
+         initialChildren: children,
+       );
+
+  static const String name = 'PanoramaViewerRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<PanoramaViewerRouteArgs>();
+      return PanoramaViewerPage(key: args.key, asset: args.asset);
+    },
+  );
+}
+
+class PanoramaViewerRouteArgs {
+  const PanoramaViewerRouteArgs({this.key, required this.asset});
+
+  final Key? key;
+
+  final BaseAsset asset;
+
+  @override
+  String toString() {
+    return 'PanoramaViewerRouteArgs{key: $key, asset: $asset}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! PanoramaViewerRouteArgs) return false;
+    return key == other.key && asset == other.asset;
+  }
+
+  @override
+  int get hashCode => key.hashCode ^ asset.hashCode;
+}
+
+/// generated route for
 /// [PinAuthPage]
 class PinAuthRoute extends PageRouteInfo<PinAuthRouteArgs> {
   PinAuthRoute({

--- a/mobile/lib/utils/panorama_xmp.dart
+++ b/mobile/lib/utils/panorama_xmp.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui';
+
+class PanoramaXmpCrop {
+  final Rect croppedArea;
+  final double? initialHeadingDegrees;
+  final double? initialPitchDegrees;
+
+  const PanoramaXmpCrop({
+    required this.croppedArea,
+    this.initialHeadingDegrees,
+    this.initialPitchDegrees,
+  });
+}
+
+// Falls back to Extended XMP chunks if GPano fields are absent from the standard packet.
+PanoramaXmpCrop? readPanoramaXmpFromBytes(Uint8List bytes) {
+  final int readSize = bytes.length;
+  if (readSize < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8) {
+    return null;
+  }
+
+  int offset = 2;
+  const String xmpNs = 'http://ns.adobe.com/xap/1.0/';
+  const String extNs = 'http://ns.adobe.com/xmp/extension/';
+
+  String? standardXmp;
+  final Map<int, Uint8List> extChunks = {}; // byte-offset → chunk data
+
+  while (offset + 4 <= readSize) {
+    if (bytes[offset] != 0xFF) {
+      break;
+    }
+    final int marker = bytes[offset + 1];
+    if (marker == 0xDA || marker == 0xD9) {
+      break; // SOS / EOI — end of metadata
+    }
+
+    final int segLen = (bytes[offset + 2] << 8) | bytes[offset + 3];
+    if (segLen < 2) {
+      break;
+    }
+
+    final int nextOffset = offset + 2 + segLen;
+
+    if (marker == 0xE1 && nextOffset <= readSize) {
+      final int dataStart = offset + 4;
+
+      if (standardXmp == null) {
+        final int nsEnd = math.min(dataStart + xmpNs.length + 1, readSize);
+        final String h = String.fromCharCodes(bytes.sublist(dataStart, nsEnd));
+        if (h.startsWith(xmpNs)) {
+          final int xmpStart = dataStart + xmpNs.length + 1;
+          standardXmp = utf8.decode(
+            bytes.sublist(xmpStart, math.min(nextOffset, readSize)),
+            allowMalformed: true,
+          );
+        }
+      }
+
+      {
+        final int nsEnd = math.min(dataStart + extNs.length + 1, readSize);
+        final String h = String.fromCharCodes(bytes.sublist(dataStart, nsEnd));
+        if (h.startsWith(extNs)) {
+          final int guidBase = dataStart + extNs.length + 1;
+          if (guidBase + 40 <= readSize) {
+            final int chunkOff = _uint32BE(bytes, guidBase + 36);
+            final int dataOff = guidBase + 40;
+            final int dataEnd = math.min(nextOffset, readSize);
+            if (dataOff < dataEnd) {
+              extChunks[chunkOff] = bytes.sublist(dataOff, dataEnd);
+            }
+          }
+        }
+      }
+    }
+
+    if (nextOffset > readSize) {
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  if (standardXmp != null) {
+    final result = _parsePanoramaXmp(standardXmp);
+    if (result != null) {
+      return result;
+    }
+  }
+
+  if (extChunks.isNotEmpty) {
+    final keys = extChunks.keys.toList()..sort();
+    final buf = StringBuffer();
+    for (final k in keys) {
+      buf.write(utf8.decode(extChunks[k]!, allowMalformed: true));
+    }
+    return _parsePanoramaXmp(buf.toString());
+  }
+
+  return null;
+}
+
+int _uint32BE(Uint8List b, int i) =>
+    (b[i] << 24) | (b[i + 1] << 16) | (b[i + 2] << 8) | b[i + 3];
+
+PanoramaXmpCrop? _parsePanoramaXmp(String xmp) {
+  if (!xmp.contains('GPano:')) {
+    return null;
+  }
+
+  double? attr(String name) {
+    final mA = RegExp('GPano:$name=["\'](-?[0-9]+(?:\\.[0-9]+)?)["\']').firstMatch(xmp);
+    if (mA != null) {
+      return double.tryParse(mA.group(1)!);
+    }
+    final mE = RegExp('<GPano:$name>(-?[0-9]+(?:\\.[0-9]+)?)</GPano:$name>').firstMatch(xmp);
+    return mE != null ? double.tryParse(mE.group(1)!) : null;
+  }
+
+  final fullW = attr('FullPanoWidthPixels');
+  final fullH = attr('FullPanoHeightPixels');
+  final cropW = attr('CroppedAreaImageWidthPixels');
+  final cropH = attr('CroppedAreaImageHeightPixels');
+  final cropL = attr('CroppedAreaLeftPixels') ?? 0.0;
+  final cropT = attr('CroppedAreaTopPixels') ?? 0.0;
+
+  if (fullW == null || fullH == null || cropW == null || cropH == null) {
+    return null;
+  }
+  if (fullW == 0 || fullH == 0 || cropW == 0 || cropH == 0) {
+    return null;
+  }
+
+  return PanoramaXmpCrop(
+    croppedArea: Rect.fromLTWH(
+      cropL / fullW,
+      cropT / fullH,
+      cropW / fullW,
+      cropH / fullH,
+    ),
+    initialHeadingDegrees: attr('InitialViewHeadingDegrees'),
+    initialPitchDegrees: attr('InitialViewPitchDegrees'),
+  );
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -330,6 +330,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  dchs_motion_sensors:
+    dependency: transitive
+    description:
+      name: dchs_motion_sensors
+      sha256: "0b09e2310b1f5f3edefaa45058c9d7bd6c5b292cdf36e733ae6bcec7db40526d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   desktop_webview_window:
     dependency: transitive
     description:
@@ -471,6 +479,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cube:
+    dependency: transitive
+    description:
+      name: flutter_cube
+      sha256: "71cf679a251166eb97f86751c56582b09abdbf859485fbf60524948813914c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   flutter_displaymode:
     dependency: "direct main"
     description:
@@ -1205,6 +1221,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  panorama_viewer:
+    dependency: "direct main"
+    description:
+      name: panorama_viewer
+      sha256: c6817bb2e202aad2d143d0bf7f95fc200b87791c2286971d7e3f29f8be916482
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   path:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
       ref: 'cdf621bdb7edaf996e118a58a48f6441187d79c6'
   network_info_plus: ^6.1.4
   octo_image: ^2.1.0
+  panorama_viewer: ^2.0.7
   openapi:
     path: openapi
   package_info_plus: ^8.3.1

--- a/mobile/test/domain/repositories/sync_stream_repository_test.dart
+++ b/mobile/test/domain/repositories/sync_stream_repository_test.dart
@@ -55,9 +55,10 @@ SyncAssetV1 _createAsset({
 
 SyncAssetExifV1 _createExif({
   required String assetId,
-  required int width,
-  required int height,
-  required String orientation,
+  int width = 1920,
+  int height = 1080,
+  String orientation = '1',
+  String? projectionType,
 }) {
   return SyncAssetExifV1(
     assetId: assetId,
@@ -81,7 +82,7 @@ SyncAssetExifV1 _createExif({
     model: null,
     modifyDate: null,
     profileDescription: null,
-    projectionType: null,
+    projectionType: projectionType,
     rating: null,
     state: null,
     timeZone: null,
@@ -186,6 +187,34 @@ void main() {
 
       expect(result.width, equals(existingWidth), reason: 'Width should remain as originally set');
       expect(result.height, equals(existingHeight), reason: 'Height should remain as originally set');
+    });
+  });
+
+  group('SyncStreamRepository - projectionType sync', () {
+    test('stores projectionType from exif sync', () async {
+      const assetId = 'panorama-asset';
+
+      await sut.updateUsersV1([_createUser()]);
+      await sut.updateAssetsV1([_createAsset(id: assetId, checksum: 'cs', fileName: 'pano.jpg')]);
+      await sut.updateAssetsExifV1([_createExif(assetId: assetId, projectionType: 'EQUIRECTANGULAR')]);
+
+      final query = db.remoteExifEntity.select()..where((tbl) => tbl.assetId.equals(assetId));
+      final result = await query.getSingle();
+
+      expect(result.projectionType, equals('EQUIRECTANGULAR'));
+    });
+
+    test('stores null projectionType for non-panorama assets', () async {
+      const assetId = 'normal-asset';
+
+      await sut.updateUsersV1([_createUser()]);
+      await sut.updateAssetsV1([_createAsset(id: assetId, checksum: 'cs2', fileName: 'photo.jpg')]);
+      await sut.updateAssetsExifV1([_createExif(assetId: assetId)]);
+
+      final query = db.remoteExifEntity.select()..where((tbl) => tbl.assetId.equals(assetId));
+      final result = await query.getSingle();
+
+      expect(result.projectionType, isNull);
     });
   });
 

--- a/mobile/test/unit/utils/panorama_xmp_test.dart
+++ b/mobile/test/unit/utils/panorama_xmp_test.dart
@@ -1,0 +1,278 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/panorama_xmp.dart';
+
+// Builds a minimal JPEG with a standard XMP APP1 segment.
+Uint8List _jpegWithXmp(String xmpPayload) {
+  const ns = 'http://ns.adobe.com/xap/1.0/\x00';
+  final nsBytes = utf8.encode(ns);
+  final xmpBytes = utf8.encode(xmpPayload);
+  final segData = [...nsBytes, ...xmpBytes];
+  final segLen = segData.length + 2;
+  return Uint8List.fromList([
+    0xFF, 0xD8, // SOI
+    0xFF, 0xE1, // APP1
+    (segLen >> 8) & 0xFF, segLen & 0xFF,
+    ...segData,
+    0xFF, 0xDA, // SOS — stops metadata parsing
+  ]);
+}
+
+// Builds a JPEG with an Extended XMP APP1 segment (no standard XMP).
+Uint8List _jpegWithExtXmp(String xmpPayload, {int chunkOffset = 0}) {
+  const ns = 'http://ns.adobe.com/xmp/extension/\x00';
+  final nsBytes = utf8.encode(ns);
+  final guid = List<int>.filled(32, 0x41); // 32-byte GUID placeholder
+  final xmpBytes = utf8.encode(xmpPayload);
+  final totalLen = xmpBytes.length;
+  final header = [
+    (totalLen >> 24) & 0xFF,
+    (totalLen >> 16) & 0xFF,
+    (totalLen >> 8) & 0xFF,
+    totalLen & 0xFF,
+    (chunkOffset >> 24) & 0xFF,
+    (chunkOffset >> 16) & 0xFF,
+    (chunkOffset >> 8) & 0xFF,
+    chunkOffset & 0xFF,
+  ];
+  final segData = [...nsBytes, ...guid, ...header, ...xmpBytes];
+  final segLen = segData.length + 2;
+  return Uint8List.fromList([
+    0xFF, 0xD8,
+    0xFF, 0xE1,
+    (segLen >> 8) & 0xFF, segLen & 0xFF,
+    ...segData,
+    0xFF, 0xDA,
+  ]);
+}
+
+const _attrXmp = 'GPano:FullPanoWidthPixels="8000" '
+    'GPano:FullPanoHeightPixels="4000" '
+    'GPano:CroppedAreaImageWidthPixels="6000" '
+    'GPano:CroppedAreaImageHeightPixels="3000" '
+    'GPano:CroppedAreaLeftPixels="1000" '
+    'GPano:CroppedAreaTopPixels="500"';
+
+void main() {
+  group('readPanoramaXmpFromBytes', () {
+    test('returns null for empty input', () {
+      expect(readPanoramaXmpFromBytes(Uint8List(0)), isNull);
+    });
+
+    test('returns null for non-JPEG bytes', () {
+      // PNG magic bytes
+      final png = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]);
+      expect(readPanoramaXmpFromBytes(png), isNull);
+    });
+
+    test('returns null for JPEG without XMP', () {
+      final bytes = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xDA]);
+      expect(readPanoramaXmpFromBytes(bytes), isNull);
+    });
+
+    test('returns null for JPEG with XMP but no GPano data', () {
+      final bytes = _jpegWithXmp('<x:xmpmeta><rdf:RDF/></x:xmpmeta>');
+      expect(readPanoramaXmpFromBytes(bytes), isNull);
+    });
+
+    group('attribute-style GPano', () {
+      test('parses crop area from pixel values', () {
+        final bytes = _jpegWithXmp('<rdf:Description $_attrXmp/>');
+        final result = readPanoramaXmpFromBytes(bytes);
+
+        expect(result, isNotNull);
+        expect(result!.croppedArea.left, closeTo(1000 / 8000, 1e-9));
+        expect(result.croppedArea.top, closeTo(500 / 4000, 1e-9));
+        expect(result.croppedArea.width, closeTo(6000 / 8000, 1e-9));
+        expect(result.croppedArea.height, closeTo(3000 / 4000, 1e-9));
+      });
+
+      test('defaults CroppedAreaLeft and CroppedAreaTop to 0 when absent', () {
+        const xmp = 'GPano:FullPanoWidthPixels="4000" '
+            'GPano:FullPanoHeightPixels="2000" '
+            'GPano:CroppedAreaImageWidthPixels="4000" '
+            'GPano:CroppedAreaImageHeightPixels="2000"';
+        final bytes = _jpegWithXmp('<rdf:Description $xmp/>');
+        final result = readPanoramaXmpFromBytes(bytes);
+
+        expect(result, isNotNull);
+        expect(result!.croppedArea, const Rect.fromLTWH(0, 0, 1, 1));
+      });
+
+      test('reads InitialViewHeadingDegrees', () {
+        final bytes = _jpegWithXmp(
+          '<rdf:Description $_attrXmp GPano:InitialViewHeadingDegrees="90"/>',
+        );
+        expect(readPanoramaXmpFromBytes(bytes)?.initialHeadingDegrees, 90.0);
+      });
+
+      test('reads negative InitialViewPitchDegrees', () {
+        final bytes = _jpegWithXmp(
+          '<rdf:Description $_attrXmp GPano:InitialViewPitchDegrees="-10"/>',
+        );
+        expect(readPanoramaXmpFromBytes(bytes)?.initialPitchDegrees, -10.0);
+      });
+
+      test('returns null when FullPanoWidthPixels is missing', () {
+        const xmp = 'GPano:FullPanoHeightPixels="4000" '
+            'GPano:CroppedAreaImageWidthPixels="4000" '
+            'GPano:CroppedAreaImageHeightPixels="4000"';
+        final bytes = _jpegWithXmp('<rdf:Description $xmp/>');
+        expect(readPanoramaXmpFromBytes(bytes), isNull);
+      });
+
+      test('returns null when CroppedAreaImageHeightPixels is missing', () {
+        const xmp = 'GPano:FullPanoWidthPixels="4000" '
+            'GPano:FullPanoHeightPixels="2000" '
+            'GPano:CroppedAreaImageWidthPixels="4000"';
+        final bytes = _jpegWithXmp('<rdf:Description $xmp/>');
+        expect(readPanoramaXmpFromBytes(bytes), isNull);
+      });
+
+      test('returns null when FullPanoWidthPixels is zero', () {
+        const xmp = 'GPano:FullPanoWidthPixels="0" '
+            'GPano:FullPanoHeightPixels="4000" '
+            'GPano:CroppedAreaImageWidthPixels="4000" '
+            'GPano:CroppedAreaImageHeightPixels="2000"';
+        final bytes = _jpegWithXmp('<rdf:Description $xmp/>');
+        expect(readPanoramaXmpFromBytes(bytes), isNull);
+      });
+    });
+
+    group('element-style GPano', () {
+      test('parses full-sphere from XML elements', () {
+        const xmp = '<GPano:FullPanoWidthPixels>8000</GPano:FullPanoWidthPixels>'
+            '<GPano:FullPanoHeightPixels>4000</GPano:FullPanoHeightPixels>'
+            '<GPano:CroppedAreaImageWidthPixels>8000</GPano:CroppedAreaImageWidthPixels>'
+            '<GPano:CroppedAreaImageHeightPixels>4000</GPano:CroppedAreaImageHeightPixels>'
+            '<GPano:CroppedAreaLeftPixels>0</GPano:CroppedAreaLeftPixels>'
+            '<GPano:CroppedAreaTopPixels>0</GPano:CroppedAreaTopPixels>';
+        final bytes = _jpegWithXmp(xmp);
+        final result = readPanoramaXmpFromBytes(bytes);
+
+        expect(result, isNotNull);
+        expect(result!.croppedArea, const Rect.fromLTWH(0, 0, 1, 1));
+      });
+
+      test('reads InitialViewHeadingDegrees from elements', () {
+        const xmp = '<GPano:FullPanoWidthPixels>4000</GPano:FullPanoWidthPixels>'
+            '<GPano:FullPanoHeightPixels>2000</GPano:FullPanoHeightPixels>'
+            '<GPano:CroppedAreaImageWidthPixels>4000</GPano:CroppedAreaImageWidthPixels>'
+            '<GPano:CroppedAreaImageHeightPixels>2000</GPano:CroppedAreaImageHeightPixels>'
+            '<GPano:InitialViewHeadingDegrees>180</GPano:InitialViewHeadingDegrees>';
+        final bytes = _jpegWithXmp(xmp);
+        expect(readPanoramaXmpFromBytes(bytes)?.initialHeadingDegrees, 180.0);
+      });
+    });
+
+    group('Extended XMP', () {
+      test('parses GPano from extended XMP when no standard XMP is present', () {
+        const xmp = 'GPano:FullPanoWidthPixels="4000" '
+            'GPano:FullPanoHeightPixels="2000" '
+            'GPano:CroppedAreaImageWidthPixels="4000" '
+            'GPano:CroppedAreaImageHeightPixels="2000"';
+        final bytes = _jpegWithExtXmp(xmp);
+        final result = readPanoramaXmpFromBytes(bytes);
+
+        expect(result, isNotNull);
+        expect(result!.croppedArea, const Rect.fromLTWH(0, 0, 1, 1));
+      });
+
+      test('standard XMP takes priority over extended XMP when both have GPano', () {
+        // Standard XMP: 2000×1000 panorama
+        const stdNs = 'http://ns.adobe.com/xap/1.0/\x00';
+        final stdNsBytes = utf8.encode(stdNs);
+        const stdXmp = 'GPano:FullPanoWidthPixels="2000" '
+            'GPano:FullPanoHeightPixels="1000" '
+            'GPano:CroppedAreaImageWidthPixels="2000" '
+            'GPano:CroppedAreaImageHeightPixels="1000"';
+        final stdSegData = [...stdNsBytes, ...utf8.encode(stdXmp)];
+        final stdSegLen = stdSegData.length + 2;
+
+        // Extended XMP: different 8000×4000 values
+        const extNs = 'http://ns.adobe.com/xmp/extension/\x00';
+        final extNsBytes = utf8.encode(extNs);
+        final guid = List<int>.filled(32, 0x43);
+        const extXmp = 'GPano:FullPanoWidthPixels="8000" '
+            'GPano:FullPanoHeightPixels="4000" '
+            'GPano:CroppedAreaImageWidthPixels="8000" '
+            'GPano:CroppedAreaImageHeightPixels="4000"';
+        final extXmpBytes = utf8.encode(extXmp);
+        final totalLen = extXmpBytes.length;
+        final extHeader = [
+          (totalLen >> 24) & 0xFF,
+          (totalLen >> 16) & 0xFF,
+          (totalLen >> 8) & 0xFF,
+          totalLen & 0xFF,
+          0, 0, 0, 0,
+        ];
+        final extSegData = [...extNsBytes, ...guid, ...extHeader, ...extXmpBytes];
+        final extSegLen = extSegData.length + 2;
+
+        final bytes = Uint8List.fromList([
+          0xFF, 0xD8,
+          0xFF, 0xE1,
+          (stdSegLen >> 8) & 0xFF, stdSegLen & 0xFF,
+          ...stdSegData,
+          0xFF, 0xE1,
+          (extSegLen >> 8) & 0xFF, extSegLen & 0xFF,
+          ...extSegData,
+          0xFF, 0xDA,
+        ]);
+
+        final result = readPanoramaXmpFromBytes(bytes);
+        expect(result, isNotNull);
+        // Must use standard XMP values, not the extended XMP 8000×4000.
+        expect(result!.croppedArea, const Rect.fromLTWH(0, 0, 1, 1));
+        expect(result.croppedArea.width, closeTo(2000 / 2000, 1e-9));
+      });
+
+      test('falls back to extended XMP when standard XMP has no GPano', () {
+        // Standard XMP segment without GPano
+        const stdNs = 'http://ns.adobe.com/xap/1.0/\x00';
+        final stdNsBytes = utf8.encode(stdNs);
+        final stdXmpBytes = utf8.encode('<x:xmpmeta/>');
+        final stdSegData = [...stdNsBytes, ...stdXmpBytes];
+        final stdSegLen = stdSegData.length + 2;
+
+        // Extended XMP segment with GPano
+        const extNs = 'http://ns.adobe.com/xmp/extension/\x00';
+        final extNsBytes = utf8.encode(extNs);
+        final guid = List<int>.filled(32, 0x42);
+        const extPayload = 'GPano:FullPanoWidthPixels="2000" '
+            'GPano:FullPanoHeightPixels="1000" '
+            'GPano:CroppedAreaImageWidthPixels="2000" '
+            'GPano:CroppedAreaImageHeightPixels="1000"';
+        final extXmpBytes = utf8.encode(extPayload);
+        final totalLen = extXmpBytes.length;
+        final extHeader = [
+          (totalLen >> 24) & 0xFF,
+          (totalLen >> 16) & 0xFF,
+          (totalLen >> 8) & 0xFF,
+          totalLen & 0xFF,
+          0, 0, 0, 0,
+        ];
+        final extSegData = [...extNsBytes, ...guid, ...extHeader, ...extXmpBytes];
+        final extSegLen = extSegData.length + 2;
+
+        final bytes = Uint8List.fromList([
+          0xFF, 0xD8,
+          0xFF, 0xE1,
+          (stdSegLen >> 8) & 0xFF, stdSegLen & 0xFF,
+          ...stdSegData,
+          0xFF, 0xE1,
+          (extSegLen >> 8) & 0xFF, extSegLen & 0xFF,
+          ...extSegData,
+          0xFF, 0xDA,
+        ]);
+
+        final result = readPanoramaXmpFromBytes(bytes);
+        expect(result, isNotNull);
+        expect(result!.croppedArea, const Rect.fromLTWH(0, 0, 1, 1));
+      });
+    });
+  });
+}

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1111,6 +1111,34 @@ describe(MetadataService.name, () => {
       );
     });
 
+    it('should use SpecialTypeID as projectionType fallback when ProjectionType is absent', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ SpecialTypeID: ['com.google.android.apps.camera.gallery.specialtype.SpecialTrait.PHOTOSPHERE'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exif: expect.objectContaining({ projectionType: 'EQUIRECTANGULAR' }),
+        }),
+      );
+    });
+
+    it('should not set projectionType when SpecialTypeID does not contain PHOTOSPHERE', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ SpecialTypeID: ['com.google.android.apps.camera.gallery.specialtype.SpecialTrait.PORTRAIT'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exif: expect.objectContaining({ projectionType: null }),
+        }),
+      );
+    });
+
     it('should extract +00:00 timezone from raw value', async () => {
       // exiftool-vendored returns "no timezone" information even though "+00:00" might be set explicitly
       // https://github.com/photostructure/exiftool-vendored.js/issues/203

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -286,7 +286,11 @@ export class MetadataService extends BaseService {
       exifImageHeight: validate(height),
       exifImageWidth: validate(width),
       orientation: validate(exifTags.Orientation)?.toString() ?? null,
-      projectionType: exifTags.ProjectionType ? String(exifTags.ProjectionType).toUpperCase() : null,
+      projectionType: exifTags.ProjectionType
+        ? String(exifTags.ProjectionType).toUpperCase()
+        : (exifTags.SpecialTypeID ?? []).some((v) => v.includes('PHOTOSPHERE'))
+          ? 'EQUIRECTANGULAR'
+          : null,
       bitsPerSample: this.getBitsPerSample(exifTags),
       colorspace: exifTags.ColorSpace === undefined ? null : String(exifTags.ColorSpace),
 


### PR DESCRIPTION
Adds opt-in 360° sphere viewing for equirectangular panorama photos. A 360° chip appears in the asset viewer when the server identifies an image as equirectangular; tapping it opens a fullscreen immersive sphere viewer.

## Description

**Detection** relies exclusively on the server's `projectionType` field. No client-side exif extraction, no filename heuristics, no aspect-ratio guards. The mobile app reads what is already stored in the local Drift DB after sync:

- The server already sets `projectionType = 'EQUIRECTANGULAR'` when exiftool finds a `ProjectionType` tag.
- This PR adds a fallback for cases where `ProjectionType` is absent (e.g. stripped during file transfer): if any `SpecialTypeID` value contains `'PHOTOSPHERE'`, `projectionType` is set to `'EQUIRECTANGULAR'`. `SpecialTypeID` is written by Android camera apps and tends to survive transfers where the standard tag does not.
- `projectionType` is already stored in the Drift entity and synced via `SyncAssetExifV1`; this PR surfaces it in the `ExifInfo` domain model and adds an `isPanorama` getter.

A 360° icon badge is shown on matching thumbnails in the timeline grid.

**Viewer** (`panorama_viewer: ^2.0.7`): when the viewer opens it fetches the preview JPEG (the same request used for rendering) and attempts to parse the XMP-GPano block from the response bytes. The server already copies GPano tags from the original file into the preview during thumbnail generation (see `media.service.ts`). Pixel values are immediately normalised against `FullPanoWidthPixels` / `FullPanoHeightPixels`, making the crop rect scale-invariant regardless of preview resolution. No additional GPano columns are synced or stored. If no GPano data is present the viewer falls back to a full-sphere view.

`InitialViewHeadingDegrees` / `InitialViewPitchDegrees` orient the initial camera angle at the scene centre. The GPano heading sign convention (clockwise) is corrected to `panorama_viewer`'s counter-clockwise longitude.

Additional viewer features: gyroscope / orientation-sensor toggle, latitude limits derived from the crop extent, immersive sticky UI mode with edge-to-edge restoration on exit.

**New dependency:** [`panorama_viewer`](https://pub.dev/packages/panorama_viewer) v2.0.7, licensed under **Apache 2.0**, compatible with Immich's AGPL-3.0.

## How Has This Been Tested?

Tested on a physical Android device:

- [x] Panoramas where `ProjectionType` is absent but `SpecialTypeID` is present (`SpecialTypeID` fallback)
- [x] Standard equirectangular photos with a `ProjectionType` tag
- [x] Assets with `InitialViewHeadingDegrees` / `InitialViewPitchDegrees`
- [x] Assets with partial crop (non-full-sphere)
- [x] Assets without GPano XMP in the preview (viewer falls back to full sphere)
- [x] Gyroscope toggle on/off
- [x] Back navigation and system UI restoration
- [x] Timeline thumbnail 360° badge
- [x] Non-panorama assets (360° chip does not appear)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="1080" height="2400" alt="Screenshot_20260515-173825" src="https://github.com/user-attachments/assets/f7f67c95-d1dc-4d94-912d-a45e4baa53ad" />
<img width="1080" height="2400" alt="Screenshot_20260515-173918" src="https://github.com/user-attachments/assets/aa962d5e-b740-46ab-99aa-6ba8b61c73d5" />
<img width="1080" height="2400" alt="Screenshot_20260515-173909" src="https://github.com/user-attachments/assets/1dd1ade8-fecb-44a2-997d-a7d5c2387290" />
<img width="1080" height="2400" alt="Screenshot_20260515-173854" src="https://github.com/user-attachments/assets/30dd44b8-778c-4de9-816b-83ad3d8b7467" />

</details>



## Checklist:

  - [x] I have carefully read CONTRIBUTING.md
  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR.
  - [x] I have confirmed that any new dependencies are strictly necessary.
  - [x] I have written tests for new code (if applicable)
  - [x] I have followed naming conventions/patterns in the surrounding code
  - [x] All code in `src/services/` uses repositories implementations for database calls, filesystem
   operations, etc.
  - [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific
   logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used Claude as a coding assistant for parts of the implementation. I reviewed, understood, and tested all changes myself on a physical Android device, and directed the overall design and feature decisions throughout.
