### PR TITLE
refactor(server): prevent sharing album with owner by filtering out user from albumUsers

### DIFF
--- a/e2e/src/specs/server/api/album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/album.e2e-spec.ts
@@ -504,13 +504,14 @@ describe('/albums', () => {
       });
     });
 
-    it('should not be able to share album with owner', async () => {
+    it('should deduplicate owner from albumUsers on create', async () => {
       const { status, body } = await request(app)
         .post('/albums')
         .send({ albumName: 'New album', albumUsers: [{ role: AlbumUserRole.Editor, userId: user1.userId }] })
         .set('Authorization', `Bearer ${user1.accessToken}`);
-      expect(status).toBe(400);
-      expect(body).toEqual(errorDto.badRequest('Cannot share album with owner'));
+      expect(status).toBe(201);
+      expect(body.albumUsers).toHaveLength(1);
+      expect(body.albumUsers[0]).toMatchObject({ role: AlbumUserRole.Owner, user: { id: user1.userId } });
     });
   });
 

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -348,17 +348,25 @@ describe(AlbumService.name, () => {
       expect(mocks.access.asset.checkOwnerAccess).toHaveBeenCalledWith(owner.id, new Set([assetId, 'asset-2']), false);
     });
 
-    it('should throw an error if the userId is the ownerId', async () => {
-      const album = AlbumFactory.create();
-      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
-      mocks.user.get.mockResolvedValue(owner);
-      await expect(
-        sut.create(AuthFactory.create(owner), {
-          albumName: 'Empty album',
-          albumUsers: [{ userId: owner.id, role: AlbumUserRole.Editor }],
-        }),
-      ).rejects.toBeInstanceOf(BadRequestException);
-      expect(mocks.album.create).not.toHaveBeenCalled();
+    it('should deduplicate owner from albumUsers on create', async () => {
+      const auth = AuthFactory.create();
+      const album = AlbumFactory.from().build();
+      mocks.album.create.mockResolvedValue(getForAlbum(album));
+      mocks.user.getMetadata.mockResolvedValue([]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set());
+
+      await sut.create(auth, {
+        albumName: 'Empty album',
+        albumUsers: [{ userId: auth.user.id, role: AlbumUserRole.Editor }],
+      });
+
+      expect(mocks.user.get).not.toHaveBeenCalled();
+      expect(mocks.album.create).toHaveBeenCalledWith(
+        expect.objectContaining({ albumName: 'Empty album' }),
+        [],
+        [{ userId: auth.user.id, role: AlbumUserRole.Owner }],
+        auth.user.id,
+      );
     });
   });
 

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -98,17 +98,13 @@ export class AlbumService extends BaseService {
   }
 
   async create(auth: AuthDto, dto: CreateAlbumDto): Promise<AlbumResponseDto> {
-    const albumUsers = dto.albumUsers || [];
+    const albumUsers = (dto.albumUsers || []).filter(({ userId }) => userId !== auth.user.id);
 
     for (const { userId } of albumUsers) {
       const exists = await this.userRepository.get(userId, {});
       if (!exists) {
         this.logger.debug('Album creation failed: user not found');
         throw new BadRequestException('Invalid user');
-      }
-
-      if (userId == auth.user.id) {
-        throw new BadRequestException('Cannot share album with owner');
       }
     }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

up for discussion. I usually prefer UX/DX-friendly or -sensible error handling, so I'd say instead of raising we just dedupe on the server

related to #28884, reverts/udpates https://github.com/immich-app/immich/pull/18802

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
