### PR TITLE
fix: Refresh local album overview page after asset deletion

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/delete_local_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_local_action_button.widget.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_bu
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 
 /// This delete action has the following behavior:
 /// - Prompt to delete the asset locally
@@ -38,6 +39,8 @@ class DeleteLocalActionButton extends ConsumerWidget {
     if (result.count == 0) {
       return;
     }
+
+    ref.invalidate(localAlbumProvider);
 
     final successMessage = 'delete_local_action_prompt'.t(context: context, args: {'count': result.count.toString()});
 


### PR DESCRIPTION
## Description

I've always had the problem that when I open a local album (Library -> On This Device -> Select Album) and delete an asset from it or delete all assets in an album, the album still appears on the local album overview page (even if it's empty) and still shows the wrong number of entries.

Now, after deletion, the album provider is invalidated so that the overview page is updated.

## How Has This Been Tested?

- [x] Manual testing on physical device

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

no llm
