### PR TITLE
chore(server): deprecate total field of asset search response

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -73,7 +73,6 @@ run = "bash ./bin/generate-dart-sdk.sh"
 env = { SHARP_IGNORE_GLOBAL_LIBVIPS = true }
 run = [
   { task = "//:plugins" },
-  { task = "//server:build" },
   { task = "//server:install" },
   { task = "//server:build" },
   { task = "//server:sync-open-api" },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20793,7 +20793,14 @@
             "description": "Total number of matching assets",
             "maximum": 9007199254740991,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-immich-history": [
+              {
+                "version": "v3.0.0",
+                "state": "Deprecated"
+              }
+            ],
+            "x-immich-state": "Deprecated"
           }
         },
         "required": [

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -186,7 +186,11 @@ const SearchAlbumResponseSchema = z
 
 const SearchAssetResponseSchema = z
   .object({
-    total: z.int().min(0).describe('Total number of matching assets'),
+    total: z
+      .int()
+      .min(0)
+      .describe('Total number of matching assets')
+      .meta(new HistoryBuilder().deprecated('v3.0.0').getExtensions()),
     count: z.int().min(0).describe('Number of assets in this page'),
     items: z.array(AssetResponseSchema),
     facets: z.array(SearchFacetResponseSchema),


### PR DESCRIPTION
## Description
Deprecate the `total` field of this DTO/endpoint because it's value is often incorrect and per a comment on the previous attempt (#25345) to fix the issue, it's better to deprecate the field.

Fixes #25325

## API Changes
/search/metadata will eventually no longer include the `total` property of the response for asset searches.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
