### PR TITLE
fix(cli): prevent out-of-memory on file upload due to undici storing the request body

### DIFF
--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -426,6 +426,7 @@ const uploadFile = async (input: string, stats: Stats): Promise<AssetMediaRespon
     redirect: 'error',
     headers: headers as Record<string, string>,
     body: formData,
+    window: null,
   });
   if (response.status !== 200 && response.status !== 201) {
     throw new Error(await response.text());

--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -426,6 +426,7 @@ const uploadFile = async (input: string, stats: Stats): Promise<AssetMediaRespon
     redirect: 'error',
     headers: headers as Record<string, string>,
     body: formData,
+    // eslint-disable-next-line unicorn/no-null
     window: null,
   });
   if (response.status !== 200 && response.status !== 201) {


### PR DESCRIPTION
## Description

Fixes fetch-caused out of memory (OOM) error for large file upload by adding `window: null` parameter to `fetch()` call in `uploadFile()`. Fixes #28720.

Cause: The (node-internal) undici v7.0 `fetch()` implementation seems to continuously use more memory during a large file upload, storing the entire upload body, even though our immich code uses a file streaming implementation. There is an open [undici bug report](https://github.com/nodejs/undici/issues/4058) that recommends to set `window: null` and `redirect: 'error'` to avoid storing the entire upload body, which seems to work.

<details><summary>unrelated undici memory leak bug reports</summary>
Memory leak bug reports in undici tend to point to the response body staying in memory if it's not consumed (see https://github.com/nodejs/node/issues/51162 and [undici docs on GC](https://undici.nodejs.org/#/?id=garbage-collection)). However, this is not the issue at hand, as the OOM occurs during the upload already.
</details>

## How Has This Been Tested?

- [x] successfully compile
- [x] successfully upload large file

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM use.
