### PR TITLE
perf(web): optimize shift+click range selection

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -85,6 +85,15 @@
   let shiftKeyIsDown = $state(false);
   let lastAssetMouseEvent: TimelineAsset | null = $state(null);
   let scrollTop = $state(0);
+
+  // Asset ID index lookup map for O(1) range computation
+  let assetIndexMap = $derived.by(() => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < assets.length; i++) {
+      map.set(assets[i].id, i);
+    }
+    return map;
+  });
   let slidingWindow = $derived.by(() => {
     const top = (scrollTop || 0) - slidingWindowOffset;
     const bottom = top + viewport.height + slidingWindowOffset;
@@ -175,8 +184,12 @@
       return;
     }
 
-    let start = assets.findIndex((a) => a.id === startAsset.id);
-    let end = assets.findIndex((a) => a.id === endAsset.id);
+    let start = assetIndexMap.get(startAsset.id);
+    let end = assetIndexMap.get(endAsset.id);
+
+    if (start === undefined || end === undefined) {
+      return;
+    }
 
     if (start > end) {
       [start, end] = [end, start];

--- a/web/src/lib/managers/asset-multi-select-manager.svelte.ts
+++ b/web/src/lib/managers/asset-multi-select-manager.svelte.ts
@@ -9,6 +9,7 @@ export type AssetMultiSelectOptions = {
 };
 export class AssetMultiSelectManager {
   #selectedMap = new SvelteMap<string, TimelineAsset>();
+  #candidateSet = new SvelteSet<string>();
 
   selectAll = $state(false);
   startAsset = $state<TimelineAsset | null>(null);
@@ -55,7 +56,7 @@ export class AssetMultiSelectManager {
   }
 
   hasSelectionCandidate(assetId: string) {
-    return this.candidates.some((asset) => asset.id === assetId);
+    return this.#candidateSet.has(assetId);
   }
 
   selectAsset(asset: TimelineAsset) {
@@ -64,7 +65,7 @@ export class AssetMultiSelectManager {
 
   selectAssets(assets: TimelineAsset[]) {
     for (const asset of assets) {
-      this.selectAsset(asset);
+      this.#selectedMap.set(asset.id, asset);
     }
   }
 
@@ -86,10 +87,15 @@ export class AssetMultiSelectManager {
 
   setAssetSelectionCandidates(assets: TimelineAsset[]) {
     this.candidates = assets;
+    this.#candidateSet.clear();
+    for (const asset of assets) {
+      this.#candidateSet.add(asset.id);
+    }
   }
 
   clearCandidates() {
     this.candidates = [];
+    this.#candidateSet.clear();
   }
 
   clear() {
@@ -101,6 +107,7 @@ export class AssetMultiSelectManager {
 
     // Range selection
     this.candidates = [];
+    this.#candidateSet.clear();
     this.startAsset = null;
   }
 }

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -131,6 +131,24 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
     [startTimelineMonth, endTimelineMonth] = [endTimelineMonth, startTimelineMonth];
   }
 
+  // Fast path: both assets in the same loaded month — collect synchronously
+  if (startTimelineMonth === endTimelineMonth && startTimelineMonth.isLoaded) {
+    const range: TimelineAsset[] = [];
+    let collecting = false;
+    for (const asset of startTimelineMonth.assetsIterator()) {
+      if (!collecting && asset.id === startAsset.id) {
+        collecting = true;
+      }
+      if (collecting) {
+        range.push(asset);
+      }
+      if (asset.id === endAsset.id) {
+        break;
+      }
+    }
+    return range;
+  }
+
   const range: TimelineAsset[] = [];
   const startTimelineDay = startTimelineMonth.findTimelineDayForAsset(startAsset);
   for await (const targetAsset of timelineManager.assetsIterator({


### PR DESCRIPTION
- Add O(1) hasSelectionCandidate via #candidateSet (was O(n) .some() scan per thumbnail)
- Add assetId index lookup map in GalleryViewer for O(1) range slicing (was O(n) findIndex x2)
- Add same-month fast path in retrieveRange() to skip async iteration"

## Description

I was experiencing performance issues in regard to range selecting (with Shift + Click). I presumed it was related to some reactivity stuff and wanted to optimize it. This PR cover that. Using `v2.7.5` on my remote instance I frequently get freezes. My two cents is when video previews are far apart dates are in the selection mix.

Basically the PR introduces a hashmap for faster lookups and improving the selection performance.

Fixes # (issue)

- Might fix #27490  

## How Has This Been Tested?

I initially tried against my remote instance since the data was there. But since there are too many breaking changes in `main` at the moment I needed to copy my data of my remote instance locally. I initially tried the performance enhancements basing myself of `v2.7.5` using my remote machine for ease to confirm that I could fix it and it proved to be way smoother.

After confirming I backed up my remote DB and photos and setup my local setup with the same data and added my performance enhancements again.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I've used an LLM to find the relevant pieces of code to adapt, setup and debug the breaking `main` branch with copying over my remote `v2.7.5` db and it generated the commit message.
