### PR TITLE
feat(server): add IMMICH_DISABLE_MIMALLOC env to opt out of libmimalloc preload

### DIFF
--- a/server/bin/start.sh
+++ b/server/bin/start.sh
@@ -16,10 +16,10 @@ log_message() {
 log_message "Initializing Immich $IMMICH_SOURCE_REF"
 
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
-if [ -f "$lib_path" ]; then
+if [ -f "$lib_path" ] && [ "${IMMICH_DISABLE_MIMALLOC:-false}" != "true" ]; then
   export LD_PRELOAD="$lib_path"
 else
-  echo "skipping libmimalloc - path not found $lib_path"
+  echo "skipping libmimalloc"
 fi
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
 SERVER_HOME="$(readlink -f "$(dirname "$0")/..")"


### PR DESCRIPTION
## Description

`server/bin/start.sh` unconditionally `LD_PRELOAD`s `libmimalloc.so.3` when the library file exists. On older Intel Atom CPUs without AVX (Goldmont, Goldmont Plus, Gemini Lake, Apollo Lake — common in low-power home servers like J4105, **N4000**, **N4200**, J4125, N5105), libmimalloc's init segfaults on the very first child-process fork:

```
start.sh[…]: segfault at 5400f0e4 ip …c19 sp … error 6 in env[…]
```

Symptom: `immich_server` enters `Restarting (139)` loop and `docker logs` is empty (env dies before the shebang can resolve bash), so the cause is invisible without `dmesg`. There is currently no way to disable the preload short of mounting a custom `start.sh` over the image.

This PR adds an opt-out env (`IMMICH_DISABLE_MIMALLOC=true`) so users on incompatible CPUs can bypass the preload without rebuilding the image or maintaining a sidecar file. Default behavior is unchanged — env unset → mimalloc still preloads as before.

```yaml
services:
  immich-server:
    environment:
      - IMMICH_DISABLE_MIMALLOC=true
```

Fixes # (no tracked issue — reproducible bug on AVX-less Atom CPUs)

## How Has This Been Tested?

- [x] **Celeron N4000 (Gemini Lake, no AVX)**: with stock image v2.7.5 → `Restarting (139)` loop, dmesg shows `env` segfault. After setting `IMMICH_DISABLE_MIMALLOC=true` → container reaches `healthy`, server logs show normal Nest startup, migrations finish, plugins load.
- [x] **Modern x86_64 host (env unset, default behavior)**: mimalloc still preloads (`log` shows initialization without the "skipping libmimalloc" branch); no regression.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable (happy to add an entry to environment-variables docs in a follow-up if requested)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (no new deps)
- [ ] I have written tests for new code (if applicable — this is a one-line opt-out in a shell script; no test infrastructure exists for start.sh in this repo as far as I can see)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (n/a — shell script only)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) (n/a — shell script only)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The root cause was identified by me (a homelab operator running immich on a Celeron N4000) using `dmesg | grep segfault` after the container fell into a `Restarting (139)` loop on a fresh `v2.7.5` pull, and then narrowed down by reproducing `env <command>` segfault patterns directly with `docker run` against the image entrypoint. The one-line opt-out in `start.sh` is mine.

An LLM (Claude) was used to:
- Draft the wording of this PR description
- Open the PR via the GitHub REST API (fork + branch + commit + pr-create)

No application/server code, tests, or documentation prose beyond this PR description was generated by an LLM.
