### PR TITLE
fix(mobile): use originalFileName for multipart filename in background uploads

### DIFF
--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -422,7 +422,7 @@ class BackgroundUploadService {
       httpRequestMethod: 'POST',
       url: url,
       headers: headers,
-      filename: filename,
+      filename: originalFileName ?? filename,
       fields: fieldsMap,
       baseDirectory: baseDirectory,
       directory: directory,

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -82,6 +82,8 @@ void main() {
 
       expect(task, isNotNull);
       expect(task!.fields['filename'], equals('OriginalPhoto.jpg'));
+      // multipart file part filename must match the clean originalFileName (foreground/background parity)
+      expect(task.filename, equals('OriginalPhoto.jpg'));
       verify(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).called(1);
     });
 
@@ -118,6 +120,7 @@ void main() {
       expect(task, isNotNull);
       // For live photos, extension should be changed to match the video file
       expect(task!.fields['filename'], equals('OriginalLivePhoto.mov'));
+      expect(task.filename, equals('OriginalLivePhoto.mov'));
       verify(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).called(1);
     });
   });


### PR DESCRIPTION
## Description

On iOS, the **foreground** and **background** upload paths send **different `filename` values in the multipart file-part header for the same asset**.

- The `filename` *form field* is consistent across both paths (both use the clean `originalFileName`, e.g. `IMG_9237.MOV`).
- The multipart *file-part* `filename` differs:
  - Foreground → clean name: `IMG_9237.MOV`
  - Background → basename of the iOS PhotoKit temp export path: `0EAAEF1B-B470-4B87-826C-12820A29631E_L0_001_1763884841.640019_o_IMG_9237.MOV`

### Root cause

In `mobile/lib/services/background_upload.service.dart`, `buildUploadTask` already resolves `originalFileName` (falling back to `asset.name`) and uses it for both the `filename` form field and the task `displayName` — but the `UploadTask.filename` (the multipart file-part name) was set to the raw `filename` returned by `Task.split(...)`, which is the PhotoKit temp basename.

```dart
return UploadTask(
  displayName: originalFileName ?? filename,
  ...
  filename: filename,                    // ← temp PhotoKit basename
  fields: { 'filename': originalFileName ?? filename, ... },
);
```

The two upload paths should be byte-for-byte equivalent for the same asset; today they are not.

### Why this matters

- **Dedup correctness.** Reverse proxies / upload optimizers (e.g. [immich-upload-optimizer](https://github.com/joojoooo/immich-upload-optimizer)) legitimately use the multipart filename as part of a dedup key. The mismatch defeats that dedup, so the *same* photo can be processed/stored twice depending on whether it went up in the foreground or background.
- **Observability.** In raw HTTP and access logs the same asset shows up under two different filenames, making one upload look like two and obscuring real duplicate detection.
- **Consistency.** Foreground vs. background uploads of the same file should be indistinguishable on the wire. The current behavior is an oversight, not an intentional difference — and it leaks an internal iOS temp path into outbound requests.

The fix is small and self-contained, the two paths converge on the same well-defined value, and the change is fully covered by tests.

### The fix

```diff
-      filename: filename,
+      filename: originalFileName ?? filename,
```

This matches the `filename` form field and the foreground path. It covers both regular and Live Photo uploads, since both route through `buildUploadTask`.

Fixes #28601

## How Has This Been Tested?

Toolchain: Flutter `3.44.0` (pinned via `mise`), `flutter test`.

- [x] **Added assertions** on `UploadTask.filename` (the multipart file-part name) to the existing `mobile/test/services/background_upload.service_test.dart`, for both a regular photo and a Live Photo.
- [x] **Green:** full suite passes with the fix — `9/9` tests pass.
- [x] **Red proof (test actually guards the bug):** reverting the one-line fix makes the new assertions fail as expected:
  ```
  getUploadTask should call getOriginalFilename from AssetMediaRepository for regular photo [E]
    Expected: 'OriginalPhoto.jpg'
      Actual: 'file.jpg'
  getUploadTask should call getOriginalFilename for live photo [E]
    Expected: 'OriginalLivePhoto.mov'
      Actual: 'file.mov'
  ```
  Restoring the fix returns the suite to green.

Run it:
```
cd mobile && flutter test test/services/background_upload.service_test.dart
```

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (None added.)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The root cause was diagnosed from the existing issue report (#28601). The idea was planned by me. The fix, the added test assertions, and the red/green verification were carried out with the assistance of an LLM (Claude Opus 4.8), while changes were directed and reviewed by me. 

The change is a single line in `buildUploadTask` plus test assertions.

