### PR TITLE
feat(mobile): iOS-style timeline pinch-zoom and "No grouping" mode

### DIFF
--- a/mobile/lib/domain/models/events.model.dart
+++ b/mobile/lib/domain/models/events.model.dart
@@ -15,6 +15,18 @@ class ScrollToDateEvent extends Event {
   const ScrollToDateEvent(this.date);
 }
 
+/// Emitted when a tile is tapped in the dense zoomed-out layout: instead of
+/// opening the asset, the timeline zooms in one stop centered on this asset.
+/// Modeled as an event (not a direct callback) so the tile widget — which lives
+/// deep inside the sliver list — doesn't need a reference to the timeline's
+/// gesture/zoom state, mirroring how [ScrollToDateEvent] decouples scrubber
+/// taps from the timeline.
+class TimelineZoomToAssetEvent extends Event {
+  final int assetIndex;
+
+  const TimelineZoomToAssetEvent(this.assetIndex);
+}
+
 // Asset Viewer Events
 class ViewerShowDetailsEvent extends Event {
   const ViewerShowDetailsEvent();

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -167,6 +167,16 @@ class TimelineService {
     return getAssets(index, count);
   }
 
+  /// Read-only fetch straight from the asset source, bypassing the shared buffer
+  /// so it can't race with the active grid. Used to pre-warm thumbnails for the
+  /// adjacent zoom levels. Returns an empty list for out-of-range requests.
+  Future<List<BaseAsset>> peekAssets(int index, int count) {
+    if (index < 0 || count <= 0 || index >= _totalAssets) {
+      return Future.value(const []);
+    }
+    return _assetSource(index, math.min(count, _totalAssets - index));
+  }
+
   bool hasRange(int index, int count) =>
       index >= 0 &&
       index < _totalAssets &&

--- a/mobile/lib/infrastructure/loaders/image_request.dart
+++ b/mobile/lib/infrastructure/loaders/image_request.dart
@@ -36,7 +36,12 @@ abstract class ImageRequest {
 
   void _onCancelled();
 
-  Future<(ui.Codec, ui.ImageDescriptor)?> _codecFromEncodedPlatformImage(int address, int length) async {
+  Future<(ui.Codec, ui.ImageDescriptor)?> _codecFromEncodedPlatformImage(
+    int address,
+    int length, {
+    int? targetWidth,
+    int? targetHeight,
+  }) async {
     final pointer = Pointer<Uint8>.fromAddress(address);
     if (_isCancelled) {
       malloc.free(pointer);
@@ -62,7 +67,7 @@ abstract class ImageRequest {
       return null;
     }
 
-    final codec = await descriptor.instantiateCodec();
+    final codec = await descriptor.instantiateCodec(targetWidth: targetWidth, targetHeight: targetHeight);
     if (_isCancelled) {
       descriptor.dispose();
       codec.dispose();
@@ -72,8 +77,18 @@ abstract class ImageRequest {
     return (codec, descriptor);
   }
 
-  Future<ui.FrameInfo?> _fromEncodedPlatformImage(int address, int length) async {
-    final result = await _codecFromEncodedPlatformImage(address, length);
+  Future<ui.FrameInfo?> _fromEncodedPlatformImage(
+    int address,
+    int length, {
+    int? targetWidth,
+    int? targetHeight,
+  }) async {
+    final result = await _codecFromEncodedPlatformImage(
+      address,
+      length,
+      targetWidth: targetWidth,
+      targetHeight: targetHeight,
+    );
     if (result == null) {
       return null;
     }
@@ -96,7 +111,14 @@ abstract class ImageRequest {
     return frame;
   }
 
-  Future<ui.FrameInfo?> _fromDecodedPlatformImage(int address, int width, int height, int rowBytes) async {
+  Future<ui.FrameInfo?> _fromDecodedPlatformImage(
+    int address,
+    int width,
+    int height,
+    int rowBytes, {
+    int? targetWidth,
+    int? targetHeight,
+  }) async {
     final pointer = Pointer<Uint8>.fromAddress(address);
     if (_isCancelled) {
       malloc.free(pointer);
@@ -125,7 +147,7 @@ abstract class ImageRequest {
     );
     buffer.dispose();
 
-    final codec = await descriptor.instantiateCodec();
+    final codec = await descriptor.instantiateCodec(targetWidth: targetWidth, targetHeight: targetHeight);
     if (_isCancelled) {
       descriptor.dispose();
       codec.dispose();

--- a/mobile/lib/infrastructure/loaders/remote_image_request.dart
+++ b/mobile/lib/infrastructure/loaders/remote_image_request.dart
@@ -3,7 +3,11 @@ part of 'image_request.dart';
 class RemoteImageRequest extends ImageRequest {
   final String uri;
 
-  RemoteImageRequest({required this.uri});
+  /// When set, the server thumbnail is downscaled to this edge (px) on decode so
+  /// tiny grid tiles use proportionally small textures. Null = full resolution.
+  final int? decodeEdge;
+
+  RemoteImageRequest({required this.uri, this.decodeEdge});
 
   @override
   Future<ImageInfo?> load(ImageDecoderCallback decode, {double scale = 1.0}) async {
@@ -14,9 +18,15 @@ class RemoteImageRequest extends ImageRequest {
     final info = await remoteImageApi.requestImage(uri, requestId: requestId, preferEncoded: false);
     // Android always returns encoded data, so we need to check for both shapes of the response.
     final frame = switch (info) {
-      {'pointer': int pointer, 'length': int length} => await _fromEncodedPlatformImage(pointer, length),
+      // Bound width only; instantiateCodec scales height proportionally, so the
+      // thumbnail keeps its aspect ratio (cover-cropped to the square tile).
+      {'pointer': int pointer, 'length': int length} => await _fromEncodedPlatformImage(
+        pointer,
+        length,
+        targetWidth: decodeEdge,
+      ),
       {'pointer': int pointer, 'width': int width, 'height': int height, 'rowBytes': int rowBytes} =>
-        await _fromDecodedPlatformImage(pointer, width, height, rowBytes),
+        await _fromDecodedPlatformImage(pointer, width, height, rowBytes, targetWidth: decodeEdge),
       _ => null,
     };
     return frame == null ? null : ImageInfo(image: frame.image, scale: scale);

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -56,7 +56,12 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
 
   Stream<List<Bucket>> _watchMainBucket(List<String> userIds, {GroupAssetsBy groupBy = GroupAssetsBy.day}) {
     if (groupBy == GroupAssetsBy.none) {
-      throw UnsupportedError("GroupAssetsBy.none is not supported for watchMainBucket");
+      // No dedicated count query exists for merged assets, so reuse the day-grouped
+      // bucket query purely as a total-count source and slice it into fixed-size segments.
+      return _db.mergedAssetDrift
+          .mergedBucket(userIds: userIds, groupBy: GroupAssetsBy.day.index)
+          .watch()
+          .map((rows) => _generateBuckets(rows.fold<int>(0, (acc, row) => acc + row.assetCount)));
     }
 
     return _db.mergedAssetDrift.mergedBucket(userIds: userIds, groupBy: groupBy.index).map((row) {

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -184,7 +184,13 @@ ImageProvider? getThumbnailImageProvider(BaseAsset asset, {Size size = kThumbnai
 
   final assetId = asset is RemoteAsset ? asset.id : (asset as LocalAsset).remoteId;
   final thumbhash = asset is RemoteAsset ? asset.thumbHash ?? "" : "";
-  return assetId != null ? RemoteImageProvider.thumbnail(assetId: assetId, thumbhash: thumbhash, edited: edited) : null;
+  // Only downscale (and cache per-edge) below the default full edge; at or above
+  // it, keep decodeEdge null so the request path is identical to before.
+  final edge = size.width.toInt();
+  final decodeEdge = edge < kThumbnailResolution.width ? edge : null;
+  return assetId != null
+      ? RemoteImageProvider.thumbnail(assetId: assetId, thumbhash: thumbhash, edited: edited, decodeEdge: decodeEdge)
+      : null;
 }
 
 bool _shouldUseLocalAsset(BaseAsset asset) =>

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -44,13 +44,13 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
       return true;
     }
     if (other is LocalThumbProvider) {
-      return id == other.id;
+      return id == other.id && size == other.size;
     }
     return false;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => id.hashCode ^ size.hashCode;
 }
 
 class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProvider>

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/infrastructure/repositories/metadata.repository.da
 import 'package:immich_mobile/presentation/widgets/images/animated_image_stream_completer.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/one_frame_multi_image_stream_completer.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:openapi/api.dart';
 
@@ -14,10 +15,28 @@ class RemoteImageProvider extends CancellableImageProvider<RemoteImageProvider>
   final String url;
   final bool edited;
 
-  RemoteImageProvider({required this.url, this.edited = true});
+  /// Optional decode edge (px). When set, the thumbnail is downscaled on decode
+  /// and cached separately per edge, so dense grid tiles get small textures.
+  final int? decodeEdge;
 
-  RemoteImageProvider.thumbnail({required String assetId, required String thumbhash, this.edited = true})
-    : url = getThumbnailUrlForRemoteId(assetId, thumbhash: thumbhash, edited: edited);
+  RemoteImageProvider({required this.url, this.edited = true, this.decodeEdge});
+
+  RemoteImageProvider.thumbnail({
+    required String assetId,
+    required String thumbhash,
+    this.edited = true,
+    this.decodeEdge,
+  }) : url = getThumbnailUrlForRemoteId(
+         assetId,
+         thumbhash: thumbhash,
+         edited: edited,
+         // Dense zoom-out tiles fetch the server's tiny "micro" thumbnail instead
+         // of the ~250px one; the server falls back to the thumbnail if it hasn't
+         // generated a micro for that asset yet.
+         type: (decodeEdge != null && decodeEdge <= kTinyThumbnailMaxEdge)
+             ? AssetMediaSize.micro
+             : AssetMediaSize.thumbnail,
+       );
 
   @override
   Future<RemoteImageProvider> obtainKey(ImageConfiguration configuration) {
@@ -37,7 +56,7 @@ class RemoteImageProvider extends CancellableImageProvider<RemoteImageProvider>
   }
 
   Stream<ImageInfo> _codec(RemoteImageProvider key, ImageDecoderCallback decode) {
-    final request = this.request = RemoteImageRequest(uri: key.url);
+    final request = this.request = RemoteImageRequest(uri: key.url, decodeEdge: key.decodeEdge);
     return loadRequest(request, decode, isFinal: true);
   }
 
@@ -47,13 +66,13 @@ class RemoteImageProvider extends CancellableImageProvider<RemoteImageProvider>
       return true;
     }
     if (other is RemoteImageProvider) {
-      return url == other.url && edited == other.edited;
+      return url == other.url && edited == other.edited && decodeEdge == other.decodeEdge;
     }
     return false;
   }
 
   @override
-  int get hashCode => url.hashCode ^ edited.hashCode;
+  int get hashCode => url.hashCode ^ edited.hashCode ^ decodeEdge.hashCode;
 }
 
 class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImageProvider>

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -21,6 +21,7 @@ class ThumbnailTile extends ConsumerStatefulWidget {
     this.lockSelection = false,
     this.heroOffset,
     this.showStackIndicator = false,
+    this.showAssetIndicators = true,
     super.key,
   });
 
@@ -31,6 +32,10 @@ class ThumbnailTile extends ConsumerStatefulWidget {
   final bool lockSelection;
   final int? heroOffset;
   final bool showStackIndicator;
+
+  /// When false, hides the type/video/live-photo, favorite and stack overlay
+  /// icons (used at the widest zoom-out levels where tiles are tiny).
+  final bool showAssetIndicators;
 
   @override
   ConsumerState<ThumbnailTile> createState() => _ThumbnailTileState();
@@ -137,7 +142,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     },
                   ),
                 ),
-                if (asset != null)
+                if (asset != null && widget.showAssetIndicators)
                   AnimatedOpacity(
                     opacity: _hideIndicators ? 0.0 : 1.0,
                     duration: Durations.short4,
@@ -182,7 +187,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     },
                   ),
 
-                if (asset != null && asset.isFavorite)
+                if (asset != null && asset.isFavorite && widget.showAssetIndicators)
                   AnimatedOpacity(
                     duration: Durations.short4,
                     opacity: _hideIndicators ? 0.0 : 1.0,

--- a/mobile/lib/presentation/widgets/timeline/constants.dart
+++ b/mobile/lib/presentation/widgets/timeline/constants.dart
@@ -5,9 +5,62 @@ const Size kTimelineFixedTileExtent = Size.square(256);
 const double kTimelineSpacing = 2.0;
 const int kTimelineColumnCount = 3;
 
+/// Absolute bounds for the number of asset tiles per row reachable by pinch.
+const int kTimelineMinColumnCount = 1;
+const int kTimelineMaxColumnCount = 32;
+
+/// Manual "assets per row" slider range (the normal grid). The wider zoom-out
+/// levels (month/year-like) are reached only by pinch / the No-grouping layout.
+const int kTimelineSliderMinColumnCount = 1;
+const int kTimelineSliderMaxColumnCount = 6;
+
+/// Discrete zoom stops the pinch snaps to and that tap-zoom steps through.
+/// Even counts (so an equal number of columns can be added to each side of the
+/// focal asset when zooming), plus a single-image-wide level.
+const List<int> kTimelineZoomStops = [1, 2, 4, 6, 16, 32];
+
+/// Densest grouped (day/month) level before pinching further switches the
+/// timeline into the continuous "No grouping" layout.
+const int kTimelineGroupedMaxColumnCount = 6;
+
+/// Floating date-label granularity boundaries in No-grouping mode: at or below
+/// [kTimelineGroupedMaxColumnCount] columns shows a day, up to this shows a
+/// month, and wider shows a year.
+const int kTimelineMonthLabelMaxColumns = 16;
+
 const double kScrubberThumbHeight = 48.0;
 const Duration kTimelineScrubberFadeInDuration = Duration(milliseconds: 300);
 const Duration kTimelineScrubberFadeOutDuration = Duration(milliseconds: 800);
 
-const Size kThumbnailResolution = Size.square(320); // TODO: make the resolution vary based on actual tile size
+/// Default (and maximum) thumbnail decode edge, in pixels. Used for every
+/// non-timeline caller and as the cap for the per-tile decode size below.
+const Size kThumbnailResolution = Size.square(320);
+
+/// Physical-pixel decode edges that timeline tiles snap up to. Decoding a tiny
+/// tile (a dense zoom level) at a small edge keeps its GPU texture and decode
+/// cost proportional to what is actually shown, instead of always decoding the
+/// full [kThumbnailResolution]. Capped at [kThumbnailResolution] so a tile is
+/// never decoded larger than the previous fixed size (no regression for the
+/// coarse, large-tile levels).
+const List<int> kThumbnailDecodeStops = [48, 96, 256];
+
+/// Thumbnails decoded at or below this edge (the dense zoom-out levels) are routed
+/// to a dedicated high-count image-cache tier, so a screenful of hundreds of tiny
+/// tiles can't evict the normal-size thumbnails — and vice-versa.
+const int kTinyThumbnailMaxEdge = 128;
+
+/// Snaps a tile's displayed edge (logical px × [devicePixelRatio]) up to a
+/// [kThumbnailDecodeStops] bucket, falling back to the full [kThumbnailResolution]
+/// edge for large tiles. Bucketing avoids fragmenting the image cache across
+/// slightly different tile sizes.
+int thumbnailDecodeEdge(double tileExtentLogical, double devicePixelRatio) {
+  final physical = tileExtentLogical * devicePixelRatio;
+  for (final stop in kThumbnailDecodeStops) {
+    if (physical <= stop) {
+      return stop;
+    }
+  }
+  return kThumbnailResolution.width.toInt();
+}
+
 const kThumbnailDiskCacheSize = 1024 << 20; // 1GiB

--- a/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
@@ -6,8 +6,11 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail_tile.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/row.dart';
@@ -87,6 +90,12 @@ class FixedSegment extends Segment {
       columnCount: columnCount,
     );
   }
+
+  @override
+  int rowIndexForAsset(int assetIndex) {
+    final assetIndexInSegment = assetIndex - firstAssetIndex;
+    return (assetIndexInSegment / columnCount).floor();
+  }
 }
 
 class _FixedSegmentRow extends ConsumerWidget {
@@ -143,6 +152,11 @@ class _FixedSegmentRow extends ConsumerWidget {
     TimelineService timelineService,
     bool isDynamicLayout,
   ) {
+    // Decode thumbnails at the displayed tile size, so dense (small-tile) zoom
+    // levels use proportionally small textures instead of the full default edge.
+    final thumbnailSize = Size.square(
+      thumbnailDecodeEdge(tileHeight, MediaQuery.devicePixelRatioOf(context)).toDouble(),
+    );
     final children = [
       for (int i = 0; i < assets.length; i++)
         TimelineAssetIndexWrapper(
@@ -152,6 +166,7 @@ class _FixedSegmentRow extends ConsumerWidget {
             key: ValueKey(Object.hash(assets[i].heroTag, assetIndex + i, timelineService.hashCode)),
             asset: assets[i],
             assetIndex: assetIndex + i,
+            thumbnailSize: thumbnailSize,
           ),
         ),
     ];
@@ -200,15 +215,29 @@ class _FixedSegmentRow extends ConsumerWidget {
 class _AssetTileWidget extends ConsumerWidget {
   final BaseAsset asset;
   final int assetIndex;
+  final Size thumbnailSize;
 
-  const _AssetTileWidget({super.key, required this.asset, required this.assetIndex});
+  const _AssetTileWidget({super.key, required this.asset, required this.assetIndex, required this.thumbnailSize});
 
   Future _handleOnTap(BuildContext ctx, WidgetRef ref, int assetIndex, BaseAsset asset, int? heroOffset) async {
+    // Ignore stray taps fired by individual fingers during a pinch-zoom gesture.
+    if (ref.read(timelineStateProvider).isPinching) {
+      return;
+    }
     final multiSelectState = ref.read(multiSelectProvider);
 
     if (multiSelectState.forceEnable || multiSelectState.isEnabled) {
       ref.read(multiSelectProvider.notifier).toggleAssetSelection(asset);
     } else {
+      // At the dense zoomed-out levels (wider than the grouped cap) tapping zooms in
+      // one stage instead of opening the asset — tiles are too small to act on
+      // directly. Use the live column count so this respects in-session pinch zoom,
+      // not just the persisted slider preference.
+      if (ref.read(timelineArgsProvider).columnCount > kTimelineGroupedMaxColumnCount) {
+        EventStream.shared.emit(TimelineZoomToAssetEvent(assetIndex));
+        return;
+      }
+
       await ref.read(timelineServiceProvider).loadAssets(assetIndex, 1);
       ref.read(isPlayingMotionVideoProvider.notifier).playing = false;
       AssetViewer.setAsset(ref, asset);
@@ -226,6 +255,10 @@ class _AssetTileWidget extends ConsumerWidget {
   }
 
   void _handleOnLongPress(WidgetRef ref, BaseAsset asset) {
+    // Don't enter selection from a finger held during a pinch-zoom gesture.
+    if (ref.read(timelineStateProvider).isPinching) {
+      return;
+    }
     final multiSelectState = ref.read(multiSelectProvider);
     if (multiSelectState.isEnabled || multiSelectState.forceEnable) {
       return;
@@ -254,21 +287,40 @@ class _AssetTileWidget extends ConsumerWidget {
     final heroOffset = TabsRouterScope.of(context)?.controller.activeIndex ?? 0;
 
     final lockSelection = _getLockSelectionStatus(ref);
-    final showStorageIndicator = ref.watch(timelineArgsProvider.select((args) => args.showStorageIndicator));
+    // Also hide all overlay icons during a zoom transition: otherwise, committing to a
+    // level that shows them makes every tile's icons fade in at once mid-animation,
+    // which reads as a stutter. They reappear once the new level has settled.
+    final isZooming = ref.watch(timelineStateProvider.select((s) => s.isPinching));
+    // Hide the cloud/storage indicator at the widest zoom-out levels (16/32) where
+    // tiles are tiny and the icons are just clutter.
+    final showStorageIndicator =
+        !isZooming &&
+        ref.watch(
+          timelineArgsProvider.select(
+            (args) => args.showStorageIndicator && args.columnCount < kTimelineMonthLabelMaxColumns,
+          ),
+        );
     final isReadonlyModeEnabled = ref.watch(readonlyModeProvider);
-    final showStackIndicator = ref.read(timelineServiceProvider).origin != TimelineOrigin.trash;
+    final showStackIndicator = !isZooming && ref.read(timelineServiceProvider).origin != TimelineOrigin.trash;
+    // At the widest zoom-out levels (16/32) hide the type/video/favorite/stack overlays.
+    final showAssetIndicators =
+        !isZooming &&
+        ref.watch(timelineArgsProvider.select((args) => args.columnCount < kTimelineMonthLabelMaxColumns));
 
+    final Widget tile = ThumbnailTile(
+      asset,
+      size: thumbnailSize,
+      lockSelection: lockSelection,
+      showStorageIndicator: showStorageIndicator,
+      showStackIndicator: showStackIndicator,
+      showAssetIndicators: showAssetIndicators,
+      heroOffset: heroOffset,
+    );
     return RepaintBoundary(
       child: GestureDetector(
         onTap: () => lockSelection ? null : _handleOnTap(context, ref, assetIndex, asset, heroOffset),
         onLongPress: () => lockSelection || isReadonlyModeEnabled ? null : _handleOnLongPress(ref, asset),
-        child: ThumbnailTile(
-          asset,
-          lockSelection: lockSelection,
-          showStorageIndicator: showStorageIndicator,
-          showStackIndicator: showStackIndicator,
-          heroOffset: heroOffset,
-        ),
+        child: tile,
       ),
     );
   }

--- a/mobile/lib/presentation/widgets/timeline/fixed/segment_builder.dart
+++ b/mobile/lib/presentation/widgets/timeline/fixed/segment_builder.dart
@@ -1,7 +1,12 @@
+import 'dart:math' as math;
+
+import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart' show kTimelineMonthLabelMaxColumns;
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment_builder.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 
 class FixedSegmentBuilder extends SegmentBuilder {
   final double tileHeight;
@@ -16,14 +21,32 @@ class FixedSegmentBuilder extends SegmentBuilder {
   });
 
   List<Segment> generate() {
+    final isContinuous = isContinuousTimelineLayout(columnCount, groupBy);
+    // At the wide zoom levels (>6 cols) with a date-based grouping
+    // (day/month/auto), aggregate consecutive buckets into one segment per
+    // visible period — month at 16-wide, year at 32-wide — and leave a blank
+    // row of vertical space between them so the user's grouping preference
+    // is still visible at a glance. "No grouping" stays asset-level chunked.
+    final usePeriodGaps = isContinuous && groupBy != GroupAssetsBy.none;
+    final isYearPeriod = columnCount >= kTimelineMonthLabelMaxColumns * 2;
+
     final segments = <Segment>[];
     int firstIndex = 0;
     double startOffset = 0;
     int assetIndex = 0;
     DateTime? previousDate;
 
-    for (int i = 0; i < buckets.length; i++) {
-      final bucket = buckets[i];
+    final List<Bucket> effectiveBuckets;
+    if (!isContinuous) {
+      effectiveBuckets = buckets;
+    } else if (usePeriodGaps) {
+      effectiveBuckets = _aggregateByPeriod(year: isYearPeriod);
+    } else {
+      effectiveBuckets = _alignContinuousBuckets();
+    }
+
+    for (int i = 0; i < effectiveBuckets.length; i++) {
+      final bucket = effectiveBuckets[i];
 
       final assetCount = bucket.assetCount;
       final numberOfRows = (assetCount / columnCount).ceil();
@@ -33,13 +56,25 @@ class FixedSegmentBuilder extends SegmentBuilder {
       firstIndex += segmentCount;
       final segmentLastIndex = firstIndex - 1;
 
-      final timelineHeader = switch (groupBy) {
-        GroupAssetsBy.month => HeaderType.month,
-        GroupAssetsBy.day || GroupAssetsBy.auto =>
-          bucket is TimeBucket && bucket.date.month != previousDate?.month ? HeaderType.monthAndDay : HeaderType.day,
-        GroupAssetsBy.none => HeaderType.none,
-      };
-      final headerExtent = SegmentBuilder.headerExtent(timelineHeader);
+      final timelineHeader = isContinuous
+          ? HeaderType.none
+          : switch (groupBy) {
+              GroupAssetsBy.month => HeaderType.month,
+              GroupAssetsBy.day || GroupAssetsBy.auto =>
+                bucket is TimeBucket && bucket.date.month != previousDate?.month
+                    ? HeaderType.monthAndDay
+                    : HeaderType.day,
+              GroupAssetsBy.none => HeaderType.none,
+            };
+      // For period-gapped segments the header is invisible (HeaderType.none)
+      // but reserves a row's worth of vertical space, so the period boundary
+      // reads as a blank gap. The very first segment skips the gap.
+      final double headerExtent;
+      if (usePeriodGaps && i > 0) {
+        headerExtent = tileHeight + spacing;
+      } else {
+        headerExtent = SegmentBuilder.headerExtent(timelineHeader);
+      }
 
       final segmentStartOffset = startOffset;
       startOffset += headerExtent + (tileHeight * numberOfRows) + spacing * (numberOfRows - 1);
@@ -67,5 +102,107 @@ class FixedSegmentBuilder extends SegmentBuilder {
       }
     }
     return segments;
+  }
+
+  /// Walks [buckets] and merges all consecutive entries whose dates fall in the
+  /// same period — same year for [year] = true, same year-and-month otherwise —
+  /// into a single [TimeBucket]. Buckets without a date (rare; only the
+  /// no-grouping merged-bucket path) flush the current accumulator and become
+  /// their own segment. Used by the wide-zoom day/month/auto layout to give one
+  /// segment per visible period.
+  List<Bucket> _aggregateByPeriod({required bool year}) {
+    if (buckets.isEmpty) {
+      return const [];
+    }
+    final result = <Bucket>[];
+    int accumulatedCount = 0;
+    DateTime? accumulatedDate;
+
+    void flush() {
+      if (accumulatedCount <= 0) {
+        return;
+      }
+      result.add(
+        accumulatedDate != null
+            ? TimeBucket(assetCount: accumulatedCount, date: accumulatedDate!)
+            : Bucket(assetCount: accumulatedCount),
+      );
+      accumulatedCount = 0;
+      accumulatedDate = null;
+    }
+
+    bool samePeriod(DateTime a, DateTime b) {
+      if (a.year != b.year) {
+        return false;
+      }
+      return year || a.month == b.month;
+    }
+
+    for (final bucket in buckets) {
+      final bucketDate = bucket is TimeBucket ? bucket.date : null;
+      if (bucketDate == null) {
+        flush();
+        result.add(Bucket(assetCount: bucket.assetCount));
+        continue;
+      }
+      if (accumulatedDate == null) {
+        accumulatedDate = bucketDate;
+        accumulatedCount = bucket.assetCount;
+      } else if (samePeriod(accumulatedDate!, bucketDate)) {
+        accumulatedCount += bucket.assetCount;
+      } else {
+        flush();
+        accumulatedDate = bucketDate;
+        accumulatedCount = bucket.assetCount;
+      }
+    }
+    flush();
+    return result;
+  }
+
+  /// Re-slices all buckets into continuous chunks whose size is a multiple of
+  /// [columnCount], so every row is full and no interior gaps appear. Each chunk
+  /// inherits the date of its first asset's source bucket so the scrubber and any
+  /// month/year UI can still resolve dates from segments at the wider zoom levels.
+  List<Bucket> _alignContinuousBuckets() {
+    if (buckets.isEmpty) {
+      return const [];
+    }
+    final chunkSize = math.max(columnCount, (kTimelineNoneSegmentSize ~/ columnCount) * columnCount);
+    final result = <Bucket>[];
+    int chunkRemaining = 0;
+    DateTime? chunkDate;
+
+    void flush() {
+      if (chunkRemaining <= 0) {
+        return;
+      }
+      result.add(
+        chunkDate != null
+            ? TimeBucket(assetCount: chunkRemaining, date: chunkDate!)
+            : Bucket(assetCount: chunkRemaining),
+      );
+      chunkRemaining = 0;
+      chunkDate = null;
+    }
+
+    for (final bucket in buckets) {
+      final bucketDate = bucket is TimeBucket ? bucket.date : null;
+      int taken = bucket.assetCount;
+      while (taken > 0) {
+        if (chunkRemaining == 0) {
+          chunkDate = bucketDate;
+        }
+        final space = chunkSize - chunkRemaining;
+        final take = math.min(taken, space);
+        chunkRemaining += take;
+        taken -= take;
+        if (chunkRemaining == chunkSize) {
+          flush();
+        }
+      }
+    }
+    flush();
+    return result;
   }
 }

--- a/mobile/lib/presentation/widgets/timeline/header.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/header.widget.dart
@@ -39,7 +39,10 @@ class TimelineHeader extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (bucket is! TimeBucket || header == HeaderType.none) {
-      return const SizedBox.shrink();
+      // [HeaderType.none] still reserves [height] in the layout — used by the
+      // wide zoom levels of day/month/auto groupings to leave a blank row gap
+      // between months/years without rendering a visible header label.
+      return height > 0 ? SizedBox(height: height) : const SizedBox.shrink();
     }
 
     final date = (bucket as TimeBucket).date;

--- a/mobile/lib/presentation/widgets/timeline/segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/segment.model.dart
@@ -48,6 +48,12 @@ abstract class Segment {
   int getMaxChildIndexForScrollOffset(double scrollOffset);
   double indexToLayoutOffset(int index);
 
+  /// Returns the in-segment row index (0-based, excluding the header) that contains
+  /// the given global [assetIndex]. The caller can compute the row's child index via
+  /// `firstIndex + 1 + rowIndexForAsset(...)` and its scroll offset via
+  /// `indexToLayoutOffset(rowChildIndex)`.
+  int rowIndexForAsset(int assetIndex);
+
   Widget builder(BuildContext context, int index);
 
   @override

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -52,21 +52,26 @@ class TimelineArgs {
 class TimelineState {
   final bool isScrubbing;
   final bool isScrolling;
+  final bool isPinching;
 
-  const TimelineState({this.isScrubbing = false, this.isScrolling = false});
+  const TimelineState({this.isScrubbing = false, this.isScrolling = false, this.isPinching = false});
 
   bool get isInteracting => isScrubbing || isScrolling;
 
   @override
   bool operator ==(covariant TimelineState other) {
-    return isScrubbing == other.isScrubbing && isScrolling == other.isScrolling;
+    return isScrubbing == other.isScrubbing && isScrolling == other.isScrolling && isPinching == other.isPinching;
   }
 
   @override
-  int get hashCode => isScrubbing.hashCode ^ isScrolling.hashCode;
+  int get hashCode => isScrubbing.hashCode ^ isScrolling.hashCode ^ isPinching.hashCode;
 
-  TimelineState copyWith({bool? isScrubbing, bool? isScrolling}) {
-    return TimelineState(isScrubbing: isScrubbing ?? this.isScrubbing, isScrolling: isScrolling ?? this.isScrolling);
+  TimelineState copyWith({bool? isScrubbing, bool? isScrolling, bool? isPinching}) {
+    return TimelineState(
+      isScrubbing: isScrubbing ?? this.isScrubbing,
+      isScrolling: isScrolling ?? this.isScrolling,
+      isPinching: isPinching ?? this.isPinching,
+    );
   }
 }
 
@@ -79,16 +84,37 @@ class TimelineStateNotifier extends Notifier<TimelineState> {
     state = state.copyWith(isScrolling: isScrolling);
   }
 
+  void setPinching(bool isPinching) {
+    state = state.copyWith(isPinching: isPinching);
+  }
+
   @override
-  TimelineState build() => const TimelineState(isScrubbing: false, isScrolling: false);
+  TimelineState build() => const TimelineState(isScrubbing: false, isScrolling: false, isPinching: false);
 }
+
+/// Session-only column count override set by the pinch-zoom gesture. Persists for
+/// the current session but is not written to metadata, so the next app launch falls
+/// back to the user's slider preference instead of inheriting the last pinch state.
+final pinchZoomColumnsProvider = StateProvider<int?>((_) => null);
+
+/// True when the timeline uses the continuous header-less layout. Two opt-in
+/// triggers — both require an explicit user action, so existing day/month/auto
+/// users never see this layout unless they choose it:
+///   1. User picked "No grouping" in settings (groupBy == none), OR
+///   2. User pinched out past [kTimelineGroupedMaxColumnCount] (the manual
+///      slider is capped at this value, so reaching the wide range is a
+///      deliberate gesture rather than a silent preference change).
+bool isContinuousTimelineLayout(int columnCount, GroupAssetsBy groupBy) =>
+    groupBy == GroupAssetsBy.none || columnCount > kTimelineGroupedMaxColumnCount;
 
 // This provider watches the buckets from the timeline service & args and serves the segments.
 // It should be used only after the timeline service and timeline args provider is overridden
 final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) async* {
   final args = ref.watch(timelineArgsProvider);
   final columnCount = args.columnCount;
-  final spacing = args.spacing;
+  // Drop the inter-tile spacing at the widest zoom-out levels (15/32) for a
+  // seamless, borderless grid.
+  final spacing = columnCount >= kTimelineMonthLabelMaxColumns ? 0.0 : args.spacing;
   final availableTileWidth = args.maxWidth - (spacing * (columnCount - 1));
   final tileExtent = math.max(0, availableTileWidth) / columnCount;
 

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -10,13 +10,13 @@ import 'package:flutter/rendering.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
-import 'package:immich_mobile/domain/models/metadata_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_status_floating_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scrubber.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
@@ -29,6 +29,11 @@ import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_sliver_app_bar.dart';
 import 'package:immich_mobile/widgets/common/mesmerizing_sliver_app_bar.dart';
 import 'package:immich_mobile/widgets/common/selection_sliver_app_bar.dart';
+import 'package:intl/intl.dart' hide TextDirection;
+
+// Fraction of the raw two-finger pinch ratio applied to the zoom z-axis. < 1
+// means the user has to pinch further to traverse a stop, for finer control.
+const double _kPinchDampening = 0.65;
 
 class Timeline extends StatelessWidget {
   const Timeline({
@@ -71,7 +76,9 @@ class Timeline extends StatelessWidget {
             (ref) => TimelineArgs(
               maxWidth: constraints.maxWidth,
               maxHeight: constraints.maxHeight,
-              columnCount: ref.watch(appConfigProvider.select((config) => config.timeline.tilesPerRow)),
+              columnCount:
+                  ref.watch(pinchZoomColumnsProvider) ??
+                  ref.watch(appConfigProvider.select((config) => config.timeline.tilesPerRow)),
               showStorageIndicator: showStorageIndicator,
               withStack: withStack,
               groupBy: groupBy,
@@ -146,21 +153,82 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
   final Set<BaseAsset> _draggedAssets = HashSet();
   ScrollPhysics? _scrollPhysics;
 
-  int _perRow = 4;
-  double _scaleFactor = 3.0;
-  double _baseScaleFactor = 3.0;
   int? _restoreAssetIndex;
+  // When restoring after a width change, keep the anchored asset at this vertical
+  // offset within the viewport instead of the very top.
+  double? _restoreFocalOffset;
+  // Pinch-commit restore: a one-shot subscription that runs scroll-restore as
+  // soon as the segment provider settles at the target column count, plus a
+  // safety watchdog that runs the restore anyway if the provider stalls.
+  ProviderSubscription? _zoomRestoreSubscription;
+  Timer? _zoomRestoreWatchdog;
+
+  // Date of the topmost visible asset, shown as a floating overlay in the
+  // continuous "No grouping" layout (which has no per-section headers).
+  final ValueNotifier<DateTime?> _floatingDate = ValueNotifier(null);
+
+  // Debounce for thumbnail-cache warming around the viewport.
+  Timer? _precacheTimer;
+
+  // Pinch-zoom state. The gesture is tracked on a continuous z-axis where
+  // z = log2(32 / cols) so a 2× pinch is one stop wide regardless of the current
+  // level. On release we snap to the nearest discrete stop in [kTimelineZoomStops]
+  // and restore scroll so the anchor asset stays under the focal point.
+  static const double _zMin = 0.0; // 32 cols
+  static const double _zMax = 5.0; // 1 col
+  double _zBase = 0.0;
+  double _zLive = 0.0;
+  bool _zoomActive = false;
+  Offset _focalViewport = Offset.zero;
+  int? _pinchAnchorAssetIndex;
+
+  double _zForColumns(double columns) => math.log(32.0 / columns) / math.ln2;
+
+  // Snaps a z value to the column count of the nearest discrete zoom stop.
+  int _colsForStopZ(double z) {
+    final cols = 32.0 / math.pow(2.0, z);
+    return kTimelineZoomStops.reduce((a, b) => (a - cols).abs() <= (b - cols).abs() ? a : b);
+  }
+
+  // Returns the asset under viewport point [focal] at [cols] columns, or null if
+  // the segments aren't ready / there are no assets. Used to anchor the pinch on
+  // the photo the user's fingers landed on.
+  int? _assetUnderFocal(List<Segment> segments, Offset focal, int cols) {
+    final rowFirstAsset = _getCurrentAssetIndex(segments, viewportOffset: focal.dy);
+    if (rowFirstAsset == null) {
+      return null;
+    }
+    final args = ref.read(timelineArgsProvider);
+    final spacing = cols >= kTimelineMonthLabelMaxColumns ? 0.0 : kTimelineSpacing;
+    final tile = (args.maxWidth - spacing * (cols - 1)) / cols;
+    final pitch = tile + spacing;
+    if (pitch <= 0) {
+      return null;
+    }
+    final total = ref.read(timelineServiceProvider).totalAssets;
+    final focalCol = (focal.dx / pitch).floor().clamp(0, cols - 1);
+    return math.max(0, math.min(total - 1, rowFirstAsset + focalCol));
+  }
+
+  void _beginZoomSession({
+    required List<Segment> segments,
+    required Offset focal,
+    required int baseCols,
+    int? anchorAssetIndex,
+    Offset? focalViewport,
+  }) {
+    _zBase = _zForColumns(baseCols.toDouble());
+    _zLive = _zBase;
+    _pinchAnchorAssetIndex = anchorAssetIndex ?? _assetUnderFocal(segments, focal, baseCols);
+    _focalViewport = focalViewport ?? focal;
+  }
 
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController(onAttach: _restoreAssetPosition);
+    _scrollController.addListener(_updateFloatingDate);
     _eventSubscription = EventStream.shared.listen(_onEvent);
-
-    final currentTilesPerRow = ref.read(appConfigProvider.select((config) => config.timeline.tilesPerRow));
-    _perRow = currentTilesPerRow;
-    _scaleFactor = 7.0 - _perRow;
-    _baseScaleFactor = _scaleFactor;
 
     ref.listenManual(multiSelectProvider.select((s) => s.isEnabled), _onMultiSelectionToggled);
   }
@@ -189,6 +257,8 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
       case ScrollToDateEvent scrollToDateEvent:
         _scrollToDate(scrollToDateEvent.date);
+      case TimelineZoomToAssetEvent zoomEvent:
+        _zoomInOnAsset(zoomEvent.assetIndex);
       case TimelineReloadEvent():
         setState(() {});
       default:
@@ -196,55 +266,307 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     }
   }
 
+  // Restores scroll so the anchor asset's row in the new layout sits at
+  // [_restoreFocalOffset] (the pinch centroid Y captured at commit).
   void _restoreAssetPosition(_) {
     if (_restoreAssetIndex == null) {
       return;
     }
-
     final asyncSegments = ref.read(timelineSegmentProvider);
-    asyncSegments.whenData((segments) {
-      final targetSegment = segments.lastWhereOrNull((segment) => segment.firstAssetIndex <= _restoreAssetIndex!);
-      if (targetSegment != null) {
-        final assetIndexInSegment = _restoreAssetIndex! - targetSegment.firstAssetIndex;
-        final newColumnCount = ref.read(timelineArgsProvider).columnCount;
-        final rowIndexInSegment = (assetIndexInSegment / newColumnCount).floor();
-        final targetRowIndex = targetSegment.firstIndex + 1 + rowIndexInSegment;
-        final targetOffset = targetSegment.indexToLayoutOffset(targetRowIndex);
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            _scrollController.jumpTo(targetOffset.clamp(0.0, _scrollController.position.maxScrollExtent));
-          }
-        });
-      }
-    });
+    // Skip if segments are still reloading for the new column count — ref.listen
+    // on the provider will call us back once new segments emit.
+    if (asyncSegments.isLoading || !asyncSegments.hasValue) {
+      return;
+    }
+    final segments = asyncSegments.value!;
+    if (segments.isEmpty) {
+      _restoreAssetIndex = null;
+      _restoreFocalOffset = null;
+      return;
+    }
+    final assetIndex = _restoreAssetIndex!;
+    final focalOffset = _restoreFocalOffset ?? 0.0;
+    final targetSegment = segments.lastWhereOrNull((segment) => segment.firstAssetIndex <= assetIndex);
+    if (targetSegment == null) {
+      return;
+    }
+    final args = ref.read(timelineArgsProvider);
+    final columnCount = args.columnCount;
+    final spacing = columnCount >= kTimelineMonthLabelMaxColumns ? 0.0 : kTimelineSpacing;
+    final tileHeight = (args.maxWidth - spacing * (columnCount - 1)) / columnCount;
+    final rowIndexInSegment = targetSegment.rowIndexForAsset(assetIndex);
+    final targetRowIndex = targetSegment.firstIndex + 1 + rowIndexInSegment;
+    final rowTop = targetSegment.indexToLayoutOffset(targetRowIndex);
+    // Place the row's vertical center at the focal Y so the photo under the
+    // fingers stays put. rowTop is segment-local; the scroll offset target
+    // adds the leading slivers' extent so the row lands at the focal Y on the
+    // actual viewport.
+    final desired = _leadingSliverExtent() + rowTop + tileHeight / 2 - focalOffset;
     _restoreAssetIndex = null;
+    _restoreFocalOffset = null;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) {
+        return;
+      }
+      final max = _scrollController.position.maxScrollExtent;
+      _scrollController.jumpTo(desired.clamp(0.0, max));
+    });
   }
 
   void _onMultiSelectionToggled(_, bool isEnabled) {
     EventStream.shared.emit(MultiSelectToggleEvent(isEnabled));
   }
 
-  int? _getCurrentAssetIndex(List<Segment> segments) {
-    final currentOffset = _scrollController.offset.clamp(0.0, _scrollController.position.maxScrollExtent);
+  // Scroll extent consumed by the slivers BEFORE the segmented list (app bar + any
+  // topSliverWidget). The segments' offsets are 0-based from the start of the
+  // segmented list, but `_scrollController.offset` is in the overall scrollable's
+  // coordinate, which includes these leading slivers. We need to subtract this when
+  // converting a viewport-Y to a segment-local Y, and add it when converting a
+  // segment-local Y to a `scrollController.offset` target.
+  double _leadingSliverExtent() {
+    if (widget.appBar == null) {
+      return widget.topSliverWidgetHeight ?? 0.0;
+    }
+    // ImmichSliverAppBar (floating, pinned: false) visually extends into the status
+    // bar area, so its scroll extent is status-bar + toolbar height.
+    return MediaQuery.paddingOf(context).top + kToolbarHeight + (widget.topSliverWidgetHeight ?? 0.0);
+  }
+
+  int? _getCurrentAssetIndex(List<Segment> segments, {double viewportOffset = 0}) {
+    final leading = _leadingSliverExtent();
+    final maxExtent = _scrollController.position.maxScrollExtent;
+    final lastEnd = segments.lastOrNull?.endOffset ?? maxExtent;
+    final currentOffset = (_scrollController.offset + viewportOffset - leading).clamp(0.0, lastEnd);
     final segment = segments.findByOffset(currentOffset) ?? segments.lastOrNull;
-    int? targetAssetIndex;
-    if (segment != null) {
-      final rowIndex = segment.getMinChildIndexForScrollOffset(currentOffset);
-      if (rowIndex > segment.firstIndex) {
-        final rowIndexInSegment = rowIndex - (segment.firstIndex + 1);
-        final assetsPerRow = ref.read(timelineArgsProvider).columnCount;
-        final assetIndexInSegment = rowIndexInSegment * assetsPerRow;
-        targetAssetIndex = segment.firstAssetIndex + assetIndexInSegment;
-      } else {
-        targetAssetIndex = segment.firstAssetIndex;
+    if (segment == null) {
+      return null;
+    }
+    final rowIndex = segment.getMinChildIndexForScrollOffset(currentOffset);
+    if (rowIndex <= segment.firstIndex) {
+      return segment.firstAssetIndex;
+    }
+    final assetsPerRow = ref.read(timelineArgsProvider).columnCount;
+    return segment.firstAssetIndex + (rowIndex - segment.firstIndex - 1) * assetsPerRow;
+  }
+
+  // Screen-space rect (unscaled) of a given asset's tile in the live grid — used to
+  // capture the focal coordinate's row position at gesture start.
+  Rect? _anchorTileRect(List<Segment> segments, int assetIndex, int columnCount, double maxWidth) {
+    if (!_scrollController.hasClients) {
+      return null;
+    }
+    final seg = segments.lastWhereOrNull((s) => s.firstAssetIndex <= assetIndex);
+    if (seg == null) {
+      return null;
+    }
+    final indexInSeg = assetIndex - seg.firstAssetIndex;
+    final col = indexInSeg % columnCount;
+    final rowInSeg = indexInSeg ~/ columnCount;
+    final spacing = columnCount >= kTimelineMonthLabelMaxColumns ? 0.0 : kTimelineSpacing;
+    final tile = (maxWidth - spacing * (columnCount - 1)) / columnCount;
+    // Segment offsets are 0-based from the start of the segmented list; the actual
+    // viewport Y is offset by the leading slivers' scroll extent.
+    final top =
+        _leadingSliverExtent() + seg.indexToLayoutOffset(seg.firstIndex + 1 + rowInSeg) - _scrollController.offset;
+    return Rect.fromLTWH(col * (tile + spacing), top, tile, tile);
+  }
+
+  // Settles the gesture: stores the restore anchor for the post-rebuild scroll
+  // jump, drops the live zoom transform, sets the new column count, and arms a
+  // one-shot listener that runs the scroll-restore as soon as the segment
+  // provider has emitted segments built for the new column count.
+  void _commitZoom(int finalCols) {
+    _restoreAssetIndex = _pinchAnchorAssetIndex;
+    _restoreFocalOffset = _focalViewport.dy;
+    ref.read(timelineStateProvider.notifier).setPinching(false);
+    setState(() => _zoomActive = false);
+    // Session-only — the user's persisted slider preference is untouched so the
+    // next app launch isn't stuck at the last pinch level.
+    ref.read(pinchZoomColumnsProvider.notifier).state = finalCols;
+    _armZoomRestore(finalCols);
+  }
+
+  // One-shot subscription that runs the post-commit scroll restore exactly once,
+  // when the segment provider emits its first settled value at [targetCols].
+  // A 1.5s watchdog runs the restore anyway if the segment provider stalls, so
+  // the user is never left with a dangling restore.
+  void _armZoomRestore(int targetCols) {
+    _zoomRestoreSubscription?.close();
+    _zoomRestoreWatchdog?.cancel();
+
+    void run() {
+      _zoomRestoreSubscription?.close();
+      _zoomRestoreSubscription = null;
+      _zoomRestoreWatchdog?.cancel();
+      _zoomRestoreWatchdog = null;
+      if (mounted) {
+        _restoreAssetPosition(null);
       }
     }
-    return targetAssetIndex;
+
+    _zoomRestoreSubscription = ref.listenManual(timelineSegmentProvider, (previous, next) {
+      if (!next.hasValue || next.isLoading) {
+        return;
+      }
+      if (ref.read(timelineArgsProvider).columnCount != targetCols) {
+        return;
+      }
+      run();
+    });
+    _zoomRestoreWatchdog = Timer(const Duration(milliseconds: 1500), () {
+      // The segment provider never emitted at the target column count — surface
+      // it in debug so a real stall is visible instead of silently swallowed.
+      assert(() {
+        debugPrint('Timeline zoom-restore watchdog fired for cols=$targetCols');
+        return true;
+      }());
+      run();
+    });
+  }
+
+  // Tapping a tile in the dense layout starts a synthetic zoom session into the tapped
+  // photo, stepping one stop denser — through the same engine as a pinch.
+  void _zoomInOnAsset(int assetIndex) {
+    final args = ref.read(timelineArgsProvider);
+    final current = args.columnCount;
+    final denser = kTimelineZoomStops.where((stop) => stop < current).toList();
+    if (denser.isEmpty) {
+      return;
+    }
+    final target = denser.reduce(math.max);
+    final segments = ref.read(timelineSegmentProvider).valueOrNull;
+    if (segments == null) {
+      return;
+    }
+    final rect = _anchorTileRect(segments, assetIndex, current, args.maxWidth);
+    final focalViewport = rect?.center ?? Offset(args.maxWidth / 2, args.maxHeight / 2);
+    _beginZoomSession(
+      segments: segments,
+      focal: focalViewport,
+      baseCols: current,
+      anchorAssetIndex: assetIndex,
+      focalViewport: focalViewport,
+    );
+    _primeZoomAssetWindow();
+    unawaited(_precacheViewportWindow());
+    _commitZoom(target);
+  }
+
+  void _updateFloatingDate() {
+    if (!_scrollController.hasClients) {
+      return;
+    }
+    // Only relevant in the continuous (header-less) layout: "No grouping" mode or
+    // the wide zoom-out levels.
+    final groupBy = ref.read(appConfigProvider.select((c) => c.timeline.groupAssetsBy));
+    final columnCount = ref.read(timelineArgsProvider).columnCount;
+    if (!isContinuousTimelineLayout(columnCount, groupBy)) {
+      _floatingDate.value = null;
+      return;
+    }
+    final segments = ref.read(timelineSegmentProvider).valueOrNull;
+    if (segments == null || segments.isEmpty) {
+      return;
+    }
+    final index = _getCurrentAssetIndex(segments);
+    if (index == null) {
+      return;
+    }
+    _floatingDate.value = ref.read(timelineServiceProvider).getAssetSafe(index)?.createdAt;
+  }
+
+  void _schedulePrecache() {
+    _precacheTimer?.cancel();
+    // 30ms is enough to coalesce a scroll burst but short enough that the first
+    // segment-settle after app launch kicks off the wide-zoom precache right away,
+    // so the cache is mostly warm by the time the user pinches out.
+    _precacheTimer = Timer(const Duration(milliseconds: 30), () => unawaited(_precacheViewportWindow()));
+  }
+
+  void _primeZoomAssetWindow() {
+    final service = ref.read(timelineServiceProvider);
+    final total = service.totalAssets;
+    if (total == 0) {
+      return;
+    }
+    const window = 512;
+    final focal = (_pinchAnchorAssetIndex ?? 0).clamp(0, total - 1);
+    final start = math.max(0, focal - window ~/ 2);
+    final count = math.min(window, total - start);
+    unawaited(service.loadAssets(start, count).catchError((_) => const <BaseAsset>[]));
+  }
+
+  // Proactively warms the thumbnail cache around the viewport so committing a zoom
+  // (in either direction) finds the new tiles already decoded instead of streaming
+  // them in on the swap. The asset window is fetched read-only via peekAssets — it
+  // never mutates the grid's shared buffer, so it can't race with scrolling — and
+  // each asset is decoded at the current level's bucket plus the adjacent stops'.
+  Future<void> _precacheViewportWindow() async {
+    if (!mounted || !_scrollController.hasClients) {
+      return;
+    }
+    final segments = ref.read(timelineSegmentProvider).valueOrNull;
+    if (segments == null || segments.isEmpty) {
+      return;
+    }
+    final service = ref.read(timelineServiceProvider);
+    if (service.totalAssets == 0) {
+      return;
+    }
+    final topIndex = _getCurrentAssetIndex(segments) ?? 0;
+    final args = ref.read(timelineArgsProvider);
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    int bucketFor(int cols) {
+      final spacing = cols >= kTimelineMonthLabelMaxColumns ? 0.0 : kTimelineSpacing;
+      final tile = (args.maxWidth - spacing * (cols - 1)) / cols;
+      return thumbnailDecodeEdge(tile, dpr);
+    }
+
+    // Warm all wider stops' thumbnails plus the next-finer stop for a zoom-in.
+    // The tiny-thumbnail cache tier (8000 entries, ~96 MiB) easily holds the
+    // dense levels so they can't evict the normal thumbnails the visible grid is
+    // using. Each "tile-budget" is set to roughly the visible window at that
+    // stop so the first time a user lands on a wide level there's nothing left
+    // to decode on screen.
+    final cols = args.columnCount;
+    final widerStops = kTimelineZoomStops.where((s) => s > cols).toList();
+    final closer = kTimelineZoomStops.where((s) => s < cols).fold<int?>(null, (a, b) => a == null ? b : math.max(a, b));
+    final targets = <int>{...widerStops, if (closer != null) closer};
+    if (targets.isEmpty) {
+      return;
+    }
+    final widest = targets.reduce(math.max);
+    // Wider stops have many more tiles per viewport, so use a larger asset
+    // window. Tuned to fit a typical visible viewport at each stop without
+    // saturating the image-decode pool against foreground tiles.
+    final window = widest >= 32
+        ? 1000
+        : widest >= 16
+        ? 480
+        : 240;
+    final assets = await service.peekAssets(math.max(0, topIndex - window ~/ 4), window);
+    if (!mounted) {
+      return;
+    }
+    for (final target in targets) {
+      final size = Size.square(bucketFor(target).toDouble());
+      for (final asset in assets) {
+        final provider = getThumbnailImageProvider(asset, size: size);
+        if (provider != null) {
+          unawaited(precacheImage(provider, context));
+        }
+      }
+    }
   }
 
   @override
   void dispose() {
+    _precacheTimer?.cancel();
+    _zoomRestoreSubscription?.close();
+    _zoomRestoreWatchdog?.cancel();
+    _scrollController.removeListener(_updateFloatingDate);
     _scrollController.dispose();
+    _floatingDate.dispose();
     _eventSubscription?.cancel();
     super.dispose();
   }
@@ -359,11 +681,36 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
   @override
   Widget build(BuildContext _) {
+    // Width-change restores: when the timeline rebuilds for a maxWidth change
+    // (e.g. orientation), didUpdateWidget seeds _restoreAssetIndex without arming
+    // the zoom-commit one-shot. This listener finishes the restore once the new
+    // segments arrive. (Zoom commits go through _armZoomRestore and do NOT rely
+    // on this listener.) The precache warm always runs on settled emissions.
+    ref.listen(timelineSegmentProvider, (previous, next) {
+      if (!next.hasValue || next.isLoading) {
+        return;
+      }
+      if (_restoreAssetIndex != null && _zoomRestoreSubscription == null) {
+        _restoreAssetPosition(null);
+      }
+      _schedulePrecache();
+    });
+
     final asyncSegments = ref.watch(timelineSegmentProvider);
     final maxHeight = ref.watch(timelineArgsProvider.select((args) => args.maxHeight));
     final isSelectionMode = ref.watch(multiSelectProvider.select((s) => s.forceEnable));
     final isMultiSelectEnabled = ref.watch(multiSelectProvider.select((s) => s.isEnabled));
     final isReadonlyModeEnabled = ref.watch(readonlyModeProvider);
+    final groupBy = ref.watch(appConfigProvider.select((c) => c.timeline.groupAssetsBy));
+    final columnCount = ref.watch(timelineArgsProvider.select((args) => args.columnCount));
+    final isContinuous = isContinuousTimelineLayout(columnCount, groupBy);
+    // At the widest zoom levels (>=16) we replace the single top floating date with
+    // a vertical strip of multiple month/year labels along the left edge — iOS's
+    // year/month-view style. At narrower continuous levels (no-grouping mode at
+    // <=6 cols) we keep the single floating label since there's effectively one
+    // date visible per scroll-burst.
+    final showLeftDateStrip = isContinuous && columnCount >= kTimelineMonthLabelMaxColumns;
+    final showFloatingDate = isContinuous && !showLeftDateStrip;
     final isMultiSelectStatusVisible = !isSelectionMode && isMultiSelectEnabled;
     final isBottomWidgetVisible =
         widget.bottomSheet != null && (isMultiSelectStatusVisible || widget.persistentBottomBar);
@@ -380,120 +727,228 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
         child: Scaffold(
           resizeToAvoidBottomInset: false,
           floatingActionButton: const DownloadStatusFloatingButton(),
+          // skipLoadingOnRefresh defaults to true — during a zoom commit the
+          // segment provider is refreshing, so the previous segments stay rendered
+          // until the new ones arrive (no white-flash). The loading widget only
+          // shows on the first-ever load when there's no previous value.
           body: asyncSegments.widgetWhen(
             onLoading: widget.loadingWidget != null ? () => widget.loadingWidget! : null,
-            onData: (segments) {
-              final childCount = (segments.lastOrNull?.lastIndex ?? -1) + 1;
-              final double appBarExpandedHeight = widget.appBar != null && widget.appBar is MesmerizingSliverAppBar
-                  ? 200
-                  : 0;
-              final topPadding = context.padding.top + (widget.appBar == null ? 0 : kToolbarHeight) + 10;
-
-              const bottomSheetOpenModifier = 120.0;
-              final contentBottomPadding =
-                  context.padding.bottom + (isMultiSelectEnabled ? bottomSheetOpenModifier : 0);
-              final scrubberBottomPadding = contentBottomPadding + kScrubberThumbHeight;
-
-              final grid = CustomScrollView(
-                primary: true,
-                physics: _scrollPhysics,
-                scrollCacheExtent: .pixels(maxHeight * 2),
-                slivers: [
-                  if (isSelectionMode) const SelectionSliverAppBar() else if (widget.appBar != null) widget.appBar!,
-                  if (widget.topSliverWidget != null) widget.topSliverWidget!,
-                  _SliverSegmentedList(
-                    segments: segments,
-                    delegate: SliverChildBuilderDelegate(
-                      (ctx, index) {
-                        if (index >= childCount) {
-                          return null;
-                        }
-                        final segment = segments.findByIndex(index);
-                        return segment?.builder(ctx, index) ?? const SizedBox.shrink();
-                      },
-                      childCount: childCount,
-                      addAutomaticKeepAlives: false,
-                      // We add repaint boundary around tiles, so skip the auto boundaries
-                      addRepaintBoundaries: false,
-                    ),
-                  ),
-                  if (widget.bottomSliverWidget != null) widget.bottomSliverWidget!,
-                  SliverPadding(padding: EdgeInsets.only(bottom: contentBottomPadding)),
-                ],
-              );
-
-              final Widget timeline;
-              if (widget.withScrubber) {
-                timeline = Scrubber(
-                  snapToMonth: widget.snapToMonth,
-                  layoutSegments: segments,
-                  timelineHeight: maxHeight,
-                  topPadding: topPadding,
-                  bottomPadding: scrubberBottomPadding,
-                  monthSegmentSnappingOffset: widget.topSliverWidgetHeight ?? 0 + appBarExpandedHeight,
-                  hasAppBar: widget.appBar != null,
-                  child: grid,
-                );
-              } else {
-                timeline = grid;
-              }
-
-              return RawGestureDetector(
-                gestures: {
-                  CustomScaleGestureRecognizer: GestureRecognizerFactoryWithHandlers<CustomScaleGestureRecognizer>(
-                    () => CustomScaleGestureRecognizer(),
-                    (CustomScaleGestureRecognizer scale) {
-                      scale.onStart = (details) {
-                        _baseScaleFactor = _scaleFactor;
-                      };
-
-                      scale.onUpdate = (details) {
-                        final newScaleFactor = math.max(math.min(5.0, _baseScaleFactor * details.scale), 1.0);
-                        final newPerRow = 7 - newScaleFactor.toInt();
-
-                        if (newPerRow != _perRow) {
-                          final targetAssetIndex = _getCurrentAssetIndex(segments);
-                          setState(() {
-                            _scaleFactor = newScaleFactor;
-                            _perRow = newPerRow;
-                            _restoreAssetIndex = targetAssetIndex;
-                          });
-
-                          ref.read(metadataProvider).write(MetadataKey.timelineTilesPerRow, _perRow);
-                        }
-                      };
-                    },
-                  ),
-                },
-                child: TimelineDragRegion(
-                  onStart: !isReadonlyModeEnabled ? _setDragStartIndex : null,
-                  onAssetEnter: _handleDragAssetEnter,
-                  onEnd: !isReadonlyModeEnabled ? _stopDrag : null,
-                  onScroll: _dragScroll,
-                  onScrollStart: () {
-                    // Minimize the bottom sheet when drag selection starts
-                    ref.read(timelineStateProvider.notifier).setScrolling(true);
-                  },
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      timeline,
-                      if (isBottomWidgetVisible)
-                        Positioned(
-                          top: MediaQuery.paddingOf(context).top,
-                          left: 25,
-                          child: const SizedBox(
-                            height: kToolbarHeight,
-                            child: Center(child: _MultiSelectStatusButton()),
-                          ),
-                        ),
-                      if (isBottomWidgetVisible) widget.bottomSheet!,
-                    ],
-                  ),
-                ),
-              );
-            },
+            onData: (segments) => _buildLoadedTimeline(
+              context,
+              segments,
+              maxHeight: maxHeight,
+              isSelectionMode: isSelectionMode,
+              isMultiSelectEnabled: isMultiSelectEnabled,
+              isReadonlyModeEnabled: isReadonlyModeEnabled,
+              columnCount: columnCount,
+              showFloatingDate: showFloatingDate,
+              showLeftDateStrip: showLeftDateStrip,
+              isBottomWidgetVisible: isBottomWidgetVisible,
+            ),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadedTimeline(
+    BuildContext context,
+    List<Segment> segments, {
+    required double maxHeight,
+    required bool isSelectionMode,
+    required bool isMultiSelectEnabled,
+    required bool isReadonlyModeEnabled,
+    required int columnCount,
+    required bool showFloatingDate,
+    required bool showLeftDateStrip,
+    required bool isBottomWidgetVisible,
+  }) {
+    final childCount = (segments.lastOrNull?.lastIndex ?? -1) + 1;
+    final double appBarExpandedHeight = widget.appBar != null && widget.appBar is MesmerizingSliverAppBar ? 200 : 0;
+    final topPadding = context.padding.top + (widget.appBar == null ? 0 : kToolbarHeight) + 10;
+
+    const bottomSheetOpenModifier = 120.0;
+    final contentBottomPadding = context.padding.bottom + (isMultiSelectEnabled ? bottomSheetOpenModifier : 0);
+    final scrubberBottomPadding = contentBottomPadding + kScrubberThumbHeight;
+
+    final grid = CustomScrollView(
+      primary: true,
+      physics: _scrollPhysics,
+      scrollCacheExtent: .pixels(maxHeight * 2),
+      slivers: [
+        // Hide the app bar during a zoom: it lives in this scroll view (for its
+        // floating behavior), so it would otherwise scale/slide with the grid. It
+        // keeps its space (no layout jump) and fades back in once the zoom settles.
+        if (isSelectionMode)
+          const SelectionSliverAppBar()
+        else if (widget.appBar != null)
+          SliverOpacity(opacity: _zoomActive ? 0.0 : 1.0, sliver: widget.appBar!),
+        if (widget.topSliverWidget != null) widget.topSliverWidget!,
+        _SliverSegmentedList(
+          segments: segments,
+          delegate: SliverChildBuilderDelegate(
+            (ctx, index) {
+              if (index >= childCount) {
+                return null;
+              }
+              final segment = segments.findByIndex(index);
+              return segment?.builder(ctx, index) ?? const SizedBox.shrink();
+            },
+            childCount: childCount,
+            addAutomaticKeepAlives: false,
+            // We add repaint boundary around tiles, so skip the auto boundaries
+            addRepaintBoundaries: false,
+          ),
+        ),
+        if (widget.bottomSliverWidget != null) widget.bottomSliverWidget!,
+        SliverPadding(padding: EdgeInsets.only(bottom: contentBottomPadding)),
+      ],
+    );
+
+    // Keep the widget tree STABLE across the pinch — toggling tree shapes (Scrubber
+    // wrapped vs Transform wrapped) re-elements the CustomScrollView, which destroys
+    // the Scrollable's ScrollPosition and snaps you back to offset 0. So the tree is
+    // always Scrubber(child: grid), and the live pinch scale is applied via a
+    // Transform.scale that's ALWAYS in the tree (identity when not zooming).
+    Widget timeline = widget.withScrubber
+        ? Scrubber(
+            snapToMonth: widget.snapToMonth,
+            layoutSegments: segments,
+            timelineHeight: maxHeight,
+            topPadding: topPadding,
+            bottomPadding: scrubberBottomPadding,
+            monthSegmentSnappingOffset: widget.topSliverWidgetHeight ?? 0 + appBarExpandedHeight,
+            hasAppBar: widget.appBar != null,
+            child: grid,
+          )
+        : grid;
+    final realScale = _zoomActive ? math.pow(2.0, _zLive - _zBase).toDouble() : 1.0;
+    timeline = Transform.scale(scale: realScale, alignment: Alignment.topLeft, origin: _focalViewport, child: timeline);
+
+    return RawGestureDetector(
+      gestures: {
+        CustomScaleGestureRecognizer: GestureRecognizerFactoryWithHandlers<CustomScaleGestureRecognizer>(
+          () => CustomScaleGestureRecognizer(),
+          (CustomScaleGestureRecognizer scale) {
+            scale.onStart = (details) {
+              // The recognizer emits a spurious onStart when a finger lifts (either just
+              // before OR just after onEnd), which would wipe the accumulated zoom state
+              // or abort an in-flight commit. Ignore any re-start while a session is
+              // already active (pinch, settle, or commit); the next real pinch begins
+              // once the session has fully revealed (_zoomActive == false).
+              if (_zoomActive) {
+                return;
+              }
+              // Capture the focal coordinate (the continuous asset position under the
+              // fingers). Cancels any in-flight settle and starts a fresh session; the
+              // session only becomes "active" once a real two-finger pinch is seen.
+              _beginZoomSession(
+                segments: segments,
+                focal: details.localFocalPoint,
+                baseCols: ref.read(timelineArgsProvider).columnCount,
+              );
+            };
+
+            scale.onUpdate = (details) {
+              // Track the live focal position (centroid for 2+ fingers, single finger
+              // otherwise) and re-capture the anchor + green highlight from it. We do
+              // this even on single-finger drags so the debug overlay always reflects
+              // what the system thinks is under the finger — except mid-pinch with a
+              // finger briefly lifted, where we keep the last 2-finger anchor stable.
+              final isPinching = _zoomActive;
+              final hasTwoFingers = details.pointerCount >= 2;
+              if (!isPinching || hasTwoFingers) {
+                _focalViewport = details.localFocalPoint;
+                final cols = ref.read(timelineArgsProvider).columnCount;
+                final anchor = _assetUnderFocal(segments, _focalViewport, cols);
+                if (anchor != null) {
+                  _pinchAnchorAssetIndex = anchor;
+                }
+              }
+              // Only a true two-finger pinch zooms; single-finger pans scroll as usual.
+              if (!hasTwoFingers) {
+                return;
+              }
+              if (!_zoomActive) {
+                _zoomActive = true;
+                ref.read(timelineStateProvider.notifier).setPinching(true);
+                _primeZoomAssetWindow();
+                unawaited(_precacheViewportWindow());
+              }
+              final rawZDelta = math.log(details.scale) / math.ln2;
+              final z = (_zBase + rawZDelta * _kPinchDampening).clamp(_zMin, _zMax).toDouble();
+              setState(() => _zLive = z);
+            };
+
+            scale.onEnd = (details) {
+              if (!_zoomActive) {
+                _zLive = _zBase;
+                return;
+              }
+              // Re-anchor on whatever was under the fingers right before release —
+              // that's the scale pivot's fixed point and the row we restore around.
+              final committed = ref.read(timelineArgsProvider).columnCount;
+              final anchor = _assetUnderFocal(segments, _focalViewport, committed);
+              if (anchor != null) {
+                _pinchAnchorAssetIndex = anchor;
+              }
+              final target = _colsForStopZ(_zLive);
+              if (target == committed) {
+                // Stayed on the committed level — just drop the live scale.
+                ref.read(timelineStateProvider.notifier).setPinching(false);
+                if (mounted) {
+                  setState(() {
+                    _zoomActive = false;
+                    _zLive = _zBase;
+                  });
+                }
+              } else {
+                _commitZoom(target);
+              }
+            };
+          },
+        ),
+      },
+      child: TimelineDragRegion(
+        onStart: !isReadonlyModeEnabled ? _setDragStartIndex : null,
+        onAssetEnter: _handleDragAssetEnter,
+        onEnd: !isReadonlyModeEnabled ? _stopDrag : null,
+        onScroll: _dragScroll,
+        onScrollStart: () {
+          // Minimize the bottom sheet when drag selection starts
+          ref.read(timelineStateProvider.notifier).setScrolling(true);
+        },
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            RepaintBoundary(child: timeline),
+            if (showFloatingDate && !_zoomActive)
+              Positioned(
+                top: topPadding,
+                left: 0,
+                right: 0,
+                child: IgnorePointer(
+                  child: _FloatingDateLabel(date: _floatingDate, columnCount: columnCount),
+                ),
+              ),
+            if (showLeftDateStrip && !_zoomActive)
+              _LeftDateStrip(
+                scrollController: _scrollController,
+                segments: segments,
+                topPadding: topPadding,
+                columnCount: columnCount,
+              ),
+            if (isBottomWidgetVisible)
+              Positioned(
+                top: MediaQuery.paddingOf(context).top,
+                left: 25,
+                child: const SizedBox(
+                  height: kToolbarHeight,
+                  child: Center(child: _MultiSelectStatusButton()),
+                ),
+              ),
+            if (isBottomWidgetVisible) widget.bottomSheet!,
+          ],
         ),
       ),
     );
@@ -503,7 +958,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 class _SliverSegmentedList extends SliverMultiBoxAdaptorWidget {
   final List<Segment> _segments;
 
-  const _SliverSegmentedList({required this._segments, required super.delegate});
+  const _SliverSegmentedList({required List<Segment> segments, required super.delegate}) : _segments = segments;
 
   @override
   _RenderSliverTimelineBoxAdaptor createRenderObject(BuildContext context) =>
@@ -527,7 +982,8 @@ class _RenderSliverTimelineBoxAdaptor extends RenderSliverMultiBoxAdaptor {
     markNeedsLayout();
   }
 
-  _RenderSliverTimelineBoxAdaptor({required super.childManager, required this._segments});
+  _RenderSliverTimelineBoxAdaptor({required super.childManager, required List<Segment> segments})
+    : _segments = segments;
 
   int getMinChildIndexForScrollOffset(double offset) =>
       _segments.findByOffset(offset)?.getMinChildIndexForScrollOffset(offset) ?? 0;
@@ -719,6 +1175,158 @@ class _MultiSelectStatusButton extends ConsumerWidget {
       ),
     );
   }
+}
+
+/// Sticky overlay showing the date of the topmost visible asset while the
+/// timeline is in the continuous "No grouping" layout (which has no headers).
+/// The label granularity coarsens as the grid zooms out.
+class _FloatingDateLabel extends StatelessWidget {
+  const _FloatingDateLabel({required this.date, required this.columnCount});
+
+  final ValueNotifier<DateTime?> date;
+  final int columnCount;
+
+  String _format(DateTime value) {
+    if (columnCount <= kTimelineGroupedMaxColumnCount) {
+      return DateFormat.yMMMd().format(value);
+    }
+    if (columnCount <= kTimelineMonthLabelMaxColumns) {
+      return DateFormat.yMMMM().format(value);
+    }
+    return DateFormat.y().format(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DateTime?>(
+      valueListenable: date,
+      builder: (context, value, _) {
+        return AnimatedOpacity(
+          opacity: value == null ? 0 : 1,
+          duration: const Duration(milliseconds: 150),
+          child: value == null
+              ? const SizedBox.shrink()
+              : Center(
+                  child: Container(
+                    margin: const EdgeInsets.only(top: 8),
+                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: context.colorScheme.surfaceContainerHighest.withValues(alpha: 0.9),
+                      borderRadius: const BorderRadius.all(Radius.circular(20)),
+                    ),
+                    child: Text(
+                      _format(value),
+                      style: context.textTheme.labelLarge?.copyWith(color: context.colorScheme.onSurface),
+                    ),
+                  ),
+                ),
+        );
+      },
+    );
+  }
+}
+
+/// Vertical strip of month/year labels along the left side of the timeline at the
+/// wide zoom levels. The strip walks the segments (chunked, each carrying its first
+/// asset's date) and emits a label whenever the month (or year, at the widest stop)
+/// changes — so multiple dates are visible at once, like the iOS Photos year/month
+/// views. Hidden while the scrubber is active to avoid showing date info twice.
+class _LeftDateStrip extends ConsumerWidget {
+  const _LeftDateStrip({
+    required this.scrollController,
+    required this.segments,
+    required this.topPadding,
+    required this.columnCount,
+  });
+
+  final ScrollController scrollController;
+  final List<Segment> segments;
+  final double topPadding;
+  final int columnCount;
+
+  bool _isNewBucket(DateTime? prev, DateTime current) {
+    if (prev == null) {
+      return true;
+    }
+    if (columnCount > kTimelineMonthLabelMaxColumns) {
+      return prev.year != current.year;
+    }
+    return prev.year != current.year || prev.month != current.month;
+  }
+
+  String _format(DateTime date) {
+    if (columnCount > kTimelineMonthLabelMaxColumns) {
+      return DateFormat.y().format(date);
+    }
+    return DateFormat.yMMM().format(date);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isScrubbing = ref.watch(timelineStateProvider.select((s) => s.isScrubbing));
+    if (isScrubbing) {
+      return const SizedBox.shrink();
+    }
+    return AnimatedBuilder(
+      animation: scrollController,
+      builder: (context, _) {
+        if (!scrollController.hasClients) {
+          return const SizedBox.shrink();
+        }
+        final scrollOffset = scrollController.offset;
+        final viewportHeight = scrollController.position.viewportDimension;
+        final labels = <_DateLabelPosition>[];
+        DateTime? previousDate;
+        for (final segment in segments) {
+          final bucket = segment.bucket;
+          if (bucket is! TimeBucket) {
+            previousDate = null;
+            continue;
+          }
+          final date = bucket.date;
+          if (_isNewBucket(previousDate, date)) {
+            final y = topPadding + segment.startOffset - scrollOffset;
+            if (y > -40 && y < viewportHeight + 40) {
+              labels.add(_DateLabelPosition(date: date, y: y));
+            }
+          }
+          previousDate = date;
+        }
+        if (labels.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            for (final label in labels)
+              Positioned(
+                top: label.y,
+                left: 6,
+                child: IgnorePointer(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: context.colorScheme.surfaceContainerHighest.withValues(alpha: 0.82),
+                      borderRadius: const BorderRadius.all(Radius.circular(10)),
+                    ),
+                    child: Text(
+                      _format(label.date),
+                      style: context.textTheme.labelSmall?.copyWith(color: context.colorScheme.onSurface),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _DateLabelPosition {
+  const _DateLabelPosition({required this.date, required this.y});
+  final DateTime date;
+  final double y;
 }
 
 /// accepts a gesture even though it should reject it (because child won)

--- a/mobile/lib/presentation/widgets/timeline/timeline_drag_region.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_drag_region.dart
@@ -39,6 +39,10 @@ class _TimelineDragRegionState extends State<TimelineDragRegion> {
   Timer? scrollTimer;
   late bool scrollNotified;
 
+  // Number of fingers currently down in this region. Drag-to-select must only start
+  // with a single finger, so a two-finger pinch-zoom doesn't also select assets.
+  int _activePointers = 0;
+
   @override
   void initState() {
     super.initState();
@@ -62,14 +66,19 @@ class _TimelineDragRegionState extends State<TimelineDragRegion> {
 
   @override
   Widget build(BuildContext context) {
-    return RawGestureDetector(
-      gestures: {
-        _CustomLongPressGestureRecognizer: GestureRecognizerFactoryWithHandlers<_CustomLongPressGestureRecognizer>(
-          () => _CustomLongPressGestureRecognizer(),
-          _registerCallbacks,
-        ),
-      },
-      child: widget.child,
+    return Listener(
+      onPointerDown: (_) => _activePointers++,
+      onPointerUp: (_) => _activePointers = _activePointers > 0 ? _activePointers - 1 : 0,
+      onPointerCancel: (_) => _activePointers = _activePointers > 0 ? _activePointers - 1 : 0,
+      child: RawGestureDetector(
+        gestures: {
+          _CustomLongPressGestureRecognizer: GestureRecognizerFactoryWithHandlers<_CustomLongPressGestureRecognizer>(
+            () => _CustomLongPressGestureRecognizer(),
+            _registerCallbacks,
+          ),
+        },
+        child: widget.child,
+      ),
     );
   }
 
@@ -97,6 +106,12 @@ class _TimelineDragRegionState extends State<TimelineDragRegion> {
   }
 
   void _onLongPressStart(LongPressStartDetails event) {
+    // Only start drag-select with a single finger; ignore it during a pinch.
+    if (_activePointers > 1) {
+      anchorAsset = null;
+      return;
+    }
+
     /// Calculate widget height and scroll offset when long press starting instead of in [initState]
     /// or [didChangeDependencies] as the grid might still be rendering into view to get the actual size
     final height = context.size?.height;

--- a/mobile/lib/utils/cache/custom_image_cache.dart
+++ b/mobile/lib/utils/cache/custom_image_cache.dart
@@ -2,19 +2,27 @@ import 'package:flutter/painting.dart';
 import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumb_hash_provider.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 
-/// [ImageCache] that uses two caches for small and large images
-/// so that a single large image does not evict all small images
+/// [ImageCache] that segments by image size so one class of image can't evict
+/// another: full images ([_large]), normal thumbnails ([_small]), the dense
+/// zoom-out tiles ([_tiny]) and thumbhashes ([_thumbhash]).
 final class CustomImageCache implements ImageCache {
   final _thumbhash = ImageCache()..maximumSize = 0;
   final _small = ImageCache();
   final _large = ImageCache()..maximumSize = 5; // Maximum 5 images
+  // Dense zoom-out grids show hundreds of tiny tiles per screen. They get their
+  // own high-count tier so they don't evict normal thumbnails; bytes stay bounded
+  // because each tile is only a few KB at these edges.
+  final _tiny = ImageCache()
+    ..maximumSize = 8000
+    ..maximumSizeBytes = 96 << 20; // 96 MiB
 
   @override
-  int get maximumSize => _small.maximumSize + _large.maximumSize;
+  int get maximumSize => _small.maximumSize + _large.maximumSize + _tiny.maximumSize;
 
   @override
-  int get maximumSizeBytes => _small.maximumSizeBytes + _large.maximumSizeBytes;
+  int get maximumSizeBytes => _small.maximumSizeBytes + _large.maximumSizeBytes + _tiny.maximumSizeBytes;
 
   @override
   set maximumSize(int value) => _small.maximumSize = value;
@@ -26,12 +34,14 @@ final class CustomImageCache implements ImageCache {
   void clear() {
     _small.clear();
     _large.clear();
+    _tiny.clear();
   }
 
   @override
   void clearLiveImages() {
     _small.clearLiveImages();
     _large.clearLiveImages();
+    _tiny.clearLiveImages();
   }
 
   /// Gets the cache for the given key
@@ -39,6 +49,8 @@ final class CustomImageCache implements ImageCache {
     return switch (key) {
       LocalFullImageProvider() || RemoteFullImageProvider() => _large,
       ThumbHashProvider() => _thumbhash,
+      RemoteImageProvider(:final decodeEdge?) when decodeEdge <= kTinyThumbnailMaxEdge => _tiny,
+      LocalThumbProvider(:final size) when size.shortestSide <= kTinyThumbnailMaxEdge => _tiny,
       _ => _small,
     };
   }
@@ -51,19 +63,19 @@ final class CustomImageCache implements ImageCache {
   }
 
   @override
-  int get currentSize => _small.currentSize + _large.currentSize;
+  int get currentSize => _small.currentSize + _large.currentSize + _tiny.currentSize;
 
   @override
-  int get currentSizeBytes => _small.currentSizeBytes + _large.currentSizeBytes;
+  int get currentSizeBytes => _small.currentSizeBytes + _large.currentSizeBytes + _tiny.currentSizeBytes;
 
   @override
   bool evict(Object key, {bool includeLive = true}) => _cacheForKey(key).evict(key, includeLive: includeLive);
 
   @override
-  int get liveImageCount => _small.liveImageCount + _large.liveImageCount;
+  int get liveImageCount => _small.liveImageCount + _large.liveImageCount + _tiny.liveImageCount;
 
   @override
-  int get pendingImageCount => _small.pendingImageCount + _large.pendingImageCount;
+  int get pendingImageCount => _small.pendingImageCount + _large.pendingImageCount + _tiny.pendingImageCount;
 
   @override
   ImageStreamCompleter? putIfAbsent(

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/metadata.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
 import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 
@@ -21,6 +22,11 @@ class GroupSettings extends HookConsumerWidget {
     Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
       await ref.read(metadataProvider).write(MetadataKey.timelineGroupAssetsBy, groupBy);
       ref.invalidate(appSettingsServiceProvider);
+      // Force the timeline service to recreate with the new grouping while we're
+      // still on the settings page — when the user returns to the timeline the
+      // new buckets are already loading and the live grid swaps in without a
+      // visible loading screen.
+      ref.invalidate(timelineServiceProvider);
     }
 
     void changeGroupValue(GroupAssetsBy? value) {
@@ -50,6 +56,10 @@ class GroupSettings extends HookConsumerWidget {
             SettingsRadioGroup(
               title: 'asset_list_layout_settings_group_automatically'.t(context: context),
               value: GroupAssetsBy.auto,
+            ),
+            SettingsRadioGroup(
+              title: 'group_no'.t(context: context),
+              value: GroupAssetsBy.none,
             ),
           ],
           groupBy: groupBy.value,

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
@@ -4,6 +4,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/metadata_key.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/metadata.provider.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
@@ -14,9 +16,18 @@ class LayoutSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final tilesPerRow = useState(ref.read(appConfigProvider.select((s) => s.timeline.tilesPerRow)));
+    // The pinch gesture can set far wider counts (up to 32) than the manual slider
+    // range, so clamp the displayed value to keep the Slider within bounds.
+    final tilesPerRow = useState(
+      ref
+          .read(appConfigProvider.select((s) => s.timeline.tilesPerRow))
+          .clamp(kTimelineSliderMinColumnCount, kTimelineSliderMaxColumnCount),
+    );
     useValueChanged<int, void>(tilesPerRow.value, (_, __) {
       ref.read(metadataProvider).write(MetadataKey.timelineTilesPerRow, tilesPerRow.value);
+      // Slider sets the persisted preference — clear any in-session pinch override
+      // so the new slider value is what the timeline actually shows.
+      ref.read(pinchZoomColumnsProvider.notifier).state = null;
     });
 
     return Column(
@@ -30,9 +41,9 @@ class LayoutSettings extends HookConsumerWidget {
           valueNotifier: tilesPerRow,
           text: 'theme_setting_asset_list_tiles_per_row_title'.tr(namedArgs: {'count': "${tilesPerRow.value}"}),
           label: "${tilesPerRow.value}",
-          maxValue: 6,
-          minValue: 2,
-          noDivisons: 4,
+          maxValue: kTimelineSliderMaxColumnCount.toDouble(),
+          minValue: kTimelineSliderMinColumnCount.toDouble(),
+          noDivisons: kTimelineSliderMaxColumnCount - kTimelineSliderMinColumnCount,
           onChangeEnd: (value) {
             ref.invalidate(appSettingsServiceProvider);
           },

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -48,6 +48,24 @@ void main() {
     });
   });
 
+  group('main assets', () {
+    test('supports GroupAssetsBy.none by slicing all assets into count-based buckets', () async {
+      final user = await ctx.newUser();
+      await ctx.newRemoteAsset(ownerId: user.id);
+      await ctx.newRemoteAsset(ownerId: user.id);
+
+      final query = sut.main([user.id], .none);
+
+      final buckets = await query.bucketSource().first;
+      // none does not group by date; the total asset count is preserved across the segments
+      final total = buckets.fold<int>(0, (acc, bucket) => acc + bucket.assetCount);
+      expect(total, 2);
+
+      final assets = await query.assetSource(0, 10);
+      expect(assets, hasLength(2));
+    });
+  });
+
   group('person assets', () {
     test('does not duplicate an asset that has multiple face records for the same person', () async {
       // Regression check for #26723: an INNER JOIN between remote_asset_entity and asset_face_entity


### PR DESCRIPTION
## Description

Adds an iOS-Photos-style continuous pinch-to-zoom to the mobile timeline, and
exposes a **"No grouping"** layout for the main Photos timeline. Two related,
additive changes (no existing behavior changes unless the user opts in):

1. **"No grouping" timeline mode** — the main Photos timeline can render as one
   continuous, header-less grid of all assets, selectable from
   Settings → Photo grid → *Group assets by* → *No grouping*. Implements #13845.
   Albums inherit the setting automatically (they fall back to the global grouping
   config), with no album-specific code.

2. **Continuous pinch-zoom** — pinching scales smoothly between discrete stops
   (1, 2, 4, 6, 16, 32 columns) instead of the previous hard 2–6 snap. The photo
   under your fingers stays anchored as the grid resizes, a target grid is
   cross-faded in for an iOS-like transition, and a floating date label
   (day → month → year) overlays the continuous grid. Pinching past the densest
   grouped level switches into the continuous layout; at the widest levels
   inter-tile spacing and overlay icons are hidden. In the zoomed-out layout,
   tapping a tile zooms in one stage (centered on that asset) instead of opening it.

**Scope:** mobile (Flutter) only. **No** server, API, DTO, SDK, or \`.drift\` SQL
changes — the "No grouping" buckets reuse the existing count-based bucket helper
over the local Drift DB.

Fixes #13845

## How Has This Been Tested?

- [x] \`mise //mobile:analyze\` (dart analyze --fatal-infos + DCM) — clean
- [x] \`mise //mobile:format\` — no changes
- [x] \`mise //mobile:test\` — all pass; added a medium test covering
      \`GroupAssetsBy.none\` on the main timeline repository
- [x] Manual, on-device: pinch in to 1 column and out to 32 with the focal photo
      staying anchored; floating date label transitions day→month→year;
      tap-to-zoom-in; grouped (day/month) modes still show date headers;
      persistence across relaunch; album/person/search timelines unaffected

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Implemented with Claude Code assistance; all code was reviewed and tested by me.