### PR TITLE
fix: error handling

### DIFF
--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -1,4 +1,4 @@
-import { HttpException, StreamableFile } from '@nestjs/common';
+import { HttpException, NotFoundException, StreamableFile } from '@nestjs/common';
 import { NextFunction, Response } from 'express';
 import { access, constants } from 'node:fs/promises';
 import { basename, extname } from 'node:path';
@@ -52,6 +52,9 @@ export const sendFile = async (
 
   try {
     const file = await handler();
+
+    await access(file.path, constants.R_OK);
+
     const cacheControlHeader = cacheControlHeaders[file.cacheControl];
     if (cacheControlHeader) {
       // set the header to Cache-Control
@@ -62,8 +65,6 @@ export const sendFile = async (
     if (file.fileName) {
       res.header('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.fileName)}`);
     }
-
-    await access(file.path, constants.R_OK);
 
     return await _sendFile(file.path, { dotfiles: 'allow' });
   } catch (error: Error | any) {
@@ -77,8 +78,7 @@ export const sendFile = async (
       logger.error(`Unable to send file: ${error}`, error.stack);
     }
 
-    res.header('Cache-Control', 'none');
-    next(error);
+    next(new NotFoundException());
   }
 };
 


### PR DESCRIPTION
- Set response headers after checking file access
- Throw 404 instead of 500 when a file cannot be read from disk