### PR TITLE
fix(web): mark partner assets as read-only in manage location

### DIFF
--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -43,9 +43,14 @@
       return;
     }
 
+    const assets = assetMultiSelectManager.ownedAssets;
+    if (assets.length === 0) {
+      return;
+    }
+
     const confirmed = await modalManager.show(GeolocationUpdateConfirmModal, {
       point,
-      assetCount: assetMultiSelectManager.assets.length,
+      assetCount: assets.length,
     });
 
     if (!confirmed) {
@@ -54,14 +59,14 @@
 
     await updateAssets({
       assetBulkUpdateDto: {
-        ids: assetMultiSelectManager.assets.map((asset) => asset.id),
+        ids: assets.map((asset) => asset.id),
         latitude: point.lat,
         longitude: point.lng,
       },
     });
 
     const updatedAssets = await Promise.all(
-      assetMultiSelectManager.assets.map(async (asset) => {
+      assets.map(async (asset) => {
         const updatedAsset = await getAssetInfo({ ...authManager.params, id: asset.id });
         return toTimelineAsset(updatedAsset);
       }),
@@ -171,11 +176,11 @@
         leadingIcon={mdiMapMarkerMultipleOutline}
         size="small"
         color="primary"
-        disabled={assetMultiSelectManager.assets.length === 0}
+        disabled={assetMultiSelectManager.ownedAssets.length === 0}
         onclick={() => handleUpdate()}
       >
         <Text class="hidden sm:inline-block">
-          {$t('apply_count', { values: { count: assetMultiSelectManager.assets.length } })}
+          {$t('apply_count', { values: { count: assetMultiSelectManager.ownedAssets.length } })}
         </Text>
       </Button>
     </div>
@@ -192,6 +197,7 @@
     enableRouting={true}
     bind:timelineManager
     {options}
+    albumUsers={data.partners}
     assetInteraction={assetMultiSelectManager}
     removeAction={AssetAction.ARCHIVE}
     onEscape={handleEscape}
@@ -200,11 +206,11 @@
   >
     {#snippet customThumbnailLayout(asset: TimelineAsset)}
       {#if hasGps(asset)}
-        <div class="absolute inset-e-3 bottom-1 rounded-xl bg-success px-4 py-1 text-xs text-black transition-colors">
+        <div class="absolute inset-s-3 bottom-1 rounded-xl bg-success px-4 py-1 text-xs text-black transition-colors">
           {asset.city || $t('gps')}
         </div>
       {:else}
-        <div class="absolute inset-e-3 bottom-1 rounded-xl bg-danger px-4 py-1 text-xs text-light transition-colors">
+        <div class="absolute inset-s-3 bottom-1 rounded-xl bg-danger px-4 py-1 text-xs text-light transition-colors">
           {$t('gps_missing')}
         </div>
       {/if}

--- a/web/src/routes/(user)/utilities/geolocation/+page.ts
+++ b/web/src/routes/(user)/utilities/geolocation/+page.ts
@@ -1,3 +1,4 @@
+import { getPartners, PartnerDirection } from '@immich/sdk';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import type { PageLoad } from './$types';
@@ -5,8 +6,10 @@ import type { PageLoad } from './$types';
 export const load = (async ({ url }) => {
   await authenticate(url);
   const $t = await getFormatter();
+  const partners = await getPartners({ direction: PartnerDirection.SharedWith });
 
   return {
+    partners,
     meta: {
       title: $t('manage_geolocation'),
     },


### PR DESCRIPTION
## Description

Manage location utility shows partner assets (withPartners) but let you select/edit them like your own, even though the server won't allow editing a partner's asset.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #21471 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] With a partner sharing GPS photos: their thumbnails show the owner name

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
