### PR TITLE
feat(mobile): add slideshow controls and playback state

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -17,9 +17,11 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/download_statu
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_page.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_preloader.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/slideshow_control_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_bottom_app_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/slideshow.provider.dart';
 import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -89,9 +91,12 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
   StreamSubscription? _reloadSubscription;
   KeepAliveLink? _stackChildrenKeepAlive;
+  Timer? _slideshowTimer;
+  Timer? _controlsHideTimer;
+  bool _isInAutoAdvance = false;
 
   void _onTapNavigate(int direction) {
-    final page = _pageController.page?.toInt();
+    final page = _pageController.page?.round();
     if (page == null) {
       return;
     }
@@ -100,7 +105,109 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     if (target >= 0 && target <= maxPage) {
       _pageController.jumpToPage(target);
       _onAssetChanged(target);
+      _restartSlideshowIfNeeded();
     }
+  }
+
+  void _restartSlideshowIfNeeded() {
+    final slideshow = ref.read(slideshowNotifierProvider);
+    if (!slideshow.isPlaying || slideshow.isPaused) return;
+    _startSlideshowTimer();
+    _showSlideshowControlsTemporarily();
+  }
+
+  void _showSlideshowControlsTemporarily() {
+    ref.read(slideshowNotifierProvider.notifier).showControls();
+    _controlsHideTimer?.cancel();
+    _controlsHideTimer = Timer(const Duration(milliseconds: 2500), () {
+      if (!mounted) return;
+      final state = ref.read(slideshowNotifierProvider);
+      if (state.isPlaying) {
+        ref.read(slideshowNotifierProvider.notifier).hideControls();
+      }
+    });
+  }
+
+  void _startSlideshowTimer() {
+    _slideshowTimer?.cancel();
+    final slideshow = ref.read(slideshowNotifierProvider);
+    if (!slideshow.isPlaying || slideshow.isPaused) return;
+
+    _slideshowTimer = Timer(Duration(seconds: slideshow.delaySeconds), () async {
+      if (!mounted) return;
+      final state = ref.read(slideshowNotifierProvider);
+      if (!state.isPlaying || state.isPaused) return;
+      _isInAutoAdvance = true;
+      await _advanceSlideshow();
+      _isInAutoAdvance = false;
+      if (mounted && ref.read(slideshowNotifierProvider).isPlaying && !ref.read(slideshowNotifierProvider).isPaused) {
+        _startSlideshowTimer();
+      }
+    });
+  }
+
+  Future<void> _advanceSlideshow() async {
+    final slideshow = ref.read(slideshowNotifierProvider);
+    final page = _pageController.page?.round() ?? _currentPage;
+
+    int? target;
+    switch (slideshow.navigation) {
+      case SlideshowNavigationMode.descending:
+        target = page + 1;
+        if (target >= _totalAssets) target = slideshow.repeat ? 0 : null;
+        break;
+      case SlideshowNavigationMode.ascending:
+        target = page - 1;
+        if (target < 0) target = slideshow.repeat ? _totalAssets - 1 : null;
+        break;
+      case SlideshowNavigationMode.shuffle:
+        if (_totalAssets <= 1) {
+          target = slideshow.repeat ? page : null;
+        } else {
+          final now = DateTime.now().microsecondsSinceEpoch;
+          var candidate = now % _totalAssets;
+          if (candidate == page) {
+            candidate = (candidate + 1) % _totalAssets;
+          }
+          target = candidate;
+        }
+        break;
+    }
+
+    if (target == null) {
+      _stopSlideshow();
+      return;
+    }
+
+    _pageController.jumpToPage(target);
+    _onAssetChanged(target);
+  }
+
+  void _stopSlideshow() {
+    _slideshowTimer?.cancel();
+    _controlsHideTimer?.cancel();
+    ref.read(slideshowNotifierProvider.notifier).stop();
+  }
+
+  void _pauseSlideshow() {
+    _slideshowTimer?.cancel();
+  }
+
+  void _resumeSlideshow() {
+    final state = ref.read(slideshowNotifierProvider);
+    if (!state.isPlaying || state.isPaused) return;
+    _slideshowTimer?.cancel();
+    _slideshowTimer = Timer(Duration(seconds: state.delaySeconds), () async {
+      if (!mounted) return;
+      final s = ref.read(slideshowNotifierProvider);
+      if (!s.isPlaying || s.isPaused) return;
+      _isInAutoAdvance = true;
+      await _advanceSlideshow();
+      _isInAutoAdvance = false;
+      if (mounted && ref.read(slideshowNotifierProvider).isPlaying && !ref.read(slideshowNotifierProvider).isPaused) {
+        _startSlideshowTimer();
+      }
+    });
   }
 
   @override
