### PR TITLE
fix(web): remove global focus-visible suppression and add consistent focus outlines

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -34,7 +34,7 @@
 }
 
 @utility immich-form-input {
-  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4;
+  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-immich-primary dark:focus-visible:outline-immich-dark-primary focus-within:ring-immich-primary/50 dark:focus-within:ring-immich-dark-primary/50;
 }
 
 @utility immich-form-label {
@@ -151,11 +151,6 @@
 
   body.asset-viewer-open {
     background-color: black;
-  }
-
-  input:focus-visible {
-    outline-offset: 0px !important;
-    outline: none !important;
   }
 
   .text-white-shadow {


### PR DESCRIPTION
## Description

Fixes #19498

Removes the global `input:focus-visible { outline: none !important }` rule in `web/src/app.css` that was blanket-suppressing keyboard focus indicators on all native inputs. This was causing broken/inconsistent focus outlines when tabbing through admin settings pages and other form-heavy views.

Additionally adds `focus-visible` outline styles and `focus-within` ring color to the `immich-form-input` utility, so styled form controls (inputs, selects, textareas) now show a visible focus ring consistent with `@immich/ui` button focus styles (`outline-2 outline-offset-2`).

### Changes

- **Removed** the global `input:focus-visible { outline-offset: 0px !important; outline: none !important; }` override
- **Added** `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-immich-primary` (with dark mode variant) to `immich-form-input`
- **Added** `focus-within:ring-immich-primary/50` (with dark mode variant) to `immich-form-input` for a subtle ring color change on focus

### How Has This Been Tested?

- Verified CSS passes `prettier --check`
- Confirmed the Tailwind utility classes are valid and consistent with existing `@immich/ui` focus patterns

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to identify the root cause from the issue comments and implement the fix. The approach and final diff were reviewed before submission.