### PR TITLE
feat(web): update geolocation assets in place after setting location

### DIFF
--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -13,8 +13,7 @@
   import GeolocationUpdateConfirmModal from '$lib/modals/GeolocationUpdateConfirmModal.svelte';
   import type { LatLng } from '$lib/types';
   import { setQueryValue } from '$lib/utils/navigation';
-  import { toTimelineAsset } from '$lib/utils/timeline-util';
-  import { AssetVisibility, getAssetInfo, updateAssets } from '@immich/sdk';
+  import { AssetVisibility, updateAssets } from '@immich/sdk';
   import { Button, LoadingSpinner, modalManager, Text } from '@immich/ui';
   import { mdiMapMarkerMultipleOutline, mdiPencilOutline, mdiSelectRemove } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -54,22 +53,21 @@
       return;
     }
 
+    const ids = assetMultiSelectManager.assets.filter((asset) => isOwnAsset(asset)).map((asset) => asset.id);
+
     await updateAssets({
       assetBulkUpdateDto: {
-        ids: assetMultiSelectManager.assets.filter((asset) => isOwnAsset(asset)).map((asset) => asset.id),
+        ids,
         latitude: point.lat,
         longitude: point.lng,
       },
     });
 
-    const updatedAssets = await Promise.all(
-      assetMultiSelectManager.assets.map(async (asset) => {
-        const updatedAsset = await getAssetInfo({ ...authManager.params, id: asset.id });
-        return toTimelineAsset(updatedAsset);
-      }),
-    );
-
-    timelineManager.upsertAssets(updatedAssets);
+    const { lat, lng } = point;
+    timelineManager.update(ids, (asset) => {
+      asset.latitude = lat;
+      asset.longitude = lng;
+    });
 
     assetMultiSelectManager.clear();
   };


### PR DESCRIPTION
## Description

Split out of #22227 as requested (@danieldietzler: "It'd still be nice for this to be a separate PR").

In the geolocation utility, after applying a location to the selected assets, the timeline is now patched **locally** with the new coordinates instead of refetching each asset individually via `getAssetInfo`. Reverse geocoding runs asynchronously on the server, so refetching right after the update returned stale (null) location data and reset the UI; updating in place reflects the change immediately and avoids one API call per selected asset.

Only assets owned by the user are updated (partner assets are excluded), matching the existing update behavior.

## How Has This Been Tested?

Manually tested on the local dev stack: selected own assets without GPS, picked a point on the map, applied it, and confirmed the assets immediately reflect the new coordinates without a refetch, and that partner assets are left untouched.

- [x] Manual test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude Code) was used to make this change and draft the description; the change was reviewed and manually tested locally by me before submitting.