@@ -127,6 +234,8 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     _preloader.dispose();
     _reloadSubscription?.cancel();
     _stackChildrenKeepAlive?.close();
+    _slideshowTimer?.cancel();
+    _controlsHideTimer?.cancel();
 
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
@@ -172,6 +281,9 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     _handleCasting();
     _stackChildrenKeepAlive?.close();
     _stackChildrenKeepAlive = ref.read(stackChildrenNotifier(asset).notifier).ref.keepAlive();
+    if (!_isInAutoAdvance) {
+      _restartSlideshowIfNeeded();
+    }
   }
 
   void _handleCasting() {
@@ -281,6 +393,20 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       _setSystemUIMode(controls, details);
     });
 
+    ref.listen(slideshowNotifierProvider, (previous, next) {
+      if (!next.isPlaying) {
+        _slideshowTimer?.cancel();
+        _controlsHideTimer?.cancel();
+        return;
+      }
+
+      if (next.isPaused) {
+        _pauseSlideshow();
+      } else {
+        _resumeSlideshow();
+      }
+    });
+
     return Scaffold(
       backgroundColor: backgroundColor,
       resizeToAvoidBottomInset: false,
@@ -323,6 +449,11 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
                 height: context.padding.top,
               ),
             ),
+          SlideshowControlBar(
+            onNext: () => _onTapNavigate(1),
+            onPrevious: () => _onTapNavigate(-1),
+            onExit: _stopSlideshow,
+          ),
         ],
       ),
     );

