### PR TITLE
fix(server): skip existing users when sharing albums

### DIFF
--- a/e2e/src/specs/server/api/album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/album.e2e-spec.ts
@@ -729,8 +729,8 @@ describe('/albums', () => {
         .set('Authorization', `Bearer ${user1.accessToken}`)
         .send({ albumUsers: [{ userId: user1.userId, role: AlbumUserRole.Editor }] });
 
-      expect(status).toBe(400);
-      expect(body).toEqual(errorDto.badRequest('User already added'));
+      expect(status).toBe(200);
+      expect(body.albumUsers.length).toEqual(1);
     });
 
     it('should not be able to add existing user to shared album', async () => {
@@ -744,8 +744,8 @@ describe('/albums', () => {
         .set('Authorization', `Bearer ${user1.accessToken}`)
         .send({ albumUsers: [{ userId: user2.userId, role: AlbumUserRole.Editor }] });
 
-      expect(status).toBe(400);
-      expect(body).toEqual(errorDto.badRequest('User already added'));
+      expect(status).toBe(200);
+      expect(body.albumUsers.length).toEqual(2);
     });
   });
 

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -464,17 +464,19 @@ describe(AlbumService.name, () => {
       expect(mocks.album.update).not.toHaveBeenCalled();
     });
 
-    it('should throw an error if the userId is already added', async () => {
+    it('should skip if the userId is already added', async () => {
       const userId = newUuid();
       const album = AlbumFactory.from().albumUser({ userId }).build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
       mocks.album.getById.mockResolvedValue(getForAlbum(album));
-      await expect(
-        sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] }),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      await expect(sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] })).resolves.toEqual(
+        expect.objectContaining({ id: album.id }),
+      );
       expect(mocks.album.update).not.toHaveBeenCalled();
       expect(mocks.user.get).not.toHaveBeenCalled();
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
+      expect(mocks.event.emit).not.toHaveBeenCalled();
     });
 
     it('should throw an error if the userId does not exist', async () => {
@@ -490,7 +492,7 @@ describe(AlbumService.name, () => {
       expect(mocks.user.get).toHaveBeenCalledWith('unknown-user', {});
     });
 
-    it('should throw an error if the userId is the ownerId', async () => {
+    it('should skip if the userId is the ownerId', async () => {
       const album = AlbumFactory.create();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
@@ -499,9 +501,11 @@ describe(AlbumService.name, () => {
         sut.addUsers(AuthFactory.create(owner), album.id, {
           albumUsers: [{ userId: owner.id }],
         }),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).resolves.toEqual(expect.objectContaining({ id: album.id }));
       expect(mocks.album.update).not.toHaveBeenCalled();
       expect(mocks.user.get).not.toHaveBeenCalled();
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
+      expect(mocks.event.emit).not.toHaveBeenCalled();
     });
 
     it('should add valid shared users', async () => {
@@ -520,6 +524,35 @@ describe(AlbumService.name, () => {
         userId: user.id,
         albumId: album.id,
       });
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
+        id: album.id,
+        userId: user.id,
+        senderName: owner.name,
+      });
+    });
+
+    it('should add new users when already-added users are included', async () => {
+      const existingUserId = newUuid();
+      const album = AlbumFactory.from().albumUser({ userId: existingUserId }).build();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      const user = UserFactory.create();
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.user.get.mockResolvedValue(user);
+      mocks.albumUser.create.mockResolvedValue(AlbumUserFactory.from().album(album).user(user).build());
+
+      await sut.addUsers(AuthFactory.create(owner), album.id, {
+        albumUsers: [{ userId: existingUserId }, { userId: user.id }],
+      });
+
+      expect(mocks.user.get).toHaveBeenCalledTimes(1);
+      expect(mocks.user.get).toHaveBeenCalledWith(user.id, {});
+      expect(mocks.albumUser.create).toHaveBeenCalledTimes(1);
+      expect(mocks.albumUser.create).toHaveBeenCalledWith({
+        userId: user.id,
+        albumId: album.id,
+      });
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
       expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
         id: album.id,
         userId: user.id,

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -294,7 +294,7 @@ export class AlbumService extends BaseService {
 
       const exists = album.albumUsers.find(({ user: { id } }) => id === userId);
       if (exists) {
-        throw new BadRequestException('User already added');
+        continue;
       }
 
       const user = await this.userRepository.get(userId, {});


### PR DESCRIPTION
## Description

Skip album users who are already shared on an album when handling add-users requests. Previously, one existing user caused the whole request to fail, so any new users in the same batch were not added.

This keeps owner validation in place and only treats existing non-owner album users as a no-op.

Fixes #28880

## How Has This Been Tested?

- [x] `git diff --check`
- [ ] Server Vitest suite was not run locally because this fresh clone has no `node_modules`, and the pnpm shim failed to fetch dependencies in the sandbox.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help inspect the code path, implement the focused change, and draft the PR description. The change was manually reviewed before submission.