### PR TITLE
feat(server): add isVideo/isImage storage template variables

### DIFF
--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -86,6 +86,7 @@ describe(StorageTemplateService.name, () => {
           '{{y}}/{{y}}-{{WW}}/{{assetId}}',
           '{{album}}/{{filename}}',
           '{{make}}/{{model}}/{{lensModel}}/{{filename}}',
+          '{{#if isVideo}}videos{{/if}}/{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}',
         ],
         secondOptions: ['s', 'ss', 'SSS'],
         weekOptions: ['W', 'WW'],
@@ -255,6 +256,53 @@ describe(StorageTemplateService.name, () => {
         newPath: expect.stringContaining(
           `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/other/${month}/${asset.originalFileName}`,
         ),
+        oldPath: asset.originalPath,
+        pathType: AssetPathType.Original,
+      });
+    });
+
+    it('should use handlebar if condition for isVideo (video asset)', async () => {
+      const user = UserFactory.create();
+      const asset = AssetFactory.from({ type: AssetType.Video }).owner(user).exif().build();
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{#if isVideo}}videos{{/if}}/{{y}}/{{filename}}';
+
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(asset));
+
+      expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
+
+      expect(mocks.move.create).toHaveBeenCalledWith({
+        entityId: asset.id,
+        newPath: expect.stringContaining(
+          `/data/library/${user.id}/videos/${asset.fileCreatedAt.getFullYear()}/${asset.originalFileName}`,
+        ),
+        oldPath: asset.originalPath,
+        pathType: AssetPathType.Original,
+      });
+    });
+
+    it('should use handlebar else condition for isVideo (image asset)', async () => {
+      const user = UserFactory.create();
+      const asset = AssetFactory.from({ type: AssetType.Image }).owner(user).exif().build();
+      const config = structuredClone(defaults);
+      config.storageTemplate.template = '{{#if isVideo}}videos{{/if}}/{{y}}/{{filename}}';
+
+      sut.onConfigInit({ newConfig: config });
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(asset));
+
+      expect(await sut.handleMigrationSingle({ id: asset.id })).toBe(JobStatus.Success);
+
+      expect(mocks.move.create).toHaveBeenCalledWith({
+        entityId: asset.id,
+        newPath: expect.not.stringContaining('videos/') &&
+          expect.stringContaining(
+            `/data/library/${user.id}/${asset.fileCreatedAt.getFullYear()}/${asset.originalFileName}`,
+          ),
         oldPath: asset.originalPath,
         pathType: AssetPathType.Original,
       });

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -54,6 +54,7 @@ const storagePresets = [
   '{{y}}/{{y}}-{{WW}}/{{assetId}}',
   '{{album}}/{{filename}}',
   '{{make}}/{{model}}/{{lensModel}}/{{filename}}',
+  '{{#if isVideo}}videos{{/if}}/{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}',
 ];
 
 export interface MoveAssetMetadata {
@@ -404,6 +405,8 @@ export class StorageTemplateService extends BaseService {
       ext: extension,
       filetype: asset.type == AssetType.Image ? 'IMG' : 'VID',
       filetypefull: asset.type == AssetType.Image ? 'IMAGE' : 'VIDEO',
+      isVideo: asset.type == AssetType.Video ? 'true' : '',
+      isImage: asset.type == AssetType.Image ? 'true' : '',
       assetId: asset.id,
       assetIdShort: asset.id.slice(-12),
       //just throw into the root if it doesn't belong to an album

--- a/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
+++ b/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
@@ -53,10 +53,12 @@
     });
 
     const substitutions: Record<string, string> = {
-      filename: 'IMAGE_56437',
-      ext: 'jpg',
-      filetype: 'IMG',
-      filetypefull: 'IMAGE',
+      filename: 'VIDEO_12345',
+      ext: 'mp4',
+      filetype: 'VID',
+      filetypefull: 'VIDEO',
+      isVideo: 'true',
+      isImage: '',
       assetId: 'a8312960-e277-447d-b4ea-56717ccba856',
       assetIdShort: '56717ccba856',
       album: $t('album_name'),

--- a/web/src/lib/components/admin-settings/SupportedVariablesPanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedVariablesPanel.svelte
@@ -21,6 +21,8 @@
         <ul>
           <li>{`{{filetype}}`} - VID or IMG</li>
           <li>{`{{filetypefull}}`} - VIDEO or IMAGE</li>
+          <li>{`{{isVideo}}`}  —  'true' if video, otherwise empty</li>
+          <li>{`{{isImage}}`}  —  'true' if image, otherwise empty</li>
         </ul>
       </div>
 


### PR DESCRIPTION
## Description

Add {{isVideo}} and {{isImage}} Handlebars template variables to the storage template system. These return 'true' when the asset type matches, or an empty string otherwise, enabling conditional storage paths using {{#if isVideo}} / {{#if isImage}} helpers.

Previously, users could only distinguish file types using {{filetype}} (VID/IMG) or {{filetypefull}} (VIDEO/IMAGE), which always produce a value. The new boolean-style variables work naturally with Handlebars #if blocks for clean conditional directory structures.

## How Has This Been Tested?

- Patch verified: `git apply --check` passes on latest main
- Unit tests added in `storage-template.service.spec.ts`:
  - `should use handlebar if condition for isVideo (video asset)` — verifies `videos/` prefix for video assets
  - `should use handlebar else condition for isVideo (image asset)` — verifies `videos/` is omitted for image assets
- All 2150 tests pass (vitest)
- Visual verification via dev Docker Compose (Vite HMR + NestJS hot reload):
  - Variable descriptions appear in System Settings → Storage Template → Variables panel
  - Template preview demo uses VIDEO asset (filename: VIDEO_12345, isVideo: true, isImage: empty)
  - Preview correctly renders `Videos/2022/VIDEO_12345.jpg` via {{#if isVideo}}
- Real-world path generation verified on production data (~400 assets):
  - Template: `{{#if isVideo}}Videos/{{y}}{{else}}{{y}}/{{#if album}}{{album}}{{else}}Other/{{MM}}{{/if}}{{/if}}/{{filename}}`
  - Videos → `Videos/{year}/` directory
  - Photos with album → `{year}/{albumName}/`
  - Photos without album → `{year}/Other/{MM}/`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

**Fig 1. Variables panel — isVideo/isImage entries under filetype section**

<img width="1908" height="858" alt="pr_template_input" src="https://github.com/user-attachments/assets/915a6265-b5e3-43b3-8d85-be991793293d" />

**Fig 2. Template input + Preview path showing Videos/ prefix**

<img width="1908" height="858" alt="pr_vars3" src="https://github.com/user-attachments/assets/2b53caf8-58a9-4b75-a023-debf9f8dbbac" />


File path structure on disk (verified on production data):

```
library/admin/
├── 2024/
│   └── AlbumA/               ← photos with album
├── 2025/
│   ├── Other/10..12/         ← photos without album
│   ├── AlbumA/
│   └── AlbumB/
├── 2026/
│   ├── Other/01..05/
│   ├── AlbumC/
│   ├── AlbumA/
│   ├── AlbumD/
│   └── AlbumE/
└── Videos/
    ├── 2024/                  ← videos → separate Videos/year
    ├── 2025/
    └── 2026/
```

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.