### PR TITLE
fix(server): fall back to embedded preview when RAW decode fails

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -988,6 +988,77 @@ describe(MediaService.name, () => {
       });
     });
 
+    it('should fall back to the embedded preview when decoding a RAW file fails', async () => {
+      const asset = AssetFactory.from({ originalFileName: 'file.dng' })
+        .exif({ fileSizeInByte: 5000, profileDescription: 'Adobe RGB', bitsPerSample: 14, orientation: undefined })
+        .build();
+      // extractEmbedded is disabled, so the original RAW is decoded directly - but libraw can't parse it.
+      mocks.systemMetadata.get.mockResolvedValue({ image: { extractEmbedded: false } });
+      mocks.media.decodeImage.mockReset();
+      mocks.media.decodeImage.mockImplementation((input) =>
+        typeof input === 'string'
+          ? Promise.reject(new Error('Unsupported file format or not RAW file'))
+          : Promise.resolve({ data: fullsizeBuffer, info: rawInfo as OutputInfo }),
+      );
+      mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await expect(sut.handleGenerateThumbnails({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      // the original decode failed, so the embedded preview was extracted and decoded instead
+      expect(mocks.media.extract).toHaveBeenCalledWith(asset.originalPath);
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, expect.anything());
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(extractedBuffer, expect.anything());
+      expect(mocks.media.generateThumbnail).toHaveBeenCalled();
+    });
+
+    it('should fall back to the embedded preview even when it is smaller than the preview size', async () => {
+      const asset = AssetFactory.from({ originalFileName: 'file.dng' })
+        .exif({ fileSizeInByte: 5000, profileDescription: 'Adobe RGB', bitsPerSample: 14, orientation: undefined })
+        .build();
+      mocks.systemMetadata.get.mockResolvedValue({ image: { extractEmbedded: true } });
+      // embedded preview is smaller than the configured preview size, so the size-gated extract returns null
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1000, height: 1000, isTransparent: false });
+      mocks.media.decodeImage.mockReset();
+      mocks.media.decodeImage.mockImplementation((input) =>
+        typeof input === 'string'
+          ? Promise.reject(new Error('Unsupported file format or not RAW file'))
+          : Promise.resolve({ data: fullsizeBuffer, info: rawInfo as OutputInfo }),
+      );
+      mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await expect(sut.handleGenerateThumbnails({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(extractedBuffer, expect.anything());
+      expect(mocks.media.generateThumbnail).toHaveBeenCalled();
+    });
+
+    it('should rethrow the decode error for a RAW file with no embedded preview', async () => {
+      const asset = AssetFactory.from({ originalFileName: 'file.dng' })
+        .exif({ fileSizeInByte: 5000, profileDescription: 'Adobe RGB', bitsPerSample: 14, orientation: undefined })
+        .build();
+      mocks.systemMetadata.get.mockResolvedValue({ image: { extractEmbedded: false } });
+      mocks.media.decodeImage.mockReset();
+      mocks.media.decodeImage.mockRejectedValue(new Error('Unsupported file format or not RAW file'));
+      mocks.media.extract.mockResolvedValue(null);
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await expect(sut.handleGenerateThumbnails({ id: asset.id })).rejects.toThrowError(
+        'Unsupported file format or not RAW file',
+      );
+    });
+
+    it('should not attempt the embedded-preview fallback for non-RAW images', async () => {
+      const asset = AssetFactory.from({ originalFileName: 'file.jpg' }).exif().build();
+      mocks.media.decodeImage.mockReset();
+      mocks.media.decodeImage.mockRejectedValue(new Error('Input buffer contains unsupported image format'));
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await expect(sut.handleGenerateThumbnails({ id: asset.id })).rejects.toThrowError();
+      expect(mocks.media.extract).not.toHaveBeenCalled();
+    });
+
     it('should resize original image if embedded image extraction is not enabled', async () => {
       const asset = AssetFactory.from({ originalFileName: 'file.dng' })
         .exif({ fileSizeInByte: 5000, profileDescription: 'Adobe RGB', bitsPerSample: 14, orientation: undefined })

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -272,22 +272,55 @@ export class MediaService extends BaseService {
   }
 
   private async extractOriginalImage(asset: ThumbnailAsset, image: SystemConfig['image'], useEdits = false) {
-    const extractEmbedded = image.extractEmbedded && mimeTypes.isRaw(asset.originalFileName);
-    const extracted = extractEmbedded ? await this.extractImage(asset.originalPath, image.preview.size) : null;
-    const generateFullsize =
-      ((image.fullsize.enabled || asset.exifInfo.projectionType === 'EQUIRECTANGULAR') &&
-        !mimeTypes.isWebSupportedImage(asset.originalPath)) ||
-      useEdits;
-    const convertFullsize = generateFullsize && (!extracted || !mimeTypes.isWebSupportedImage(` .${extracted.format}`));
+    const isRaw = mimeTypes.isRaw(asset.originalFileName);
+    const extractEmbedded = image.extractEmbedded && isRaw;
+    let extracted = extractEmbedded ? await this.extractImage(asset.originalPath, image.preview.size) : null;
 
-    const thumbSource = extracted ? extracted.buffer : asset.originalPath;
-    const { data, info, colorspace } = await this.decodeImage(
-      thumbSource,
-      // only specify orientation to extracted images which don't have EXIF orientation data
-      // or it can double rotate the image
-      extracted ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
-      convertFullsize ? undefined : image.preview.size,
-    );
+    const decode = async () => {
+      const generateFullsize =
+        ((image.fullsize.enabled || asset.exifInfo.projectionType === 'EQUIRECTANGULAR') &&
+          !mimeTypes.isWebSupportedImage(asset.originalPath)) ||
+        useEdits;
+      const convertFullsize =
+        generateFullsize && (!extracted || !mimeTypes.isWebSupportedImage(` .${extracted.format}`));
+
+      const thumbSource = extracted ? extracted.buffer : asset.originalPath;
+      const { data, info, colorspace } = await this.decodeImage(
+        thumbSource,
+        // only specify orientation to extracted images which don't have EXIF orientation data
+        // or it can double rotate the image
+        extracted ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
+        convertFullsize ? undefined : image.preview.size,
+      );
+
+      return { data, info, colorspace, convertFullsize, generateFullsize };
+    };
+
+    let decoded: Awaited<ReturnType<typeof decode>>;
+    try {
+      decoded = await decode();
+    } catch (error: any) {
+      // Some RAW files (e.g. certain DNGs produced by Lightroom HDR/panorama merges) cannot be
+      // decoded by libraw. Rather than failing the whole asset, fall back to the embedded preview
+      // even when it's smaller than the configured preview size — a reduced-resolution image is
+      // preferable to a broken one. Only attempt this when we decoded the original RAW directly.
+      if (!isRaw || extracted) {
+        throw error;
+      }
+
+      const fallback = await this.mediaRepository.extract(asset.originalPath);
+      if (!fallback) {
+        throw error;
+      }
+
+      this.logger.warn(
+        `Failed to decode RAW image ${asset.originalPath}, falling back to its embedded preview: ${error.message ?? error}`,
+      );
+      extracted = fallback;
+      decoded = await decode();
+    }
+
+    const { data, info, colorspace, convertFullsize, generateFullsize } = decoded;
 
     let isTransparent = false;
     if (!extracted && mimeTypes.canBeTransparent(asset.originalPath)) {


### PR DESCRIPTION
## Description

Certain DNG files — notably those produced by Lightroom HDR-merge / panorama-stitch operations on Sony ARW raws — cannot be decoded by **libraw**, which sits under `sharp → libvips → ImageMagick`. When this happens, `decodeImage()` throws `Unsupported file format or not RAW file` and the whole thumbnail job fails, so the asset shows as **broken** even though its metadata (read via a separate exiftool path) displays correctly.

These files always carry a full-resolution **embedded JPEG preview**. Immich already extracts embedded previews via exiftool (which bypasses libraw entirely), but only when *Extract Embedded Preview* is enabled **and** the preview is at least as large as the configured preview size — so by default these files still break.

This change makes embedded-preview extraction a **last-resort fallback** in `extractOriginalImage`: if decoding the original RAW throws, it retries using the embedded preview, even when that preview is smaller than the configured preview size — a reduced-resolution image is preferable to a broken asset. Behavior is otherwise unchanged:

- Only triggers for RAW files decoded directly; non-RAW errors and already-extracted-buffer errors propagate unchanged.
- The original decode error is rethrown when no embedded preview exists.
- `generateFullsize` / `convertFullsize` / orientation / transparency logic is recomputed against the fallback buffer, so fullsize output stays correct.
- The happy path is unchanged.

This resolves the user-visible bug without the weight and licensing burden of bundling the Adobe DNG SDK (the originally proposed fix), which would only be needed for RAWs that have *no* usable embedded preview.

Fixes #13029

## How Has This Been Tested?

- [x] Added 4 unit tests in `server/src/services/media.service.spec.ts`: fallback on decode failure, fallback when the embedded preview is below the configured preview size, rethrow when no embedded preview exists, and no-fallback for non-RAW images.
- [x] Full unit suite passes (`pnpm --filter @immich/server test src/services/media.service.spec.ts`): **196/196**.
- [x] `eslint`, `prettier --check`, and `tsc --noEmit` all clean on the changed files.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was authored with substantial assistance from an LLM (Claude). The LLM traced the decode pipeline, identified the root cause, wrote the implementation and the unit tests, and ran the test/lint/typecheck suite. The approach and final code were reviewed by myself before submission.