### PR TITLE
fix(web): restore focus-visible outlines on native inputs

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -153,11 +153,6 @@
     background-color: black;
   }
 
-  input:focus-visible {
-    outline-offset: 0px !important;
-    outline: none !important;
-  }
-
   .text-white-shadow {
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
   }


### PR DESCRIPTION
## Description

A global rule in `web/src/app.css` was unconditionally suppressing `:focus-visible` outlines on all native `<input>` elements:

```css
input:focus-visible {
  outline-offset: 0px !important;
  outline: none !important;
}
```

This caused inconsistent keyboard-focus behavior: `@immich/ui` buttons retained their `focus-visible:outline-2` styles, but native inputs on admin settings pages showed no focus indicator at all.

**Fix:** remove the global suppression rule. Inputs using the `immich-form-input` utility class already declare `outline-none` and surface focus via a `focus-within:ring-primary` ring — they are unaffected. Bare inputs (DurationInput, DateInput, SearchBar) will now correctly show the browser's default `:focus-visible` outline.

Fixes #19498

## How Has This Been Tested?

- [ ] Tab through admin settings page inputs — each input shows a focus ring
- [ ] Tab through `@immich/ui` buttons — focus rings unchanged
- [ ] Tab through search bar and date inputs — browser `:focus-visible` outline appears
- [ ] Dark mode: focus outlines visible against dark backgrounds
- [ ] Inputs with `immich-form-input` (e.g. storage template fields) — ring-based focus still works, no double outline

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code (claude-sonnet-4-6) was used to identify the root cause, locate the relevant file, and write the commit. The fix itself is a 5-line deletion of a CSS rule — no new logic was generated. The diagnosis was informed by a comment on the issue by Sean-Kenneth-Doherty that identified the exact conflicting rule.