### PR TITLE
fix(web): defer revoking object URL so Safari downloads start

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -291,7 +291,10 @@ export const downloadUrl = (url: string, filename: string) => {
   anchor.click();
   anchor.remove();
 
-  URL.revokeObjectURL(url);
+  // Safari starts the anchor download asynchronously after the current task, so
+  // revoking the object URL synchronously cancels the download before it begins.
+  // Defer the revoke to give the browser time to start downloading.
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
 };
 
 export const downloadBlob = (data: Blob, filename: string) => downloadUrl(URL.createObjectURL(data), filename);


### PR DESCRIPTION
On Safari (macOS/iOS), bulk downloads such as albums hang around 30% and the browser download never starts.

The cause is in `downloadUrl()`: the object URL is revoked synchronously right after `anchor.click()`. Safari starts the anchor's download asynchronously after the current task, so the blob URL is already revoked before the download begins. Chromium and Firefox snapshot the blob synchronously, which is why they are not affected.

This defers `URL.revokeObjectURL` with a `setTimeout` (5s, matching the existing `downloadManager.clear` delay in the same file) so the browser has time to start the download. For non-`blob:` URLs `revokeObjectURL` is effectively a no-op, so the delay is harmless there.

Fixes #28316
