### PR TITLE
fix(server): prevent locked assets from leaking to partners

### DIFF
--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -75,7 +75,7 @@ export class SearchService extends BaseService {
 
     const page = dto.page ?? 1;
     const size = dto.size || 250;
-    const userIds = await this.getUserIdsToSearch(auth);
+    const userIds = await this.getUserIdsToSearch(auth, dto.visibility);
     const { hasNextPage, items } = await this.searchRepository.searchMetadata(
       { page, size },
       {
@@ -103,7 +103,7 @@ export class SearchService extends BaseService {
       requireElevatedPermission(auth);
     }
 
-    const userIds = await this.getUserIdsToSearch(auth);
+    const userIds = await this.getUserIdsToSearch(auth, dto.visibility);
     const items = await this.searchRepository.searchRandom(dto.size || 250, { ...dto, userIds });
     return items.map((item) => mapAsset(item, { auth }));
   }
@@ -113,7 +113,7 @@ export class SearchService extends BaseService {
       requireElevatedPermission(auth);
     }
 
-    const userIds = await this.getUserIdsToSearch(auth);
+    const userIds = await this.getUserIdsToSearch(auth, dto.visibility);
     const items = await this.searchRepository.searchLargeAssets(dto.size || 250, { ...dto, userIds });
     return items.map((item) => mapAsset(item, { auth }));
   }
@@ -128,7 +128,7 @@ export class SearchService extends BaseService {
       throw new BadRequestException('Smart search is not enabled');
     }
 
-    const userIds = this.getUserIdsToSearch(auth);
+    const userIds = this.getUserIdsToSearch(auth, dto.visibility);
     let embedding;
     if (dto.query) {
       const key = machineLearning.clip.modelName + dto.query + dto.language;
@@ -202,7 +202,11 @@ export class SearchService extends BaseService {
     }
   }
 
-  private async getUserIdsToSearch(auth: AuthDto): Promise<string[]> {
+  private async getUserIdsToSearch(auth: AuthDto, visibility?: AssetVisibility): Promise<string[]> {
+    // Locked assets are personal. Never include partner IDs, regardless of A's elevated session.
+    if (visibility === AssetVisibility.Locked) {
+      return [auth.user.id];
+    }
     const partnerIds = await getMyPartnerIds({
       userId: auth.user.id,
       repository: this.partnerRepository,

--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -204,5 +204,16 @@ describe(TimelineService.name, () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('should throw an error if withPartners is true and visibility is locked', async () => {
+      await expect(
+        sut.getTimeBucket(authStub.adminWithElevatedPermission, {
+          timeBucket: 'bucket',
+          visibility: AssetVisibility.Locked,
+          withPartners: true,
+          userId: authStub.adminWithElevatedPermission.user.id,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -71,13 +71,14 @@ export class TimelineService extends BaseService {
     }
 
     if (dto.withPartners) {
+      const requestedLocked = dto.visibility === AssetVisibility.Locked;
       const requestedArchived = dto.visibility === AssetVisibility.Archive || dto.visibility === undefined;
       const requestedFavorite = dto.isFavorite === true || dto.isFavorite === false;
       const requestedTrash = dto.isTrashed === true;
 
-      if (requestedArchived || requestedFavorite || requestedTrash) {
+      if (requestedLocked || requestedArchived || requestedFavorite || requestedTrash) {
         throw new BadRequestException(
-          'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+          'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
         );
       }
     }

--- a/server/test/fixtures/auth.stub.ts
+++ b/server/test/fixtures/auth.stub.ts
@@ -41,6 +41,13 @@ export const authStub = {
       id: 'token-id',
     } as AuthSession,
   }),
+  adminWithElevatedPermission: Object.freeze<AuthDto>({
+    user: authUser.admin,
+    session: {
+      id: 'token-id-elevated',
+      hasElevatedPermission: true,
+    } as AuthSession,
+  }),
   adminSharedLink: Object.freeze({
     user: authUser.admin,
     sharedLink: {

--- a/server/test/medium/specs/services/timeline.service.spec.ts
+++ b/server/test/medium/specs/services/timeline.service.spec.ts
@@ -51,13 +51,13 @@ describe(TimelineService.name, () => {
       const response1 = sut.getTimeBuckets(auth, { withPartners: true, visibility: AssetVisibility.Archive });
       await expect(response1).rejects.toBeInstanceOf(BadRequestException);
       await expect(response1).rejects.toThrow(
-        'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+        'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
       );
 
       const response2 = sut.getTimeBuckets(auth, { withPartners: true });
       await expect(response2).rejects.toBeInstanceOf(BadRequestException);
       await expect(response2).rejects.toThrow(
-        'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+        'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
       );
     });
 
@@ -67,13 +67,13 @@ describe(TimelineService.name, () => {
       const response1 = sut.getTimeBuckets(auth, { withPartners: true, isFavorite: false });
       await expect(response1).rejects.toBeInstanceOf(BadRequestException);
       await expect(response1).rejects.toThrow(
-        'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+        'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
       );
 
       const response2 = sut.getTimeBuckets(auth, { withPartners: true, isFavorite: true });
       await expect(response2).rejects.toBeInstanceOf(BadRequestException);
       await expect(response2).rejects.toThrow(
-        'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+        'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
       );
     });
 
@@ -83,7 +83,7 @@ describe(TimelineService.name, () => {
       const response = sut.getTimeBuckets(auth, { withPartners: true, isTrashed: true });
       await expect(response).rejects.toBeInstanceOf(BadRequestException);
       await expect(response).rejects.toThrow(
-        'withPartners is only supported for non-archived, non-trashed, non-favorited assets',
+        'withPartners is only supported for non-archived, non-trashed, non-favorited, non-locked assets',
       );
     });
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`requireElevatedPermission` gates the Locked folder behind PIN/biometric re-auth on the requesting user's session. It does not grant access to a partner's locked assets, but two code paths allowed partner IDs to slip into the owner filter:

- `timeline.service.ts`: the withPartners guard rejected Archive, isFavorite, and isTrashed combinations but not Locked, so { visibility: 'locked', withPartners: true } would  expose B's locked assets to A.
- `search.service.ts`: `getUserIdsToSearch` always returned [self, ...partnerIds] regardless of visibility, meaning all four search endpoints (searchMetadata, searchRandom, searchLargeAssets, searchSmart) queried across partner IDs even when filtering for locked assets.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

identify leaking sites
