### PR TITLE
fix: external library statistics for excluded assets

### DIFF
--- a/server/src/queries/library.repository.sql
+++ b/server/src/queries/library.repository.sql
@@ -51,7 +51,8 @@ from
   inner join "asset" on "asset"."libraryId" = "library"."id"
   left join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
 where
-  "library"."id" = $6
+  "asset"."deletedAt" is null
+  and "library"."id" = $6
 group by
   "library"."id"
 select

--- a/server/src/repositories/library.repository.ts
+++ b/server/src/repositories/library.repository.ts
@@ -92,6 +92,7 @@ export class LibraryRepository {
           .as('videos'),
       )
       .select((eb) => eb.fn.coalesce((eb) => eb.fn.sum('asset_exif.fileSizeInByte'), eb.val(0)).as('usage'))
+      .where('asset.deletedAt', 'is', null)
       .groupBy('library.id')
       .where('library.id', '=', id)
       .executeTakeFirst();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change fixes external library statistics to exclude assets that have been soft-deleted during a library rescan.

Currently, when assets are imported into an external library first and later excluded via exclusion patterns, a rescan correctly removes them from the main timeline by marking them as deleted/offline. However, the external library statistics query still counts those assets, which causes the displayed photo/video counts and storage usage to remain inflated.

This patch updates the external library statistics query so it only counts active, non-deleted assets. This makes the library statistics consistent with the rest of the UI and with the actual visible assets after rescanning.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Ran the relevant server unit tests with pnpm test
- [x] Manually verified the query change and updated the generated SQL snapshot accordingly

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help inspect the existing code paths.