### PR TITLE
docs: add PikaPods to one-click cloud providers

### DIFF
--- a/docs/docs/install/one-click.md
+++ b/docs/docs/install/one-click.md
@@ -21,6 +21,10 @@ Go to the provider's marketplace and choose Immich, then follow the provided ins
 
 https://marketplace.digitalocean.com/apps/immich
 
+### PikaPods
+
+https://www.pikapods.com/pods?run=immich
+
 ### Vultr
 
 https://www.vultr.com/marketplace/apps/immich


### PR DESCRIPTION
## Description

Adds **PikaPods** to the list of one-click cloud service providers on the One-Click install docs page (`docs/docs/install/one-click.md`).

PikaPods offers a one-click Immich deployment, so it belongs alongside the other marketplace providers. The entry is inserted in alphabetical order, between DigitalOcean and Vultr, and links to https://www.pikapods.com/pods?run=immich.

## How Has This Been Tested?

- [x] Docs-only change; verified the added entry renders correctly and the one-click link resolves to the PikaPods Immich run URL.
- [x] Confirmed no unrelated changes — a single 4-line addition to one Markdown file.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This documentation change was drafted with the assistance of Claude Code. The change itself is a small, manually reviewed Markdown edit.
