### PR TITLE
fix(mobile): invisible ink splashes in asset sheet

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/sheet_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/sheet_tile.widget.dart
@@ -63,16 +63,19 @@ class SheetTile extends ConsumerWidget {
       subtitleWidget = null;
     }
 
-    return ListTile(
-      dense: true,
-      visualDensity: VisualDensity.compact,
-      title: GestureDetector(onLongPress: () => copyTitle(context, ref), child: titleWidget),
-      titleAlignment: ListTileTitleAlignment.center,
-      leading: leading,
-      trailing: trailing,
-      contentPadding: leading == null ? null : const EdgeInsets.only(left: 25),
-      subtitle: subtitleWidget,
-      onTap: onTap,
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        dense: true,
+        visualDensity: VisualDensity.compact,
+        title: GestureDetector(onLongPress: () => copyTitle(context, ref), child: titleWidget),
+        titleAlignment: ListTileTitleAlignment.center,
+        leading: leading,
+        trailing: trailing,
+        contentPadding: leading == null ? null : const EdgeInsets.only(left: 25),
+        subtitle: subtitleWidget,
+        onTap: onTap,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ListTile tap animations in the asset detail bottom sheet were painted behind the sheet's background, making them invisible and triggering a debug assertion. Wrapping SheetTile in a transparent Material gives the ListTile a local paint target directly behind each row.

<details><summary>Exception</summary>
<p>

```
  ══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞══════════════════════
  The following assertion was thrown:
  ListTile background color or ink splashes may be invisible.
  The ListTile is wrapped in a DecoratedBox that has a background
  color. Because ListTile paints its background and ink splashes on
  the nearest Material ancestor, this DecoratedBox will hide those
  effects.
  To fix this, wrap the ListTile in its own Material widget, or
  remove the background color from the intermediate DecoratedBox.

  ListTile:
    ListTile(dense: true, visualDensity: VisualDensity#1d285(h: -2.0, v: -2.0)(horizontal: -2.0, vertical: -2.0), contentPadding: EdgeInsets(25.0, 0.0, 0.0, 0.0), onTap: Closure: () => void from Function
  'editLocation':., titleAlignment: ListTileTitleAlignment.center)
  DecoratedBox: DecoratedBox(bg:
      BoxDecoration(color: Color(alpha: 1.0000, red: 0.9843, green: 0.9725, blue: 1.0000, colorSpace: ColorSpace.sRGB), borderRadius: BorderRadius.only(topLeft: Radius.circular(20.0), topRight:
  Radius.circular(20.0)),
        boxShadow: [BoxShadow(Color(alpha: 0.2000, red: 0.0000, green:
          0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB), Offset(0.0,
          -3.0), 10.0, 2.0, BlurStyle.normal)]
        )
    )
  ═════════════════════════════════════════════════════════════════

  Exception: ListTile background color or ink splashes may be invisible.
  The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
  To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.

  Exception: ListTile background color or ink splashes may be invisible.
  The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
  To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.
  Library: Flutter framework
  Context: null
```

</p>
</details> 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Reproduce before and after patch and check logs

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

suggest fix
