### PR TITLE
fix(devcontainer): update build cache volume

### DIFF
--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ${UPLOAD_LOCATION:-upload-devcontainer-volume}${UPLOAD_LOCATION:+/photos}:/data
       - /etc/localtime:/etc/localtime:ro
-      - pnpm_store_server:/buildcache/pnpm-store
+      - build_cache:/buildcache
       - ../packages/plugin-core:/build/plugins/immich-plugin-core
   immich-web:
     env_file: !reset []


### PR DESCRIPTION
Applies the change from https://github.com/immich-app/immich/pull/28649 to devcontainer overrides, otherwise it just throws an error that the volume is missing when building the dev container.