### PR TITLE
fix(mobile): cronet thumbnail buffer overflow regression from #28439

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/RemoteImagesImpl.kt
@@ -265,18 +265,14 @@ private class CronetImageFetcher : ImageFetcher {
       byteBuffer: ByteBuffer
     ) {
       try {
-        val b = buffer!!
-        b.advance(byteBuffer.position())
-        // Reuse the caller-supplied ByteBuffer as long as we don't need to grow.
-        // It already points at our native memory with position advanced past the
-        // written bytes — Cronet can keep writing into the remaining tail.
-        // Only when the buffer is full do we grow (which may realloc + move the
-        // native pointer) and need a fresh wrap.
-        val buf = if (b.offset == b.capacity) {
-          b.ensureHeadroom()
-          b.wrapRemaining()
-        } else {
-          byteBuffer
+        // Always pass a fresh wrap so byteBuffer.position() represents only the
+        // bytes Cronet wrote in this iteration. Reusing the caller-supplied
+        // ByteBuffer breaks advance(): Cronet's position keeps accumulating
+        // across reads, which would double-count previous iterations' bytes.
+        val buf = buffer!!.run {
+          advance(byteBuffer.position())
+          ensureHeadroom()
+          wrapRemaining()
         }
         request.read(buf)
       } catch (e: Exception) {


### PR DESCRIPTION
## Description

#28439 added a hybrid in `CronetImageFetcher.FetchCallback.onReadCompleted` that reuses Cronet's `ByteBuffer` between reads when no grow is needed, to save a JNI wrap call. That reuse is broken — Cronet's `ByteBuffer.position()` is cumulative across reads, not per-iteration. So calling `advance(byteBuffer.position())` every iteration double-counts the prior reads. `b.offset` overshoots `b.capacity`, the reuse branch keeps firing on a now-empty `byteBuffer`, and the next `request.read()` throws the original `IllegalArgumentException: ByteBuffer is already full.` exception that #28439 was supposed to kill.

Drop the hybrid. Always pass a fresh wrap from `wrapRemaining()` so `byteBuffer.position()` reflects only this iteration's bytes. Same shape as the original PR's first commit before the broken optimization got layered on. ~1 µs per fetch on the table, no measurable real-world cost — the safe simple version wins.

Closes the regression reported on #28419.

Verified on a Pixel 9a against a local node proxy that gzips real upstream thumbnails with fixed `Content-Length` (same trigger conditions the reporter's Sophos WAF produces):

| build | thumbnails fetched (gzip + fixed CL) | `ByteBuffer is already full` errors |
|---|---|---|
| `main` (#28439 merged) | 62 | 31 (≈50% trigger) |
| this fix | 31 | 0 |

The 50% trigger rate matches gdamx's "some load, some don't" pattern exactly.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

claude helped trace the regression in the hybrid and ran the controlled before/after on my pixel. fix and verification mine.