### PR TITLE
fix(mobile): map timeline layout crash

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/map_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/map_bottom_sheet.widget.dart
@@ -23,7 +23,7 @@ class MapBottomSheet extends StatelessWidget {
       resizeOnScroll: false,
       actions: [],
       backgroundColor: context.themeData.colorScheme.surface,
-      slivers: [const SliverFillRemaining(hasScrollBody: false, child: _ScopedMapTimeline())],
+      slivers: [const SliverFillRemaining(hasScrollBody: true, child: _ScopedMapTimeline())],
     );
   }
 }


### PR DESCRIPTION
## Description

Changes `hasScrollBody` in the map timeline widget to `true` to skip the intrinsic measurement and hand the remaining viewport height directly to the child.

