### PR TITLE
fix(web): preserve album sort order when closing asset viewer (#28383)

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -206,7 +206,7 @@
     }
   });
 
-  let album = $derived(data.album);
+  let album = $state(data.album);
   let albumId = $derived(album.id);
 
   const containsEditors = $derived(album?.shared && album.albumUsers.some(({ role }) => role === AlbumUserRole.Editor));
@@ -331,7 +331,9 @@
   {onAlbumShare}
   {onAlbumUserUpdate}
   onAlbumUserDelete={refreshAlbum}
-  onAlbumUpdate={(newAlbum) => (album = newAlbum)}
+  onAlbumUpdate={(newAlbum) => {
+    Object.assign(album, newAlbum);
+  }}
 />
 <CommandPaletteDefaultProvider name={$t('album')} actions={[AddAssets, Upload, Close]} />
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the album sort order resets to the database value after opening and closing the asset viewer, instead of preserving the user's selected sort order.

**The problem:**
When viewing an album, users can change the display order via the album settings. However, when they open an asset in full-screen view and then close it, the sort order reverts to the original order stored in the database.

**Root cause:**
The `album` variable was defined as a `$derived` reactive value based on `data.album`. When navigating back from the asset viewer, the page loader re-executed and reloaded `data.album` from the database. Since `album` was derived, it automatically updated to match `data.album`, overriding the locally updated `order` value.

**The solution:**
- Changed `album` from `$derived(data.album)` to `$state(data.album)`
- Modified `onAlbumUpdate` to use `Object.assign(album, newAlbum)` instead of reassigning the entire object
- This preserves the `order` value set by the user, even when the page reloads data from the database

Fixes #28383

## How Has This Been Tested?

**Test environment:**
- OS: Ubuntu 25.04
- Immich version: v2.7.5
- Development setup: `make dev` (http://localhost:3000)
- Browser: Firefox 148.0

**Steps to reproduce and verify the fix:**
1. Created an album with photos
2. Changed the sort order via album settings
3. Verified the photo order changed in the gallery
4. Opened a photo in full-screen view
5. Pressed Escape to close
6. Before fix: sort order reverted
7. After fix: sort order remained as selected

The fix was also verified by running `pnpm run format` -> "All matched files use Prettier code style!"

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No screenshots needed.

</details>

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.