### PR TITLE
chore(mobile): make openapi requests abortable

### DIFF
--- a/mobile/openapi/lib/api/activities_api.dart
+++ b/mobile/openapi/lib/api/activities_api.dart
@@ -25,7 +25,7 @@ class ActivitiesApi {
   /// Parameters:
   ///
   /// * [ActivityCreateDto] activityCreateDto (required):
-  Future<Response> createActivityWithHttpInfo(ActivityCreateDto activityCreateDto,) async {
+  Future<Response> createActivityWithHttpInfo(ActivityCreateDto activityCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/activities';
 
@@ -47,6 +47,7 @@ class ActivitiesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class ActivitiesApi {
   /// Parameters:
   ///
   /// * [ActivityCreateDto] activityCreateDto (required):
-  Future<ActivityResponseDto?> createActivity(ActivityCreateDto activityCreateDto,) async {
-    final response = await createActivityWithHttpInfo(activityCreateDto,);
+  Future<ActivityResponseDto?> createActivity(ActivityCreateDto activityCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createActivityWithHttpInfo(activityCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class ActivitiesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteActivityWithHttpInfo(String id,) async {
+  Future<Response> deleteActivityWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/activities/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class ActivitiesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class ActivitiesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteActivity(String id,) async {
-    final response = await deleteActivityWithHttpInfo(id,);
+  Future<void> deleteActivity(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteActivityWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -141,7 +143,7 @@ class ActivitiesApi {
   ///
   /// * [String] userId:
   ///   Filter by user ID
-  Future<Response> getActivitiesWithHttpInfo(String albumId, { String? assetId, ReactionLevel? level, ReactionType? type, String? userId, }) async {
+  Future<Response> getActivitiesWithHttpInfo(String albumId, { String? assetId, ReactionLevel? level, ReactionType? type, String? userId, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/activities';
 
@@ -177,6 +179,7 @@ class ActivitiesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -198,8 +201,8 @@ class ActivitiesApi {
   ///
   /// * [String] userId:
   ///   Filter by user ID
-  Future<List<ActivityResponseDto>?> getActivities(String albumId, { String? assetId, ReactionLevel? level, ReactionType? type, String? userId, }) async {
-    final response = await getActivitiesWithHttpInfo(albumId,  assetId: assetId, level: level, type: type, userId: userId, );
+  Future<List<ActivityResponseDto>?> getActivities(String albumId, { String? assetId, ReactionLevel? level, ReactionType? type, String? userId, Future<void>? abortTrigger, }) async {
+    final response = await getActivitiesWithHttpInfo(albumId, assetId: assetId, level: level, type: type, userId: userId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -229,7 +232,7 @@ class ActivitiesApi {
   ///
   /// * [String] assetId:
   ///   Asset ID (if activity is for an asset)
-  Future<Response> getActivityStatisticsWithHttpInfo(String albumId, { String? assetId, }) async {
+  Future<Response> getActivityStatisticsWithHttpInfo(String albumId, { String? assetId, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/activities/statistics';
 
@@ -256,6 +259,7 @@ class ActivitiesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -270,8 +274,8 @@ class ActivitiesApi {
   ///
   /// * [String] assetId:
   ///   Asset ID (if activity is for an asset)
-  Future<ActivityStatisticsResponseDto?> getActivityStatistics(String albumId, { String? assetId, }) async {
-    final response = await getActivityStatisticsWithHttpInfo(albumId,  assetId: assetId, );
+  Future<ActivityStatisticsResponseDto?> getActivityStatistics(String albumId, { String? assetId, Future<void>? abortTrigger, }) async {
+    final response = await getActivityStatisticsWithHttpInfo(albumId, assetId: assetId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/albums_api.dart
+++ b/mobile/openapi/lib/api/albums_api.dart
@@ -27,7 +27,7 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> addAssetsToAlbumWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> addAssetsToAlbumWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/assets'
       .replaceAll('{id}', id);
@@ -50,6 +50,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -62,8 +63,8 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> addAssetsToAlbum(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await addAssetsToAlbumWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> addAssetsToAlbum(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await addAssetsToAlbumWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -89,7 +90,7 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [AlbumsAddAssetsDto] albumsAddAssetsDto (required):
-  Future<Response> addAssetsToAlbumsWithHttpInfo(AlbumsAddAssetsDto albumsAddAssetsDto,) async {
+  Future<Response> addAssetsToAlbumsWithHttpInfo(AlbumsAddAssetsDto albumsAddAssetsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/assets';
 
@@ -111,6 +112,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -121,8 +123,8 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [AlbumsAddAssetsDto] albumsAddAssetsDto (required):
-  Future<AlbumsAddAssetsResponseDto?> addAssetsToAlbums(AlbumsAddAssetsDto albumsAddAssetsDto,) async {
-    final response = await addAssetsToAlbumsWithHttpInfo(albumsAddAssetsDto,);
+  Future<AlbumsAddAssetsResponseDto?> addAssetsToAlbums(AlbumsAddAssetsDto albumsAddAssetsDto, { Future<void>? abortTrigger, }) async {
+    final response = await addAssetsToAlbumsWithHttpInfo(albumsAddAssetsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -147,7 +149,7 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [AddUsersDto] addUsersDto (required):
-  Future<Response> addUsersToAlbumWithHttpInfo(String id, AddUsersDto addUsersDto,) async {
+  Future<Response> addUsersToAlbumWithHttpInfo(String id, AddUsersDto addUsersDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/users'
       .replaceAll('{id}', id);
@@ -170,6 +172,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -182,8 +185,8 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [AddUsersDto] addUsersDto (required):
-  Future<AlbumResponseDto?> addUsersToAlbum(String id, AddUsersDto addUsersDto,) async {
-    final response = await addUsersToAlbumWithHttpInfo(id, addUsersDto,);
+  Future<AlbumResponseDto?> addUsersToAlbum(String id, AddUsersDto addUsersDto, { Future<void>? abortTrigger, }) async {
+    final response = await addUsersToAlbumWithHttpInfo(id, addUsersDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -206,7 +209,7 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [CreateAlbumDto] createAlbumDto (required):
-  Future<Response> createAlbumWithHttpInfo(CreateAlbumDto createAlbumDto,) async {
+  Future<Response> createAlbumWithHttpInfo(CreateAlbumDto createAlbumDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums';
 
@@ -228,6 +231,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -238,8 +242,8 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [CreateAlbumDto] createAlbumDto (required):
-  Future<AlbumResponseDto?> createAlbum(CreateAlbumDto createAlbumDto,) async {
-    final response = await createAlbumWithHttpInfo(createAlbumDto,);
+  Future<AlbumResponseDto?> createAlbum(CreateAlbumDto createAlbumDto, { Future<void>? abortTrigger, }) async {
+    final response = await createAlbumWithHttpInfo(createAlbumDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -262,7 +266,7 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteAlbumWithHttpInfo(String id,) async {
+  Future<Response> deleteAlbumWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}'
       .replaceAll('{id}', id);
@@ -285,6 +289,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -295,8 +300,8 @@ class AlbumsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteAlbum(String id,) async {
-    final response = await deleteAlbumWithHttpInfo(id,);
+  Future<void> deleteAlbum(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteAlbumWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -315,7 +320,7 @@ class AlbumsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getAlbumInfoWithHttpInfo(String id, { String? key, String? slug, }) async {
+  Future<Response> getAlbumInfoWithHttpInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}'
       .replaceAll('{id}', id);
@@ -345,6 +350,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -359,8 +365,8 @@ class AlbumsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<AlbumResponseDto?> getAlbumInfo(String id, { String? key, String? slug, }) async {
-    final response = await getAlbumInfoWithHttpInfo(id,  key: key, slug: slug, );
+  Future<AlbumResponseDto?> getAlbumInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await getAlbumInfoWithHttpInfo(id, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -387,7 +393,7 @@ class AlbumsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getAlbumMapMarkersWithHttpInfo(String id, { String? key, String? slug, }) async {
+  Future<Response> getAlbumMapMarkersWithHttpInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/map-markers'
       .replaceAll('{id}', id);
@@ -417,6 +423,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -431,8 +438,8 @@ class AlbumsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<List<MapMarkerResponseDto>?> getAlbumMapMarkers(String id, { String? key, String? slug, }) async {
-    final response = await getAlbumMapMarkersWithHttpInfo(id,  key: key, slug: slug, );
+  Future<List<MapMarkerResponseDto>?> getAlbumMapMarkers(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await getAlbumMapMarkersWithHttpInfo(id, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -454,7 +461,7 @@ class AlbumsApi {
   /// Returns statistics about the albums available to the authenticated user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAlbumStatisticsWithHttpInfo() async {
+  Future<Response> getAlbumStatisticsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/statistics';
 
@@ -476,14 +483,15 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve album statistics
   ///
   /// Returns statistics about the albums available to the authenticated user.
-  Future<AlbumStatisticsResponseDto?> getAlbumStatistics() async {
-    final response = await getAlbumStatisticsWithHttpInfo();
+  Future<AlbumStatisticsResponseDto?> getAlbumStatistics({ Future<void>? abortTrigger, }) async {
+    final response = await getAlbumStatisticsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -519,7 +527,7 @@ class AlbumsApi {
   ///
   /// * [String] name:
   ///   Album name (exact match)
-  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, String? id, bool? isOwned, bool? isShared, String? name, }) async {
+  Future<Response> getAllAlbumsWithHttpInfo({ String? assetId, String? id, bool? isOwned, bool? isShared, String? name, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums';
 
@@ -557,6 +565,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -580,8 +589,8 @@ class AlbumsApi {
   ///
   /// * [String] name:
   ///   Album name (exact match)
-  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, String? id, bool? isOwned, bool? isShared, String? name, }) async {
-    final response = await getAllAlbumsWithHttpInfo( assetId: assetId, id: id, isOwned: isOwned, isShared: isShared, name: name, );
+  Future<List<AlbumResponseDto>?> getAllAlbums({ String? assetId, String? id, bool? isOwned, bool? isShared, String? name, Future<void>? abortTrigger, }) async {
+    final response = await getAllAlbumsWithHttpInfo(assetId: assetId, id: id, isOwned: isOwned, isShared: isShared, name: name, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -609,7 +618,7 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> removeAssetFromAlbumWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> removeAssetFromAlbumWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/assets'
       .replaceAll('{id}', id);
@@ -632,6 +641,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -644,8 +654,8 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> removeAssetFromAlbum(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await removeAssetFromAlbumWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> removeAssetFromAlbum(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await removeAssetFromAlbumWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -673,7 +683,7 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [String] userId (required):
-  Future<Response> removeUserFromAlbumWithHttpInfo(String id, String userId,) async {
+  Future<Response> removeUserFromAlbumWithHttpInfo(String id, String userId, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/user/{userId}'
       .replaceAll('{id}', id)
@@ -697,6 +707,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -709,8 +720,8 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [String] userId (required):
-  Future<void> removeUserFromAlbum(String id, String userId,) async {
-    final response = await removeUserFromAlbumWithHttpInfo(id, userId,);
+  Future<void> removeUserFromAlbum(String id, String userId, { Future<void>? abortTrigger, }) async {
+    final response = await removeUserFromAlbumWithHttpInfo(id, userId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -727,7 +738,7 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [UpdateAlbumDto] updateAlbumDto (required):
-  Future<Response> updateAlbumInfoWithHttpInfo(String id, UpdateAlbumDto updateAlbumDto,) async {
+  Future<Response> updateAlbumInfoWithHttpInfo(String id, UpdateAlbumDto updateAlbumDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}'
       .replaceAll('{id}', id);
@@ -750,6 +761,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -762,8 +774,8 @@ class AlbumsApi {
   /// * [String] id (required):
   ///
   /// * [UpdateAlbumDto] updateAlbumDto (required):
-  Future<AlbumResponseDto?> updateAlbumInfo(String id, UpdateAlbumDto updateAlbumDto,) async {
-    final response = await updateAlbumInfoWithHttpInfo(id, updateAlbumDto,);
+  Future<AlbumResponseDto?> updateAlbumInfo(String id, UpdateAlbumDto updateAlbumDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAlbumInfoWithHttpInfo(id, updateAlbumDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -790,7 +802,7 @@ class AlbumsApi {
   /// * [String] userId (required):
   ///
   /// * [UpdateAlbumUserDto] updateAlbumUserDto (required):
-  Future<Response> updateAlbumUserWithHttpInfo(String id, String userId, UpdateAlbumUserDto updateAlbumUserDto,) async {
+  Future<Response> updateAlbumUserWithHttpInfo(String id, String userId, UpdateAlbumUserDto updateAlbumUserDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/albums/{id}/user/{userId}'
       .replaceAll('{id}', id)
@@ -814,6 +826,7 @@ class AlbumsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -828,8 +841,8 @@ class AlbumsApi {
   /// * [String] userId (required):
   ///
   /// * [UpdateAlbumUserDto] updateAlbumUserDto (required):
-  Future<void> updateAlbumUser(String id, String userId, UpdateAlbumUserDto updateAlbumUserDto,) async {
-    final response = await updateAlbumUserWithHttpInfo(id, userId, updateAlbumUserDto,);
+  Future<void> updateAlbumUser(String id, String userId, UpdateAlbumUserDto updateAlbumUserDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAlbumUserWithHttpInfo(id, userId, updateAlbumUserDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/api_keys_api.dart
+++ b/mobile/openapi/lib/api/api_keys_api.dart
@@ -25,7 +25,7 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [ApiKeyCreateDto] apiKeyCreateDto (required):
-  Future<Response> createApiKeyWithHttpInfo(ApiKeyCreateDto apiKeyCreateDto,) async {
+  Future<Response> createApiKeyWithHttpInfo(ApiKeyCreateDto apiKeyCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys';
 
@@ -47,6 +47,7 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [ApiKeyCreateDto] apiKeyCreateDto (required):
-  Future<ApiKeyCreateResponseDto?> createApiKey(ApiKeyCreateDto apiKeyCreateDto,) async {
-    final response = await createApiKeyWithHttpInfo(apiKeyCreateDto,);
+  Future<ApiKeyCreateResponseDto?> createApiKey(ApiKeyCreateDto apiKeyCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createApiKeyWithHttpInfo(apiKeyCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteApiKeyWithHttpInfo(String id,) async {
+  Future<Response> deleteApiKeyWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteApiKey(String id,) async {
-    final response = await deleteApiKeyWithHttpInfo(id,);
+  Future<void> deleteApiKey(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteApiKeyWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -130,7 +132,7 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getApiKeyWithHttpInfo(String id,) async {
+  Future<Response> getApiKeyWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys/{id}'
       .replaceAll('{id}', id);
@@ -153,6 +155,7 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -163,8 +166,8 @@ class APIKeysApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<ApiKeyResponseDto?> getApiKey(String id,) async {
-    final response = await getApiKeyWithHttpInfo(id,);
+  Future<ApiKeyResponseDto?> getApiKey(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getApiKeyWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -183,7 +186,7 @@ class APIKeysApi {
   /// Retrieve all API keys of the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getApiKeysWithHttpInfo() async {
+  Future<Response> getApiKeysWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys';
 
@@ -205,14 +208,15 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// List all API keys
   ///
   /// Retrieve all API keys of the current user.
-  Future<List<ApiKeyResponseDto>?> getApiKeys() async {
-    final response = await getApiKeysWithHttpInfo();
+  Future<List<ApiKeyResponseDto>?> getApiKeys({ Future<void>? abortTrigger, }) async {
+    final response = await getApiKeysWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -234,7 +238,7 @@ class APIKeysApi {
   /// Retrieve the API key that is used to access this endpoint.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getMyApiKeyWithHttpInfo() async {
+  Future<Response> getMyApiKeyWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys/me';
 
@@ -256,14 +260,15 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve the current API key
   ///
   /// Retrieve the API key that is used to access this endpoint.
-  Future<ApiKeyResponseDto?> getMyApiKey() async {
-    final response = await getMyApiKeyWithHttpInfo();
+  Future<ApiKeyResponseDto?> getMyApiKey({ Future<void>? abortTrigger, }) async {
+    final response = await getMyApiKeyWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -288,7 +293,7 @@ class APIKeysApi {
   /// * [String] id (required):
   ///
   /// * [ApiKeyUpdateDto] apiKeyUpdateDto (required):
-  Future<Response> updateApiKeyWithHttpInfo(String id, ApiKeyUpdateDto apiKeyUpdateDto,) async {
+  Future<Response> updateApiKeyWithHttpInfo(String id, ApiKeyUpdateDto apiKeyUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/api-keys/{id}'
       .replaceAll('{id}', id);
@@ -311,6 +316,7 @@ class APIKeysApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -323,8 +329,8 @@ class APIKeysApi {
   /// * [String] id (required):
   ///
   /// * [ApiKeyUpdateDto] apiKeyUpdateDto (required):
-  Future<ApiKeyResponseDto?> updateApiKey(String id, ApiKeyUpdateDto apiKeyUpdateDto,) async {
-    final response = await updateApiKeyWithHttpInfo(id, apiKeyUpdateDto,);
+  Future<ApiKeyResponseDto?> updateApiKey(String id, ApiKeyUpdateDto apiKeyUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateApiKeyWithHttpInfo(id, apiKeyUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -25,7 +25,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUploadCheckDto] assetBulkUploadCheckDto (required):
-  Future<Response> checkBulkUploadWithHttpInfo(AssetBulkUploadCheckDto assetBulkUploadCheckDto,) async {
+  Future<Response> checkBulkUploadWithHttpInfo(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/bulk-upload-check';
 
@@ -47,6 +47,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUploadCheckDto] assetBulkUploadCheckDto (required):
-  Future<AssetBulkUploadCheckResponseDto?> checkBulkUpload(AssetBulkUploadCheckDto assetBulkUploadCheckDto,) async {
-    final response = await checkBulkUploadWithHttpInfo(assetBulkUploadCheckDto,);
+  Future<AssetBulkUploadCheckResponseDto?> checkBulkUpload(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { Future<void>? abortTrigger, }) async {
+    final response = await checkBulkUploadWithHttpInfo(assetBulkUploadCheckDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetCopyDto] assetCopyDto (required):
-  Future<Response> copyAssetWithHttpInfo(AssetCopyDto assetCopyDto,) async {
+  Future<Response> copyAssetWithHttpInfo(AssetCopyDto assetCopyDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/copy';
 
@@ -103,6 +104,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -113,8 +115,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetCopyDto] assetCopyDto (required):
-  Future<void> copyAsset(AssetCopyDto assetCopyDto,) async {
-    final response = await copyAssetWithHttpInfo(assetCopyDto,);
+  Future<void> copyAsset(AssetCopyDto assetCopyDto, { Future<void>? abortTrigger, }) async {
+    final response = await copyAssetWithHttpInfo(assetCopyDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -133,7 +135,7 @@ class AssetsApi {
   ///
   /// * [String] key (required):
   ///   Metadata key
-  Future<Response> deleteAssetMetadataWithHttpInfo(String id, String key,) async {
+  Future<Response> deleteAssetMetadataWithHttpInfo(String id, String key, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/metadata/{key}'
       .replaceAll('{id}', id)
@@ -157,6 +159,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -171,8 +174,8 @@ class AssetsApi {
   ///
   /// * [String] key (required):
   ///   Metadata key
-  Future<void> deleteAssetMetadata(String id, String key,) async {
-    final response = await deleteAssetMetadataWithHttpInfo(id, key,);
+  Future<void> deleteAssetMetadata(String id, String key, { Future<void>? abortTrigger, }) async {
+    final response = await deleteAssetMetadataWithHttpInfo(id, key, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -187,7 +190,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkDeleteDto] assetBulkDeleteDto (required):
-  Future<Response> deleteAssetsWithHttpInfo(AssetBulkDeleteDto assetBulkDeleteDto,) async {
+  Future<Response> deleteAssetsWithHttpInfo(AssetBulkDeleteDto assetBulkDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets';
 
@@ -209,6 +212,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -219,8 +223,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkDeleteDto] assetBulkDeleteDto (required):
-  Future<void> deleteAssets(AssetBulkDeleteDto assetBulkDeleteDto,) async {
-    final response = await deleteAssetsWithHttpInfo(assetBulkDeleteDto,);
+  Future<void> deleteAssets(AssetBulkDeleteDto assetBulkDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteAssetsWithHttpInfo(assetBulkDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -235,7 +239,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetMetadataBulkDeleteDto] assetMetadataBulkDeleteDto (required):
-  Future<Response> deleteBulkAssetMetadataWithHttpInfo(AssetMetadataBulkDeleteDto assetMetadataBulkDeleteDto,) async {
+  Future<Response> deleteBulkAssetMetadataWithHttpInfo(AssetMetadataBulkDeleteDto assetMetadataBulkDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/metadata';
 
@@ -257,6 +261,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -267,8 +272,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetMetadataBulkDeleteDto] assetMetadataBulkDeleteDto (required):
-  Future<void> deleteBulkAssetMetadata(AssetMetadataBulkDeleteDto assetMetadataBulkDeleteDto,) async {
-    final response = await deleteBulkAssetMetadataWithHttpInfo(assetMetadataBulkDeleteDto,);
+  Future<void> deleteBulkAssetMetadata(AssetMetadataBulkDeleteDto assetMetadataBulkDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteBulkAssetMetadataWithHttpInfo(assetMetadataBulkDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -290,7 +295,7 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> downloadAssetWithHttpInfo(String id, { bool? edited, String? key, String? slug, }) async {
+  Future<Response> downloadAssetWithHttpInfo(String id, { bool? edited, String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/original'
       .replaceAll('{id}', id);
@@ -323,6 +328,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -340,8 +346,8 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<MultipartFile?> downloadAsset(String id, { bool? edited, String? key, String? slug, }) async {
-    final response = await downloadAssetWithHttpInfo(id,  edited: edited, key: key, slug: slug, );
+  Future<MultipartFile?> downloadAsset(String id, { bool? edited, String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await downloadAssetWithHttpInfo(id, edited: edited, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -366,7 +372,7 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [AssetEditsCreateDto] assetEditsCreateDto (required):
-  Future<Response> editAssetWithHttpInfo(String id, AssetEditsCreateDto assetEditsCreateDto,) async {
+  Future<Response> editAssetWithHttpInfo(String id, AssetEditsCreateDto assetEditsCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/edits'
       .replaceAll('{id}', id);
@@ -389,6 +395,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -401,8 +408,8 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [AssetEditsCreateDto] assetEditsCreateDto (required):
-  Future<AssetEditsResponseDto?> editAsset(String id, AssetEditsCreateDto assetEditsCreateDto,) async {
-    final response = await editAssetWithHttpInfo(id, assetEditsCreateDto,);
+  Future<AssetEditsResponseDto?> editAsset(String id, AssetEditsCreateDto assetEditsCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await editAssetWithHttpInfo(id, assetEditsCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -425,7 +432,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getAssetEditsWithHttpInfo(String id,) async {
+  Future<Response> getAssetEditsWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/edits'
       .replaceAll('{id}', id);
@@ -448,6 +455,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -458,8 +466,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<AssetEditsResponseDto?> getAssetEdits(String id,) async {
-    final response = await getAssetEditsWithHttpInfo(id,);
+  Future<AssetEditsResponseDto?> getAssetEdits(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getAssetEditsWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -486,7 +494,7 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getAssetInfoWithHttpInfo(String id, { String? key, String? slug, }) async {
+  Future<Response> getAssetInfoWithHttpInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}'
       .replaceAll('{id}', id);
@@ -516,6 +524,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -530,8 +539,8 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<AssetResponseDto?> getAssetInfo(String id, { String? key, String? slug, }) async {
-    final response = await getAssetInfoWithHttpInfo(id,  key: key, slug: slug, );
+  Future<AssetResponseDto?> getAssetInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await getAssetInfoWithHttpInfo(id, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -554,7 +563,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getAssetMetadataWithHttpInfo(String id,) async {
+  Future<Response> getAssetMetadataWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/metadata'
       .replaceAll('{id}', id);
@@ -577,6 +586,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -587,8 +597,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<List<AssetMetadataResponseDto>?> getAssetMetadata(String id,) async {
-    final response = await getAssetMetadataWithHttpInfo(id,);
+  Future<List<AssetMetadataResponseDto>?> getAssetMetadata(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getAssetMetadataWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -618,7 +628,7 @@ class AssetsApi {
   ///
   /// * [String] key (required):
   ///   Metadata key
-  Future<Response> getAssetMetadataByKeyWithHttpInfo(String id, String key,) async {
+  Future<Response> getAssetMetadataByKeyWithHttpInfo(String id, String key, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/metadata/{key}'
       .replaceAll('{id}', id)
@@ -642,6 +652,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -656,8 +667,8 @@ class AssetsApi {
   ///
   /// * [String] key (required):
   ///   Metadata key
-  Future<AssetMetadataResponseDto?> getAssetMetadataByKey(String id, String key,) async {
-    final response = await getAssetMetadataByKeyWithHttpInfo(id, key,);
+  Future<AssetMetadataResponseDto?> getAssetMetadataByKey(String id, String key, { Future<void>? abortTrigger, }) async {
+    final response = await getAssetMetadataByKeyWithHttpInfo(id, key, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -680,7 +691,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getAssetOcrWithHttpInfo(String id,) async {
+  Future<Response> getAssetOcrWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/ocr'
       .replaceAll('{id}', id);
@@ -703,6 +714,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -713,8 +725,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<List<AssetOcrResponseDto>?> getAssetOcr(String id,) async {
-    final response = await getAssetOcrWithHttpInfo(id,);
+  Future<List<AssetOcrResponseDto>?> getAssetOcr(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getAssetOcrWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -746,7 +758,7 @@ class AssetsApi {
   ///   Filter by trash status
   ///
   /// * [AssetVisibility] visibility:
-  Future<Response> getAssetStatisticsWithHttpInfo({ bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, }) async {
+  Future<Response> getAssetStatisticsWithHttpInfo({ bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/statistics';
 
@@ -778,6 +790,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -794,8 +807,8 @@ class AssetsApi {
   ///   Filter by trash status
   ///
   /// * [AssetVisibility] visibility:
-  Future<AssetStatsResponseDto?> getAssetStatistics({ bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, }) async {
-    final response = await getAssetStatisticsWithHttpInfo( isFavorite: isFavorite, isTrashed: isTrashed, visibility: visibility, );
+  Future<AssetStatsResponseDto?> getAssetStatistics({ bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
+    final response = await getAssetStatisticsWithHttpInfo(isFavorite: isFavorite, isTrashed: isTrashed, visibility: visibility, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -822,7 +835,7 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> playAssetVideoWithHttpInfo(String id, { String? key, String? slug, }) async {
+  Future<Response> playAssetVideoWithHttpInfo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/video/playback'
       .replaceAll('{id}', id);
@@ -852,6 +865,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -866,8 +880,8 @@ class AssetsApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<MultipartFile?> playAssetVideo(String id, { String? key, String? slug, }) async {
-    final response = await playAssetVideoWithHttpInfo(id,  key: key, slug: slug, );
+  Future<MultipartFile?> playAssetVideo(String id, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await playAssetVideoWithHttpInfo(id, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -890,7 +904,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> removeAssetEditsWithHttpInfo(String id,) async {
+  Future<Response> removeAssetEditsWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/edits'
       .replaceAll('{id}', id);
@@ -913,6 +927,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -923,8 +938,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> removeAssetEdits(String id,) async {
-    final response = await removeAssetEditsWithHttpInfo(id,);
+  Future<void> removeAssetEdits(String id, { Future<void>? abortTrigger, }) async {
+    final response = await removeAssetEditsWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -939,7 +954,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetJobsDto] assetJobsDto (required):
-  Future<Response> runAssetJobsWithHttpInfo(AssetJobsDto assetJobsDto,) async {
+  Future<Response> runAssetJobsWithHttpInfo(AssetJobsDto assetJobsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/jobs';
 
@@ -961,6 +976,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -971,8 +987,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetJobsDto] assetJobsDto (required):
-  Future<void> runAssetJobs(AssetJobsDto assetJobsDto,) async {
-    final response = await runAssetJobsWithHttpInfo(assetJobsDto,);
+  Future<void> runAssetJobs(AssetJobsDto assetJobsDto, { Future<void>? abortTrigger, }) async {
+    final response = await runAssetJobsWithHttpInfo(assetJobsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -989,7 +1005,7 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [UpdateAssetDto] updateAssetDto (required):
-  Future<Response> updateAssetWithHttpInfo(String id, UpdateAssetDto updateAssetDto,) async {
+  Future<Response> updateAssetWithHttpInfo(String id, UpdateAssetDto updateAssetDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}'
       .replaceAll('{id}', id);
@@ -1012,6 +1028,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1024,8 +1041,8 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [UpdateAssetDto] updateAssetDto (required):
-  Future<AssetResponseDto?> updateAsset(String id, UpdateAssetDto updateAssetDto,) async {
-    final response = await updateAssetWithHttpInfo(id, updateAssetDto,);
+  Future<AssetResponseDto?> updateAsset(String id, UpdateAssetDto updateAssetDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAssetWithHttpInfo(id, updateAssetDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1050,7 +1067,7 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [AssetMetadataUpsertDto] assetMetadataUpsertDto (required):
-  Future<Response> updateAssetMetadataWithHttpInfo(String id, AssetMetadataUpsertDto assetMetadataUpsertDto,) async {
+  Future<Response> updateAssetMetadataWithHttpInfo(String id, AssetMetadataUpsertDto assetMetadataUpsertDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/metadata'
       .replaceAll('{id}', id);
@@ -1073,6 +1090,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1085,8 +1103,8 @@ class AssetsApi {
   /// * [String] id (required):
   ///
   /// * [AssetMetadataUpsertDto] assetMetadataUpsertDto (required):
-  Future<List<AssetMetadataResponseDto>?> updateAssetMetadata(String id, AssetMetadataUpsertDto assetMetadataUpsertDto,) async {
-    final response = await updateAssetMetadataWithHttpInfo(id, assetMetadataUpsertDto,);
+  Future<List<AssetMetadataResponseDto>?> updateAssetMetadata(String id, AssetMetadataUpsertDto assetMetadataUpsertDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAssetMetadataWithHttpInfo(id, assetMetadataUpsertDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1112,7 +1130,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUpdateDto] assetBulkUpdateDto (required):
-  Future<Response> updateAssetsWithHttpInfo(AssetBulkUpdateDto assetBulkUpdateDto,) async {
+  Future<Response> updateAssetsWithHttpInfo(AssetBulkUpdateDto assetBulkUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets';
 
@@ -1134,6 +1152,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1144,8 +1163,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUpdateDto] assetBulkUpdateDto (required):
-  Future<void> updateAssets(AssetBulkUpdateDto assetBulkUpdateDto,) async {
-    final response = await updateAssetsWithHttpInfo(assetBulkUpdateDto,);
+  Future<void> updateAssets(AssetBulkUpdateDto assetBulkUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAssetsWithHttpInfo(assetBulkUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1160,7 +1179,7 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetMetadataBulkUpsertDto] assetMetadataBulkUpsertDto (required):
-  Future<Response> updateBulkAssetMetadataWithHttpInfo(AssetMetadataBulkUpsertDto assetMetadataBulkUpsertDto,) async {
+  Future<Response> updateBulkAssetMetadataWithHttpInfo(AssetMetadataBulkUpsertDto assetMetadataBulkUpsertDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/metadata';
 
@@ -1182,6 +1201,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1192,8 +1212,8 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetMetadataBulkUpsertDto] assetMetadataBulkUpsertDto (required):
-  Future<List<AssetMetadataBulkResponseDto>?> updateBulkAssetMetadata(AssetMetadataBulkUpsertDto assetMetadataBulkUpsertDto,) async {
-    final response = await updateBulkAssetMetadataWithHttpInfo(assetMetadataBulkUpsertDto,);
+  Future<List<AssetMetadataBulkResponseDto>?> updateBulkAssetMetadata(AssetMetadataBulkUpsertDto assetMetadataBulkUpsertDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateBulkAssetMetadataWithHttpInfo(assetMetadataBulkUpsertDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1253,7 +1273,7 @@ class AssetsApi {
   ///   Sidecar file data
   ///
   /// * [AssetVisibility] visibility:
-  Future<Response> uploadAssetWithHttpInfo(MultipartFile assetData, DateTime fileCreatedAt, DateTime fileModifiedAt, { String? key, String? slug, String? xImmichChecksum, int? duration, String? filename, bool? isFavorite, String? livePhotoVideoId, List<AssetMetadataUpsertItemDto>? metadata, MultipartFile? sidecarData, AssetVisibility? visibility, }) async {
+  Future<Response> uploadAssetWithHttpInfo(MultipartFile assetData, DateTime fileCreatedAt, DateTime fileModifiedAt, { String? key, String? slug, String? xImmichChecksum, int? duration, String? filename, bool? isFavorite, String? livePhotoVideoId, List<AssetMetadataUpsertItemDto>? metadata, MultipartFile? sidecarData, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets';
 
@@ -1333,6 +1353,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1377,8 +1398,8 @@ class AssetsApi {
   ///   Sidecar file data
   ///
   /// * [AssetVisibility] visibility:
-  Future<AssetMediaResponseDto?> uploadAsset(MultipartFile assetData, DateTime fileCreatedAt, DateTime fileModifiedAt, { String? key, String? slug, String? xImmichChecksum, int? duration, String? filename, bool? isFavorite, String? livePhotoVideoId, List<AssetMetadataUpsertItemDto>? metadata, MultipartFile? sidecarData, AssetVisibility? visibility, }) async {
-    final response = await uploadAssetWithHttpInfo(assetData, fileCreatedAt, fileModifiedAt,  key: key, slug: slug, xImmichChecksum: xImmichChecksum, duration: duration, filename: filename, isFavorite: isFavorite, livePhotoVideoId: livePhotoVideoId, metadata: metadata, sidecarData: sidecarData, visibility: visibility, );
+  Future<AssetMediaResponseDto?> uploadAsset(MultipartFile assetData, DateTime fileCreatedAt, DateTime fileModifiedAt, { String? key, String? slug, String? xImmichChecksum, int? duration, String? filename, bool? isFavorite, String? livePhotoVideoId, List<AssetMetadataUpsertItemDto>? metadata, MultipartFile? sidecarData, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
+    final response = await uploadAssetWithHttpInfo(assetData, fileCreatedAt, fileModifiedAt, key: key, slug: slug, xImmichChecksum: xImmichChecksum, duration: duration, filename: filename, isFavorite: isFavorite, livePhotoVideoId: livePhotoVideoId, metadata: metadata, sidecarData: sidecarData, visibility: visibility, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1410,7 +1431,7 @@ class AssetsApi {
   /// * [AssetMediaSize] size:
   ///
   /// * [String] slug:
-  Future<Response> viewAssetWithHttpInfo(String id, { bool? edited, String? key, AssetMediaSize? size, String? slug, }) async {
+  Future<Response> viewAssetWithHttpInfo(String id, { bool? edited, String? key, AssetMediaSize? size, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/thumbnail'
       .replaceAll('{id}', id);
@@ -1446,6 +1467,7 @@ class AssetsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -1465,8 +1487,8 @@ class AssetsApi {
   /// * [AssetMediaSize] size:
   ///
   /// * [String] slug:
-  Future<MultipartFile?> viewAsset(String id, { bool? edited, String? key, AssetMediaSize? size, String? slug, }) async {
-    final response = await viewAssetWithHttpInfo(id,  edited: edited, key: key, size: size, slug: slug, );
+  Future<MultipartFile?> viewAsset(String id, { bool? edited, String? key, AssetMediaSize? size, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await viewAssetWithHttpInfo(id, edited: edited, key: key, size: size, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/authentication_admin_api.dart
+++ b/mobile/openapi/lib/api/authentication_admin_api.dart
@@ -21,7 +21,7 @@ class AuthenticationAdminApi {
   /// Unlinks all OAuth accounts associated with user accounts in the system.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> unlinkAllOAuthAccountsAdminWithHttpInfo() async {
+  Future<Response> unlinkAllOAuthAccountsAdminWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/auth/unlink-all';
 
@@ -43,14 +43,15 @@ class AuthenticationAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Unlink all OAuth accounts
   ///
   /// Unlinks all OAuth accounts associated with user accounts in the system.
-  Future<void> unlinkAllOAuthAccountsAdmin() async {
-    final response = await unlinkAllOAuthAccountsAdminWithHttpInfo();
+  Future<void> unlinkAllOAuthAccountsAdmin({ Future<void>? abortTrigger, }) async {
+    final response = await unlinkAllOAuthAccountsAdminWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/authentication_api.dart
+++ b/mobile/openapi/lib/api/authentication_api.dart
@@ -25,7 +25,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [ChangePasswordDto] changePasswordDto (required):
-  Future<Response> changePasswordWithHttpInfo(ChangePasswordDto changePasswordDto,) async {
+  Future<Response> changePasswordWithHttpInfo(ChangePasswordDto changePasswordDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/change-password';
 
@@ -47,6 +47,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [ChangePasswordDto] changePasswordDto (required):
-  Future<UserAdminResponseDto?> changePassword(ChangePasswordDto changePasswordDto,) async {
-    final response = await changePasswordWithHttpInfo(changePasswordDto,);
+  Future<UserAdminResponseDto?> changePassword(ChangePasswordDto changePasswordDto, { Future<void>? abortTrigger, }) async {
+    final response = await changePasswordWithHttpInfo(changePasswordDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeChangeDto] pinCodeChangeDto (required):
-  Future<Response> changePinCodeWithHttpInfo(PinCodeChangeDto pinCodeChangeDto,) async {
+  Future<Response> changePinCodeWithHttpInfo(PinCodeChangeDto pinCodeChangeDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/pin-code';
 
@@ -103,6 +104,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -113,8 +115,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeChangeDto] pinCodeChangeDto (required):
-  Future<void> changePinCode(PinCodeChangeDto pinCodeChangeDto,) async {
-    final response = await changePinCodeWithHttpInfo(pinCodeChangeDto,);
+  Future<void> changePinCode(PinCodeChangeDto pinCodeChangeDto, { Future<void>? abortTrigger, }) async {
+    final response = await changePinCodeWithHttpInfo(pinCodeChangeDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -129,7 +131,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthCallbackDto] oAuthCallbackDto (required):
-  Future<Response> finishOAuthWithHttpInfo(OAuthCallbackDto oAuthCallbackDto,) async {
+  Future<Response> finishOAuthWithHttpInfo(OAuthCallbackDto oAuthCallbackDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/callback';
 
@@ -151,6 +153,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -161,8 +164,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthCallbackDto] oAuthCallbackDto (required):
-  Future<LoginResponseDto?> finishOAuth(OAuthCallbackDto oAuthCallbackDto,) async {
-    final response = await finishOAuthWithHttpInfo(oAuthCallbackDto,);
+  Future<LoginResponseDto?> finishOAuth(OAuthCallbackDto oAuthCallbackDto, { Future<void>? abortTrigger, }) async {
+    final response = await finishOAuthWithHttpInfo(oAuthCallbackDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -181,7 +184,7 @@ class AuthenticationApi {
   /// Get information about the current session, including whether the user has a password, and if the session can access locked assets.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAuthStatusWithHttpInfo() async {
+  Future<Response> getAuthStatusWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/status';
 
@@ -203,14 +206,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve auth status
   ///
   /// Get information about the current session, including whether the user has a password, and if the session can access locked assets.
-  Future<AuthStatusResponseDto?> getAuthStatus() async {
-    final response = await getAuthStatusWithHttpInfo();
+  Future<AuthStatusResponseDto?> getAuthStatus({ Future<void>? abortTrigger, }) async {
+    final response = await getAuthStatusWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -233,7 +237,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthCallbackDto] oAuthCallbackDto (required):
-  Future<Response> linkOAuthAccountWithHttpInfo(OAuthCallbackDto oAuthCallbackDto,) async {
+  Future<Response> linkOAuthAccountWithHttpInfo(OAuthCallbackDto oAuthCallbackDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/link';
 
@@ -255,6 +259,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -265,8 +270,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthCallbackDto] oAuthCallbackDto (required):
-  Future<UserAdminResponseDto?> linkOAuthAccount(OAuthCallbackDto oAuthCallbackDto,) async {
-    final response = await linkOAuthAccountWithHttpInfo(oAuthCallbackDto,);
+  Future<UserAdminResponseDto?> linkOAuthAccount(OAuthCallbackDto oAuthCallbackDto, { Future<void>? abortTrigger, }) async {
+    final response = await linkOAuthAccountWithHttpInfo(oAuthCallbackDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -285,7 +290,7 @@ class AuthenticationApi {
   /// Remove elevated access to locked assets from the current session.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> lockAuthSessionWithHttpInfo() async {
+  Future<Response> lockAuthSessionWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/session/lock';
 
@@ -307,14 +312,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Lock auth session
   ///
   /// Remove elevated access to locked assets from the current session.
-  Future<void> lockAuthSession() async {
-    final response = await lockAuthSessionWithHttpInfo();
+  Future<void> lockAuthSession({ Future<void>? abortTrigger, }) async {
+    final response = await lockAuthSessionWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -329,7 +335,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [LoginCredentialDto] loginCredentialDto (required):
-  Future<Response> loginWithHttpInfo(LoginCredentialDto loginCredentialDto,) async {
+  Future<Response> loginWithHttpInfo(LoginCredentialDto loginCredentialDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/login';
 
@@ -351,6 +357,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -361,8 +368,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [LoginCredentialDto] loginCredentialDto (required):
-  Future<LoginResponseDto?> login(LoginCredentialDto loginCredentialDto,) async {
-    final response = await loginWithHttpInfo(loginCredentialDto,);
+  Future<LoginResponseDto?> login(LoginCredentialDto loginCredentialDto, { Future<void>? abortTrigger, }) async {
+    final response = await loginWithHttpInfo(loginCredentialDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -381,7 +388,7 @@ class AuthenticationApi {
   /// Logout the current user and invalidate the session token.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> logoutWithHttpInfo() async {
+  Future<Response> logoutWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/logout';
 
@@ -403,14 +410,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Logout
   ///
   /// Logout the current user and invalidate the session token.
-  Future<LogoutResponseDto?> logout() async {
-    final response = await logoutWithHttpInfo();
+  Future<LogoutResponseDto?> logout({ Future<void>? abortTrigger, }) async {
+    final response = await logoutWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -434,7 +442,7 @@ class AuthenticationApi {
   ///
   /// * [String] logoutToken (required):
   ///   OAuth logout token
-  Future<Response> logoutOAuthWithHttpInfo(String logoutToken,) async {
+  Future<Response> logoutOAuthWithHttpInfo(String logoutToken, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/backchannel-logout';
 
@@ -459,6 +467,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -470,8 +479,8 @@ class AuthenticationApi {
   ///
   /// * [String] logoutToken (required):
   ///   OAuth logout token
-  Future<void> logoutOAuth(String logoutToken,) async {
-    final response = await logoutOAuthWithHttpInfo(logoutToken,);
+  Future<void> logoutOAuth(String logoutToken, { Future<void>? abortTrigger, }) async {
+    final response = await logoutOAuthWithHttpInfo(logoutToken, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -482,7 +491,7 @@ class AuthenticationApi {
   /// Requests to this URL are automatically forwarded to the mobile app, and is used in some cases for OAuth redirecting.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> redirectOAuthToMobileWithHttpInfo() async {
+  Future<Response> redirectOAuthToMobileWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/mobile-redirect';
 
@@ -504,14 +513,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Redirect OAuth to mobile
   ///
   /// Requests to this URL are automatically forwarded to the mobile app, and is used in some cases for OAuth redirecting.
-  Future<void> redirectOAuthToMobile() async {
-    final response = await redirectOAuthToMobileWithHttpInfo();
+  Future<void> redirectOAuthToMobile({ Future<void>? abortTrigger, }) async {
+    final response = await redirectOAuthToMobileWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -526,7 +536,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeResetDto] pinCodeResetDto (required):
-  Future<Response> resetPinCodeWithHttpInfo(PinCodeResetDto pinCodeResetDto,) async {
+  Future<Response> resetPinCodeWithHttpInfo(PinCodeResetDto pinCodeResetDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/pin-code';
 
@@ -548,6 +558,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -558,8 +569,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeResetDto] pinCodeResetDto (required):
-  Future<void> resetPinCode(PinCodeResetDto pinCodeResetDto,) async {
-    final response = await resetPinCodeWithHttpInfo(pinCodeResetDto,);
+  Future<void> resetPinCode(PinCodeResetDto pinCodeResetDto, { Future<void>? abortTrigger, }) async {
+    final response = await resetPinCodeWithHttpInfo(pinCodeResetDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -574,7 +585,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeSetupDto] pinCodeSetupDto (required):
-  Future<Response> setupPinCodeWithHttpInfo(PinCodeSetupDto pinCodeSetupDto,) async {
+  Future<Response> setupPinCodeWithHttpInfo(PinCodeSetupDto pinCodeSetupDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/pin-code';
 
@@ -596,6 +607,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -606,8 +618,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [PinCodeSetupDto] pinCodeSetupDto (required):
-  Future<void> setupPinCode(PinCodeSetupDto pinCodeSetupDto,) async {
-    final response = await setupPinCodeWithHttpInfo(pinCodeSetupDto,);
+  Future<void> setupPinCode(PinCodeSetupDto pinCodeSetupDto, { Future<void>? abortTrigger, }) async {
+    final response = await setupPinCodeWithHttpInfo(pinCodeSetupDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -622,7 +634,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [SignUpDto] signUpDto (required):
-  Future<Response> signUpAdminWithHttpInfo(SignUpDto signUpDto,) async {
+  Future<Response> signUpAdminWithHttpInfo(SignUpDto signUpDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/admin-sign-up';
 
@@ -644,6 +656,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -654,8 +667,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [SignUpDto] signUpDto (required):
-  Future<UserAdminResponseDto?> signUpAdmin(SignUpDto signUpDto,) async {
-    final response = await signUpAdminWithHttpInfo(signUpDto,);
+  Future<UserAdminResponseDto?> signUpAdmin(SignUpDto signUpDto, { Future<void>? abortTrigger, }) async {
+    final response = await signUpAdminWithHttpInfo(signUpDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -678,7 +691,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthConfigDto] oAuthConfigDto (required):
-  Future<Response> startOAuthWithHttpInfo(OAuthConfigDto oAuthConfigDto,) async {
+  Future<Response> startOAuthWithHttpInfo(OAuthConfigDto oAuthConfigDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/authorize';
 
@@ -700,6 +713,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -710,8 +724,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [OAuthConfigDto] oAuthConfigDto (required):
-  Future<OAuthAuthorizeResponseDto?> startOAuth(OAuthConfigDto oAuthConfigDto,) async {
-    final response = await startOAuthWithHttpInfo(oAuthConfigDto,);
+  Future<OAuthAuthorizeResponseDto?> startOAuth(OAuthConfigDto oAuthConfigDto, { Future<void>? abortTrigger, }) async {
+    final response = await startOAuthWithHttpInfo(oAuthConfigDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -730,7 +744,7 @@ class AuthenticationApi {
   /// Unlink the OAuth account from the authenticated user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> unlinkOAuthAccountWithHttpInfo() async {
+  Future<Response> unlinkOAuthAccountWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/oauth/unlink';
 
@@ -752,14 +766,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Unlink OAuth account
   ///
   /// Unlink the OAuth account from the authenticated user.
-  Future<UserAdminResponseDto?> unlinkOAuthAccount() async {
-    final response = await unlinkOAuthAccountWithHttpInfo();
+  Future<UserAdminResponseDto?> unlinkOAuthAccount({ Future<void>? abortTrigger, }) async {
+    final response = await unlinkOAuthAccountWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -782,7 +797,7 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [SessionUnlockDto] sessionUnlockDto (required):
-  Future<Response> unlockAuthSessionWithHttpInfo(SessionUnlockDto sessionUnlockDto,) async {
+  Future<Response> unlockAuthSessionWithHttpInfo(SessionUnlockDto sessionUnlockDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/session/unlock';
 
@@ -804,6 +819,7 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -814,8 +830,8 @@ class AuthenticationApi {
   /// Parameters:
   ///
   /// * [SessionUnlockDto] sessionUnlockDto (required):
-  Future<void> unlockAuthSession(SessionUnlockDto sessionUnlockDto,) async {
-    final response = await unlockAuthSessionWithHttpInfo(sessionUnlockDto,);
+  Future<void> unlockAuthSession(SessionUnlockDto sessionUnlockDto, { Future<void>? abortTrigger, }) async {
+    final response = await unlockAuthSessionWithHttpInfo(sessionUnlockDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -826,7 +842,7 @@ class AuthenticationApi {
   /// Validate the current authorization method is still valid.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> validateAccessTokenWithHttpInfo() async {
+  Future<Response> validateAccessTokenWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/auth/validateToken';
 
@@ -848,14 +864,15 @@ class AuthenticationApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Validate access token
   ///
   /// Validate the current authorization method is still valid.
-  Future<ValidateAccessTokenResponseDto?> validateAccessToken() async {
-    final response = await validateAccessTokenWithHttpInfo();
+  Future<ValidateAccessTokenResponseDto?> validateAccessToken({ Future<void>? abortTrigger, }) async {
+    final response = await validateAccessTokenWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/database_backups_admin_api.dart
+++ b/mobile/openapi/lib/api/database_backups_admin_api.dart
@@ -25,7 +25,7 @@ class DatabaseBackupsAdminApi {
   /// Parameters:
   ///
   /// * [DatabaseBackupDeleteDto] databaseBackupDeleteDto (required):
-  Future<Response> deleteDatabaseBackupWithHttpInfo(DatabaseBackupDeleteDto databaseBackupDeleteDto,) async {
+  Future<Response> deleteDatabaseBackupWithHttpInfo(DatabaseBackupDeleteDto databaseBackupDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/database-backups';
 
@@ -47,6 +47,7 @@ class DatabaseBackupsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class DatabaseBackupsAdminApi {
   /// Parameters:
   ///
   /// * [DatabaseBackupDeleteDto] databaseBackupDeleteDto (required):
-  Future<void> deleteDatabaseBackup(DatabaseBackupDeleteDto databaseBackupDeleteDto,) async {
-    final response = await deleteDatabaseBackupWithHttpInfo(databaseBackupDeleteDto,);
+  Future<void> deleteDatabaseBackup(DatabaseBackupDeleteDto databaseBackupDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteDatabaseBackupWithHttpInfo(databaseBackupDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -73,7 +74,7 @@ class DatabaseBackupsAdminApi {
   /// Parameters:
   ///
   /// * [String] filename (required):
-  Future<Response> downloadDatabaseBackupWithHttpInfo(String filename,) async {
+  Future<Response> downloadDatabaseBackupWithHttpInfo(String filename, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/database-backups/{filename}'
       .replaceAll('{filename}', filename);
@@ -96,6 +97,7 @@ class DatabaseBackupsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -106,8 +108,8 @@ class DatabaseBackupsAdminApi {
   /// Parameters:
   ///
   /// * [String] filename (required):
-  Future<MultipartFile?> downloadDatabaseBackup(String filename,) async {
-    final response = await downloadDatabaseBackupWithHttpInfo(filename,);
+  Future<MultipartFile?> downloadDatabaseBackup(String filename, { Future<void>? abortTrigger, }) async {
+    final response = await downloadDatabaseBackupWithHttpInfo(filename, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -126,7 +128,7 @@ class DatabaseBackupsAdminApi {
   /// Get the list of the successful and failed backups
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> listDatabaseBackupsWithHttpInfo() async {
+  Future<Response> listDatabaseBackupsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/database-backups';
 
@@ -148,14 +150,15 @@ class DatabaseBackupsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// List database backups
   ///
   /// Get the list of the successful and failed backups
-  Future<DatabaseBackupListResponseDto?> listDatabaseBackups() async {
-    final response = await listDatabaseBackupsWithHttpInfo();
+  Future<DatabaseBackupListResponseDto?> listDatabaseBackups({ Future<void>? abortTrigger, }) async {
+    final response = await listDatabaseBackupsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -174,7 +177,7 @@ class DatabaseBackupsAdminApi {
   /// Put Immich into maintenance mode to restore a backup (Immich must not be configured)
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> startDatabaseRestoreFlowWithHttpInfo() async {
+  Future<Response> startDatabaseRestoreFlowWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/database-backups/start-restore';
 
@@ -196,14 +199,15 @@ class DatabaseBackupsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Start database backup restore flow
   ///
   /// Put Immich into maintenance mode to restore a backup (Immich must not be configured)
-  Future<void> startDatabaseRestoreFlow() async {
-    final response = await startDatabaseRestoreFlowWithHttpInfo();
+  Future<void> startDatabaseRestoreFlow({ Future<void>? abortTrigger, }) async {
+    final response = await startDatabaseRestoreFlowWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -219,7 +223,7 @@ class DatabaseBackupsAdminApi {
   ///
   /// * [MultipartFile] file:
   ///   Database backup file
-  Future<Response> uploadDatabaseBackupWithHttpInfo({ MultipartFile? file, }) async {
+  Future<Response> uploadDatabaseBackupWithHttpInfo({ MultipartFile? file, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/database-backups/upload';
 
@@ -251,6 +255,7 @@ class DatabaseBackupsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -262,8 +267,8 @@ class DatabaseBackupsAdminApi {
   ///
   /// * [MultipartFile] file:
   ///   Database backup file
-  Future<void> uploadDatabaseBackup({ MultipartFile? file, }) async {
-    final response = await uploadDatabaseBackupWithHttpInfo( file: file, );
+  Future<void> uploadDatabaseBackup({ MultipartFile? file, Future<void>? abortTrigger, }) async {
+    final response = await uploadDatabaseBackupWithHttpInfo(file: file, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/deprecated_api.dart
+++ b/mobile/openapi/lib/api/deprecated_api.dart
@@ -25,7 +25,7 @@ class DeprecatedApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> createPartnerDeprecatedWithHttpInfo(String id,) async {
+  Future<Response> createPartnerDeprecatedWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners/{id}'
       .replaceAll('{id}', id);
@@ -48,6 +48,7 @@ class DeprecatedApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -58,8 +59,8 @@ class DeprecatedApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<PartnerResponseDto?> createPartnerDeprecated(String id,) async {
-    final response = await createPartnerDeprecatedWithHttpInfo(id,);
+  Future<PartnerResponseDto?> createPartnerDeprecated(String id, { Future<void>? abortTrigger, }) async {
+    final response = await createPartnerDeprecatedWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -78,7 +79,7 @@ class DeprecatedApi {
   /// Retrieve the counts of the current queue, as well as the current status.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getQueuesLegacyWithHttpInfo() async {
+  Future<Response> getQueuesLegacyWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/jobs';
 
@@ -100,14 +101,15 @@ class DeprecatedApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve queue counts and status
   ///
   /// Retrieve the counts of the current queue, as well as the current status.
-  Future<QueuesResponseLegacyDto?> getQueuesLegacy() async {
-    final response = await getQueuesLegacyWithHttpInfo();
+  Future<QueuesResponseLegacyDto?> getQueuesLegacy({ Future<void>? abortTrigger, }) async {
+    final response = await getQueuesLegacyWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -132,7 +134,7 @@ class DeprecatedApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueCommandDto] queueCommandDto (required):
-  Future<Response> runQueueCommandLegacyWithHttpInfo(QueueName name, QueueCommandDto queueCommandDto,) async {
+  Future<Response> runQueueCommandLegacyWithHttpInfo(QueueName name, QueueCommandDto queueCommandDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/jobs/{name}'
       .replaceAll('{name}', name.toString());
@@ -155,6 +157,7 @@ class DeprecatedApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -167,8 +170,8 @@ class DeprecatedApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueCommandDto] queueCommandDto (required):
-  Future<QueueResponseLegacyDto?> runQueueCommandLegacy(QueueName name, QueueCommandDto queueCommandDto,) async {
-    final response = await runQueueCommandLegacyWithHttpInfo(name, queueCommandDto,);
+  Future<QueueResponseLegacyDto?> runQueueCommandLegacy(QueueName name, QueueCommandDto queueCommandDto, { Future<void>? abortTrigger, }) async {
+    final response = await runQueueCommandLegacyWithHttpInfo(name, queueCommandDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/download_api.dart
+++ b/mobile/openapi/lib/api/download_api.dart
@@ -29,7 +29,7 @@ class DownloadApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> downloadArchiveWithHttpInfo(DownloadArchiveDto downloadArchiveDto, { String? key, String? slug, }) async {
+  Future<Response> downloadArchiveWithHttpInfo(DownloadArchiveDto downloadArchiveDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/download/archive';
 
@@ -58,6 +58,7 @@ class DownloadApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -72,8 +73,8 @@ class DownloadApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<MultipartFile?> downloadArchive(DownloadArchiveDto downloadArchiveDto, { String? key, String? slug, }) async {
-    final response = await downloadArchiveWithHttpInfo(downloadArchiveDto,  key: key, slug: slug, );
+  Future<MultipartFile?> downloadArchive(DownloadArchiveDto downloadArchiveDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await downloadArchiveWithHttpInfo(downloadArchiveDto, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -100,7 +101,7 @@ class DownloadApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getDownloadInfoWithHttpInfo(DownloadInfoDto downloadInfoDto, { String? key, String? slug, }) async {
+  Future<Response> getDownloadInfoWithHttpInfo(DownloadInfoDto downloadInfoDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/download/info';
 
@@ -129,6 +130,7 @@ class DownloadApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -143,8 +145,8 @@ class DownloadApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<DownloadResponseDto?> getDownloadInfo(DownloadInfoDto downloadInfoDto, { String? key, String? slug, }) async {
-    final response = await getDownloadInfoWithHttpInfo(downloadInfoDto,  key: key, slug: slug, );
+  Future<DownloadResponseDto?> getDownloadInfo(DownloadInfoDto downloadInfoDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await getDownloadInfoWithHttpInfo(downloadInfoDto, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/duplicates_api.dart
+++ b/mobile/openapi/lib/api/duplicates_api.dart
@@ -25,7 +25,7 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteDuplicateWithHttpInfo(String id,) async {
+  Future<Response> deleteDuplicateWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/duplicates/{id}'
       .replaceAll('{id}', id);
@@ -48,6 +48,7 @@ class DuplicatesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -58,8 +59,8 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteDuplicate(String id,) async {
-    final response = await deleteDuplicateWithHttpInfo(id,);
+  Future<void> deleteDuplicate(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteDuplicateWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -74,7 +75,7 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> deleteDuplicatesWithHttpInfo(BulkIdsDto bulkIdsDto,) async {
+  Future<Response> deleteDuplicatesWithHttpInfo(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/duplicates';
 
@@ -96,6 +97,7 @@ class DuplicatesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -106,8 +108,8 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<void> deleteDuplicates(BulkIdsDto bulkIdsDto,) async {
-    final response = await deleteDuplicatesWithHttpInfo(bulkIdsDto,);
+  Future<void> deleteDuplicates(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteDuplicatesWithHttpInfo(bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -118,7 +120,7 @@ class DuplicatesApi {
   /// Retrieve a list of duplicate assets available to the authenticated user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAssetDuplicatesWithHttpInfo() async {
+  Future<Response> getAssetDuplicatesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/duplicates';
 
@@ -140,14 +142,15 @@ class DuplicatesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve duplicates
   ///
   /// Retrieve a list of duplicate assets available to the authenticated user.
-  Future<List<DuplicateResponseDto>?> getAssetDuplicates() async {
-    final response = await getAssetDuplicatesWithHttpInfo();
+  Future<List<DuplicateResponseDto>?> getAssetDuplicates({ Future<void>? abortTrigger, }) async {
+    final response = await getAssetDuplicatesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -173,7 +176,7 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [DuplicateResolveDto] duplicateResolveDto (required):
-  Future<Response> resolveDuplicatesWithHttpInfo(DuplicateResolveDto duplicateResolveDto,) async {
+  Future<Response> resolveDuplicatesWithHttpInfo(DuplicateResolveDto duplicateResolveDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/duplicates/resolve';
 
@@ -195,6 +198,7 @@ class DuplicatesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -205,8 +209,8 @@ class DuplicatesApi {
   /// Parameters:
   ///
   /// * [DuplicateResolveDto] duplicateResolveDto (required):
-  Future<List<BulkIdResponseDto>?> resolveDuplicates(DuplicateResolveDto duplicateResolveDto,) async {
-    final response = await resolveDuplicatesWithHttpInfo(duplicateResolveDto,);
+  Future<List<BulkIdResponseDto>?> resolveDuplicates(DuplicateResolveDto duplicateResolveDto, { Future<void>? abortTrigger, }) async {
+    final response = await resolveDuplicatesWithHttpInfo(duplicateResolveDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/faces_api.dart
+++ b/mobile/openapi/lib/api/faces_api.dart
@@ -25,7 +25,7 @@ class FacesApi {
   /// Parameters:
   ///
   /// * [AssetFaceCreateDto] assetFaceCreateDto (required):
-  Future<Response> createFaceWithHttpInfo(AssetFaceCreateDto assetFaceCreateDto,) async {
+  Future<Response> createFaceWithHttpInfo(AssetFaceCreateDto assetFaceCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/faces';
 
@@ -47,6 +47,7 @@ class FacesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class FacesApi {
   /// Parameters:
   ///
   /// * [AssetFaceCreateDto] assetFaceCreateDto (required):
-  Future<void> createFace(AssetFaceCreateDto assetFaceCreateDto,) async {
-    final response = await createFaceWithHttpInfo(assetFaceCreateDto,);
+  Future<void> createFace(AssetFaceCreateDto assetFaceCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createFaceWithHttpInfo(assetFaceCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -75,7 +76,7 @@ class FacesApi {
   /// * [String] id (required):
   ///
   /// * [AssetFaceDeleteDto] assetFaceDeleteDto (required):
-  Future<Response> deleteFaceWithHttpInfo(String id, AssetFaceDeleteDto assetFaceDeleteDto,) async {
+  Future<Response> deleteFaceWithHttpInfo(String id, AssetFaceDeleteDto assetFaceDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/faces/{id}'
       .replaceAll('{id}', id);
@@ -98,6 +99,7 @@ class FacesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -110,8 +112,8 @@ class FacesApi {
   /// * [String] id (required):
   ///
   /// * [AssetFaceDeleteDto] assetFaceDeleteDto (required):
-  Future<void> deleteFace(String id, AssetFaceDeleteDto assetFaceDeleteDto,) async {
-    final response = await deleteFaceWithHttpInfo(id, assetFaceDeleteDto,);
+  Future<void> deleteFace(String id, AssetFaceDeleteDto assetFaceDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteFaceWithHttpInfo(id, assetFaceDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -127,7 +129,7 @@ class FacesApi {
   ///
   /// * [String] id (required):
   ///   Face ID
-  Future<Response> getFacesWithHttpInfo(String id,) async {
+  Future<Response> getFacesWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/faces';
 
@@ -151,6 +153,7 @@ class FacesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -162,8 +165,8 @@ class FacesApi {
   ///
   /// * [String] id (required):
   ///   Face ID
-  Future<List<AssetFaceResponseDto>?> getFaces(String id,) async {
-    final response = await getFacesWithHttpInfo(id,);
+  Future<List<AssetFaceResponseDto>?> getFaces(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getFacesWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -191,7 +194,7 @@ class FacesApi {
   /// * [String] id (required):
   ///
   /// * [FaceDto] faceDto (required):
-  Future<Response> reassignFacesByIdWithHttpInfo(String id, FaceDto faceDto,) async {
+  Future<Response> reassignFacesByIdWithHttpInfo(String id, FaceDto faceDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/faces/{id}'
       .replaceAll('{id}', id);
@@ -214,6 +217,7 @@ class FacesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -226,8 +230,8 @@ class FacesApi {
   /// * [String] id (required):
   ///
   /// * [FaceDto] faceDto (required):
-  Future<PersonResponseDto?> reassignFacesById(String id, FaceDto faceDto,) async {
-    final response = await reassignFacesByIdWithHttpInfo(id, faceDto,);
+  Future<PersonResponseDto?> reassignFacesById(String id, FaceDto faceDto, { Future<void>? abortTrigger, }) async {
+    final response = await reassignFacesByIdWithHttpInfo(id, faceDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/jobs_api.dart
+++ b/mobile/openapi/lib/api/jobs_api.dart
@@ -25,7 +25,7 @@ class JobsApi {
   /// Parameters:
   ///
   /// * [JobCreateDto] jobCreateDto (required):
-  Future<Response> createJobWithHttpInfo(JobCreateDto jobCreateDto,) async {
+  Future<Response> createJobWithHttpInfo(JobCreateDto jobCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/jobs';
 
@@ -47,6 +47,7 @@ class JobsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class JobsApi {
   /// Parameters:
   ///
   /// * [JobCreateDto] jobCreateDto (required):
-  Future<void> createJob(JobCreateDto jobCreateDto,) async {
-    final response = await createJobWithHttpInfo(jobCreateDto,);
+  Future<void> createJob(JobCreateDto jobCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createJobWithHttpInfo(jobCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -69,7 +70,7 @@ class JobsApi {
   /// Retrieve the counts of the current queue, as well as the current status.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getQueuesLegacyWithHttpInfo() async {
+  Future<Response> getQueuesLegacyWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/jobs';
 
@@ -91,14 +92,15 @@ class JobsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve queue counts and status
   ///
   /// Retrieve the counts of the current queue, as well as the current status.
-  Future<QueuesResponseLegacyDto?> getQueuesLegacy() async {
-    final response = await getQueuesLegacyWithHttpInfo();
+  Future<QueuesResponseLegacyDto?> getQueuesLegacy({ Future<void>? abortTrigger, }) async {
+    final response = await getQueuesLegacyWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -123,7 +125,7 @@ class JobsApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueCommandDto] queueCommandDto (required):
-  Future<Response> runQueueCommandLegacyWithHttpInfo(QueueName name, QueueCommandDto queueCommandDto,) async {
+  Future<Response> runQueueCommandLegacyWithHttpInfo(QueueName name, QueueCommandDto queueCommandDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/jobs/{name}'
       .replaceAll('{name}', name.toString());
@@ -146,6 +148,7 @@ class JobsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -158,8 +161,8 @@ class JobsApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueCommandDto] queueCommandDto (required):
-  Future<QueueResponseLegacyDto?> runQueueCommandLegacy(QueueName name, QueueCommandDto queueCommandDto,) async {
-    final response = await runQueueCommandLegacyWithHttpInfo(name, queueCommandDto,);
+  Future<QueueResponseLegacyDto?> runQueueCommandLegacy(QueueName name, QueueCommandDto queueCommandDto, { Future<void>? abortTrigger, }) async {
+    final response = await runQueueCommandLegacyWithHttpInfo(name, queueCommandDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/libraries_api.dart
+++ b/mobile/openapi/lib/api/libraries_api.dart
@@ -25,7 +25,7 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [CreateLibraryDto] createLibraryDto (required):
-  Future<Response> createLibraryWithHttpInfo(CreateLibraryDto createLibraryDto,) async {
+  Future<Response> createLibraryWithHttpInfo(CreateLibraryDto createLibraryDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries';
 
@@ -47,6 +47,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [CreateLibraryDto] createLibraryDto (required):
-  Future<LibraryResponseDto?> createLibrary(CreateLibraryDto createLibraryDto,) async {
-    final response = await createLibraryWithHttpInfo(createLibraryDto,);
+  Future<LibraryResponseDto?> createLibrary(CreateLibraryDto createLibraryDto, { Future<void>? abortTrigger, }) async {
+    final response = await createLibraryWithHttpInfo(createLibraryDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteLibraryWithHttpInfo(String id,) async {
+  Future<Response> deleteLibraryWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteLibrary(String id,) async {
-    final response = await deleteLibraryWithHttpInfo(id,);
+  Future<void> deleteLibrary(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteLibraryWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -126,7 +128,7 @@ class LibrariesApi {
   /// Retrieve a list of external libraries.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAllLibrariesWithHttpInfo() async {
+  Future<Response> getAllLibrariesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries';
 
@@ -148,14 +150,15 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve libraries
   ///
   /// Retrieve a list of external libraries.
-  Future<List<LibraryResponseDto>?> getAllLibraries() async {
-    final response = await getAllLibrariesWithHttpInfo();
+  Future<List<LibraryResponseDto>?> getAllLibraries({ Future<void>? abortTrigger, }) async {
+    final response = await getAllLibrariesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -181,7 +184,7 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getLibraryWithHttpInfo(String id,) async {
+  Future<Response> getLibraryWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}'
       .replaceAll('{id}', id);
@@ -204,6 +207,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -214,8 +218,8 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<LibraryResponseDto?> getLibrary(String id,) async {
-    final response = await getLibraryWithHttpInfo(id,);
+  Future<LibraryResponseDto?> getLibrary(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getLibraryWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -238,7 +242,7 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getLibraryStatisticsWithHttpInfo(String id,) async {
+  Future<Response> getLibraryStatisticsWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}/statistics'
       .replaceAll('{id}', id);
@@ -261,6 +265,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -271,8 +276,8 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<LibraryStatsResponseDto?> getLibraryStatistics(String id,) async {
-    final response = await getLibraryStatisticsWithHttpInfo(id,);
+  Future<LibraryStatsResponseDto?> getLibraryStatistics(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getLibraryStatisticsWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -295,7 +300,7 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> scanLibraryWithHttpInfo(String id,) async {
+  Future<Response> scanLibraryWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}/scan'
       .replaceAll('{id}', id);
@@ -318,6 +323,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -328,8 +334,8 @@ class LibrariesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> scanLibrary(String id,) async {
-    final response = await scanLibraryWithHttpInfo(id,);
+  Future<void> scanLibrary(String id, { Future<void>? abortTrigger, }) async {
+    final response = await scanLibraryWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -346,7 +352,7 @@ class LibrariesApi {
   /// * [String] id (required):
   ///
   /// * [UpdateLibraryDto] updateLibraryDto (required):
-  Future<Response> updateLibraryWithHttpInfo(String id, UpdateLibraryDto updateLibraryDto,) async {
+  Future<Response> updateLibraryWithHttpInfo(String id, UpdateLibraryDto updateLibraryDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}'
       .replaceAll('{id}', id);
@@ -369,6 +375,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -381,8 +388,8 @@ class LibrariesApi {
   /// * [String] id (required):
   ///
   /// * [UpdateLibraryDto] updateLibraryDto (required):
-  Future<LibraryResponseDto?> updateLibrary(String id, UpdateLibraryDto updateLibraryDto,) async {
-    final response = await updateLibraryWithHttpInfo(id, updateLibraryDto,);
+  Future<LibraryResponseDto?> updateLibrary(String id, UpdateLibraryDto updateLibraryDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateLibraryWithHttpInfo(id, updateLibraryDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -407,7 +414,7 @@ class LibrariesApi {
   /// * [String] id (required):
   ///
   /// * [ValidateLibraryDto] validateLibraryDto (required):
-  Future<Response> validateWithHttpInfo(String id, ValidateLibraryDto validateLibraryDto,) async {
+  Future<Response> validateWithHttpInfo(String id, ValidateLibraryDto validateLibraryDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/libraries/{id}/validate'
       .replaceAll('{id}', id);
@@ -430,6 +437,7 @@ class LibrariesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -442,8 +450,8 @@ class LibrariesApi {
   /// * [String] id (required):
   ///
   /// * [ValidateLibraryDto] validateLibraryDto (required):
-  Future<ValidateLibraryResponseDto?> validate(String id, ValidateLibraryDto validateLibraryDto,) async {
-    final response = await validateWithHttpInfo(id, validateLibraryDto,);
+  Future<ValidateLibraryResponseDto?> validate(String id, ValidateLibraryDto validateLibraryDto, { Future<void>? abortTrigger, }) async {
+    final response = await validateWithHttpInfo(id, validateLibraryDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/maintenance_admin_api.dart
+++ b/mobile/openapi/lib/api/maintenance_admin_api.dart
@@ -21,7 +21,7 @@ class MaintenanceAdminApi {
   /// Collect integrity checks and other heuristics about local data.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> detectPriorInstallWithHttpInfo() async {
+  Future<Response> detectPriorInstallWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/maintenance/detect-install';
 
@@ -43,14 +43,15 @@ class MaintenanceAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Detect existing install
   ///
   /// Collect integrity checks and other heuristics about local data.
-  Future<MaintenanceDetectInstallResponseDto?> detectPriorInstall() async {
-    final response = await detectPriorInstallWithHttpInfo();
+  Future<MaintenanceDetectInstallResponseDto?> detectPriorInstall({ Future<void>? abortTrigger, }) async {
+    final response = await detectPriorInstallWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -69,7 +70,7 @@ class MaintenanceAdminApi {
   /// Fetch information about the currently running maintenance action.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getMaintenanceStatusWithHttpInfo() async {
+  Future<Response> getMaintenanceStatusWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/maintenance/status';
 
@@ -91,14 +92,15 @@ class MaintenanceAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get maintenance mode status
   ///
   /// Fetch information about the currently running maintenance action.
-  Future<MaintenanceStatusResponseDto?> getMaintenanceStatus() async {
-    final response = await getMaintenanceStatusWithHttpInfo();
+  Future<MaintenanceStatusResponseDto?> getMaintenanceStatus({ Future<void>? abortTrigger, }) async {
+    final response = await getMaintenanceStatusWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -121,7 +123,7 @@ class MaintenanceAdminApi {
   /// Parameters:
   ///
   /// * [MaintenanceLoginDto] maintenanceLoginDto (required):
-  Future<Response> maintenanceLoginWithHttpInfo(MaintenanceLoginDto maintenanceLoginDto,) async {
+  Future<Response> maintenanceLoginWithHttpInfo(MaintenanceLoginDto maintenanceLoginDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/maintenance/login';
 
@@ -143,6 +145,7 @@ class MaintenanceAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -153,8 +156,8 @@ class MaintenanceAdminApi {
   /// Parameters:
   ///
   /// * [MaintenanceLoginDto] maintenanceLoginDto (required):
-  Future<MaintenanceAuthDto?> maintenanceLogin(MaintenanceLoginDto maintenanceLoginDto,) async {
-    final response = await maintenanceLoginWithHttpInfo(maintenanceLoginDto,);
+  Future<MaintenanceAuthDto?> maintenanceLogin(MaintenanceLoginDto maintenanceLoginDto, { Future<void>? abortTrigger, }) async {
+    final response = await maintenanceLoginWithHttpInfo(maintenanceLoginDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -177,7 +180,7 @@ class MaintenanceAdminApi {
   /// Parameters:
   ///
   /// * [SetMaintenanceModeDto] setMaintenanceModeDto (required):
-  Future<Response> setMaintenanceModeWithHttpInfo(SetMaintenanceModeDto setMaintenanceModeDto,) async {
+  Future<Response> setMaintenanceModeWithHttpInfo(SetMaintenanceModeDto setMaintenanceModeDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/maintenance';
 
@@ -199,6 +202,7 @@ class MaintenanceAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -209,8 +213,8 @@ class MaintenanceAdminApi {
   /// Parameters:
   ///
   /// * [SetMaintenanceModeDto] setMaintenanceModeDto (required):
-  Future<void> setMaintenanceMode(SetMaintenanceModeDto setMaintenanceModeDto,) async {
-    final response = await setMaintenanceModeWithHttpInfo(setMaintenanceModeDto,);
+  Future<void> setMaintenanceMode(SetMaintenanceModeDto setMaintenanceModeDto, { Future<void>? abortTrigger, }) async {
+    final response = await setMaintenanceModeWithHttpInfo(setMaintenanceModeDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/map_api.dart
+++ b/mobile/openapi/lib/api/map_api.dart
@@ -41,7 +41,7 @@ class MapApi {
   ///
   /// * [bool] withSharedAlbums:
   ///   Include shared album assets
-  Future<Response> getMapMarkersWithHttpInfo({ DateTime? fileCreatedAfter, DateTime? fileCreatedBefore, bool? isArchived, bool? isFavorite, bool? withPartners, bool? withSharedAlbums, }) async {
+  Future<Response> getMapMarkersWithHttpInfo({ DateTime? fileCreatedAfter, DateTime? fileCreatedBefore, bool? isArchived, bool? isFavorite, bool? withPartners, bool? withSharedAlbums, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/map/markers';
 
@@ -82,6 +82,7 @@ class MapApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -108,8 +109,8 @@ class MapApi {
   ///
   /// * [bool] withSharedAlbums:
   ///   Include shared album assets
-  Future<List<MapMarkerResponseDto>?> getMapMarkers({ DateTime? fileCreatedAfter, DateTime? fileCreatedBefore, bool? isArchived, bool? isFavorite, bool? withPartners, bool? withSharedAlbums, }) async {
-    final response = await getMapMarkersWithHttpInfo( fileCreatedAfter: fileCreatedAfter, fileCreatedBefore: fileCreatedBefore, isArchived: isArchived, isFavorite: isFavorite, withPartners: withPartners, withSharedAlbums: withSharedAlbums, );
+  Future<List<MapMarkerResponseDto>?> getMapMarkers({ DateTime? fileCreatedAfter, DateTime? fileCreatedBefore, bool? isArchived, bool? isFavorite, bool? withPartners, bool? withSharedAlbums, Future<void>? abortTrigger, }) async {
+    final response = await getMapMarkersWithHttpInfo(fileCreatedAfter: fileCreatedAfter, fileCreatedBefore: fileCreatedBefore, isArchived: isArchived, isFavorite: isFavorite, withPartners: withPartners, withSharedAlbums: withSharedAlbums, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -139,7 +140,7 @@ class MapApi {
   ///
   /// * [double] lon (required):
   ///   Longitude (-180 to 180)
-  Future<Response> reverseGeocodeWithHttpInfo(double lat, double lon,) async {
+  Future<Response> reverseGeocodeWithHttpInfo(double lat, double lon, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/map/reverse-geocode';
 
@@ -164,6 +165,7 @@ class MapApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -178,8 +180,8 @@ class MapApi {
   ///
   /// * [double] lon (required):
   ///   Longitude (-180 to 180)
-  Future<List<MapReverseGeocodeResponseDto>?> reverseGeocode(double lat, double lon,) async {
-    final response = await reverseGeocodeWithHttpInfo(lat, lon,);
+  Future<List<MapReverseGeocodeResponseDto>?> reverseGeocode(double lat, double lon, { Future<void>? abortTrigger, }) async {
+    final response = await reverseGeocodeWithHttpInfo(lat, lon, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/memories_api.dart
+++ b/mobile/openapi/lib/api/memories_api.dart
@@ -27,7 +27,7 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> addMemoryAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> addMemoryAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/{id}/assets'
       .replaceAll('{id}', id);
@@ -50,6 +50,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -62,8 +63,8 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> addMemoryAssets(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await addMemoryAssetsWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> addMemoryAssets(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await addMemoryAssetsWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -89,7 +90,7 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [MemoryCreateDto] memoryCreateDto (required):
-  Future<Response> createMemoryWithHttpInfo(MemoryCreateDto memoryCreateDto,) async {
+  Future<Response> createMemoryWithHttpInfo(MemoryCreateDto memoryCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories';
 
@@ -111,6 +112,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -121,8 +123,8 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [MemoryCreateDto] memoryCreateDto (required):
-  Future<MemoryResponseDto?> createMemory(MemoryCreateDto memoryCreateDto,) async {
-    final response = await createMemoryWithHttpInfo(memoryCreateDto,);
+  Future<MemoryResponseDto?> createMemory(MemoryCreateDto memoryCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createMemoryWithHttpInfo(memoryCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -145,7 +147,7 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteMemoryWithHttpInfo(String id,) async {
+  Future<Response> deleteMemoryWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/{id}'
       .replaceAll('{id}', id);
@@ -168,6 +170,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -178,8 +181,8 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteMemory(String id,) async {
-    final response = await deleteMemoryWithHttpInfo(id,);
+  Future<void> deleteMemory(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteMemoryWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -194,7 +197,7 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getMemoryWithHttpInfo(String id,) async {
+  Future<Response> getMemoryWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/{id}'
       .replaceAll('{id}', id);
@@ -217,6 +220,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -227,8 +231,8 @@ class MemoriesApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<MemoryResponseDto?> getMemory(String id,) async {
-    final response = await getMemoryWithHttpInfo(id,);
+  Future<MemoryResponseDto?> getMemory(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getMemoryWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -265,7 +269,7 @@ class MemoriesApi {
   ///   Number of memories to return
   ///
   /// * [MemoryType] type:
-  Future<Response> memoriesStatisticsWithHttpInfo({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, }) async {
+  Future<Response> memoriesStatisticsWithHttpInfo({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/statistics';
 
@@ -306,6 +310,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -330,8 +335,8 @@ class MemoriesApi {
   ///   Number of memories to return
   ///
   /// * [MemoryType] type:
-  Future<MemoryStatisticsResponseDto?> memoriesStatistics({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, }) async {
-    final response = await memoriesStatisticsWithHttpInfo( for_: for_, isSaved: isSaved, isTrashed: isTrashed, order: order, size: size, type: type, );
+  Future<MemoryStatisticsResponseDto?> memoriesStatistics({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, Future<void>? abortTrigger, }) async {
+    final response = await memoriesStatisticsWithHttpInfo(for_: for_, isSaved: isSaved, isTrashed: isTrashed, order: order, size: size, type: type, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -356,7 +361,7 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> removeMemoryAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> removeMemoryAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/{id}/assets'
       .replaceAll('{id}', id);
@@ -379,6 +384,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -391,8 +397,8 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> removeMemoryAssets(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await removeMemoryAssetsWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> removeMemoryAssets(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await removeMemoryAssetsWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -432,7 +438,7 @@ class MemoriesApi {
   ///   Number of memories to return
   ///
   /// * [MemoryType] type:
-  Future<Response> searchMemoriesWithHttpInfo({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, }) async {
+  Future<Response> searchMemoriesWithHttpInfo({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories';
 
@@ -473,6 +479,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -497,8 +504,8 @@ class MemoriesApi {
   ///   Number of memories to return
   ///
   /// * [MemoryType] type:
-  Future<List<MemoryResponseDto>?> searchMemories({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, }) async {
-    final response = await searchMemoriesWithHttpInfo( for_: for_, isSaved: isSaved, isTrashed: isTrashed, order: order, size: size, type: type, );
+  Future<List<MemoryResponseDto>?> searchMemories({ DateTime? for_, bool? isSaved, bool? isTrashed, MemorySearchOrder? order, int? size, MemoryType? type, Future<void>? abortTrigger, }) async {
+    final response = await searchMemoriesWithHttpInfo(for_: for_, isSaved: isSaved, isTrashed: isTrashed, order: order, size: size, type: type, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -526,7 +533,7 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [MemoryUpdateDto] memoryUpdateDto (required):
-  Future<Response> updateMemoryWithHttpInfo(String id, MemoryUpdateDto memoryUpdateDto,) async {
+  Future<Response> updateMemoryWithHttpInfo(String id, MemoryUpdateDto memoryUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/memories/{id}'
       .replaceAll('{id}', id);
@@ -549,6 +556,7 @@ class MemoriesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -561,8 +569,8 @@ class MemoriesApi {
   /// * [String] id (required):
   ///
   /// * [MemoryUpdateDto] memoryUpdateDto (required):
-  Future<MemoryResponseDto?> updateMemory(String id, MemoryUpdateDto memoryUpdateDto,) async {
-    final response = await updateMemoryWithHttpInfo(id, memoryUpdateDto,);
+  Future<MemoryResponseDto?> updateMemory(String id, MemoryUpdateDto memoryUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateMemoryWithHttpInfo(id, memoryUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/notifications_admin_api.dart
+++ b/mobile/openapi/lib/api/notifications_admin_api.dart
@@ -25,7 +25,7 @@ class NotificationsAdminApi {
   /// Parameters:
   ///
   /// * [NotificationCreateDto] notificationCreateDto (required):
-  Future<Response> createNotificationWithHttpInfo(NotificationCreateDto notificationCreateDto,) async {
+  Future<Response> createNotificationWithHttpInfo(NotificationCreateDto notificationCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/notifications';
 
@@ -47,6 +47,7 @@ class NotificationsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class NotificationsAdminApi {
   /// Parameters:
   ///
   /// * [NotificationCreateDto] notificationCreateDto (required):
-  Future<NotificationDto?> createNotification(NotificationCreateDto notificationCreateDto,) async {
-    final response = await createNotificationWithHttpInfo(notificationCreateDto,);
+  Future<NotificationDto?> createNotification(NotificationCreateDto notificationCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createNotificationWithHttpInfo(notificationCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -83,7 +84,7 @@ class NotificationsAdminApi {
   /// * [String] name (required):
   ///
   /// * [TemplateDto] templateDto (required):
-  Future<Response> getNotificationTemplateAdminWithHttpInfo(String name, TemplateDto templateDto,) async {
+  Future<Response> getNotificationTemplateAdminWithHttpInfo(String name, TemplateDto templateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/notifications/templates/{name}'
       .replaceAll('{name}', name);
@@ -106,6 +107,7 @@ class NotificationsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -118,8 +120,8 @@ class NotificationsAdminApi {
   /// * [String] name (required):
   ///
   /// * [TemplateDto] templateDto (required):
-  Future<TemplateResponseDto?> getNotificationTemplateAdmin(String name, TemplateDto templateDto,) async {
-    final response = await getNotificationTemplateAdminWithHttpInfo(name, templateDto,);
+  Future<TemplateResponseDto?> getNotificationTemplateAdmin(String name, TemplateDto templateDto, { Future<void>? abortTrigger, }) async {
+    final response = await getNotificationTemplateAdminWithHttpInfo(name, templateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -142,7 +144,7 @@ class NotificationsAdminApi {
   /// Parameters:
   ///
   /// * [SystemConfigSmtpDto] systemConfigSmtpDto (required):
-  Future<Response> sendTestEmailAdminWithHttpInfo(SystemConfigSmtpDto systemConfigSmtpDto,) async {
+  Future<Response> sendTestEmailAdminWithHttpInfo(SystemConfigSmtpDto systemConfigSmtpDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/notifications/test-email';
 
@@ -164,6 +166,7 @@ class NotificationsAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -174,8 +177,8 @@ class NotificationsAdminApi {
   /// Parameters:
   ///
   /// * [SystemConfigSmtpDto] systemConfigSmtpDto (required):
-  Future<TestEmailResponseDto?> sendTestEmailAdmin(SystemConfigSmtpDto systemConfigSmtpDto,) async {
-    final response = await sendTestEmailAdminWithHttpInfo(systemConfigSmtpDto,);
+  Future<TestEmailResponseDto?> sendTestEmailAdmin(SystemConfigSmtpDto systemConfigSmtpDto, { Future<void>? abortTrigger, }) async {
+    final response = await sendTestEmailAdminWithHttpInfo(systemConfigSmtpDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/notifications_api.dart
+++ b/mobile/openapi/lib/api/notifications_api.dart
@@ -25,7 +25,7 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteNotificationWithHttpInfo(String id,) async {
+  Future<Response> deleteNotificationWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications/{id}'
       .replaceAll('{id}', id);
@@ -48,6 +48,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -58,8 +59,8 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteNotification(String id,) async {
-    final response = await deleteNotificationWithHttpInfo(id,);
+  Future<void> deleteNotification(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteNotificationWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -74,7 +75,7 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [NotificationDeleteAllDto] notificationDeleteAllDto (required):
-  Future<Response> deleteNotificationsWithHttpInfo(NotificationDeleteAllDto notificationDeleteAllDto,) async {
+  Future<Response> deleteNotificationsWithHttpInfo(NotificationDeleteAllDto notificationDeleteAllDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications';
 
@@ -96,6 +97,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -106,8 +108,8 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [NotificationDeleteAllDto] notificationDeleteAllDto (required):
-  Future<void> deleteNotifications(NotificationDeleteAllDto notificationDeleteAllDto,) async {
-    final response = await deleteNotificationsWithHttpInfo(notificationDeleteAllDto,);
+  Future<void> deleteNotifications(NotificationDeleteAllDto notificationDeleteAllDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteNotificationsWithHttpInfo(notificationDeleteAllDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -122,7 +124,7 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getNotificationWithHttpInfo(String id,) async {
+  Future<Response> getNotificationWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications/{id}'
       .replaceAll('{id}', id);
@@ -145,6 +147,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -155,8 +158,8 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<NotificationDto?> getNotification(String id,) async {
-    final response = await getNotificationWithHttpInfo(id,);
+  Future<NotificationDto?> getNotification(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getNotificationWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -187,7 +190,7 @@ class NotificationsApi {
   ///
   /// * [bool] unread:
   ///   Filter by unread status
-  Future<Response> getNotificationsWithHttpInfo({ String? id, NotificationLevel? level, NotificationType? type, bool? unread, }) async {
+  Future<Response> getNotificationsWithHttpInfo({ String? id, NotificationLevel? level, NotificationType? type, bool? unread, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications';
 
@@ -222,6 +225,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -240,8 +244,8 @@ class NotificationsApi {
   ///
   /// * [bool] unread:
   ///   Filter by unread status
-  Future<List<NotificationDto>?> getNotifications({ String? id, NotificationLevel? level, NotificationType? type, bool? unread, }) async {
-    final response = await getNotificationsWithHttpInfo( id: id, level: level, type: type, unread: unread, );
+  Future<List<NotificationDto>?> getNotifications({ String? id, NotificationLevel? level, NotificationType? type, bool? unread, Future<void>? abortTrigger, }) async {
+    final response = await getNotificationsWithHttpInfo(id: id, level: level, type: type, unread: unread, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -269,7 +273,7 @@ class NotificationsApi {
   /// * [String] id (required):
   ///
   /// * [NotificationUpdateDto] notificationUpdateDto (required):
-  Future<Response> updateNotificationWithHttpInfo(String id, NotificationUpdateDto notificationUpdateDto,) async {
+  Future<Response> updateNotificationWithHttpInfo(String id, NotificationUpdateDto notificationUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications/{id}'
       .replaceAll('{id}', id);
@@ -292,6 +296,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -304,8 +309,8 @@ class NotificationsApi {
   /// * [String] id (required):
   ///
   /// * [NotificationUpdateDto] notificationUpdateDto (required):
-  Future<NotificationDto?> updateNotification(String id, NotificationUpdateDto notificationUpdateDto,) async {
-    final response = await updateNotificationWithHttpInfo(id, notificationUpdateDto,);
+  Future<NotificationDto?> updateNotification(String id, NotificationUpdateDto notificationUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateNotificationWithHttpInfo(id, notificationUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -328,7 +333,7 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [NotificationUpdateAllDto] notificationUpdateAllDto (required):
-  Future<Response> updateNotificationsWithHttpInfo(NotificationUpdateAllDto notificationUpdateAllDto,) async {
+  Future<Response> updateNotificationsWithHttpInfo(NotificationUpdateAllDto notificationUpdateAllDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/notifications';
 
@@ -350,6 +355,7 @@ class NotificationsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -360,8 +366,8 @@ class NotificationsApi {
   /// Parameters:
   ///
   /// * [NotificationUpdateAllDto] notificationUpdateAllDto (required):
-  Future<void> updateNotifications(NotificationUpdateAllDto notificationUpdateAllDto,) async {
-    final response = await updateNotificationsWithHttpInfo(notificationUpdateAllDto,);
+  Future<void> updateNotifications(NotificationUpdateAllDto notificationUpdateAllDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateNotificationsWithHttpInfo(notificationUpdateAllDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/partners_api.dart
+++ b/mobile/openapi/lib/api/partners_api.dart
@@ -25,7 +25,7 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [PartnerCreateDto] partnerCreateDto (required):
-  Future<Response> createPartnerWithHttpInfo(PartnerCreateDto partnerCreateDto,) async {
+  Future<Response> createPartnerWithHttpInfo(PartnerCreateDto partnerCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners';
 
@@ -47,6 +47,7 @@ class PartnersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [PartnerCreateDto] partnerCreateDto (required):
-  Future<PartnerResponseDto?> createPartner(PartnerCreateDto partnerCreateDto,) async {
-    final response = await createPartnerWithHttpInfo(partnerCreateDto,);
+  Future<PartnerResponseDto?> createPartner(PartnerCreateDto partnerCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createPartnerWithHttpInfo(partnerCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> createPartnerDeprecatedWithHttpInfo(String id,) async {
+  Future<Response> createPartnerDeprecatedWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class PartnersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<PartnerResponseDto?> createPartnerDeprecated(String id,) async {
-    final response = await createPartnerDeprecatedWithHttpInfo(id,);
+  Future<PartnerResponseDto?> createPartnerDeprecated(String id, { Future<void>? abortTrigger, }) async {
+    final response = await createPartnerDeprecatedWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -138,7 +140,7 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [PartnerDirection] direction (required):
-  Future<Response> getPartnersWithHttpInfo(PartnerDirection direction,) async {
+  Future<Response> getPartnersWithHttpInfo(PartnerDirection direction, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners';
 
@@ -162,6 +164,7 @@ class PartnersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -172,8 +175,8 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [PartnerDirection] direction (required):
-  Future<List<PartnerResponseDto>?> getPartners(PartnerDirection direction,) async {
-    final response = await getPartnersWithHttpInfo(direction,);
+  Future<List<PartnerResponseDto>?> getPartners(PartnerDirection direction, { Future<void>? abortTrigger, }) async {
+    final response = await getPartnersWithHttpInfo(direction, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -199,7 +202,7 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> removePartnerWithHttpInfo(String id,) async {
+  Future<Response> removePartnerWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners/{id}'
       .replaceAll('{id}', id);
@@ -222,6 +225,7 @@ class PartnersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -232,8 +236,8 @@ class PartnersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> removePartner(String id,) async {
-    final response = await removePartnerWithHttpInfo(id,);
+  Future<void> removePartner(String id, { Future<void>? abortTrigger, }) async {
+    final response = await removePartnerWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -250,7 +254,7 @@ class PartnersApi {
   /// * [String] id (required):
   ///
   /// * [PartnerUpdateDto] partnerUpdateDto (required):
-  Future<Response> updatePartnerWithHttpInfo(String id, PartnerUpdateDto partnerUpdateDto,) async {
+  Future<Response> updatePartnerWithHttpInfo(String id, PartnerUpdateDto partnerUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/partners/{id}'
       .replaceAll('{id}', id);
@@ -273,6 +277,7 @@ class PartnersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -285,8 +290,8 @@ class PartnersApi {
   /// * [String] id (required):
   ///
   /// * [PartnerUpdateDto] partnerUpdateDto (required):
-  Future<PartnerResponseDto?> updatePartner(String id, PartnerUpdateDto partnerUpdateDto,) async {
-    final response = await updatePartnerWithHttpInfo(id, partnerUpdateDto,);
+  Future<PartnerResponseDto?> updatePartner(String id, PartnerUpdateDto partnerUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updatePartnerWithHttpInfo(id, partnerUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/people_api.dart
+++ b/mobile/openapi/lib/api/people_api.dart
@@ -25,7 +25,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [PersonCreateDto] personCreateDto (required):
-  Future<Response> createPersonWithHttpInfo(PersonCreateDto personCreateDto,) async {
+  Future<Response> createPersonWithHttpInfo(PersonCreateDto personCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people';
 
@@ -47,6 +47,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [PersonCreateDto] personCreateDto (required):
-  Future<PersonResponseDto?> createPerson(PersonCreateDto personCreateDto,) async {
-    final response = await createPersonWithHttpInfo(personCreateDto,);
+  Future<PersonResponseDto?> createPerson(PersonCreateDto personCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createPersonWithHttpInfo(personCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> deletePeopleWithHttpInfo(BulkIdsDto bulkIdsDto,) async {
+  Future<Response> deletePeopleWithHttpInfo(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people';
 
@@ -103,6 +104,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -113,8 +115,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<void> deletePeople(BulkIdsDto bulkIdsDto,) async {
-    final response = await deletePeopleWithHttpInfo(bulkIdsDto,);
+  Future<void> deletePeople(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await deletePeopleWithHttpInfo(bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -129,7 +131,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deletePersonWithHttpInfo(String id,) async {
+  Future<Response> deletePersonWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}'
       .replaceAll('{id}', id);
@@ -152,6 +154,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -162,8 +165,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deletePerson(String id,) async {
-    final response = await deletePersonWithHttpInfo(id,);
+  Future<void> deletePerson(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deletePersonWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -191,7 +194,7 @@ class PeopleApi {
   ///
   /// * [bool] withHidden:
   ///   Include hidden people
-  Future<Response> getAllPeopleWithHttpInfo({ String? closestAssetId, String? closestPersonId, int? page, int? size, bool? withHidden, }) async {
+  Future<Response> getAllPeopleWithHttpInfo({ String? closestAssetId, String? closestPersonId, int? page, int? size, bool? withHidden, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people';
 
@@ -229,6 +232,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -252,8 +256,8 @@ class PeopleApi {
   ///
   /// * [bool] withHidden:
   ///   Include hidden people
-  Future<PeopleResponseDto?> getAllPeople({ String? closestAssetId, String? closestPersonId, int? page, int? size, bool? withHidden, }) async {
-    final response = await getAllPeopleWithHttpInfo( closestAssetId: closestAssetId, closestPersonId: closestPersonId, page: page, size: size, withHidden: withHidden, );
+  Future<PeopleResponseDto?> getAllPeople({ String? closestAssetId, String? closestPersonId, int? page, int? size, bool? withHidden, Future<void>? abortTrigger, }) async {
+    final response = await getAllPeopleWithHttpInfo(closestAssetId: closestAssetId, closestPersonId: closestPersonId, page: page, size: size, withHidden: withHidden, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -276,7 +280,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getPersonWithHttpInfo(String id,) async {
+  Future<Response> getPersonWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}'
       .replaceAll('{id}', id);
@@ -299,6 +303,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -309,8 +314,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<PersonResponseDto?> getPerson(String id,) async {
-    final response = await getPersonWithHttpInfo(id,);
+  Future<PersonResponseDto?> getPerson(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getPersonWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -333,7 +338,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getPersonStatisticsWithHttpInfo(String id,) async {
+  Future<Response> getPersonStatisticsWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}/statistics'
       .replaceAll('{id}', id);
@@ -356,6 +361,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -366,8 +372,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<PersonStatisticsResponseDto?> getPersonStatistics(String id,) async {
-    final response = await getPersonStatisticsWithHttpInfo(id,);
+  Future<PersonStatisticsResponseDto?> getPersonStatistics(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getPersonStatisticsWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -390,7 +396,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getPersonThumbnailWithHttpInfo(String id,) async {
+  Future<Response> getPersonThumbnailWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}/thumbnail'
       .replaceAll('{id}', id);
@@ -413,6 +419,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -423,8 +430,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<MultipartFile?> getPersonThumbnail(String id,) async {
-    final response = await getPersonThumbnailWithHttpInfo(id,);
+  Future<MultipartFile?> getPersonThumbnail(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getPersonThumbnailWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -449,7 +456,7 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [MergePersonDto] mergePersonDto (required):
-  Future<Response> mergePersonWithHttpInfo(String id, MergePersonDto mergePersonDto,) async {
+  Future<Response> mergePersonWithHttpInfo(String id, MergePersonDto mergePersonDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}/merge'
       .replaceAll('{id}', id);
@@ -472,6 +479,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -484,8 +492,8 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [MergePersonDto] mergePersonDto (required):
-  Future<List<BulkIdResponseDto>?> mergePerson(String id, MergePersonDto mergePersonDto,) async {
-    final response = await mergePersonWithHttpInfo(id, mergePersonDto,);
+  Future<List<BulkIdResponseDto>?> mergePerson(String id, MergePersonDto mergePersonDto, { Future<void>? abortTrigger, }) async {
+    final response = await mergePersonWithHttpInfo(id, mergePersonDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -513,7 +521,7 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [AssetFaceUpdateDto] assetFaceUpdateDto (required):
-  Future<Response> reassignFacesWithHttpInfo(String id, AssetFaceUpdateDto assetFaceUpdateDto,) async {
+  Future<Response> reassignFacesWithHttpInfo(String id, AssetFaceUpdateDto assetFaceUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}/reassign'
       .replaceAll('{id}', id);
@@ -536,6 +544,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -548,8 +557,8 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [AssetFaceUpdateDto] assetFaceUpdateDto (required):
-  Future<List<PersonResponseDto>?> reassignFaces(String id, AssetFaceUpdateDto assetFaceUpdateDto,) async {
-    final response = await reassignFacesWithHttpInfo(id, assetFaceUpdateDto,);
+  Future<List<PersonResponseDto>?> reassignFaces(String id, AssetFaceUpdateDto assetFaceUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await reassignFacesWithHttpInfo(id, assetFaceUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -575,7 +584,7 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [PeopleUpdateDto] peopleUpdateDto (required):
-  Future<Response> updatePeopleWithHttpInfo(PeopleUpdateDto peopleUpdateDto,) async {
+  Future<Response> updatePeopleWithHttpInfo(PeopleUpdateDto peopleUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people';
 
@@ -597,6 +606,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -607,8 +617,8 @@ class PeopleApi {
   /// Parameters:
   ///
   /// * [PeopleUpdateDto] peopleUpdateDto (required):
-  Future<List<BulkIdResponseDto>?> updatePeople(PeopleUpdateDto peopleUpdateDto,) async {
-    final response = await updatePeopleWithHttpInfo(peopleUpdateDto,);
+  Future<List<BulkIdResponseDto>?> updatePeople(PeopleUpdateDto peopleUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updatePeopleWithHttpInfo(peopleUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -636,7 +646,7 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [PersonUpdateDto] personUpdateDto (required):
-  Future<Response> updatePersonWithHttpInfo(String id, PersonUpdateDto personUpdateDto,) async {
+  Future<Response> updatePersonWithHttpInfo(String id, PersonUpdateDto personUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/people/{id}'
       .replaceAll('{id}', id);
@@ -659,6 +669,7 @@ class PeopleApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -671,8 +682,8 @@ class PeopleApi {
   /// * [String] id (required):
   ///
   /// * [PersonUpdateDto] personUpdateDto (required):
-  Future<PersonResponseDto?> updatePerson(String id, PersonUpdateDto personUpdateDto,) async {
-    final response = await updatePersonWithHttpInfo(id, personUpdateDto,);
+  Future<PersonResponseDto?> updatePerson(String id, PersonUpdateDto personUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updatePersonWithHttpInfo(id, personUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/plugins_api.dart
+++ b/mobile/openapi/lib/api/plugins_api.dart
@@ -25,7 +25,7 @@ class PluginsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getPluginWithHttpInfo(String id,) async {
+  Future<Response> getPluginWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/plugins/{id}'
       .replaceAll('{id}', id);
@@ -48,6 +48,7 @@ class PluginsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -58,8 +59,8 @@ class PluginsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<PluginResponseDto?> getPlugin(String id,) async {
-    final response = await getPluginWithHttpInfo(id,);
+  Future<PluginResponseDto?> getPlugin(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getPluginWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -104,7 +105,7 @@ class PluginsApi {
   ///
   /// * [WorkflowType] type:
   ///   Workflow types
-  Future<Response> searchPluginMethodsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, String? pluginName, String? pluginVersion, String? title, WorkflowTrigger? trigger, WorkflowType? type, }) async {
+  Future<Response> searchPluginMethodsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, String? pluginName, String? pluginVersion, String? title, WorkflowTrigger? trigger, WorkflowType? type, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/plugins/methods';
 
@@ -154,6 +155,7 @@ class PluginsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -186,8 +188,8 @@ class PluginsApi {
   ///
   /// * [WorkflowType] type:
   ///   Workflow types
-  Future<List<PluginMethodResponseDto>?> searchPluginMethods({ String? description, bool? enabled, String? id, String? name, String? pluginName, String? pluginVersion, String? title, WorkflowTrigger? trigger, WorkflowType? type, }) async {
-    final response = await searchPluginMethodsWithHttpInfo( description: description, enabled: enabled, id: id, name: name, pluginName: pluginName, pluginVersion: pluginVersion, title: title, trigger: trigger, type: type, );
+  Future<List<PluginMethodResponseDto>?> searchPluginMethods({ String? description, bool? enabled, String? id, String? name, String? pluginName, String? pluginVersion, String? title, WorkflowTrigger? trigger, WorkflowType? type, Future<void>? abortTrigger, }) async {
+    final response = await searchPluginMethodsWithHttpInfo(description: description, enabled: enabled, id: id, name: name, pluginName: pluginName, pluginVersion: pluginVersion, title: title, trigger: trigger, type: type, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -209,7 +211,7 @@ class PluginsApi {
   /// Retrieve workflow templates provided by installed plugins
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> searchPluginTemplatesWithHttpInfo() async {
+  Future<Response> searchPluginTemplatesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/plugins/templates';
 
@@ -231,14 +233,15 @@ class PluginsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve workflow templates
   ///
   /// Retrieve workflow templates provided by installed plugins
-  Future<List<PluginTemplateResponseDto>?> searchPluginTemplates() async {
-    final response = await searchPluginTemplatesWithHttpInfo();
+  Future<List<PluginTemplateResponseDto>?> searchPluginTemplates({ Future<void>? abortTrigger, }) async {
+    final response = await searchPluginTemplatesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -276,7 +279,7 @@ class PluginsApi {
   /// * [String] title:
   ///
   /// * [String] version:
-  Future<Response> searchPluginsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, String? title, String? version, }) async {
+  Future<Response> searchPluginsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, String? title, String? version, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/plugins';
 
@@ -317,6 +320,7 @@ class PluginsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -339,8 +343,8 @@ class PluginsApi {
   /// * [String] title:
   ///
   /// * [String] version:
-  Future<List<PluginResponseDto>?> searchPlugins({ String? description, bool? enabled, String? id, String? name, String? title, String? version, }) async {
-    final response = await searchPluginsWithHttpInfo( description: description, enabled: enabled, id: id, name: name, title: title, version: version, );
+  Future<List<PluginResponseDto>?> searchPlugins({ String? description, bool? enabled, String? id, String? name, String? title, String? version, Future<void>? abortTrigger, }) async {
+    final response = await searchPluginsWithHttpInfo(description: description, enabled: enabled, id: id, name: name, title: title, version: version, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/queues_api.dart
+++ b/mobile/openapi/lib/api/queues_api.dart
@@ -27,7 +27,7 @@ class QueuesApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueDeleteDto] queueDeleteDto (required):
-  Future<Response> emptyQueueWithHttpInfo(QueueName name, QueueDeleteDto queueDeleteDto,) async {
+  Future<Response> emptyQueueWithHttpInfo(QueueName name, QueueDeleteDto queueDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/queues/{name}/jobs'
       .replaceAll('{name}', name.toString());
@@ -50,6 +50,7 @@ class QueuesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -62,8 +63,8 @@ class QueuesApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueDeleteDto] queueDeleteDto (required):
-  Future<void> emptyQueue(QueueName name, QueueDeleteDto queueDeleteDto,) async {
-    final response = await emptyQueueWithHttpInfo(name, queueDeleteDto,);
+  Future<void> emptyQueue(QueueName name, QueueDeleteDto queueDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await emptyQueueWithHttpInfo(name, queueDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -78,7 +79,7 @@ class QueuesApi {
   /// Parameters:
   ///
   /// * [QueueName] name (required):
-  Future<Response> getQueueWithHttpInfo(QueueName name,) async {
+  Future<Response> getQueueWithHttpInfo(QueueName name, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/queues/{name}'
       .replaceAll('{name}', name.toString());
@@ -101,6 +102,7 @@ class QueuesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -111,8 +113,8 @@ class QueuesApi {
   /// Parameters:
   ///
   /// * [QueueName] name (required):
-  Future<QueueResponseDto?> getQueue(QueueName name,) async {
-    final response = await getQueueWithHttpInfo(name,);
+  Future<QueueResponseDto?> getQueue(QueueName name, { Future<void>? abortTrigger, }) async {
+    final response = await getQueueWithHttpInfo(name, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -138,7 +140,7 @@ class QueuesApi {
   ///
   /// * [List<QueueJobStatus>] status:
   ///   Filter jobs by status
-  Future<Response> getQueueJobsWithHttpInfo(QueueName name, { List<QueueJobStatus>? status, }) async {
+  Future<Response> getQueueJobsWithHttpInfo(QueueName name, { List<QueueJobStatus>? status, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/queues/{name}/jobs'
       .replaceAll('{name}', name.toString());
@@ -165,6 +167,7 @@ class QueuesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -178,8 +181,8 @@ class QueuesApi {
   ///
   /// * [List<QueueJobStatus>] status:
   ///   Filter jobs by status
-  Future<List<QueueJobResponseDto>?> getQueueJobs(QueueName name, { List<QueueJobStatus>? status, }) async {
-    final response = await getQueueJobsWithHttpInfo(name,  status: status, );
+  Future<List<QueueJobResponseDto>?> getQueueJobs(QueueName name, { List<QueueJobStatus>? status, Future<void>? abortTrigger, }) async {
+    final response = await getQueueJobsWithHttpInfo(name, status: status, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -201,7 +204,7 @@ class QueuesApi {
   /// Retrieves a list of queues.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getQueuesWithHttpInfo() async {
+  Future<Response> getQueuesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/queues';
 
@@ -223,14 +226,15 @@ class QueuesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// List all queues
   ///
   /// Retrieves a list of queues.
-  Future<List<QueueResponseDto>?> getQueues() async {
-    final response = await getQueuesWithHttpInfo();
+  Future<List<QueueResponseDto>?> getQueues({ Future<void>? abortTrigger, }) async {
+    final response = await getQueuesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -258,7 +262,7 @@ class QueuesApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueUpdateDto] queueUpdateDto (required):
-  Future<Response> updateQueueWithHttpInfo(QueueName name, QueueUpdateDto queueUpdateDto,) async {
+  Future<Response> updateQueueWithHttpInfo(QueueName name, QueueUpdateDto queueUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/queues/{name}'
       .replaceAll('{name}', name.toString());
@@ -281,6 +285,7 @@ class QueuesApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -293,8 +298,8 @@ class QueuesApi {
   /// * [QueueName] name (required):
   ///
   /// * [QueueUpdateDto] queueUpdateDto (required):
-  Future<QueueResponseDto?> updateQueue(QueueName name, QueueUpdateDto queueUpdateDto,) async {
-    final response = await updateQueueWithHttpInfo(name, queueUpdateDto,);
+  Future<QueueResponseDto?> updateQueue(QueueName name, QueueUpdateDto queueUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateQueueWithHttpInfo(name, queueUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -21,7 +21,7 @@ class SearchApi {
   /// Retrieve a list of assets with each asset belonging to a different city. This endpoint is used on the places pages to show a single thumbnail for each city the user has assets in.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAssetsByCityWithHttpInfo() async {
+  Future<Response> getAssetsByCityWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/cities';
 
@@ -43,14 +43,15 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve assets by city
   ///
   /// Retrieve a list of assets with each asset belonging to a different city. This endpoint is used on the places pages to show a single thumbnail for each city the user has assets in.
-  Future<List<AssetResponseDto>?> getAssetsByCity() async {
-    final response = await getAssetsByCityWithHttpInfo();
+  Future<List<AssetResponseDto>?> getAssetsByCity({ Future<void>? abortTrigger, }) async {
+    final response = await getAssetsByCityWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -72,7 +73,7 @@ class SearchApi {
   /// Retrieve data for the explore section, such as popular people and places.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getExploreDataWithHttpInfo() async {
+  Future<Response> getExploreDataWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/explore';
 
@@ -94,14 +95,15 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve explore data
   ///
   /// Retrieve data for the explore section, such as popular people and places.
-  Future<List<SearchExploreResponseDto>?> getExploreData() async {
-    final response = await getExploreDataWithHttpInfo();
+  Future<List<SearchExploreResponseDto>?> getExploreData({ Future<void>? abortTrigger, }) async {
+    final response = await getExploreDataWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -145,7 +147,7 @@ class SearchApi {
   ///
   /// * [String] state:
   ///   Filter by state/province
-  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? state, }) async {
+  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? state, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/suggestions';
 
@@ -187,6 +189,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -215,8 +218,8 @@ class SearchApi {
   ///
   /// * [String] state:
   ///   Filter by state/province
-  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? state, }) async {
-    final response = await getSearchSuggestionsWithHttpInfo(type,  country: country, includeNull: includeNull, lensModel: lensModel, make: make, model: model, state: state, );
+  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? state, Future<void>? abortTrigger, }) async {
+    final response = await getSearchSuggestionsWithHttpInfo(type, country: country, includeNull: includeNull, lensModel: lensModel, make: make, model: model, state: state, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -242,7 +245,7 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [StatisticsSearchDto] statisticsSearchDto (required):
-  Future<Response> searchAssetStatisticsWithHttpInfo(StatisticsSearchDto statisticsSearchDto,) async {
+  Future<Response> searchAssetStatisticsWithHttpInfo(StatisticsSearchDto statisticsSearchDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/statistics';
 
@@ -264,6 +267,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -274,8 +278,8 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [StatisticsSearchDto] statisticsSearchDto (required):
-  Future<SearchStatisticsResponseDto?> searchAssetStatistics(StatisticsSearchDto statisticsSearchDto,) async {
-    final response = await searchAssetStatisticsWithHttpInfo(statisticsSearchDto,);
+  Future<SearchStatisticsResponseDto?> searchAssetStatistics(StatisticsSearchDto statisticsSearchDto, { Future<void>? abortTrigger, }) async {
+    final response = await searchAssetStatisticsWithHttpInfo(statisticsSearchDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -298,7 +302,7 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [MetadataSearchDto] metadataSearchDto (required):
-  Future<Response> searchAssetsWithHttpInfo(MetadataSearchDto metadataSearchDto,) async {
+  Future<Response> searchAssetsWithHttpInfo(MetadataSearchDto metadataSearchDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/metadata';
 
@@ -320,6 +324,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -330,8 +335,8 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [MetadataSearchDto] metadataSearchDto (required):
-  Future<SearchResponseDto?> searchAssets(MetadataSearchDto metadataSearchDto,) async {
-    final response = await searchAssetsWithHttpInfo(metadataSearchDto,);
+  Future<SearchResponseDto?> searchAssets(MetadataSearchDto metadataSearchDto, { Future<void>? abortTrigger, }) async {
+    final response = await searchAssetsWithHttpInfo(metadataSearchDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -443,7 +448,7 @@ class SearchApi {
   ///
   /// * [bool] withExif:
   ///   Include EXIF data in response
-  Future<Response> searchLargeAssetsWithHttpInfo({ List<String>? albumIds, String? city, String? country, DateTime? createdAfter, DateTime? createdBefore, bool? isEncoded, bool? isFavorite, bool? isMotion, bool? isNotInAlbum, bool? isOffline, String? lensModel, String? libraryId, String? make, int? minFileSize, String? model, String? ocr, List<String>? personIds, int? rating, int? size, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, DateTime? trashedAfter, DateTime? trashedBefore, AssetTypeEnum? type, DateTime? updatedAfter, DateTime? updatedBefore, AssetVisibility? visibility, bool? withDeleted, bool? withExif, }) async {
+  Future<Response> searchLargeAssetsWithHttpInfo({ List<String>? albumIds, String? city, String? country, DateTime? createdAfter, DateTime? createdBefore, bool? isEncoded, bool? isFavorite, bool? isMotion, bool? isNotInAlbum, bool? isOffline, String? lensModel, String? libraryId, String? make, int? minFileSize, String? model, String? ocr, List<String>? personIds, int? rating, int? size, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, DateTime? trashedAfter, DateTime? trashedBefore, AssetTypeEnum? type, DateTime? updatedAfter, DateTime? updatedBefore, AssetVisibility? visibility, bool? withDeleted, bool? withExif, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/large-assets';
 
@@ -559,6 +564,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -658,8 +664,8 @@ class SearchApi {
   ///
   /// * [bool] withExif:
   ///   Include EXIF data in response
-  Future<List<AssetResponseDto>?> searchLargeAssets({ List<String>? albumIds, String? city, String? country, DateTime? createdAfter, DateTime? createdBefore, bool? isEncoded, bool? isFavorite, bool? isMotion, bool? isNotInAlbum, bool? isOffline, String? lensModel, String? libraryId, String? make, int? minFileSize, String? model, String? ocr, List<String>? personIds, int? rating, int? size, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, DateTime? trashedAfter, DateTime? trashedBefore, AssetTypeEnum? type, DateTime? updatedAfter, DateTime? updatedBefore, AssetVisibility? visibility, bool? withDeleted, bool? withExif, }) async {
-    final response = await searchLargeAssetsWithHttpInfo( albumIds: albumIds, city: city, country: country, createdAfter: createdAfter, createdBefore: createdBefore, isEncoded: isEncoded, isFavorite: isFavorite, isMotion: isMotion, isNotInAlbum: isNotInAlbum, isOffline: isOffline, lensModel: lensModel, libraryId: libraryId, make: make, minFileSize: minFileSize, model: model, ocr: ocr, personIds: personIds, rating: rating, size: size, state: state, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, trashedAfter: trashedAfter, trashedBefore: trashedBefore, type: type, updatedAfter: updatedAfter, updatedBefore: updatedBefore, visibility: visibility, withDeleted: withDeleted, withExif: withExif, );
+  Future<List<AssetResponseDto>?> searchLargeAssets({ List<String>? albumIds, String? city, String? country, DateTime? createdAfter, DateTime? createdBefore, bool? isEncoded, bool? isFavorite, bool? isMotion, bool? isNotInAlbum, bool? isOffline, String? lensModel, String? libraryId, String? make, int? minFileSize, String? model, String? ocr, List<String>? personIds, int? rating, int? size, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, DateTime? trashedAfter, DateTime? trashedBefore, AssetTypeEnum? type, DateTime? updatedAfter, DateTime? updatedBefore, AssetVisibility? visibility, bool? withDeleted, bool? withExif, Future<void>? abortTrigger, }) async {
+    final response = await searchLargeAssetsWithHttpInfo(albumIds: albumIds, city: city, country: country, createdAfter: createdAfter, createdBefore: createdBefore, isEncoded: isEncoded, isFavorite: isFavorite, isMotion: isMotion, isNotInAlbum: isNotInAlbum, isOffline: isOffline, lensModel: lensModel, libraryId: libraryId, make: make, minFileSize: minFileSize, model: model, ocr: ocr, personIds: personIds, rating: rating, size: size, state: state, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, trashedAfter: trashedAfter, trashedBefore: trashedBefore, type: type, updatedAfter: updatedAfter, updatedBefore: updatedBefore, visibility: visibility, withDeleted: withDeleted, withExif: withExif, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -689,7 +695,7 @@ class SearchApi {
   ///
   /// * [bool] withHidden:
   ///   Include hidden people
-  Future<Response> searchPersonWithHttpInfo(String name, { bool? withHidden, }) async {
+  Future<Response> searchPersonWithHttpInfo(String name, { bool? withHidden, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/person';
 
@@ -716,6 +722,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -730,8 +737,8 @@ class SearchApi {
   ///
   /// * [bool] withHidden:
   ///   Include hidden people
-  Future<List<PersonResponseDto>?> searchPerson(String name, { bool? withHidden, }) async {
-    final response = await searchPersonWithHttpInfo(name,  withHidden: withHidden, );
+  Future<List<PersonResponseDto>?> searchPerson(String name, { bool? withHidden, Future<void>? abortTrigger, }) async {
+    final response = await searchPersonWithHttpInfo(name, withHidden: withHidden, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -758,7 +765,7 @@ class SearchApi {
   ///
   /// * [String] name (required):
   ///   Place name to search for
-  Future<Response> searchPlacesWithHttpInfo(String name,) async {
+  Future<Response> searchPlacesWithHttpInfo(String name, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/places';
 
@@ -782,6 +789,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -793,8 +801,8 @@ class SearchApi {
   ///
   /// * [String] name (required):
   ///   Place name to search for
-  Future<List<PlacesResponseDto>?> searchPlaces(String name,) async {
-    final response = await searchPlacesWithHttpInfo(name,);
+  Future<List<PlacesResponseDto>?> searchPlaces(String name, { Future<void>? abortTrigger, }) async {
+    final response = await searchPlacesWithHttpInfo(name, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -820,7 +828,7 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [RandomSearchDto] randomSearchDto (required):
-  Future<Response> searchRandomWithHttpInfo(RandomSearchDto randomSearchDto,) async {
+  Future<Response> searchRandomWithHttpInfo(RandomSearchDto randomSearchDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/random';
 
@@ -842,6 +850,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -852,8 +861,8 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [RandomSearchDto] randomSearchDto (required):
-  Future<List<AssetResponseDto>?> searchRandom(RandomSearchDto randomSearchDto,) async {
-    final response = await searchRandomWithHttpInfo(randomSearchDto,);
+  Future<List<AssetResponseDto>?> searchRandom(RandomSearchDto randomSearchDto, { Future<void>? abortTrigger, }) async {
+    final response = await searchRandomWithHttpInfo(randomSearchDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -879,7 +888,7 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [SmartSearchDto] smartSearchDto (required):
-  Future<Response> searchSmartWithHttpInfo(SmartSearchDto smartSearchDto,) async {
+  Future<Response> searchSmartWithHttpInfo(SmartSearchDto smartSearchDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/smart';
 
@@ -901,6 +910,7 @@ class SearchApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -911,8 +921,8 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [SmartSearchDto] smartSearchDto (required):
-  Future<SearchResponseDto?> searchSmart(SmartSearchDto smartSearchDto,) async {
-    final response = await searchSmartWithHttpInfo(smartSearchDto,);
+  Future<SearchResponseDto?> searchSmart(SmartSearchDto smartSearchDto, { Future<void>? abortTrigger, }) async {
+    final response = await searchSmartWithHttpInfo(smartSearchDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/server_api.dart
+++ b/mobile/openapi/lib/api/server_api.dart
@@ -21,7 +21,7 @@ class ServerApi {
   /// Delete the currently set server product key.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> deleteServerLicenseWithHttpInfo() async {
+  Future<Response> deleteServerLicenseWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/license';
 
@@ -43,14 +43,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Delete server product key
   ///
   /// Delete the currently set server product key.
-  Future<void> deleteServerLicense() async {
-    final response = await deleteServerLicenseWithHttpInfo();
+  Future<void> deleteServerLicense({ Future<void>? abortTrigger, }) async {
+    final response = await deleteServerLicenseWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -61,7 +62,7 @@ class ServerApi {
   /// Retrieve a list of information about the server.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAboutInfoWithHttpInfo() async {
+  Future<Response> getAboutInfoWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/about';
 
@@ -83,14 +84,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get server information
   ///
   /// Retrieve a list of information about the server.
-  Future<ServerAboutResponseDto?> getAboutInfo() async {
-    final response = await getAboutInfoWithHttpInfo();
+  Future<ServerAboutResponseDto?> getAboutInfo({ Future<void>? abortTrigger, }) async {
+    final response = await getAboutInfoWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -109,7 +111,7 @@ class ServerApi {
   /// Retrieve links to the APKs for the current server version.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getApkLinksWithHttpInfo() async {
+  Future<Response> getApkLinksWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/apk-links';
 
@@ -131,14 +133,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get APK links
   ///
   /// Retrieve links to the APKs for the current server version.
-  Future<ServerApkLinksDto?> getApkLinks() async {
-    final response = await getApkLinksWithHttpInfo();
+  Future<ServerApkLinksDto?> getApkLinks({ Future<void>? abortTrigger, }) async {
+    final response = await getApkLinksWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -157,7 +160,7 @@ class ServerApi {
   /// Retrieve the current server configuration.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getServerConfigWithHttpInfo() async {
+  Future<Response> getServerConfigWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/config';
 
@@ -179,14 +182,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get config
   ///
   /// Retrieve the current server configuration.
-  Future<ServerConfigDto?> getServerConfig() async {
-    final response = await getServerConfigWithHttpInfo();
+  Future<ServerConfigDto?> getServerConfig({ Future<void>? abortTrigger, }) async {
+    final response = await getServerConfigWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -205,7 +209,7 @@ class ServerApi {
   /// Retrieve available features supported by this server.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getServerFeaturesWithHttpInfo() async {
+  Future<Response> getServerFeaturesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/features';
 
@@ -227,14 +231,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get features
   ///
   /// Retrieve available features supported by this server.
-  Future<ServerFeaturesDto?> getServerFeatures() async {
-    final response = await getServerFeaturesWithHttpInfo();
+  Future<ServerFeaturesDto?> getServerFeatures({ Future<void>? abortTrigger, }) async {
+    final response = await getServerFeaturesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -253,7 +258,7 @@ class ServerApi {
   /// Retrieve information about whether the server currently has a product key registered.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getServerLicenseWithHttpInfo() async {
+  Future<Response> getServerLicenseWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/license';
 
@@ -275,14 +280,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get product key
   ///
   /// Retrieve information about whether the server currently has a product key registered.
-  Future<UserLicense?> getServerLicense() async {
-    final response = await getServerLicenseWithHttpInfo();
+  Future<UserLicense?> getServerLicense({ Future<void>? abortTrigger, }) async {
+    final response = await getServerLicenseWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -301,7 +307,7 @@ class ServerApi {
   /// Retrieve statistics about the entire Immich instance such as asset counts.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getServerStatisticsWithHttpInfo() async {
+  Future<Response> getServerStatisticsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/statistics';
 
@@ -323,14 +329,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get statistics
   ///
   /// Retrieve statistics about the entire Immich instance such as asset counts.
-  Future<ServerStatsResponseDto?> getServerStatistics() async {
-    final response = await getServerStatisticsWithHttpInfo();
+  Future<ServerStatsResponseDto?> getServerStatistics({ Future<void>? abortTrigger, }) async {
+    final response = await getServerStatisticsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -349,7 +356,7 @@ class ServerApi {
   /// Retrieve the current server version in semantic versioning (semver) format.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getServerVersionWithHttpInfo() async {
+  Future<Response> getServerVersionWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/version';
 
@@ -371,14 +378,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get server version
   ///
   /// Retrieve the current server version in semantic versioning (semver) format.
-  Future<ServerVersionResponseDto?> getServerVersion() async {
-    final response = await getServerVersionWithHttpInfo();
+  Future<ServerVersionResponseDto?> getServerVersion({ Future<void>? abortTrigger, }) async {
+    final response = await getServerVersionWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -397,7 +405,7 @@ class ServerApi {
   /// Retrieve the current storage utilization information of the server.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getStorageWithHttpInfo() async {
+  Future<Response> getStorageWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/storage';
 
@@ -419,14 +427,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get storage
   ///
   /// Retrieve the current storage utilization information of the server.
-  Future<ServerStorageResponseDto?> getStorage() async {
-    final response = await getStorageWithHttpInfo();
+  Future<ServerStorageResponseDto?> getStorage({ Future<void>? abortTrigger, }) async {
+    final response = await getStorageWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -445,7 +454,7 @@ class ServerApi {
   /// Retrieve all media types supported by the server.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getSupportedMediaTypesWithHttpInfo() async {
+  Future<Response> getSupportedMediaTypesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/media-types';
 
@@ -467,14 +476,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get supported media types
   ///
   /// Retrieve all media types supported by the server.
-  Future<ServerMediaTypesResponseDto?> getSupportedMediaTypes() async {
-    final response = await getSupportedMediaTypesWithHttpInfo();
+  Future<ServerMediaTypesResponseDto?> getSupportedMediaTypes({ Future<void>? abortTrigger, }) async {
+    final response = await getSupportedMediaTypesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -493,7 +503,7 @@ class ServerApi {
   /// Retrieve information about the last time the version check ran.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getVersionCheckWithHttpInfo() async {
+  Future<Response> getVersionCheckWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/version-check';
 
@@ -515,14 +525,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get version check status
   ///
   /// Retrieve information about the last time the version check ran.
-  Future<VersionCheckStateResponseDto?> getVersionCheck() async {
-    final response = await getVersionCheckWithHttpInfo();
+  Future<VersionCheckStateResponseDto?> getVersionCheck({ Future<void>? abortTrigger, }) async {
+    final response = await getVersionCheckWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -541,7 +552,7 @@ class ServerApi {
   /// Retrieve a list of past versions the server has been on.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getVersionHistoryWithHttpInfo() async {
+  Future<Response> getVersionHistoryWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/version-history';
 
@@ -563,14 +574,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get version history
   ///
   /// Retrieve a list of past versions the server has been on.
-  Future<List<ServerVersionHistoryResponseDto>?> getVersionHistory() async {
-    final response = await getVersionHistoryWithHttpInfo();
+  Future<List<ServerVersionHistoryResponseDto>?> getVersionHistory({ Future<void>? abortTrigger, }) async {
+    final response = await getVersionHistoryWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -592,7 +604,7 @@ class ServerApi {
   /// Pong
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> pingServerWithHttpInfo() async {
+  Future<Response> pingServerWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/ping';
 
@@ -614,14 +626,15 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Ping
   ///
   /// Pong
-  Future<ServerPingResponse?> pingServer() async {
-    final response = await pingServerWithHttpInfo();
+  Future<ServerPingResponse?> pingServer({ Future<void>? abortTrigger, }) async {
+    final response = await pingServerWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -644,7 +657,7 @@ class ServerApi {
   /// Parameters:
   ///
   /// * [LicenseKeyDto] licenseKeyDto (required):
-  Future<Response> setServerLicenseWithHttpInfo(LicenseKeyDto licenseKeyDto,) async {
+  Future<Response> setServerLicenseWithHttpInfo(LicenseKeyDto licenseKeyDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/license';
 
@@ -666,6 +679,7 @@ class ServerApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -676,8 +690,8 @@ class ServerApi {
   /// Parameters:
   ///
   /// * [LicenseKeyDto] licenseKeyDto (required):
-  Future<UserLicense?> setServerLicense(LicenseKeyDto licenseKeyDto,) async {
-    final response = await setServerLicenseWithHttpInfo(licenseKeyDto,);
+  Future<UserLicense?> setServerLicense(LicenseKeyDto licenseKeyDto, { Future<void>? abortTrigger, }) async {
+    final response = await setServerLicenseWithHttpInfo(licenseKeyDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/sessions_api.dart
+++ b/mobile/openapi/lib/api/sessions_api.dart
@@ -25,7 +25,7 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [SessionCreateDto] sessionCreateDto (required):
-  Future<Response> createSessionWithHttpInfo(SessionCreateDto sessionCreateDto,) async {
+  Future<Response> createSessionWithHttpInfo(SessionCreateDto sessionCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions';
 
@@ -47,6 +47,7 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [SessionCreateDto] sessionCreateDto (required):
-  Future<SessionCreateResponseDto?> createSession(SessionCreateDto sessionCreateDto,) async {
-    final response = await createSessionWithHttpInfo(sessionCreateDto,);
+  Future<SessionCreateResponseDto?> createSession(SessionCreateDto sessionCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createSessionWithHttpInfo(sessionCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -77,7 +78,7 @@ class SessionsApi {
   /// Delete all sessions for the user. This will not delete the current session.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> deleteAllSessionsWithHttpInfo() async {
+  Future<Response> deleteAllSessionsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions';
 
@@ -99,14 +100,15 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Delete all sessions
   ///
   /// Delete all sessions for the user. This will not delete the current session.
-  Future<void> deleteAllSessions() async {
-    final response = await deleteAllSessionsWithHttpInfo();
+  Future<void> deleteAllSessions({ Future<void>? abortTrigger, }) async {
+    final response = await deleteAllSessionsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -121,7 +123,7 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteSessionWithHttpInfo(String id,) async {
+  Future<Response> deleteSessionWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions/{id}'
       .replaceAll('{id}', id);
@@ -144,6 +146,7 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -154,8 +157,8 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteSession(String id,) async {
-    final response = await deleteSessionWithHttpInfo(id,);
+  Future<void> deleteSession(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteSessionWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -166,7 +169,7 @@ class SessionsApi {
   /// Retrieve a list of sessions for the user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getSessionsWithHttpInfo() async {
+  Future<Response> getSessionsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions';
 
@@ -188,14 +191,15 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve sessions
   ///
   /// Retrieve a list of sessions for the user.
-  Future<List<SessionResponseDto>?> getSessions() async {
-    final response = await getSessionsWithHttpInfo();
+  Future<List<SessionResponseDto>?> getSessions({ Future<void>? abortTrigger, }) async {
+    final response = await getSessionsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -221,7 +225,7 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> lockSessionWithHttpInfo(String id,) async {
+  Future<Response> lockSessionWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions/{id}/lock'
       .replaceAll('{id}', id);
@@ -244,6 +248,7 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -254,8 +259,8 @@ class SessionsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> lockSession(String id,) async {
-    final response = await lockSessionWithHttpInfo(id,);
+  Future<void> lockSession(String id, { Future<void>? abortTrigger, }) async {
+    final response = await lockSessionWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -272,7 +277,7 @@ class SessionsApi {
   /// * [String] id (required):
   ///
   /// * [SessionUpdateDto] sessionUpdateDto (required):
-  Future<Response> updateSessionWithHttpInfo(String id, SessionUpdateDto sessionUpdateDto,) async {
+  Future<Response> updateSessionWithHttpInfo(String id, SessionUpdateDto sessionUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sessions/{id}'
       .replaceAll('{id}', id);
@@ -295,6 +300,7 @@ class SessionsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -307,8 +313,8 @@ class SessionsApi {
   /// * [String] id (required):
   ///
   /// * [SessionUpdateDto] sessionUpdateDto (required):
-  Future<SessionResponseDto?> updateSession(String id, SessionUpdateDto sessionUpdateDto,) async {
-    final response = await updateSessionWithHttpInfo(id, sessionUpdateDto,);
+  Future<SessionResponseDto?> updateSession(String id, SessionUpdateDto sessionUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateSessionWithHttpInfo(id, sessionUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/shared_links_api.dart
+++ b/mobile/openapi/lib/api/shared_links_api.dart
@@ -27,7 +27,7 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [AssetIdsDto] assetIdsDto (required):
-  Future<Response> addSharedLinkAssetsWithHttpInfo(String id, AssetIdsDto assetIdsDto,) async {
+  Future<Response> addSharedLinkAssetsWithHttpInfo(String id, AssetIdsDto assetIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/{id}/assets'
       .replaceAll('{id}', id);
@@ -50,6 +50,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -62,8 +63,8 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [AssetIdsDto] assetIdsDto (required):
-  Future<List<AssetIdsResponseDto>?> addSharedLinkAssets(String id, AssetIdsDto assetIdsDto,) async {
-    final response = await addSharedLinkAssetsWithHttpInfo(id, assetIdsDto,);
+  Future<List<AssetIdsResponseDto>?> addSharedLinkAssets(String id, AssetIdsDto assetIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await addSharedLinkAssetsWithHttpInfo(id, assetIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -89,7 +90,7 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [SharedLinkCreateDto] sharedLinkCreateDto (required):
-  Future<Response> createSharedLinkWithHttpInfo(SharedLinkCreateDto sharedLinkCreateDto,) async {
+  Future<Response> createSharedLinkWithHttpInfo(SharedLinkCreateDto sharedLinkCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links';
 
@@ -111,6 +112,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -121,8 +123,8 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [SharedLinkCreateDto] sharedLinkCreateDto (required):
-  Future<SharedLinkResponseDto?> createSharedLink(SharedLinkCreateDto sharedLinkCreateDto,) async {
-    final response = await createSharedLinkWithHttpInfo(sharedLinkCreateDto,);
+  Future<SharedLinkResponseDto?> createSharedLink(SharedLinkCreateDto sharedLinkCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createSharedLinkWithHttpInfo(sharedLinkCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -149,7 +151,7 @@ class SharedLinksApi {
   ///
   /// * [String] id:
   ///   Filter by shared link ID
-  Future<Response> getAllSharedLinksWithHttpInfo({ String? albumId, String? id, }) async {
+  Future<Response> getAllSharedLinksWithHttpInfo({ String? albumId, String? id, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links';
 
@@ -178,6 +180,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -192,8 +195,8 @@ class SharedLinksApi {
   ///
   /// * [String] id:
   ///   Filter by shared link ID
-  Future<List<SharedLinkResponseDto>?> getAllSharedLinks({ String? albumId, String? id, }) async {
-    final response = await getAllSharedLinksWithHttpInfo( albumId: albumId, id: id, );
+  Future<List<SharedLinkResponseDto>?> getAllSharedLinks({ String? albumId, String? id, Future<void>? abortTrigger, }) async {
+    final response = await getAllSharedLinksWithHttpInfo(albumId: albumId, id: id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -221,7 +224,7 @@ class SharedLinksApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getMySharedLinkWithHttpInfo({ String? key, String? slug, }) async {
+  Future<Response> getMySharedLinkWithHttpInfo({ String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/me';
 
@@ -250,6 +253,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -262,8 +266,8 @@ class SharedLinksApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<SharedLinkResponseDto?> getMySharedLink({ String? key, String? slug, }) async {
-    final response = await getMySharedLinkWithHttpInfo( key: key, slug: slug, );
+  Future<SharedLinkResponseDto?> getMySharedLink({ String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await getMySharedLinkWithHttpInfo(key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -286,7 +290,7 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getSharedLinkByIdWithHttpInfo(String id,) async {
+  Future<Response> getSharedLinkByIdWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/{id}'
       .replaceAll('{id}', id);
@@ -309,6 +313,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -319,8 +324,8 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<SharedLinkResponseDto?> getSharedLinkById(String id,) async {
-    final response = await getSharedLinkByIdWithHttpInfo(id,);
+  Future<SharedLinkResponseDto?> getSharedLinkById(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getSharedLinkByIdWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -343,7 +348,7 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> removeSharedLinkWithHttpInfo(String id,) async {
+  Future<Response> removeSharedLinkWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/{id}'
       .replaceAll('{id}', id);
@@ -366,6 +371,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -376,8 +382,8 @@ class SharedLinksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> removeSharedLink(String id,) async {
-    final response = await removeSharedLinkWithHttpInfo(id,);
+  Future<void> removeSharedLink(String id, { Future<void>? abortTrigger, }) async {
+    final response = await removeSharedLinkWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -394,7 +400,7 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [AssetIdsDto] assetIdsDto (required):
-  Future<Response> removeSharedLinkAssetsWithHttpInfo(String id, AssetIdsDto assetIdsDto,) async {
+  Future<Response> removeSharedLinkAssetsWithHttpInfo(String id, AssetIdsDto assetIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/{id}/assets'
       .replaceAll('{id}', id);
@@ -417,6 +423,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -429,8 +436,8 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [AssetIdsDto] assetIdsDto (required):
-  Future<List<AssetIdsResponseDto>?> removeSharedLinkAssets(String id, AssetIdsDto assetIdsDto,) async {
-    final response = await removeSharedLinkAssetsWithHttpInfo(id, assetIdsDto,);
+  Future<List<AssetIdsResponseDto>?> removeSharedLinkAssets(String id, AssetIdsDto assetIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await removeSharedLinkAssetsWithHttpInfo(id, assetIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -460,7 +467,7 @@ class SharedLinksApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> sharedLinkLoginWithHttpInfo(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, }) async {
+  Future<Response> sharedLinkLoginWithHttpInfo(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/login';
 
@@ -489,6 +496,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -503,8 +511,8 @@ class SharedLinksApi {
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<SharedLinkResponseDto?> sharedLinkLogin(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, }) async {
-    final response = await sharedLinkLoginWithHttpInfo(sharedLinkLoginDto,  key: key, slug: slug, );
+  Future<SharedLinkResponseDto?> sharedLinkLogin(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await sharedLinkLoginWithHttpInfo(sharedLinkLoginDto, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -529,7 +537,7 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [SharedLinkEditDto] sharedLinkEditDto (required):
-  Future<Response> updateSharedLinkWithHttpInfo(String id, SharedLinkEditDto sharedLinkEditDto,) async {
+  Future<Response> updateSharedLinkWithHttpInfo(String id, SharedLinkEditDto sharedLinkEditDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-links/{id}'
       .replaceAll('{id}', id);
@@ -552,6 +560,7 @@ class SharedLinksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -564,8 +573,8 @@ class SharedLinksApi {
   /// * [String] id (required):
   ///
   /// * [SharedLinkEditDto] sharedLinkEditDto (required):
-  Future<SharedLinkResponseDto?> updateSharedLink(String id, SharedLinkEditDto sharedLinkEditDto,) async {
-    final response = await updateSharedLinkWithHttpInfo(id, sharedLinkEditDto,);
+  Future<SharedLinkResponseDto?> updateSharedLink(String id, SharedLinkEditDto sharedLinkEditDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateSharedLinkWithHttpInfo(id, sharedLinkEditDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/stacks_api.dart
+++ b/mobile/openapi/lib/api/stacks_api.dart
@@ -25,7 +25,7 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [StackCreateDto] stackCreateDto (required):
-  Future<Response> createStackWithHttpInfo(StackCreateDto stackCreateDto,) async {
+  Future<Response> createStackWithHttpInfo(StackCreateDto stackCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks';
 
@@ -47,6 +47,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [StackCreateDto] stackCreateDto (required):
-  Future<StackResponseDto?> createStack(StackCreateDto stackCreateDto,) async {
-    final response = await createStackWithHttpInfo(stackCreateDto,);
+  Future<StackResponseDto?> createStack(StackCreateDto stackCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createStackWithHttpInfo(stackCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteStackWithHttpInfo(String id,) async {
+  Future<Response> deleteStackWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteStack(String id,) async {
-    final response = await deleteStackWithHttpInfo(id,);
+  Future<void> deleteStack(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteStackWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -130,7 +132,7 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> deleteStacksWithHttpInfo(BulkIdsDto bulkIdsDto,) async {
+  Future<Response> deleteStacksWithHttpInfo(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks';
 
@@ -152,6 +154,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -162,8 +165,8 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<void> deleteStacks(BulkIdsDto bulkIdsDto,) async {
-    final response = await deleteStacksWithHttpInfo(bulkIdsDto,);
+  Future<void> deleteStacks(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteStacksWithHttpInfo(bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -178,7 +181,7 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getStackWithHttpInfo(String id,) async {
+  Future<Response> getStackWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks/{id}'
       .replaceAll('{id}', id);
@@ -201,6 +204,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -211,8 +215,8 @@ class StacksApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<StackResponseDto?> getStack(String id,) async {
-    final response = await getStackWithHttpInfo(id,);
+  Future<StackResponseDto?> getStack(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getStackWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -237,7 +241,7 @@ class StacksApi {
   /// * [String] assetId (required):
   ///
   /// * [String] id (required):
-  Future<Response> removeAssetFromStackWithHttpInfo(String assetId, String id,) async {
+  Future<Response> removeAssetFromStackWithHttpInfo(String assetId, String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks/{id}/assets/{assetId}'
       .replaceAll('{assetId}', assetId)
@@ -261,6 +265,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -273,8 +278,8 @@ class StacksApi {
   /// * [String] assetId (required):
   ///
   /// * [String] id (required):
-  Future<void> removeAssetFromStack(String assetId, String id,) async {
-    final response = await removeAssetFromStackWithHttpInfo(assetId, id,);
+  Future<void> removeAssetFromStack(String assetId, String id, { Future<void>? abortTrigger, }) async {
+    final response = await removeAssetFromStackWithHttpInfo(assetId, id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -290,7 +295,7 @@ class StacksApi {
   ///
   /// * [String] primaryAssetId:
   ///   Filter by primary asset ID
-  Future<Response> searchStacksWithHttpInfo({ String? primaryAssetId, }) async {
+  Future<Response> searchStacksWithHttpInfo({ String? primaryAssetId, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks';
 
@@ -316,6 +321,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -327,8 +333,8 @@ class StacksApi {
   ///
   /// * [String] primaryAssetId:
   ///   Filter by primary asset ID
-  Future<List<StackResponseDto>?> searchStacks({ String? primaryAssetId, }) async {
-    final response = await searchStacksWithHttpInfo( primaryAssetId: primaryAssetId, );
+  Future<List<StackResponseDto>?> searchStacks({ String? primaryAssetId, Future<void>? abortTrigger, }) async {
+    final response = await searchStacksWithHttpInfo(primaryAssetId: primaryAssetId, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -356,7 +362,7 @@ class StacksApi {
   /// * [String] id (required):
   ///
   /// * [StackUpdateDto] stackUpdateDto (required):
-  Future<Response> updateStackWithHttpInfo(String id, StackUpdateDto stackUpdateDto,) async {
+  Future<Response> updateStackWithHttpInfo(String id, StackUpdateDto stackUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/stacks/{id}'
       .replaceAll('{id}', id);
@@ -379,6 +385,7 @@ class StacksApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -391,8 +398,8 @@ class StacksApi {
   /// * [String] id (required):
   ///
   /// * [StackUpdateDto] stackUpdateDto (required):
-  Future<StackResponseDto?> updateStack(String id, StackUpdateDto stackUpdateDto,) async {
-    final response = await updateStackWithHttpInfo(id, stackUpdateDto,);
+  Future<StackResponseDto?> updateStack(String id, StackUpdateDto stackUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateStackWithHttpInfo(id, stackUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/sync_api.dart
+++ b/mobile/openapi/lib/api/sync_api.dart
@@ -25,7 +25,7 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncAckDeleteDto] syncAckDeleteDto (required):
-  Future<Response> deleteSyncAckWithHttpInfo(SyncAckDeleteDto syncAckDeleteDto,) async {
+  Future<Response> deleteSyncAckWithHttpInfo(SyncAckDeleteDto syncAckDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sync/ack';
 
@@ -47,6 +47,7 @@ class SyncApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncAckDeleteDto] syncAckDeleteDto (required):
-  Future<void> deleteSyncAck(SyncAckDeleteDto syncAckDeleteDto,) async {
-    final response = await deleteSyncAckWithHttpInfo(syncAckDeleteDto,);
+  Future<void> deleteSyncAck(SyncAckDeleteDto syncAckDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteSyncAckWithHttpInfo(syncAckDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -69,7 +70,7 @@ class SyncApi {
   /// Retrieve the synchronization acknowledgments for the current session.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getSyncAckWithHttpInfo() async {
+  Future<Response> getSyncAckWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sync/ack';
 
@@ -91,14 +92,15 @@ class SyncApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve acknowledgements
   ///
   /// Retrieve the synchronization acknowledgments for the current session.
-  Future<List<SyncAckDto>?> getSyncAck() async {
-    final response = await getSyncAckWithHttpInfo();
+  Future<List<SyncAckDto>?> getSyncAck({ Future<void>? abortTrigger, }) async {
+    final response = await getSyncAckWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -124,7 +126,7 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncStreamDto] syncStreamDto (required):
-  Future<Response> getSyncStreamWithHttpInfo(SyncStreamDto syncStreamDto,) async {
+  Future<Response> getSyncStreamWithHttpInfo(SyncStreamDto syncStreamDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sync/stream';
 
@@ -146,6 +148,7 @@ class SyncApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -156,8 +159,8 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncStreamDto] syncStreamDto (required):
-  Future<void> getSyncStream(SyncStreamDto syncStreamDto,) async {
-    final response = await getSyncStreamWithHttpInfo(syncStreamDto,);
+  Future<void> getSyncStream(SyncStreamDto syncStreamDto, { Future<void>? abortTrigger, }) async {
+    final response = await getSyncStreamWithHttpInfo(syncStreamDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -172,7 +175,7 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncAckSetDto] syncAckSetDto (required):
-  Future<Response> sendSyncAckWithHttpInfo(SyncAckSetDto syncAckSetDto,) async {
+  Future<Response> sendSyncAckWithHttpInfo(SyncAckSetDto syncAckSetDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/sync/ack';
 
@@ -194,6 +197,7 @@ class SyncApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -204,8 +208,8 @@ class SyncApi {
   /// Parameters:
   ///
   /// * [SyncAckSetDto] syncAckSetDto (required):
-  Future<void> sendSyncAck(SyncAckSetDto syncAckSetDto,) async {
-    final response = await sendSyncAckWithHttpInfo(syncAckSetDto,);
+  Future<void> sendSyncAck(SyncAckSetDto syncAckSetDto, { Future<void>? abortTrigger, }) async {
+    final response = await sendSyncAckWithHttpInfo(syncAckSetDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/system_config_api.dart
+++ b/mobile/openapi/lib/api/system_config_api.dart
@@ -21,7 +21,7 @@ class SystemConfigApi {
   /// Retrieve the current system configuration.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getConfigWithHttpInfo() async {
+  Future<Response> getConfigWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-config';
 
@@ -43,14 +43,15 @@ class SystemConfigApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get system configuration
   ///
   /// Retrieve the current system configuration.
-  Future<SystemConfigDto?> getConfig() async {
-    final response = await getConfigWithHttpInfo();
+  Future<SystemConfigDto?> getConfig({ Future<void>? abortTrigger, }) async {
+    final response = await getConfigWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -69,7 +70,7 @@ class SystemConfigApi {
   /// Retrieve the default values for the system configuration.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getConfigDefaultsWithHttpInfo() async {
+  Future<Response> getConfigDefaultsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-config/defaults';
 
@@ -91,14 +92,15 @@ class SystemConfigApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get system configuration defaults
   ///
   /// Retrieve the default values for the system configuration.
-  Future<SystemConfigDto?> getConfigDefaults() async {
-    final response = await getConfigDefaultsWithHttpInfo();
+  Future<SystemConfigDto?> getConfigDefaults({ Future<void>? abortTrigger, }) async {
+    final response = await getConfigDefaultsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -117,7 +119,7 @@ class SystemConfigApi {
   /// Retrieve exemplary storage template options.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getStorageTemplateOptionsWithHttpInfo() async {
+  Future<Response> getStorageTemplateOptionsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-config/storage-template-options';
 
@@ -139,14 +141,15 @@ class SystemConfigApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get storage template options
   ///
   /// Retrieve exemplary storage template options.
-  Future<SystemConfigTemplateStorageOptionDto?> getStorageTemplateOptions() async {
-    final response = await getStorageTemplateOptionsWithHttpInfo();
+  Future<SystemConfigTemplateStorageOptionDto?> getStorageTemplateOptions({ Future<void>? abortTrigger, }) async {
+    final response = await getStorageTemplateOptionsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -169,7 +172,7 @@ class SystemConfigApi {
   /// Parameters:
   ///
   /// * [SystemConfigDto] systemConfigDto (required):
-  Future<Response> updateConfigWithHttpInfo(SystemConfigDto systemConfigDto,) async {
+  Future<Response> updateConfigWithHttpInfo(SystemConfigDto systemConfigDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-config';
 
@@ -191,6 +194,7 @@ class SystemConfigApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -201,8 +205,8 @@ class SystemConfigApi {
   /// Parameters:
   ///
   /// * [SystemConfigDto] systemConfigDto (required):
-  Future<SystemConfigDto?> updateConfig(SystemConfigDto systemConfigDto,) async {
-    final response = await updateConfigWithHttpInfo(systemConfigDto,);
+  Future<SystemConfigDto?> updateConfig(SystemConfigDto systemConfigDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateConfigWithHttpInfo(systemConfigDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/system_metadata_api.dart
+++ b/mobile/openapi/lib/api/system_metadata_api.dart
@@ -21,7 +21,7 @@ class SystemMetadataApi {
   /// Retrieve the current admin onboarding status.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAdminOnboardingWithHttpInfo() async {
+  Future<Response> getAdminOnboardingWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-metadata/admin-onboarding';
 
@@ -43,14 +43,15 @@ class SystemMetadataApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve admin onboarding
   ///
   /// Retrieve the current admin onboarding status.
-  Future<AdminOnboardingUpdateDto?> getAdminOnboarding() async {
-    final response = await getAdminOnboardingWithHttpInfo();
+  Future<AdminOnboardingUpdateDto?> getAdminOnboarding({ Future<void>? abortTrigger, }) async {
+    final response = await getAdminOnboardingWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -69,7 +70,7 @@ class SystemMetadataApi {
   /// Retrieve the current state of the reverse geocoding import.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getReverseGeocodingStateWithHttpInfo() async {
+  Future<Response> getReverseGeocodingStateWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-metadata/reverse-geocoding-state';
 
@@ -91,14 +92,15 @@ class SystemMetadataApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve reverse geocoding state
   ///
   /// Retrieve the current state of the reverse geocoding import.
-  Future<ReverseGeocodingStateResponseDto?> getReverseGeocodingState() async {
-    final response = await getReverseGeocodingStateWithHttpInfo();
+  Future<ReverseGeocodingStateResponseDto?> getReverseGeocodingState({ Future<void>? abortTrigger, }) async {
+    final response = await getReverseGeocodingStateWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -117,7 +119,7 @@ class SystemMetadataApi {
   /// Retrieve the current state of the version check process.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getVersionCheckStateWithHttpInfo() async {
+  Future<Response> getVersionCheckStateWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-metadata/version-check-state';
 
@@ -139,14 +141,15 @@ class SystemMetadataApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve version check state
   ///
   /// Retrieve the current state of the version check process.
-  Future<VersionCheckStateResponseDto?> getVersionCheckState() async {
-    final response = await getVersionCheckStateWithHttpInfo();
+  Future<VersionCheckStateResponseDto?> getVersionCheckState({ Future<void>? abortTrigger, }) async {
+    final response = await getVersionCheckStateWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -169,7 +172,7 @@ class SystemMetadataApi {
   /// Parameters:
   ///
   /// * [AdminOnboardingUpdateDto] adminOnboardingUpdateDto (required):
-  Future<Response> updateAdminOnboardingWithHttpInfo(AdminOnboardingUpdateDto adminOnboardingUpdateDto,) async {
+  Future<Response> updateAdminOnboardingWithHttpInfo(AdminOnboardingUpdateDto adminOnboardingUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/system-metadata/admin-onboarding';
 
@@ -191,6 +194,7 @@ class SystemMetadataApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -201,8 +205,8 @@ class SystemMetadataApi {
   /// Parameters:
   ///
   /// * [AdminOnboardingUpdateDto] adminOnboardingUpdateDto (required):
-  Future<void> updateAdminOnboarding(AdminOnboardingUpdateDto adminOnboardingUpdateDto,) async {
-    final response = await updateAdminOnboardingWithHttpInfo(adminOnboardingUpdateDto,);
+  Future<void> updateAdminOnboarding(AdminOnboardingUpdateDto adminOnboardingUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateAdminOnboardingWithHttpInfo(adminOnboardingUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/tags_api.dart
+++ b/mobile/openapi/lib/api/tags_api.dart
@@ -25,7 +25,7 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagBulkAssetsDto] tagBulkAssetsDto (required):
-  Future<Response> bulkTagAssetsWithHttpInfo(TagBulkAssetsDto tagBulkAssetsDto,) async {
+  Future<Response> bulkTagAssetsWithHttpInfo(TagBulkAssetsDto tagBulkAssetsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/assets';
 
@@ -47,6 +47,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagBulkAssetsDto] tagBulkAssetsDto (required):
-  Future<TagBulkAssetsResponseDto?> bulkTagAssets(TagBulkAssetsDto tagBulkAssetsDto,) async {
-    final response = await bulkTagAssetsWithHttpInfo(tagBulkAssetsDto,);
+  Future<TagBulkAssetsResponseDto?> bulkTagAssets(TagBulkAssetsDto tagBulkAssetsDto, { Future<void>? abortTrigger, }) async {
+    final response = await bulkTagAssetsWithHttpInfo(tagBulkAssetsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagCreateDto] tagCreateDto (required):
-  Future<Response> createTagWithHttpInfo(TagCreateDto tagCreateDto,) async {
+  Future<Response> createTagWithHttpInfo(TagCreateDto tagCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags';
 
@@ -103,6 +104,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -113,8 +115,8 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagCreateDto] tagCreateDto (required):
-  Future<TagResponseDto?> createTag(TagCreateDto tagCreateDto,) async {
-    final response = await createTagWithHttpInfo(tagCreateDto,);
+  Future<TagResponseDto?> createTag(TagCreateDto tagCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createTagWithHttpInfo(tagCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -137,7 +139,7 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteTagWithHttpInfo(String id,) async {
+  Future<Response> deleteTagWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/{id}'
       .replaceAll('{id}', id);
@@ -160,6 +162,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -170,8 +173,8 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteTag(String id,) async {
-    final response = await deleteTagWithHttpInfo(id,);
+  Future<void> deleteTag(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteTagWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -182,7 +185,7 @@ class TagsApi {
   /// Retrieve a list of all tags.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getAllTagsWithHttpInfo() async {
+  Future<Response> getAllTagsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags';
 
@@ -204,14 +207,15 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve tags
   ///
   /// Retrieve a list of all tags.
-  Future<List<TagResponseDto>?> getAllTags() async {
-    final response = await getAllTagsWithHttpInfo();
+  Future<List<TagResponseDto>?> getAllTags({ Future<void>? abortTrigger, }) async {
+    final response = await getAllTagsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -237,7 +241,7 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getTagByIdWithHttpInfo(String id,) async {
+  Future<Response> getTagByIdWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/{id}'
       .replaceAll('{id}', id);
@@ -260,6 +264,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -270,8 +275,8 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<TagResponseDto?> getTagById(String id,) async {
-    final response = await getTagByIdWithHttpInfo(id,);
+  Future<TagResponseDto?> getTagById(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getTagByIdWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -296,7 +301,7 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> tagAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> tagAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/{id}/assets'
       .replaceAll('{id}', id);
@@ -319,6 +324,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -331,8 +337,8 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> tagAssets(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await tagAssetsWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> tagAssets(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await tagAssetsWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -360,7 +366,7 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> untagAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto,) async {
+  Future<Response> untagAssetsWithHttpInfo(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/{id}/assets'
       .replaceAll('{id}', id);
@@ -383,6 +389,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -395,8 +402,8 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<List<BulkIdResponseDto>?> untagAssets(String id, BulkIdsDto bulkIdsDto,) async {
-    final response = await untagAssetsWithHttpInfo(id, bulkIdsDto,);
+  Future<List<BulkIdResponseDto>?> untagAssets(String id, BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await untagAssetsWithHttpInfo(id, bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -424,7 +431,7 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [TagUpdateDto] tagUpdateDto (required):
-  Future<Response> updateTagWithHttpInfo(String id, TagUpdateDto tagUpdateDto,) async {
+  Future<Response> updateTagWithHttpInfo(String id, TagUpdateDto tagUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags/{id}'
       .replaceAll('{id}', id);
@@ -447,6 +454,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -459,8 +467,8 @@ class TagsApi {
   /// * [String] id (required):
   ///
   /// * [TagUpdateDto] tagUpdateDto (required):
-  Future<TagResponseDto?> updateTag(String id, TagUpdateDto tagUpdateDto,) async {
-    final response = await updateTagWithHttpInfo(id, tagUpdateDto,);
+  Future<TagResponseDto?> updateTag(String id, TagUpdateDto tagUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateTagWithHttpInfo(id, tagUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -483,7 +491,7 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagUpsertDto] tagUpsertDto (required):
-  Future<Response> upsertTagsWithHttpInfo(TagUpsertDto tagUpsertDto,) async {
+  Future<Response> upsertTagsWithHttpInfo(TagUpsertDto tagUpsertDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/tags';
 
@@ -505,6 +513,7 @@ class TagsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -515,8 +524,8 @@ class TagsApi {
   /// Parameters:
   ///
   /// * [TagUpsertDto] tagUpsertDto (required):
-  Future<List<TagResponseDto>?> upsertTags(TagUpsertDto tagUpsertDto,) async {
-    final response = await upsertTagsWithHttpInfo(tagUpsertDto,);
+  Future<List<TagResponseDto>?> upsertTags(TagUpsertDto tagUpsertDto, { Future<void>? abortTrigger, }) async {
+    final response = await upsertTagsWithHttpInfo(tagUpsertDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/timeline_api.dart
+++ b/mobile/openapi/lib/api/timeline_api.dart
@@ -69,7 +69,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/bucket';
 
@@ -138,6 +138,7 @@ class TimelineApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -192,8 +193,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
-    final response = await getTimeBucketWithHttpInfo(timeBucket,  albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, orderBy: orderBy, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
+  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, Future<void>? abortTrigger, }) async {
+    final response = await getTimeBucketWithHttpInfo(timeBucket, albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, orderBy: orderBy, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -257,7 +258,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
+  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/buckets';
 
@@ -325,6 +326,7 @@ class TimelineApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -376,8 +378,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, }) async {
-    final response = await getTimeBucketsWithHttpInfo( albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, orderBy: orderBy, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, );
+  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, bool? isFavorite, bool? isTrashed, String? key, AssetOrder? order, AssetOrderBy? orderBy, String? personId, String? slug, String? tagId, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withStacked, Future<void>? abortTrigger, }) async {
+    final response = await getTimeBucketsWithHttpInfo(albumId: albumId, bbox: bbox, isFavorite: isFavorite, isTrashed: isTrashed, key: key, order: order, orderBy: orderBy, personId: personId, slug: slug, tagId: tagId, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withStacked: withStacked, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/trash_api.dart
+++ b/mobile/openapi/lib/api/trash_api.dart
@@ -21,7 +21,7 @@ class TrashApi {
   /// Permanently delete all items in the trash.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> emptyTrashWithHttpInfo() async {
+  Future<Response> emptyTrashWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/trash/empty';
 
@@ -43,14 +43,15 @@ class TrashApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Empty trash
   ///
   /// Permanently delete all items in the trash.
-  Future<TrashResponseDto?> emptyTrash() async {
-    final response = await emptyTrashWithHttpInfo();
+  Future<TrashResponseDto?> emptyTrash({ Future<void>? abortTrigger, }) async {
+    final response = await emptyTrashWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -73,7 +74,7 @@ class TrashApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<Response> restoreAssetsWithHttpInfo(BulkIdsDto bulkIdsDto,) async {
+  Future<Response> restoreAssetsWithHttpInfo(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/trash/restore/assets';
 
@@ -95,6 +96,7 @@ class TrashApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -105,8 +107,8 @@ class TrashApi {
   /// Parameters:
   ///
   /// * [BulkIdsDto] bulkIdsDto (required):
-  Future<TrashResponseDto?> restoreAssets(BulkIdsDto bulkIdsDto,) async {
-    final response = await restoreAssetsWithHttpInfo(bulkIdsDto,);
+  Future<TrashResponseDto?> restoreAssets(BulkIdsDto bulkIdsDto, { Future<void>? abortTrigger, }) async {
+    final response = await restoreAssetsWithHttpInfo(bulkIdsDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -125,7 +127,7 @@ class TrashApi {
   /// Restore all items in the trash.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> restoreTrashWithHttpInfo() async {
+  Future<Response> restoreTrashWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/trash/restore';
 
@@ -147,14 +149,15 @@ class TrashApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Restore trash
   ///
   /// Restore all items in the trash.
-  Future<TrashResponseDto?> restoreTrash() async {
-    final response = await restoreTrashWithHttpInfo();
+  Future<TrashResponseDto?> restoreTrash({ Future<void>? abortTrigger, }) async {
+    final response = await restoreTrashWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/users_admin_api.dart
+++ b/mobile/openapi/lib/api/users_admin_api.dart
@@ -25,7 +25,7 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [UserAdminCreateDto] userAdminCreateDto (required):
-  Future<Response> createUserAdminWithHttpInfo(UserAdminCreateDto userAdminCreateDto,) async {
+  Future<Response> createUserAdminWithHttpInfo(UserAdminCreateDto userAdminCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users';
 
@@ -47,6 +47,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [UserAdminCreateDto] userAdminCreateDto (required):
-  Future<UserAdminResponseDto?> createUserAdmin(UserAdminCreateDto userAdminCreateDto,) async {
-    final response = await createUserAdminWithHttpInfo(userAdminCreateDto,);
+  Future<UserAdminResponseDto?> createUserAdmin(UserAdminCreateDto userAdminCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createUserAdminWithHttpInfo(userAdminCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -83,7 +84,7 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserAdminDeleteDto] userAdminDeleteDto (required):
-  Future<Response> deleteUserAdminWithHttpInfo(String id, UserAdminDeleteDto userAdminDeleteDto,) async {
+  Future<Response> deleteUserAdminWithHttpInfo(String id, UserAdminDeleteDto userAdminDeleteDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}'
       .replaceAll('{id}', id);
@@ -106,6 +107,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -118,8 +120,8 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserAdminDeleteDto] userAdminDeleteDto (required):
-  Future<UserAdminResponseDto?> deleteUserAdmin(String id, UserAdminDeleteDto userAdminDeleteDto,) async {
-    final response = await deleteUserAdminWithHttpInfo(id, userAdminDeleteDto,);
+  Future<UserAdminResponseDto?> deleteUserAdmin(String id, UserAdminDeleteDto userAdminDeleteDto, { Future<void>? abortTrigger, }) async {
+    final response = await deleteUserAdminWithHttpInfo(id, userAdminDeleteDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -142,7 +144,7 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getUserAdminWithHttpInfo(String id,) async {
+  Future<Response> getUserAdminWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}'
       .replaceAll('{id}', id);
@@ -165,6 +167,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -175,8 +178,8 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<UserAdminResponseDto?> getUserAdmin(String id,) async {
-    final response = await getUserAdminWithHttpInfo(id,);
+  Future<UserAdminResponseDto?> getUserAdmin(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getUserAdminWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -199,7 +202,7 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getUserPreferencesAdminWithHttpInfo(String id,) async {
+  Future<Response> getUserPreferencesAdminWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}/preferences'
       .replaceAll('{id}', id);
@@ -222,6 +225,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -232,8 +236,8 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<UserPreferencesResponseDto?> getUserPreferencesAdmin(String id,) async {
-    final response = await getUserPreferencesAdminWithHttpInfo(id,);
+  Future<UserPreferencesResponseDto?> getUserPreferencesAdmin(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getUserPreferencesAdminWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -256,7 +260,7 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getUserSessionsAdminWithHttpInfo(String id,) async {
+  Future<Response> getUserSessionsAdminWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}/sessions'
       .replaceAll('{id}', id);
@@ -279,6 +283,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -289,8 +294,8 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<List<SessionResponseDto>?> getUserSessionsAdmin(String id,) async {
-    final response = await getUserSessionsAdminWithHttpInfo(id,);
+  Future<List<SessionResponseDto>?> getUserSessionsAdmin(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getUserSessionsAdminWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -324,7 +329,7 @@ class UsersAdminApi {
   ///   Filter by trash status
   ///
   /// * [AssetVisibility] visibility:
-  Future<Response> getUserStatisticsAdminWithHttpInfo(String id, { bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, }) async {
+  Future<Response> getUserStatisticsAdminWithHttpInfo(String id, { bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}/statistics'
       .replaceAll('{id}', id);
@@ -357,6 +362,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -375,8 +381,8 @@ class UsersAdminApi {
   ///   Filter by trash status
   ///
   /// * [AssetVisibility] visibility:
-  Future<AssetStatsResponseDto?> getUserStatisticsAdmin(String id, { bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, }) async {
-    final response = await getUserStatisticsAdminWithHttpInfo(id,  isFavorite: isFavorite, isTrashed: isTrashed, visibility: visibility, );
+  Future<AssetStatsResponseDto?> getUserStatisticsAdmin(String id, { bool? isFavorite, bool? isTrashed, AssetVisibility? visibility, Future<void>? abortTrigger, }) async {
+    final response = await getUserStatisticsAdminWithHttpInfo(id, isFavorite: isFavorite, isTrashed: isTrashed, visibility: visibility, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -399,7 +405,7 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> restoreUserAdminWithHttpInfo(String id,) async {
+  Future<Response> restoreUserAdminWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}/restore'
       .replaceAll('{id}', id);
@@ -422,6 +428,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -432,8 +439,8 @@ class UsersAdminApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<UserAdminResponseDto?> restoreUserAdmin(String id,) async {
-    final response = await restoreUserAdminWithHttpInfo(id,);
+  Future<UserAdminResponseDto?> restoreUserAdmin(String id, { Future<void>? abortTrigger, }) async {
+    final response = await restoreUserAdminWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -460,7 +467,7 @@ class UsersAdminApi {
   ///
   /// * [bool] withDeleted:
   ///   Include deleted users
-  Future<Response> searchUsersAdminWithHttpInfo({ String? id, bool? withDeleted, }) async {
+  Future<Response> searchUsersAdminWithHttpInfo({ String? id, bool? withDeleted, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users';
 
@@ -489,6 +496,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -503,8 +511,8 @@ class UsersAdminApi {
   ///
   /// * [bool] withDeleted:
   ///   Include deleted users
-  Future<List<UserAdminResponseDto>?> searchUsersAdmin({ String? id, bool? withDeleted, }) async {
-    final response = await searchUsersAdminWithHttpInfo( id: id, withDeleted: withDeleted, );
+  Future<List<UserAdminResponseDto>?> searchUsersAdmin({ String? id, bool? withDeleted, Future<void>? abortTrigger, }) async {
+    final response = await searchUsersAdminWithHttpInfo(id: id, withDeleted: withDeleted, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -532,7 +540,7 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserAdminUpdateDto] userAdminUpdateDto (required):
-  Future<Response> updateUserAdminWithHttpInfo(String id, UserAdminUpdateDto userAdminUpdateDto,) async {
+  Future<Response> updateUserAdminWithHttpInfo(String id, UserAdminUpdateDto userAdminUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}'
       .replaceAll('{id}', id);
@@ -555,6 +563,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -567,8 +576,8 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserAdminUpdateDto] userAdminUpdateDto (required):
-  Future<UserAdminResponseDto?> updateUserAdmin(String id, UserAdminUpdateDto userAdminUpdateDto,) async {
-    final response = await updateUserAdminWithHttpInfo(id, userAdminUpdateDto,);
+  Future<UserAdminResponseDto?> updateUserAdmin(String id, UserAdminUpdateDto userAdminUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateUserAdminWithHttpInfo(id, userAdminUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -593,7 +602,7 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserPreferencesUpdateDto] userPreferencesUpdateDto (required):
-  Future<Response> updateUserPreferencesAdminWithHttpInfo(String id, UserPreferencesUpdateDto userPreferencesUpdateDto,) async {
+  Future<Response> updateUserPreferencesAdminWithHttpInfo(String id, UserPreferencesUpdateDto userPreferencesUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/admin/users/{id}/preferences'
       .replaceAll('{id}', id);
@@ -616,6 +625,7 @@ class UsersAdminApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -628,8 +638,8 @@ class UsersAdminApi {
   /// * [String] id (required):
   ///
   /// * [UserPreferencesUpdateDto] userPreferencesUpdateDto (required):
-  Future<UserPreferencesResponseDto?> updateUserPreferencesAdmin(String id, UserPreferencesUpdateDto userPreferencesUpdateDto,) async {
-    final response = await updateUserPreferencesAdminWithHttpInfo(id, userPreferencesUpdateDto,);
+  Future<UserPreferencesResponseDto?> updateUserPreferencesAdmin(String id, UserPreferencesUpdateDto userPreferencesUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateUserPreferencesAdminWithHttpInfo(id, userPreferencesUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/users_api.dart
+++ b/mobile/openapi/lib/api/users_api.dart
@@ -26,7 +26,7 @@ class UsersApi {
   ///
   /// * [MultipartFile] file (required):
   ///   Profile image file
-  Future<Response> createProfileImageWithHttpInfo(MultipartFile file,) async {
+  Future<Response> createProfileImageWithHttpInfo(MultipartFile file, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/profile-image';
 
@@ -58,6 +58,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -69,8 +70,8 @@ class UsersApi {
   ///
   /// * [MultipartFile] file (required):
   ///   Profile image file
-  Future<CreateProfileImageResponseDto?> createProfileImage(MultipartFile file,) async {
-    final response = await createProfileImageWithHttpInfo(file,);
+  Future<CreateProfileImageResponseDto?> createProfileImage(MultipartFile file, { Future<void>? abortTrigger, }) async {
+    final response = await createProfileImageWithHttpInfo(file, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -89,7 +90,7 @@ class UsersApi {
   /// Delete the profile image of the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> deleteProfileImageWithHttpInfo() async {
+  Future<Response> deleteProfileImageWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/profile-image';
 
@@ -111,14 +112,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Delete user profile image
   ///
   /// Delete the profile image of the current user.
-  Future<void> deleteProfileImage() async {
-    final response = await deleteProfileImageWithHttpInfo();
+  Future<void> deleteProfileImage({ Future<void>? abortTrigger, }) async {
+    final response = await deleteProfileImageWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -129,7 +131,7 @@ class UsersApi {
   /// Delete the registered product key for the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> deleteUserLicenseWithHttpInfo() async {
+  Future<Response> deleteUserLicenseWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/license';
 
@@ -151,14 +153,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Delete user product key
   ///
   /// Delete the registered product key for the current user.
-  Future<void> deleteUserLicense() async {
-    final response = await deleteUserLicenseWithHttpInfo();
+  Future<void> deleteUserLicense({ Future<void>? abortTrigger, }) async {
+    final response = await deleteUserLicenseWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -169,7 +172,7 @@ class UsersApi {
   /// Delete the onboarding status of the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> deleteUserOnboardingWithHttpInfo() async {
+  Future<Response> deleteUserOnboardingWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/onboarding';
 
@@ -191,14 +194,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Delete user onboarding
   ///
   /// Delete the onboarding status of the current user.
-  Future<void> deleteUserOnboarding() async {
-    final response = await deleteUserOnboardingWithHttpInfo();
+  Future<void> deleteUserOnboarding({ Future<void>? abortTrigger, }) async {
+    final response = await deleteUserOnboardingWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -209,7 +213,7 @@ class UsersApi {
   /// Retrieve the preferences for the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getMyPreferencesWithHttpInfo() async {
+  Future<Response> getMyPreferencesWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/preferences';
 
@@ -231,14 +235,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get my preferences
   ///
   /// Retrieve the preferences for the current user.
-  Future<UserPreferencesResponseDto?> getMyPreferences() async {
-    final response = await getMyPreferencesWithHttpInfo();
+  Future<UserPreferencesResponseDto?> getMyPreferences({ Future<void>? abortTrigger, }) async {
+    final response = await getMyPreferencesWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -257,7 +262,7 @@ class UsersApi {
   /// Retrieve information about the user making the API request.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getMyUserWithHttpInfo() async {
+  Future<Response> getMyUserWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me';
 
@@ -279,14 +284,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get current user
   ///
   /// Retrieve information about the user making the API request.
-  Future<UserAdminResponseDto?> getMyUser() async {
-    final response = await getMyUserWithHttpInfo();
+  Future<UserAdminResponseDto?> getMyUser({ Future<void>? abortTrigger, }) async {
+    final response = await getMyUserWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -309,7 +315,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getProfileImageWithHttpInfo(String id,) async {
+  Future<Response> getProfileImageWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/{id}/profile-image'
       .replaceAll('{id}', id);
@@ -332,6 +338,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -342,8 +349,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<MultipartFile?> getProfileImage(String id,) async {
-    final response = await getProfileImageWithHttpInfo(id,);
+  Future<MultipartFile?> getProfileImage(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getProfileImageWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -366,7 +373,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getUserWithHttpInfo(String id,) async {
+  Future<Response> getUserWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/{id}'
       .replaceAll('{id}', id);
@@ -389,6 +396,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -399,8 +407,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<UserResponseDto?> getUser(String id,) async {
-    final response = await getUserWithHttpInfo(id,);
+  Future<UserResponseDto?> getUser(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getUserWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -419,7 +427,7 @@ class UsersApi {
   /// Retrieve information about whether the current user has a registered product key.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getUserLicenseWithHttpInfo() async {
+  Future<Response> getUserLicenseWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/license';
 
@@ -441,14 +449,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve user product key
   ///
   /// Retrieve information about whether the current user has a registered product key.
-  Future<UserLicense?> getUserLicense() async {
-    final response = await getUserLicenseWithHttpInfo();
+  Future<UserLicense?> getUserLicense({ Future<void>? abortTrigger, }) async {
+    final response = await getUserLicenseWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -467,7 +476,7 @@ class UsersApi {
   /// Retrieve the onboarding status of the current user.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getUserOnboardingWithHttpInfo() async {
+  Future<Response> getUserOnboardingWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/onboarding';
 
@@ -489,14 +498,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve user onboarding
   ///
   /// Retrieve the onboarding status of the current user.
-  Future<OnboardingResponseDto?> getUserOnboarding() async {
-    final response = await getUserOnboardingWithHttpInfo();
+  Future<OnboardingResponseDto?> getUserOnboarding({ Future<void>? abortTrigger, }) async {
+    final response = await getUserOnboardingWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -515,7 +525,7 @@ class UsersApi {
   /// Retrieve a list of all users on the server.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> searchUsersWithHttpInfo() async {
+  Future<Response> searchUsersWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users';
 
@@ -537,14 +547,15 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Get all users
   ///
   /// Retrieve a list of all users on the server.
-  Future<List<UserResponseDto>?> searchUsers() async {
-    final response = await searchUsersWithHttpInfo();
+  Future<List<UserResponseDto>?> searchUsers({ Future<void>? abortTrigger, }) async {
+    final response = await searchUsersWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -570,7 +581,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [LicenseKeyDto] licenseKeyDto (required):
-  Future<Response> setUserLicenseWithHttpInfo(LicenseKeyDto licenseKeyDto,) async {
+  Future<Response> setUserLicenseWithHttpInfo(LicenseKeyDto licenseKeyDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/license';
 
@@ -592,6 +603,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -602,8 +614,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [LicenseKeyDto] licenseKeyDto (required):
-  Future<UserLicense?> setUserLicense(LicenseKeyDto licenseKeyDto,) async {
-    final response = await setUserLicenseWithHttpInfo(licenseKeyDto,);
+  Future<UserLicense?> setUserLicense(LicenseKeyDto licenseKeyDto, { Future<void>? abortTrigger, }) async {
+    final response = await setUserLicenseWithHttpInfo(licenseKeyDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -626,7 +638,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [OnboardingDto] onboardingDto (required):
-  Future<Response> setUserOnboardingWithHttpInfo(OnboardingDto onboardingDto,) async {
+  Future<Response> setUserOnboardingWithHttpInfo(OnboardingDto onboardingDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/onboarding';
 
@@ -648,6 +660,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -658,8 +671,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [OnboardingDto] onboardingDto (required):
-  Future<OnboardingResponseDto?> setUserOnboarding(OnboardingDto onboardingDto,) async {
-    final response = await setUserOnboardingWithHttpInfo(onboardingDto,);
+  Future<OnboardingResponseDto?> setUserOnboarding(OnboardingDto onboardingDto, { Future<void>? abortTrigger, }) async {
+    final response = await setUserOnboardingWithHttpInfo(onboardingDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -682,7 +695,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [UserPreferencesUpdateDto] userPreferencesUpdateDto (required):
-  Future<Response> updateMyPreferencesWithHttpInfo(UserPreferencesUpdateDto userPreferencesUpdateDto,) async {
+  Future<Response> updateMyPreferencesWithHttpInfo(UserPreferencesUpdateDto userPreferencesUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me/preferences';
 
@@ -704,6 +717,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -714,8 +728,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [UserPreferencesUpdateDto] userPreferencesUpdateDto (required):
-  Future<UserPreferencesResponseDto?> updateMyPreferences(UserPreferencesUpdateDto userPreferencesUpdateDto,) async {
-    final response = await updateMyPreferencesWithHttpInfo(userPreferencesUpdateDto,);
+  Future<UserPreferencesResponseDto?> updateMyPreferences(UserPreferencesUpdateDto userPreferencesUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateMyPreferencesWithHttpInfo(userPreferencesUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -738,7 +752,7 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [UserUpdateMeDto] userUpdateMeDto (required):
-  Future<Response> updateMyUserWithHttpInfo(UserUpdateMeDto userUpdateMeDto,) async {
+  Future<Response> updateMyUserWithHttpInfo(UserUpdateMeDto userUpdateMeDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/users/me';
 
@@ -760,6 +774,7 @@ class UsersApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -770,8 +785,8 @@ class UsersApi {
   /// Parameters:
   ///
   /// * [UserUpdateMeDto] userUpdateMeDto (required):
-  Future<UserAdminResponseDto?> updateMyUser(UserUpdateMeDto userUpdateMeDto,) async {
-    final response = await updateMyUserWithHttpInfo(userUpdateMeDto,);
+  Future<UserAdminResponseDto?> updateMyUser(UserUpdateMeDto userUpdateMeDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateMyUserWithHttpInfo(userUpdateMeDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/views_api.dart
+++ b/mobile/openapi/lib/api/views_api.dart
@@ -25,7 +25,7 @@ class ViewsApi {
   /// Parameters:
   ///
   /// * [String] path (required):
-  Future<Response> getAssetsByOriginalPathWithHttpInfo(String path,) async {
+  Future<Response> getAssetsByOriginalPathWithHttpInfo(String path, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/view/folder';
 
@@ -49,6 +49,7 @@ class ViewsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -59,8 +60,8 @@ class ViewsApi {
   /// Parameters:
   ///
   /// * [String] path (required):
-  Future<List<AssetResponseDto>?> getAssetsByOriginalPath(String path,) async {
-    final response = await getAssetsByOriginalPathWithHttpInfo(path,);
+  Future<List<AssetResponseDto>?> getAssetsByOriginalPath(String path, { Future<void>? abortTrigger, }) async {
+    final response = await getAssetsByOriginalPathWithHttpInfo(path, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -82,7 +83,7 @@ class ViewsApi {
   /// Retrieve a list of unique folder paths from asset original paths.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getUniqueOriginalPathsWithHttpInfo() async {
+  Future<Response> getUniqueOriginalPathsWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/view/folder/unique-paths';
 
@@ -104,14 +105,15 @@ class ViewsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// Retrieve unique paths
   ///
   /// Retrieve a list of unique folder paths from asset original paths.
-  Future<List<String>?> getUniqueOriginalPaths() async {
-    final response = await getUniqueOriginalPathsWithHttpInfo();
+  Future<List<String>?> getUniqueOriginalPaths({ Future<void>? abortTrigger, }) async {
+    final response = await getUniqueOriginalPathsWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/workflows_api.dart
+++ b/mobile/openapi/lib/api/workflows_api.dart
@@ -25,7 +25,7 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [WorkflowCreateDto] workflowCreateDto (required):
-  Future<Response> createWorkflowWithHttpInfo(WorkflowCreateDto workflowCreateDto,) async {
+  Future<Response> createWorkflowWithHttpInfo(WorkflowCreateDto workflowCreateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows';
 
@@ -47,6 +47,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -57,8 +58,8 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [WorkflowCreateDto] workflowCreateDto (required):
-  Future<WorkflowResponseDto?> createWorkflow(WorkflowCreateDto workflowCreateDto,) async {
-    final response = await createWorkflowWithHttpInfo(workflowCreateDto,);
+  Future<WorkflowResponseDto?> createWorkflow(WorkflowCreateDto workflowCreateDto, { Future<void>? abortTrigger, }) async {
+    final response = await createWorkflowWithHttpInfo(workflowCreateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -81,7 +82,7 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> deleteWorkflowWithHttpInfo(String id,) async {
+  Future<Response> deleteWorkflowWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows/{id}'
       .replaceAll('{id}', id);
@@ -104,6 +105,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -114,8 +116,8 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<void> deleteWorkflow(String id,) async {
-    final response = await deleteWorkflowWithHttpInfo(id,);
+  Future<void> deleteWorkflow(String id, { Future<void>? abortTrigger, }) async {
+    final response = await deleteWorkflowWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -130,7 +132,7 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getWorkflowWithHttpInfo(String id,) async {
+  Future<Response> getWorkflowWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows/{id}'
       .replaceAll('{id}', id);
@@ -153,6 +155,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -163,8 +166,8 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<WorkflowResponseDto?> getWorkflow(String id,) async {
-    final response = await getWorkflowWithHttpInfo(id,);
+  Future<WorkflowResponseDto?> getWorkflow(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getWorkflowWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -187,7 +190,7 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<Response> getWorkflowForShareWithHttpInfo(String id,) async {
+  Future<Response> getWorkflowForShareWithHttpInfo(String id, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows/{id}/share'
       .replaceAll('{id}', id);
@@ -210,6 +213,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -220,8 +224,8 @@ class WorkflowsApi {
   /// Parameters:
   ///
   /// * [String] id (required):
-  Future<WorkflowShareResponseDto?> getWorkflowForShare(String id,) async {
-    final response = await getWorkflowForShareWithHttpInfo(id,);
+  Future<WorkflowShareResponseDto?> getWorkflowForShare(String id, { Future<void>? abortTrigger, }) async {
+    final response = await getWorkflowForShareWithHttpInfo(id, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -240,7 +244,7 @@ class WorkflowsApi {
   /// Retrieve a list of all available workflow triggers.
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getWorkflowTriggersWithHttpInfo() async {
+  Future<Response> getWorkflowTriggersWithHttpInfo({ Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows/triggers';
 
@@ -262,14 +266,15 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
   /// List all workflow triggers
   ///
   /// Retrieve a list of all available workflow triggers.
-  Future<List<WorkflowTriggerResponseDto>?> getWorkflowTriggers() async {
-    final response = await getWorkflowTriggersWithHttpInfo();
+  Future<List<WorkflowTriggerResponseDto>?> getWorkflowTriggers({ Future<void>? abortTrigger, }) async {
+    final response = await getWorkflowTriggersWithHttpInfo(abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -308,7 +313,7 @@ class WorkflowsApi {
   ///
   /// * [WorkflowTrigger] trigger:
   ///   Workflow trigger type
-  Future<Response> searchWorkflowsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, WorkflowTrigger? trigger, }) async {
+  Future<Response> searchWorkflowsWithHttpInfo({ String? description, bool? enabled, String? id, String? name, WorkflowTrigger? trigger, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows';
 
@@ -346,6 +351,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -369,8 +375,8 @@ class WorkflowsApi {
   ///
   /// * [WorkflowTrigger] trigger:
   ///   Workflow trigger type
-  Future<List<WorkflowResponseDto>?> searchWorkflows({ String? description, bool? enabled, String? id, String? name, WorkflowTrigger? trigger, }) async {
-    final response = await searchWorkflowsWithHttpInfo( description: description, enabled: enabled, id: id, name: name, trigger: trigger, );
+  Future<List<WorkflowResponseDto>?> searchWorkflows({ String? description, bool? enabled, String? id, String? name, WorkflowTrigger? trigger, Future<void>? abortTrigger, }) async {
+    final response = await searchWorkflowsWithHttpInfo(description: description, enabled: enabled, id: id, name: name, trigger: trigger, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -398,7 +404,7 @@ class WorkflowsApi {
   /// * [String] id (required):
   ///
   /// * [WorkflowUpdateDto] workflowUpdateDto (required):
-  Future<Response> updateWorkflowWithHttpInfo(String id, WorkflowUpdateDto workflowUpdateDto,) async {
+  Future<Response> updateWorkflowWithHttpInfo(String id, WorkflowUpdateDto workflowUpdateDto, { Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/workflows/{id}'
       .replaceAll('{id}', id);
@@ -421,6 +427,7 @@ class WorkflowsApi {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -433,8 +440,8 @@ class WorkflowsApi {
   /// * [String] id (required):
   ///
   /// * [WorkflowUpdateDto] workflowUpdateDto (required):
-  Future<WorkflowResponseDto?> updateWorkflow(String id, WorkflowUpdateDto workflowUpdateDto,) async {
-    final response = await updateWorkflowWithHttpInfo(id, workflowUpdateDto,);
+  Future<WorkflowResponseDto?> updateWorkflow(String id, WorkflowUpdateDto workflowUpdateDto, { Future<void>? abortTrigger, }) async {
+    final response = await updateWorkflowWithHttpInfo(id, workflowUpdateDto, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -44,8 +44,9 @@ class ApiClient {
     Object? body,
     Map<String, String> headerParams,
     Map<String, String> formParams,
-    String? contentType,
-  ) async {
+    String? contentType, {
+    Future<void>? abortTrigger,
+  }) async {
     await authentication?.applyToParams(queryParams, headerParams);
 
     headerParams.addAll(_defaultHeaderMap);
@@ -63,7 +64,7 @@ class ApiClient {
         body is MultipartFile && (contentType == null ||
         !contentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, uri);
+        final request = AbortableStreamedRequest(method, uri, abortTrigger: abortTrigger);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -78,7 +79,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, uri);
+        final request = AbortableMultipartRequest(method, uri, abortTrigger: abortTrigger);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);
@@ -92,14 +93,19 @@ class ApiClient {
         : await serializeAsync(body);
       final nullableHeaderParams = headerParams.isEmpty ? null : headerParams;
 
-      switch(method) {
-        case 'POST': return await _client.post(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PUT': return await _client.put(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'DELETE': return await _client.delete(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'PATCH': return await _client.patch(uri, headers: nullableHeaderParams, body: msgBody,);
-        case 'HEAD': return await _client.head(uri, headers: nullableHeaderParams,);
-        case 'GET': return await _client.get(uri, headers: nullableHeaderParams,);
+      final request = AbortableRequest(method, uri, abortTrigger: abortTrigger);
+      if (nullableHeaderParams != null) {
+        request.headers.addAll(nullableHeaderParams);
       }
+      if (msgBody is String) {
+        request.body = msgBody;
+      } else if (msgBody is List<int>) {
+        request.bodyBytes = msgBody;
+      } else if (msgBody is Map<String, String>) {
+        request.bodyFields = msgBody;
+      }
+      final response = await _client.send(request);
+      return Response.fromStream(response);
     } on SocketException catch (error, trace) {
       throw ApiException.withInner(
         HttpStatus.badRequest,
@@ -136,11 +142,6 @@ class ApiClient {
         trace,
       );
     }
-
-    throw ApiException(
-      HttpStatus.badRequest,
-      'Invalid HTTP operation: $method $path',
-    );
   }
 
   Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) =>

--- a/open-api/patch/api_client.dart.patch
+++ b/open-api/patch/api_client.dart.patch
@@ -1,30 +1,96 @@
 @@ -13,7 +13,7 @@
  class ApiClient {
    ApiClient({this.basePath = '/api', this.authentication,});
-
+ 
 -  final String basePath;
 +  String basePath;
    final Authentication? authentication;
-
+ 
    var _client = Client();
-@@ -143,19 +143,19 @@
-     );
+@@ -44,8 +44,9 @@
+     Object? body,
+     Map<String, String> headerParams,
+     Map<String, String> formParams,
+-    String? contentType,
+-  ) async {
++    String? contentType, {
++    Future<void>? abortTrigger,
++  }) async {
+     await authentication?.applyToParams(queryParams, headerParams);
+ 
+     headerParams.addAll(_defaultHeaderMap);
+@@ -63,7 +64,7 @@
+         body is MultipartFile && (contentType == null ||
+         !contentType.toLowerCase().startsWith('multipart/form-data'))
+       ) {
+-        final request = StreamedRequest(method, uri);
++        final request = AbortableStreamedRequest(method, uri, abortTrigger: abortTrigger);
+         request.headers.addAll(headerParams);
+         request.contentLength = body.length;
+         body.finalize().listen(
+@@ -78,7 +79,7 @@
+       }
+ 
+       if (body is MultipartRequest) {
+-        final request = MultipartRequest(method, uri);
++        final request = AbortableMultipartRequest(method, uri, abortTrigger: abortTrigger);
+         request.fields.addAll(body.fields);
+         request.files.addAll(body.files);
+         request.headers.addAll(body.headers);
+@@ -92,14 +93,19 @@
+         : await serializeAsync(body);
+       final nullableHeaderParams = headerParams.isEmpty ? null : headerParams;
+ 
+-      switch(method) {
+-        case 'POST': return await _client.post(uri, headers: nullableHeaderParams, body: msgBody,);
+-        case 'PUT': return await _client.put(uri, headers: nullableHeaderParams, body: msgBody,);
+-        case 'DELETE': return await _client.delete(uri, headers: nullableHeaderParams, body: msgBody,);
+-        case 'PATCH': return await _client.patch(uri, headers: nullableHeaderParams, body: msgBody,);
+-        case 'HEAD': return await _client.head(uri, headers: nullableHeaderParams,);
+-        case 'GET': return await _client.get(uri, headers: nullableHeaderParams,);
++      final request = AbortableRequest(method, uri, abortTrigger: abortTrigger);
++      if (nullableHeaderParams != null) {
++        request.headers.addAll(nullableHeaderParams);
+       }
++      if (msgBody is String) {
++        request.body = msgBody;
++      } else if (msgBody is List<int>) {
++        request.bodyBytes = msgBody;
++      } else if (msgBody is Map<String, String>) {
++        request.bodyFields = msgBody;
++      }
++      final response = await _client.send(request);
++      return Response.fromStream(response);
+     } on SocketException catch (error, trace) {
+       throw ApiException.withInner(
+         HttpStatus.badRequest,
+@@ -136,26 +146,21 @@
+         trace,
+       );
+     }
+-
+-    throw ApiException(
+-      HttpStatus.badRequest,
+-      'Invalid HTTP operation: $method $path',
+-    );
    }
-
+ 
 -  Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>
 +  Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) =>
      // ignore: deprecated_member_use_from_same_package
      deserialize(value, targetType, growable: growable);
-
+ 
    @Deprecated('Scheduled for removal in OpenAPI Generator 6.x. Use deserializeAsync() instead.')
 -  dynamic deserialize(String value, String targetType, {bool growable = false,}) {
 +  Future<dynamic> deserialize(String value, String targetType, {bool growable = false,}) async {
      // Remove all spaces. Necessary for regular expressions as well.
      targetType = targetType.replaceAll(' ', ''); // ignore: parameter_assignments
-
+ 
      // If the expected target type is String, nothing to do...
      return targetType == 'String'
        ? value
 -      : fromJson(json.decode(value), targetType, growable: growable);
 +      : fromJson(await compute((String j) => json.decode(j), value), targetType, growable: growable);
    }
+ 
+   // ignore: deprecated_member_use_from_same_package

--- a/open-api/templates/mobile/api.mustache
+++ b/open-api/templates/mobile/api.mustache
@@ -49,7 +49,7 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'{{{path}}}'{{#pathParams}}
       .replaceAll({{=<% %>=}}'{<% baseName %>}'<%={{ }}=%>, {{{paramName}}}{{^isString}}.toString(){{/isString}}){{/pathParams}};
@@ -128,6 +128,7 @@ class {{{classname}}} {
       headerParams,
       formParams,
       contentTypes.isEmpty ? null : contentTypes.first,
+      abortTrigger: abortTrigger,
     );
   }
 
@@ -161,8 +162,8 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
-    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
+  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
+    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}}, {{/required}}{{/allParams}}{{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}}, {{/required}}{{/allParams}}abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/templates/mobile/api.mustache.patch
+++ b/open-api/templates/mobile/api.mustache.patch
@@ -1,8 +1,11 @@
---- api.mustache	2025-01-22 05:50:25
-+++ api.mustache.modified	2025-01-22 05:52:23
-@@ -51,7 +51,7 @@
+--- api.mustache
++++ api.mustache.modified
+@@ -49,9 +49,9 @@
+   ///
+     {{/-last}}
    {{/allParams}}
-   Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+-  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
++  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
      // ignore: prefer_const_declarations
 -    final path = r'{{{path}}}'{{#pathParams}}
 +    final apiPath = r'{{{path}}}'{{#pathParams}}
@@ -18,7 +21,7 @@
      {{#formParams}}
      {{^isFile}}
      if ({{{paramName}}} != null) {
-@@ -121,7 +121,7 @@
+@@ -121,13 +121,14 @@
      {{/isMultipart}}
  
      return apiClient.invokeAPI(
@@ -27,3 +30,21 @@
        '{{{httpMethod}}}',
        queryParams,
        postBody,
+       headerParams,
+       formParams,
+       contentTypes.isEmpty ? null : contentTypes.first,
++      abortTrigger: abortTrigger,
+     );
+   }
+ 
+@@ -161,8 +162,8 @@
+   ///
+     {{/-last}}
+   {{/allParams}}
+-  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+-    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
++  Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}, {{/required}}{{/allParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}}, {{/required}}{{/allParams}}Future<void>? abortTrigger, }) async {
++    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}}, {{/required}}{{/allParams}}{{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}}, {{/required}}{{/allParams}}abortTrigger: abortTrigger,);
+     if (response.statusCode >= HttpStatus.badRequest) {
+       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+     }


### PR DESCRIPTION
## Description

This PR allows using the standard `http.Client` mechanism to abort requests, which is useful for both teardown and overall responsiveness.