### PR TITLE
feat(mobile): add 'Cloud only' quick link on search page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1917,6 +1917,7 @@
   "remote": "Remote",
   "remote_assets": "Remote Assets",
   "remote_media_summary": "Remote Media Summary",
+  "remote_only_assets": "Cloud only",
   "remove": "Remove",
   "remove_assets_album_confirmation": "Are you sure you want to remove {count, plural, one {# asset} other {# assets}} from the album?",
   "remove_assets_shared_link_confirmation": "Are you sure you want to remove {count, plural, one {# asset} other {# assets}} from this shared link?",

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -71,6 +71,8 @@ class TimelineFactory {
 
   TimelineService video(String userId) => TimelineService(_timelineRepository.video(userId, groupBy));
 
+  TimelineService remoteOnly(String userId) => TimelineService(_timelineRepository.remoteOnly(userId, groupBy));
+
   TimelineService place(String place) => TimelineService(_timelineRepository.place(place, groupBy));
 
   TimelineService person(String userId, String personId) =>

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -371,6 +371,21 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     groupBy: groupBy,
   );
 
+  TimelineQuery remoteOnly(String userId, GroupAssetsBy groupBy) {
+    final localChecksums = _db.localAssetEntity.selectOnly()
+      ..addColumns([_db.localAssetEntity.checksum])
+      ..where(_db.localAssetEntity.checksum.isNotNull());
+    return _remoteQueryBuilder(
+      filter: (row) =>
+          row.deletedAt.isNull() &
+          row.ownerId.equals(userId) &
+          row.visibility.equalsValue(AssetVisibility.timeline) &
+          row.checksum.isInQuery(localChecksums).not(),
+      origin: TimelineOrigin.remoteAssets,
+      groupBy: groupBy,
+    );
+  }
+
   TimelineQuery place(String place, GroupAssetsBy groupBy) => (
     bucketSource: () => _watchPlaceBucket(place, groupBy: groupBy),
     assetSource: (offset, count) => _getPlaceBucketAssets(place, offset: offset, count: count),

--- a/mobile/lib/presentation/pages/drift_remote_only.page.dart
+++ b/mobile/lib/presentation/pages/drift_remote_only.page.dart
@@ -1,0 +1,37 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/widgets/common/mesmerizing_sliver_app_bar.dart';
+
+@RoutePage()
+class DriftRemoteOnlyPage extends StatelessWidget {
+  const DriftRemoteOnlyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: [
+        timelineServiceProvider.overrideWith((ref) {
+          final user = ref.watch(currentUserProvider);
+          if (user == null) {
+            throw Exception('User must be logged in to access cloud-only assets');
+          }
+
+          final timelineService = ref.watch(timelineFactoryProvider).remoteOnly(user.id);
+          ref.onDispose(timelineService.dispose);
+          return timelineService;
+        }),
+      ],
+      child: Timeline(
+        appBar: MesmerizingSliverAppBar(
+          title: 'remote_only_assets'.t(context: context),
+          icon: Icons.cloud_outlined,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -897,8 +897,13 @@ class _QuickLinkList extends StatelessWidget {
           _QuickLink(
             title: 'favorites'.t(context: context),
             icon: Icons.favorite_border_rounded,
-            isBottom: true,
             onTap: () => context.pushRoute(const DriftFavoriteRoute()),
+          ),
+          _QuickLink(
+            title: 'remote_only_assets'.t(context: context),
+            icon: Icons.cloud_outlined,
+            isBottom: true,
+            onTap: () => context.pushRoute(const DriftRemoteOnlyRoute()),
           ),
         ],
       ),

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -60,6 +60,7 @@ import 'package:immich_mobile/presentation/pages/drift_place_detail.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_recently_added.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_recently_taken.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_remote_album.page.dart';
+import 'package:immich_mobile/presentation/pages/drift_remote_only.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_slideshow.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_trash.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_user_selection.page.dart';
@@ -166,6 +167,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: DriftArchiveRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftLockedFolderRoute.page, guards: [_authGuard, _lockedGuard, _duplicateGuard]),
     AutoRoute(page: DriftVideoRoute.page, guards: [_authGuard, _duplicateGuard]),
+    AutoRoute(page: DriftRemoteOnlyRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftLibraryRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftAssetSelectionTimelineRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftPartnerDetailRoute.page, guards: [_authGuard, _duplicateGuard]),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -1064,6 +1064,22 @@ class DriftRecentlyTakenRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [DriftRemoteOnlyPage]
+class DriftRemoteOnlyRoute extends PageRouteInfo<void> {
+  const DriftRemoteOnlyRoute({List<PageRouteInfo>? children})
+    : super(DriftRemoteOnlyRoute.name, initialChildren: children);
+
+  static const String name = 'DriftRemoteOnlyRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const DriftRemoteOnlyPage();
+    },
+  );
+}
+
+/// generated route for
 /// [DriftSearchPage]
 class DriftSearchRoute extends PageRouteInfo<void> {
   const DriftSearchRoute({List<PageRouteInfo>? children})


### PR DESCRIPTION
## Description

Adds a **Cloud only** quick link to the mobile search page that lists remote assets without a local copy on this device, so users can bulk-select and trash them in one go instead of hand-picking each one.

This is a direct answer to the feature request discussed in [#26569](https://github.com/immich-app/immich/discussions/26569) (closed, asked again in [#2155](https://github.com/immich-app/immich/discussions/2155)):

> I have auto-backup enabled. Often, I review my photos using the native phone gallery and delete unwanted or bad shots locally. However, since these photos have already been backed up to Immich, they remain on the server. Over time, this leads to a buildup of \"junk\" photos on the server that I intended to delete. Currently, it is very difficult to identify which photos have been deleted locally but are still taking up space on the server.

### The problem

The mobile app today already distinguishes three states per asset (per the [FAQ](https://docs.immich.app/FAQ/#what-is-the-difference-between-the-cloud-icons-on-the-mobile-app)):
- ☁️ solid cloud — on server, **not** on this device
- ☁️ crossed cloud — local only
- ☁️ cloud-with-check — both

But there is no way to *filter* the timeline by that state. Users with auto-backup who clean up locally in the system gallery end up with a long tail of solid-cloud assets that they have to find one-by-one if they want to remove them from the server too.

### The fix

A new quick link on the search page opens a timeline scoped to remote assets whose checksum has no match in the local asset table. The standard timeline multi-select + bottom-sheet delete then handles bulk trashing.

### Implementation

- `DriftTimelineRepository.remoteOnly(userId, groupBy)` reuses `_remoteQueryBuilder` and adds a filter \`row.checksum.isInQuery(localChecksums).not()\`, mirroring the join pattern already used in `_getRemoteAlbumBucketAssets` and the `joinLocal: true` path in `_getRemoteAssets`. The subquery excludes null checksums to avoid SQL \`NOT IN\` returning UNKNOWN for every row.
- `TimelineFactory.remoteOnly(userId)` exposes the new query.
- New `DriftRemoteOnlyPage` mirrors `DriftRecentlyAddedPage` / `DriftFavoritePage` and uses the default `GeneralBottomSheet` from `Timeline`, so multi-select + delete come for free.
- A new entry is added at the bottom of `_QuickLinkList` in `drift_search.page.dart`, next to *Favorites* / *Videos* / *Recently added*.
- New i18n key `remote_only_assets` (English: \"Cloud only\").

No server-side changes, no new dependencies, no schema migration — the answer is already in the Drift DB the mobile app maintains.

## How Has This Been Tested?

- [x] \`flutter analyze\` on the touched files: no issues.
- [x] \`flutter build apk --debug\` succeeds against this branch.
- [x] Smoke-tested on a real Android device by the PR author: the new *Cloud only* quick link appears on the search page, the resulting timeline shows exactly the assets marked with the solid-cloud icon, and multi-select + delete behaves like other timeline views.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Drafted with the assistance of an LLM (Claude). The implementation pattern was chosen by reading the existing Drift timeline queries (\`favorite\`, \`recentlyAdded\`, \`_getRemoteAlbumBucketAssets\`) and following the same conventions. Author reviewed each change before submission and smoke-tested the build on device.