### PR TITLE
chore: cleanup mobile mise config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -28,6 +28,13 @@ version = "1.37.0"
 bin = "dcm"
 postinstall = "chmod +x \"$MISE_TOOL_INSTALL_PATH/dcm\" || true"
 
+[tools."github:CQLabs/homebrew-dcm".platforms]
+linux-x64 = { asset_pattern = "dcm-linux-x64-release.zip" }
+linux-arm64 = { asset_pattern = "dcm-linux-arm-release.zip" }
+macos-x64 = { asset_pattern = "dcm-macos-x64-release.zip" }
+macos-arm64 = { asset_pattern = "dcm-macos-arm-release.zip" }
+windows-x64 = { asset_pattern = "dcm-windows-release.zip" }
+
 [tools."github:jellyfin/jellyfin-ffmpeg"]
 version = "7.1.3-6"
 

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,11 +1,3 @@
-[tools]
-flutter = "3.41.9"
-
-[tools."github:CQLabs/homebrew-dcm"]
-version = "1.30.0"
-bin = "dcm"
-postinstall = "chmod +x $MISE_TOOL_INSTALL_PATH/dcm"
-
 [tasks."codegen:dart"]
 alias = "codegen"
 description = "Execute build_runner to auto-generate dart code"


### PR DESCRIPTION
- Removed redundant & stale mise tools config in mobile directory
- Added platform asset pattern for dcm (It was picking the wrong version on apple silicon)
