### PR TITLE
feat(web): warn before overwriting existing locations in geolocation utility

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2246,6 +2246,7 @@
   "slideshow_repeat_description": "Loop back to beginning when slideshow ends",
   "slideshow_settings": "Slideshow settings",
   "smart_album": "Smart album",
+  "some_assets_already_have_a_location_warning": "Some of the selected assets already have a location",
   "sort_albums_by": "Sort albums by...",
   "sort_created": "Date created",
   "sort_items": "Number of items",

--- a/web/src/lib/modals/GeolocationUpdateConfirmModal.svelte
+++ b/web/src/lib/modals/GeolocationUpdateConfirmModal.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import type { LatLng } from '$lib/types';
-  import { ConfirmModal, Icon } from '@immich/ui';
-  import { mdiAlertCircle } from '@mdi/js';
+  import { Alert, ConfirmModal } from '@immich/ui';
   import { t } from 'svelte-i18n';
 
   type Props = {
@@ -21,10 +20,7 @@
 <ConfirmModal title={$t('confirm')} size="small" confirmColor="primary" {onClose}>
   {#snippet prompt()}
     {#if hasExistingLocations}
-      <div class="mb-4 flex items-start gap-3 rounded-lg border border-warning bg-warning/20 p-4">
-        <Icon icon={mdiAlertCircle} size="24px" class="mt-1 shrink-0 text-warning" />
-        <p class="font-semibold text-warning">{$t('some_assets_already_have_a_location_warning')}</p>
-      </div>
+      <Alert color="warning" class="mb-4">{$t('some_assets_already_have_a_location_warning')}</Alert>
     {/if}
     <p>{$t('update_location_action_prompt', { values: { count: assetCount } })}</p>
     <p>- {$t('latitude')}: {point.lat}</p>

--- a/web/src/lib/modals/GeolocationUpdateConfirmModal.svelte
+++ b/web/src/lib/modals/GeolocationUpdateConfirmModal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import type { LatLng } from '$lib/types';
-  import { ConfirmModal } from '@immich/ui';
+  import { ConfirmModal, Icon } from '@immich/ui';
+  import { mdiAlertCircle } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   type Props = {
@@ -9,11 +11,21 @@
     onClose: (confirm: boolean) => void;
   };
 
-  let { point, assetCount, onClose }: Props = $props();
+  const { point, assetCount, onClose }: Props = $props();
+
+  const hasExistingLocations = $derived(
+    assetMultiSelectManager.assets.some((asset) => asset.latitude != null || asset.longitude != null),
+  );
 </script>
 
 <ConfirmModal title={$t('confirm')} size="small" confirmColor="primary" {onClose}>
   {#snippet prompt()}
+    {#if hasExistingLocations}
+      <div class="mb-4 flex items-start gap-3 rounded-lg border border-warning bg-warning/20 p-4">
+        <Icon icon={mdiAlertCircle} size="24px" class="mt-1 shrink-0 text-warning" />
+        <p class="font-semibold text-warning">{$t('some_assets_already_have_a_location_warning')}</p>
+      </div>
+    {/if}
     <p>{$t('update_location_action_prompt', { values: { count: assetCount } })}</p>
     <p>- {$t('latitude')}: {point.lat}</p>
     <p>- {$t('longitude')}: {point.lng}</p>


### PR DESCRIPTION
## Description

Split out of #22227 as requested, to keep each change in its own PR.

In the geolocation utility, the location update confirmation modal now shows a warning when one or more of the selected assets **already has GPS coordinates**, so an existing location isn't overwritten unintentionally.

The check (`hasExistingLocations`) is computed inside the modal from the shared `assetMultiSelectManager`, so no extra prop has to be passed in (addressing earlier review feedback). It uses the `Icon` component and `!= null` checks so a real coordinate of `0` still counts as an existing location.

## How Has This Been Tested?

Manually tested on the local dev stack: selecting an asset that already has a location and clicking Apply shows the warning in the confirm modal; selecting only assets without GPS shows no warning. Confirm and cancel behave as before.

- [x] Manual test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude Code) was used to make this change and draft the description; the change was reviewed and manually tested locally by me before submitting.
