### PR TITLE
fix: api repositories using stale endpoint

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -13,7 +13,7 @@ import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 
 class ApiService {
-  late ApiClient _apiClient;
+  final ApiClient _apiClient = ApiClient(basePath: '');
 
   late UsersApi usersApi;
   late AuthenticationApi authenticationApi;
@@ -54,7 +54,7 @@ class ApiService {
   }
 
   setEndpoint(String endpoint) {
-    _apiClient = ApiClient(basePath: endpoint);
+    _apiClient.basePath = endpoint;
     _apiClient.client = NetworkRepository.client;
     usersApi = UsersApi(_apiClient);
     authenticationApi = AuthenticationApi(_apiClient);

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ApiClient {
   ApiClient({this.basePath = '/api', this.authentication,});
 
-  final String basePath;
+  String basePath;
   final Authentication? authentication;
 
   var _client = Client();

--- a/open-api/patch/api_client.dart.patch
+++ b/open-api/patch/api_client.dart.patch
@@ -1,3 +1,12 @@
+@@ -13,7 +13,7 @@
+ class ApiClient {
+   ApiClient({this.basePath = '/api', this.authentication,});
+
+-  final String basePath;
++  String basePath;
+   final Authentication? authentication;
+
+   var _client = Client();
 @@ -143,19 +143,19 @@
      );
    }


### PR DESCRIPTION
Fixes #24510

The API repository providers read the APIs from the API Service Provider which is not rebuilt when endpoints are switched. However, invalidating the API service would force a rebuild on all services / repos / provider depending on it which includes the Auth provider. This is a surgical fix that mutates the existing client used in the API classes with the new basePath so new requests will be made to it and not the old endpoint