### PR TITLE
fix: improve form control focus visibility

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -37,6 +37,10 @@
   @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4;
 }
 
+.immich-form-input:focus-visible {
+  box-shadow: 0 0 0 2px var(--immich-ui-primary-500);
+}
+
 @utility immich-form-label {
   @apply font-medium text-gray-500 dark:text-gray-300;
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -34,11 +34,7 @@
 }
 
 @utility immich-form-input {
-  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4;
-}
-
-.immich-form-input:focus-visible {
-  box-shadow: 0 0 0 2px var(--immich-ui-primary-500);
+  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-primary focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 dark:focus-within:ring-primary flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4;
 }
 
 @utility immich-form-label {


### PR DESCRIPTION
## Description

Refs #19498

Adds a visible focus ring for `.immich-form-input` controls so keyboard focus is easier to identify on admin settings inputs, selects,and textareas.

## How Has This Been Tested?

- Verified keyboard focus on Job Settings number inputs
- Verified keyboard focus on Logging level select
- Ran `prettier --check src/app.css`

<details><summary><h2>Screenshots</h2></summary>

  
<img width="923" height="324" alt="focus-level-select" src="https://github.com/user-attachments/assets/53332ba1-4828-47d3-9aff-e24af63f86ed" />
<img width="926" height="237" alt="focus-number-input" src="https://github.com/user-attachments/assets/fd0b9cd3-4d89-467e-bdba-2d2f38f931dc" />


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used an LLM to help inspect the issue, set up the local environment, and validate the change. I reviewed the final diff before submitting.