### PR TITLE
refactor(mobile): use Optional only on API boundary

### DIFF
--- a/mobile/lib/domain/services/remote_album.service.dart
+++ b/mobile/lib/domain/services/remote_album.service.dart
@@ -8,7 +8,7 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_album.repository.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
-import 'package:openapi/api.dart' show Optional;
+import 'package:immich_mobile/utils/option.dart';
 import 'package:immich_mobile/repositories/drift_album_api_repository.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:logging/logging.dart';
@@ -138,7 +138,7 @@ class RemoteAlbumService {
   Future<RemoteAlbum> updateAlbum(
     String albumId, {
     String? name,
-    Optional<String?> description = const Optional.absent(),
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -11,7 +11,7 @@ import 'package:immich_mobile/models/shared_link/shared_link.model.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/shared_link.provider.dart';
 import 'package:immich_mobile/services/shared_link.service.dart';
-import 'package:openapi/api.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
@@ -366,10 +366,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
       bool? download;
       bool? upload;
       bool? meta;
-      var password = const Optional<String?>.absent();
-      var description = const Optional<String?>.absent();
+      var password = const Option<String?>.none();
+      var description = const Option<String?>.none();
       String? slug;
-      var expiry = const Optional<DateTime?>.absent();
+      var expiry = const Option<DateTime?>.none();
 
       if (allowDownload.value != existingLink!.allowDownload) {
         download = allowDownload.value;
@@ -385,14 +385,12 @@ class SharedLinkEditPage extends HookConsumerWidget {
 
       if (descriptionController.text != (existingLink!.description ?? '')) {
         description = descriptionController.text.isEmpty
-            ? const Optional.present(null)
-            : Optional.present(descriptionController.text);
+            ? const Option.some(null)
+            : Option.some(descriptionController.text);
       }
 
       if (passwordController.text != (existingLink!.password ?? '')) {
-        password = passwordController.text.isEmpty
-            ? const Optional.present(null)
-            : Optional.present(passwordController.text);
+        password = passwordController.text.isEmpty ? const Option.some(null) : Option.some(passwordController.text);
       }
 
       if (slugController.text != (existingLink!.slug ?? "")) {
@@ -403,7 +401,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
 
       final newExpiry = expiryAfter.value;
       if (newExpiry?.toUtc() != existingLink!.expiresAt?.toUtc()) {
-        expiry = newExpiry == null ? const Optional.present(null) : Optional.present(newExpiry.toUtc());
+        expiry = newExpiry == null ? const Option.some(null) : Option.some(newExpiry.toUtc());
       }
 
       await ref

--- a/mobile/lib/presentation/pages/drift_remote_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_remote_album.page.dart
@@ -18,9 +18,9 @@ import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dar
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/remote_album_sliver_app_bar.dart';
-import 'package:openapi/api.dart' show Optional;
 
 @RoutePage()
 class RemoteAlbumPage extends ConsumerStatefulWidget {
@@ -249,8 +249,8 @@ class _EditAlbumDialogState extends ConsumerState<_EditAlbumDialog> {
       final newTitle = titleController.text.trim();
       final newDescription = descriptionController.text.trim();
       final description = newDescription.isEmpty
-          ? const Optional<String?>.present(null)
-          : Optional<String?>.present(newDescription);
+          ? const Option<String?>.some(null)
+          : Option<String?>.some(newDescription);
 
       await ref
           .read(remoteAlbumProvider.notifier)

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -8,7 +8,7 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
-import 'package:openapi/api.dart' show Optional;
+import 'package:immich_mobile/utils/option.dart';
 import 'package:immich_mobile/providers/album/pending_album_uploads.provider.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
@@ -154,7 +154,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
   Future<RemoteAlbum?> updateAlbum(
     String albumId, {
     String? name,
-    Optional<String?> description = const Optional.absent(),
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,

--- a/mobile/lib/repositories/drift_album_api_repository.dart
+++ b/mobile/lib/repositories/drift_album_api_repository.dart
@@ -3,6 +3,7 @@ import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/repositories/api.repository.dart';
+import 'package:immich_mobile/utils/option.dart';
 // ignore: import_rule_openapi
 import 'package:openapi/api.dart' hide AlbumUserRole;
 
@@ -71,7 +72,7 @@ class DriftAlbumApiRepository extends ApiRepository {
     String albumId,
     UserDto owner, {
     String? name,
-    Optional<String?> description = const Optional.absent(),
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,
@@ -86,7 +87,7 @@ class DriftAlbumApiRepository extends ApiRepository {
         albumId,
         UpdateAlbumDto(
           albumName: name == null ? const Optional.absent() : Optional.present(name),
-          description: description,
+          description: description.toOptional(),
           albumThumbnailAssetId: thumbnailAssetId == null
               ? const Optional.absent()
               : Optional.present(thumbnailAssetId),

--- a/mobile/lib/services/shared_link.service.dart
+++ b/mobile/lib/services/shared_link.service.dart
@@ -2,6 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/models/shared_link/shared_link.model.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 
@@ -88,10 +89,10 @@ class SharedLinkService {
     required bool? showMeta,
     required bool? allowDownload,
     required bool? allowUpload,
-    Optional<String?> password = const Optional.absent(),
-    Optional<String?> description = const Optional.absent(),
+    Option<String?> password = const Option.none(),
+    Option<String?> description = const Option.none(),
     String? slug,
-    Optional<DateTime?> expiresAt = const Optional.absent(),
+    Option<DateTime?> expiresAt = const Option.none(),
   }) async {
     try {
       final responseDto = await _apiService.sharedLinksApi.updateSharedLink(
@@ -100,9 +101,9 @@ class SharedLinkService {
           showMetadata: showMeta == null ? const Optional.absent() : Optional.present(showMeta),
           allowDownload: allowDownload == null ? const Optional.absent() : Optional.present(allowDownload),
           allowUpload: allowUpload == null ? const Optional.absent() : Optional.present(allowUpload),
-          password: password,
-          description: description,
-          expiresAt: expiresAt,
+          password: password.toOptional(),
+          description: description.toOptional(),
+          expiresAt: expiresAt.toOptional(),
           slug: slug == null ? const Optional.absent() : Optional.present(slug),
         ),
       );


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

as discussed on Discord we use the generated `Optional` class only on the SDK/API boundary. Internally we use our own `Option`, this keeps us future-proof on upstream changes and enhanced type safety. `toOptional()` can be used to map from `Option` to `Optional`.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