--- a/mobile/lib/presentation/widgets/asset_viewer/slideshow_control_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/slideshow_control_bar.widget.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/asset_viewer/slideshow.provider.dart';
+
+class SlideshowControlBar extends ConsumerWidget {
+  final VoidCallback onNext;
+  final VoidCallback onPrevious;
+  final VoidCallback onExit;
+
+  const SlideshowControlBar({super.key, required this.onNext, required this.onPrevious, required this.onExit});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(slideshowNotifierProvider);
+    final notifier = ref.read(slideshowNotifierProvider.notifier);
+
+    if (!state.isPlaying || !state.showControls) {
+      return const SizedBox.shrink();
+    }
+
+    return SafeArea(
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Container(
+          margin: const EdgeInsets.only(top: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.black54,
+            borderRadius: BorderRadius.circular(24),
+          ),
+          child: Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 0,
+            runSpacing: 0,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              // Close
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                onPressed: onExit,
+                icon: const Icon(Icons.close, color: Colors.white),
+                tooltip: 'Exit slideshow',
+              ),
+              // Previous
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                onPressed: onPrevious,
+                icon: const Icon(Icons.chevron_left, color: Colors.white),
+                tooltip: 'Previous',
+              ),
+              // Play/Pause
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                onPressed: state.isPaused ? notifier.resume : notifier.pause,
+                icon: Icon(state.isPaused ? Icons.play_arrow : Icons.pause, color: Colors.white),
+                tooltip: state.isPaused ? 'Resume' : 'Pause',
+              ),
+              // Next
+              IconButton(
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                onPressed: onNext,
+                icon: const Icon(Icons.chevron_right, color: Colors.white),
+                tooltip: 'Next',
+              ),
+              // Delay selector — shows current value
+              _DelayMenu(
+                currentDelay: state.delaySeconds,
+                onSelected: notifier.setDelay,
+              ),
+              // Repeat toggle
+              IconButton(
+                onPressed: () => notifier.setRepeat(!state.repeat),
+                icon: Icon(
+                  state.repeat ? Icons.repeat : Icons.repeat_one_on,
+                  color: Colors.white,
+                ),
+                tooltip: state.repeat ? 'Repeat on' : 'Repeat off',
+              ),
+              // Navigation mode selector — shows current mode
+              _NavigationMenu(
+                currentMode: state.navigation,
+                onSelected: notifier.setNavigation,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DelayMenu extends StatelessWidget {
+  final int currentDelay;
+  final void Function(int) onSelected;
+
+  const _DelayMenu({required this.currentDelay, required this.onSelected});
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<int>(
+      icon: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.timer_outlined, color: Colors.white),
+          const SizedBox(width: 2),
+          Text(
+            '${currentDelay}s',
+            style: const TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ],
+      ),
+      tooltip: 'Delay',
+      onSelected: onSelected,
+      itemBuilder: (context) => [
+        _buildItem(3, '3s'),
+        _buildItem(5, '5s'),
+        _buildItem(10, '10s'),
+      ],
+    );
+  }
+
+  PopupMenuItem<int> _buildItem(int value, String label) {
+    final isSelected = value == currentDelay;
+    return PopupMenuItem<int>(
+      value: value,
+      child: Row(
+        children: [
+          if (isSelected)
+            const Icon(Icons.check, size: 16, color: Colors.grey)
+          else
+            const SizedBox(width: 16),
+          const SizedBox(width: 8),
+          Text(label),
+          if (isSelected) ...[
+            const SizedBox(width: 4),
+            const Text('✓', style: TextStyle(color: Colors.grey, fontSize: 12)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _NavigationMenu extends StatelessWidget {
+  final SlideshowNavigationMode currentMode;
+  final void Function(SlideshowNavigationMode) onSelected;
+
+  const _NavigationMenu({required this.currentMode, required this.onSelected});
+
+  IconData get _icon {
+    switch (currentMode) {
+      case SlideshowNavigationMode.descending:
+        return Icons.arrow_forward;
+      case SlideshowNavigationMode.ascending:
+        return Icons.arrow_back;
+      case SlideshowNavigationMode.shuffle:
+        return Icons.shuffle;
+    }
+  }
+
+  String get _label {
+    switch (currentMode) {
+      case SlideshowNavigationMode.descending:
+        return 'Next →';
+      case SlideshowNavigationMode.ascending:
+        return '← Prev';
+      case SlideshowNavigationMode.shuffle:
+        return 'Shuffle';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<SlideshowNavigationMode>(
+      icon: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(_icon, color: Colors.white),
+          const SizedBox(width: 2),
+          Text(
+            _label,
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ],
+      ),
+      tooltip: 'Navigation',
+      onSelected: onSelected,
+      itemBuilder: (context) => [
+        _buildItem(SlideshowNavigationMode.descending, Icons.arrow_forward, 'Next →'),
+        _buildItem(SlideshowNavigationMode.ascending, Icons.arrow_back, '← Prev'),
+        _buildItem(SlideshowNavigationMode.shuffle, Icons.shuffle, 'Shuffle'),
+      ],
+    );
+  }
+
+  PopupMenuItem<SlideshowNavigationMode> _buildItem(
+    SlideshowNavigationMode value,
+    IconData icon,
+    String label,
+  ) {
+    final isSelected = value == currentMode;
+    return PopupMenuItem<SlideshowNavigationMode>(
+      value: value,
+      child: Row(
+        children: [
+          if (isSelected)
+            const Icon(Icons.check, size: 16, color: Colors.grey)
+          else
+            const SizedBox(width: 16),
+          const SizedBox(width: 8),
+          Icon(icon, size: 18),
+          const SizedBox(width: 8),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_top_app_bar.widget.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/unfavorite_act
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart';
 import 'package:immich_mobile/providers/activity.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/slideshow.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
@@ -37,6 +38,7 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final isReadonlyModeEnabled = ref.watch(readonlyModeProvider);
 
     final showingDetails = ref.watch(assetViewerProvider.select((state) => state.showingDetails));
+    final slideshow = ref.watch(slideshowNotifierProvider);
 
     if (album != null && album.isActivityEnabled && album.isShared && asset is RemoteAsset) {
       ref.watch(albumActivityProvider((album.id, asset.id)));
@@ -67,6 +69,17 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
         const FavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
       if (asset.hasRemote && isOwner && asset.isFavorite)
         const UnFavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
+      IconButton(
+        icon: Icon(slideshow.isPlaying ? Icons.slideshow_rounded : Icons.slideshow_outlined),
+        onPressed: () {
+          final notifier = ref.read(slideshowNotifierProvider.notifier);
+          if (slideshow.isPlaying) {
+            notifier.stop();
+          } else {
+            notifier.start();
+          }
+        },
+      ),
 
       ViewerKebabMenu(originalTheme: originalTheme),
     ];

--- a/mobile/lib/providers/asset_viewer/slideshow.provider.dart
+++ b/mobile/lib/providers/asset_viewer/slideshow.provider.dart
@@ -1,0 +1,88 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'slideshow.provider.g.dart';
+
+enum SlideshowNavigationMode { descending, ascending, shuffle }
+
+class SlideshowState {
+  final bool isPlaying;
+  final bool isPaused;
+  final int delaySeconds;
+  final bool repeat;
+  final SlideshowNavigationMode navigation;
+  final bool showControls;
+
+  const SlideshowState({
+    this.isPlaying = false,
+    this.isPaused = false,
+    this.delaySeconds = 5,
+    this.repeat = true,
+    this.navigation = SlideshowNavigationMode.descending,
+    this.showControls = true,
+  });
+
+  SlideshowState copyWith({
+    bool? isPlaying,
+    bool? isPaused,
+    int? delaySeconds,
+    bool? repeat,
+    SlideshowNavigationMode? navigation,
+    bool? showControls,
+  }) {
+    return SlideshowState(
+      isPlaying: isPlaying ?? this.isPlaying,
+      isPaused: isPaused ?? this.isPaused,
+      delaySeconds: delaySeconds ?? this.delaySeconds,
+      repeat: repeat ?? this.repeat,
+      navigation: navigation ?? this.navigation,
+      showControls: showControls ?? this.showControls,
+    );
+  }
+}
+
+@riverpod
+class SlideshowNotifier extends _$SlideshowNotifier {
+  @override
+  SlideshowState build() => const SlideshowState();
+
+  void start() {
+    state = state.copyWith(isPlaying: true, isPaused: false, showControls: true);
+  }
+
+  void pause() {
+    if (!state.isPlaying) return;
+    state = state.copyWith(isPaused: true);
+  }
+
+  void resume() {
+    if (!state.isPlaying) return;
+    state = state.copyWith(isPaused: false);
+  }
+
+  void stop() {
+    state = state.copyWith(isPlaying: false, isPaused: false, showControls: true);
+  }
+
+  void setDelay(int seconds) {
+    if (seconds < 1) return;
+    state = state.copyWith(delaySeconds: seconds);
+  }
+
+  void setRepeat(bool repeat) {
+    state = state.copyWith(repeat: repeat);
+  }
+
+  void setNavigation(SlideshowNavigationMode mode) {
+    state = state.copyWith(navigation: mode);
+  }
+
+  void showControls() {
+    if (!state.isPlaying) return;
+    state = state.copyWith(showControls: true);
+  }
+
+  void hideControls() {
+    if (!state.isPlaying) return;
+    state = state.copyWith(showControls: false);
+  }
+}

--- a/mobile/lib/providers/asset_viewer/slideshow.provider.g.dart
+++ b/mobile/lib/providers/asset_viewer/slideshow.provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'slideshow.provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$slideshowNotifierHash() => r'9ae509797f097b8cca188b097140fb9a72388a01';
+
+/// See also [SlideshowNotifier].
+@ProviderFor(SlideshowNotifier)
+final slideshowNotifierProvider =
+    AutoDisposeNotifierProvider<SlideshowNotifier, SlideshowState>.internal(
+      SlideshowNotifier.new,
+      name: r'slideshowNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$slideshowNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SlideshowNotifier = AutoDisposeNotifier<SlideshowState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
## Description

Add slideshow controls and playback state management for mobile asset viewer.

- New `slideshow_control_bar.widget.dart` with play/pause, previous/next, and close controls
- New `slideshow.provider.dart` state management with timer-based auto-advance
- Slideshow toggle in top app bar (available in read-only mode)
- Fix overflow on small screens by switching Row to Wrap layout

## How Has This Been Tested?

### Mobile Checklist (docs/docs/developer/pr-checklist.md)

| Check | Command | Result |
|-------|---------|--------|
| codegen:pigeon | dart run pigeon + dart format | ✅ |
| codegen:dart | dart run build_runner build --delete-conflicting-outputs | ✅ |
| codegen:translation | dart run easy_localization:generate + generate_keys.dart | ✅ |
| lint | dart analyze --fatal-infos | ⚠️ (pre-existing warnings, see below) |
| format | dart format --set-exit-if-changed . | ✅ |
| test | flutter test | ✅ All tests passed! |

**lint known issue**: The repo has pre-existing URI errors in `packages/ui/showcase/*` unrelated to this change.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="561" height="952" alt="2026-05-20_233243" src="https://github.com/user-attachments/assets/54befa57-5d0a-4c5a-a152-1ab45b53a744" />
<img width="565" height="946" alt="2026-05-20_233258" src="https://github.com/user-attachments/assets/c8723eaf-f918-44eb-8fc6-839a28b4ec48" />
<img width="555" height="946" alt="2026-05-20_233318" src="https://github.com/user-attachments/assets/95d616e8-6be1-4ff3-ba48-74714417be85" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

AI (via Hermes Agent CLI) was used as a development tool to execute human-directed tasks such as code formatting, test execution, linting, and PR preparation. Feature decisions, code review, and testing were performed by a human developer.

<!-- generated by Hermes Agent -->
