### PR TITLE
fix(mobile): don't force-unwrap nil localizedTitle in ios getAlbums

### DIFF
--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -110,7 +110,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
         
         var domainAlbum = PlatformAlbum(
           id: album.localIdentifier,
-          name: album.localizedTitle!,
+          name: album.localizedTitle ?? album.localIdentifier,
           updatedAt: nil,
           isCloud: isCloud,
           assetCount: Int64(assets.count)


### PR DESCRIPTION
## Description

ios app crashes on launch on iOS 26 when a PHAssetCollection in the photo library has a nil `localizedTitle`. our `getAlbums()` at `MessagesImpl.swift:113` was force-unwrapping that field, but apple's docs have it as nullable for years.

confirmed across three .ips files from #28428 — identical signature each time: `brk #1` on `FLTSerialTaskQueue`, x0=0, x2=`OBJC_CLASS_$_PHPhotoLibrary`, same PC offset. happens within 0.4s of launch on a fresh install because the first local sync runs full-sync path which calls `getAlbums()`.

couldn't repro on our libraries because we don't have the offending album. fix is defensive: coalesce to `album.localIdentifier` (always non-nil) so the album still shows up with a usable name.

related: fluttercandies/flutter_photo_manager#1391 hits the same class of bug in their dart code, merged 2026-05-14.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

claude code helped analyze the .ips files and locate the force-unwrap. fix and review are mine.