### PR TITLE
 fix(mobile): add missing backward-compat defaults in openapi_patching

### DIFF
--- a/mobile/lib/utils/openapi_patching.dart
+++ b/mobile/lib/utils/openapi_patching.dart
@@ -47,6 +47,16 @@ dynamic upgradeDto(dynamic value, String targetType) {
         addDefault(value, 'profileChangedAt', DateTime.now().toIso8601String());
         addDefault(value, 'hasProfileImage', false);
       }
+    case 'AssetEditActionItemDtoParameters':
+      if (value is Map) {
+        addDefault(value, 'angle', 0);
+        addDefault(value, 'x', 0);
+        addDefault(value, 'y', 0);
+        addDefault(value, 'width', 0);
+        addDefault(value, 'height', 0);
+        addDefault(value, 'axis', 'horizontal');
+      }
+      break;
     case 'SyncAssetV1':
       if (value is Map) {
         addDefault(value, 'isEdited', false);

--- a/mobile/lib/utils/openapi_patching.dart
+++ b/mobile/lib/utils/openapi_patching.dart
@@ -50,7 +50,11 @@ dynamic upgradeDto(dynamic value, String targetType) {
     case 'SyncAssetV1':
       if (value is Map) {
         addDefault(value, 'isEdited', false);
+    case 'ServerVersionResponseDto':
+      if (value is Map) {
+        addDefault(value, 'prerelease', null);
       }
+      break;
     case 'ServerFeaturesDto':
       if (value is Map) {
         addDefault(value, 'ocr', false);

--- a/mobile/lib/utils/openapi_patching.dart
+++ b/mobile/lib/utils/openapi_patching.dart
@@ -50,6 +50,12 @@ dynamic upgradeDto(dynamic value, String targetType) {
     case 'SyncAssetV1':
       if (value is Map) {
         addDefault(value, 'isEdited', false);
+        addDefault(value, 'createdAt', null);
+      }
+    case 'SyncAssetV2':
+      if (value is Map) {
+        addDefault(value, 'createdAt', null);
+      }
     case 'ServerVersionResponseDto':
       if (value is Map) {
         addDefault(value, 'prerelease', null);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The 
- `prerelease` field was added to `ServerVersionResponseDto` in #28665
- `createdAt` was added to `SyncAssetV1`/`SyncAssetV2` in #28272
- `AssetEditActionItemDtoParameters` has always had a union type mismatch since #24155

All three had their assertions patched out in the dart client, hiding the bugs. The regenerated dart client (from #27231) will (on merge) restore those assertions, causing debug-mode crashes.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
