### PR TITLE
fix: reload timeline on group by setting change

### DIFF
--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
 import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 
@@ -20,6 +21,7 @@ class GroupSettings extends HookConsumerWidget {
     Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
       await ref.read(settingsProvider).write(.timelineGroupAssetsBy, groupBy);
       ref.invalidate(appSettingsServiceProvider);
+      ref.invalidate(timelineServiceProvider);
     }
 
     void changeGroupValue(GroupAssetsBy? value) {
@@ -45,10 +47,6 @@ class GroupSettings extends HookConsumerWidget {
             SettingsRadioGroup(
               title: 'month'.t(context: context),
               value: GroupAssetsBy.month,
-            ),
-            SettingsRadioGroup(
-              title: 'asset_list_layout_settings_group_automatically'.t(context: context),
-              value: GroupAssetsBy.auto,
             ),
           ],
           groupBy: groupBy.value,


### PR DESCRIPTION
Fixes #21468
Closes #21995

## Description

- Removes the automatic grouping setting
- Reloads the timeline on the group by setting change