### PR TITLE
test: fix tests when OpenVINO provider is available

### DIFF
--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -740,6 +740,10 @@ class TestFaceRecognition:
 
     def test_recognition(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
+        mocker.patch(
+            "immich_ml.models.facial_recognition.recognition.ort.get_available_providers",
+            return_value=["CPUExecutionProvider"],
+        )
         face_recognizer = FaceRecognizer("buffalo_s", min_score=0.0, cache_dir="test_cache")
 
         num_faces = 2
@@ -784,6 +788,10 @@ class TestFaceRecognition:
         )
         mocker.patch("immich_ml.models.base.InferenceModel.download")
         mocker.patch("immich_ml.models.facial_recognition.recognition.ArcFaceONNX")
+        mocker.patch(
+            "immich_ml.models.facial_recognition.recognition.ort.get_available_providers",
+            return_value=["CPUExecutionProvider"],
+        )
         ort_session.return_value.get_inputs.return_value = [SimpleNamespace(name="input.1", shape=(1, 3, 224, 224))]
         ort_session.return_value.get_outputs.return_value = [SimpleNamespace(name="output.1", shape=(1, 800))]
         path.return_value.__truediv__.return_value.__truediv__.return_value.suffix = ".onnx"
@@ -818,6 +826,10 @@ class TestFaceRecognition:
         )
         mocker.patch("immich_ml.models.base.InferenceModel.download")
         mocker.patch("immich_ml.models.facial_recognition.recognition.ArcFaceONNX")
+        mocker.patch(
+            "immich_ml.models.facial_recognition.recognition.ort.get_available_providers",
+            return_value=["CPUExecutionProvider"],
+        )
         path.return_value.__truediv__.return_value.__truediv__.return_value.suffix = ".onnx"
 
         inputs = [SimpleNamespace(name="input.1", shape=("batch", 3, 224, 224))]
@@ -892,6 +904,10 @@ class TestFaceRecognition:
 
     def test_ignore_other_custom_max_batch_size(self, mocker: MockerFixture) -> None:
         mocker.patch.object(settings, "max_batch_size", MaxBatchSize(ocr=2))
+        mocker.patch(
+            "immich_ml.models.facial_recognition.recognition.ort.get_available_providers",
+            return_value=["CPUExecutionProvider"],
+        )
 
         recognizer = FaceRecognizer("buffalo_l", cache_dir="test_cache")
 


### PR DESCRIPTION
Heya, first contribution and more of a drive-by one at that, just saw that tests were failing, so I fixed the assumptions as I understood them.

## Description

Fixes https://github.com/immich-app/immich/issues/23456, that issue contains the failures we observed before the patch:
```
====================================================== short test summary info =======================================================
FAILED test_main.py::TestFaceRecognition::test_recognition - AssertionError: Expected 'get_feat' to have been called once. Called 2 times.
FAILED test_main.py::TestFaceRecognition::test_recognition_adds_batch_axis_for_ort - assert 1 is None
FAILED test_main.py::TestFaceRecognition::test_recognition_does_not_add_batch_axis_if_exists - assert 1 is None
FAILED test_main.py::TestFaceRecognition::test_ignore_other_custom_max_batch_size - assert 1 is None
======================================== 4 failed, 94 passed, 3 skipped, 8 warnings in 1.29s =========================================
```

## How Has This Been Tested?

passes tests locally with a python3 env with...
- [x] `onnxruntime.get_available_providers() == ['CPUExecutionProvider']`
- [x] `onnxruntime.get_available_providers() == ['OpenVINOExecutionProvider', 'CPUExecutionProvider']`

I can't test it with other providers like `CUDAExecutionProvider` as I lack the hardware to do so, apologies if that breaks assumptions in this PR.

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Good old manual thinking and typing in vim