### PR TITLE
fix(web): prevent partner assets from being selected in geolocation utility

### DIFF
--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -38,6 +38,8 @@
     withCoordinates: true,
   };
 
+  const isOwnAsset = (asset: TimelineAsset) => asset.ownerId === authManager.user.id;
+
   const handleUpdate = async () => {
     if (!point) {
       return;
@@ -54,7 +56,7 @@
 
     await updateAssets({
       assetBulkUpdateDto: {
-        ids: assetMultiSelectManager.assets.filter((asset) => asset.ownerId === authManager.user.id).map((asset) => asset.id),
+        ids: assetMultiSelectManager.assets.filter((asset) => isOwnAsset(asset)).map((asset) => asset.id),
         latitude: point.lat,
         longitude: point.lng,
       },
@@ -105,8 +107,6 @@
 
   const hasGps = (asset: TimelineAsset | AssetPoint): asset is AssetPoint =>
     isDefined(asset.latitude) && isDefined(asset.longitude);
-
-  const isOwnAsset = (asset: TimelineAsset) => asset.ownerId === authManager.user.id;
 
   const handleThumbnailClick = (
     asset: TimelineAsset,
@@ -202,7 +202,7 @@
   >
     {#snippet customThumbnailLayout(asset: TimelineAsset)}
       {#if !isOwnAsset(asset)}
-        <div class="absolute inset-0 bg-black/40 pointer-events-none rounded" />
+        <div class="pointer-events-none absolute inset-0 rounded-sm bg-black/40"></div>
       {/if}
       {#if hasGps(asset)}
         <div class="absolute inset-e-3 bottom-1 rounded-xl bg-success px-4 py-1 text-xs text-black transition-colors">

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -54,7 +54,7 @@
 
     await updateAssets({
       assetBulkUpdateDto: {
-        ids: assetMultiSelectManager.assets.map((asset) => asset.id),
+        ids: assetMultiSelectManager.assets.filter((asset) => asset.ownerId === authManager.user.id).map((asset) => asset.id),
         latitude: point.lat,
         longitude: point.lng,
       },
@@ -106,6 +106,8 @@
   const hasGps = (asset: TimelineAsset | AssetPoint): asset is AssetPoint =>
     isDefined(asset.latitude) && isDefined(asset.longitude);
 
+  const isOwnAsset = (asset: TimelineAsset) => asset.ownerId === authManager.user.id;
+
   const handleThumbnailClick = (
     asset: TimelineAsset,
     timelineManager: TimelineManager,
@@ -124,7 +126,7 @@
       }, 1500);
       point = { lat: asset.latitude, lng: asset.longitude };
       void setQueryValue('at', asset.id);
-    } else {
+    } else if (isOwnAsset(asset)) {
       onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
     }
   };
@@ -199,6 +201,9 @@
     onThumbnailClick={handleThumbnailClick}
   >
     {#snippet customThumbnailLayout(asset: TimelineAsset)}
+      {#if !isOwnAsset(asset)}
+        <div class="absolute inset-0 bg-black/40 pointer-events-none rounded" />
+      {/if}
       {#if hasGps(asset)}
         <div class="absolute inset-e-3 bottom-1 rounded-xl bg-success px-4 py-1 text-xs text-black transition-colors">
           {asset.city || $t('gps')}


### PR DESCRIPTION
## Description

The geolocation utility loads partner assets alongside your own (`withPartners: true`). Partner assets showed up as fully interactive — you could select them and they'd be included in the bulk location update, even though you don't own them and the API would silently skip them (or error).

Fixes #21471

Three changes, all in `+page.svelte`:

1. **Blocks selection** — partner assets without GPS no longer trigger the multi-select `onClick`. Clicking them does nothing, rather than adding them to the selection.
2. **Preserves GPS reference** — partner assets with GPS coordinates still set the point on click (the useful part — using a partner's photo location as a reference).
3. **Visual indicator** — a semi-transparent overlay (`bg-black/40`) marks partner asset thumbnails as non-editable, so it's obvious at a glance which ones you own.
4. **Safety filter on submit** — `updateAssets` now filters to `ownerId === authManager.user.id` before sending IDs, as a last line of defense even if something bypasses the click guard.

**Before:** partner thumbnails looked identical to owned assets, could be selected, and were silently included in bulk updates.

**After:** partner thumbnails are visually dimmed and non-selectable, but still useful as GPS reference points.

## How Has This Been Tested?

- [ ] Tested with a partner account sharing assets — partner thumbnails are visually dimmed and non-selectable
- [ ] Owned assets remain fully interactive and included in bulk updates
- [ ] Partner assets with GPS still set the reference point on click

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.