### PR TITLE
fix(mobile): mounted check in ThumbnailTile hero flight listener

### DIFF
--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -120,7 +120,9 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     },
                     flightShuttleBuilder: (context, animation, direction, from, to) {
                       void animationStatusListener(AnimationStatus status) {
-                        if (!mounted) return;
+                        if (!mounted) {
+                          return;
+                        }
                         final heroInFlight = status == AnimationStatus.forward || status == AnimationStatus.reverse;
                         if (_hideIndicators != heroInFlight) {
                           setState(() => _hideIndicators = heroInFlight);

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -120,6 +120,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     },
                     flightShuttleBuilder: (context, animation, direction, from, to) {
                       void animationStatusListener(AnimationStatus status) {
+                        if (!mounted) return;
                         final heroInFlight = status == AnimationStatus.forward || status == AnimationStatus.reverse;
                         if (_hideIndicators != heroInFlight) {
                           setState(() => _hideIndicators = heroInFlight);


### PR DESCRIPTION
## Description

When the user pops back from the asset viewer while a hero flight is still animating, `_ThumbnailTileState` can be disposed before the `flightShuttleBuilder`'s `animationStatusListener` fires its last callback. The listener then calls `setState` on a disposed state and throws `Null check operator used on a null value` from `State._element!`.

Stack reported on #28419 (post-fix testing):
```
#0  State.setState (framework.dart:1219)
#1  _ThumbnailTileState.build.<anonymous closure>.animationStatusListener
      (thumbnail_tile.widget.dart:125)
#2  AnimationLocalStatusListenersMixin.notifyStatusListeners
#3  AnimationController._checkStatusChanged
... AnimationController.reverse → TransitionRoute.didPop → _RouteEntry.handlePop ...
```

One-line guard with `if (!mounted) return;` — same shape as #28300 fixed in the album sync action.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.