### PR TITLE
feat(web): new map ui controls, heatmap visulization

### DIFF
--- a/e2e/src/ui/mock-network/map-network.ts
+++ b/e2e/src/ui/mock-network/map-network.ts
@@ -1,0 +1,32 @@
+import type { MapMarkerResponseDto } from '@immich/sdk';
+import { BrowserContext } from '@playwright/test';
+import { TimelineData } from 'src/ui/generators/timeline';
+
+export const setupMapMockApiRoutes = async (context: BrowserContext, timelineData: TimelineData) => {
+  await context.route('**/api/map/markers', async (route) => {
+    const markers: MapMarkerResponseDto[] = [];
+
+    for (const bucket of timelineData.buckets.values()) {
+      for (const asset of bucket) {
+        // Only include assets with GPS coordinates
+        if (asset.latitude !== null && asset.longitude !== null) {
+          markers.push({
+            id: asset.id,
+            lat: asset.latitude,
+            lon: asset.longitude,
+            city: asset.city,
+            state: null,
+            country: asset.country,
+          });
+        }
+      }
+    }
+    markers.sort((a, b) => a.id.localeCompare(b.id));
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      json: markers,
+    });
+  });
+};

--- a/e2e/src/ui/specs/map/map.e2e-spec.ts
+++ b/e2e/src/ui/specs/map/map.e2e-spec.ts
@@ -1,0 +1,121 @@
+import { faker } from '@faker-js/faker';
+import { expect, test } from '@playwright/test';
+import { createDefaultTimelineConfig, generateTimelineData, TimelineData } from 'src/ui/generators/timeline';
+import { setupBaseMockApiRoutes } from 'src/ui/mock-network/base-network';
+import { setupMapMockApiRoutes } from 'src/ui/mock-network/map-network';
+import { utils } from 'src/utils';
+import { mapUtils } from './utils';
+
+test.describe.configure({ mode: 'parallel' });
+test.describe('Map', () => {
+  let adminUserId: string;
+  let mapTestData: TimelineData;
+
+  test.beforeAll(async () => {
+    test.fail(
+      process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1',
+      'This test requires env var: PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1',
+    );
+    utils.initSdk();
+    adminUserId = faker.string.uuid();
+
+    // Generate timeline data with GPS coordinates
+    mapTestData = generateTimelineData({
+      ...createDefaultTimelineConfig(),
+      ownerId: adminUserId,
+    });
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await setupBaseMockApiRoutes(context, adminUserId);
+    await setupMapMockApiRoutes(context, mapTestData);
+  });
+
+  test('/map page loads with cluster markers', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+    await mapUtils.expectMapVisible(page);
+    await mapUtils.expectClustersVisible(page);
+  });
+
+  test('cluster shows point count', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+
+    const firstCluster = mapUtils.getFirstCluster(page);
+    await expect(firstCluster).toBeVisible();
+
+    const count = await mapUtils.getClusterCount(page, firstCluster);
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('cluster count is positive number', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+
+    const clusters = mapUtils.getClusters(page);
+    const clusterCount = await clusters.count();
+
+    if (clusterCount > 0) {
+      for (let i = 0; i < clusterCount; i++) {
+        const cluster = clusters.nth(i);
+        const count = await mapUtils.getClusterCount(page, cluster);
+        expect(count).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('map has zoom controls visible and functional', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+    await mapUtils.expectMapControlsVisible(page);
+
+    await mapUtils.zoomIn(page);
+    await mapUtils.expectMapVisible(page);
+
+    await mapUtils.zoomOut(page);
+    await mapUtils.expectMapVisible(page);
+  });
+
+  test('map has settings button', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+    await expect(mapUtils.getSettingsButton(page)).toBeVisible();
+  });
+
+  test('map fetches and displays markers from API', async ({ page }) => {
+    const markersPromise = mapUtils.waitForMarkersAPI(page);
+
+    await mapUtils.navigateToMap(page);
+
+    const response = await markersPromise;
+    const data = await response.json();
+
+    expect(Array.isArray(data)).toBe(true);
+    if (data.length > 0) {
+      const marker = data[0];
+      expect(marker).toHaveProperty('id');
+      expect(marker).toHaveProperty('lat');
+      expect(marker).toHaveProperty('lon');
+    }
+  });
+
+  test('map renders without console errors', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+
+    const errors = await mapUtils.captureConsoleErrors(page, async () => {
+      await mapUtils.expectMapVisible(page);
+      await page.waitForTimeout(500);
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('cluster button text contains numeric count', async ({ page }) => {
+    await mapUtils.navigateToMap(page);
+
+    const clusters = mapUtils.getClusters(page);
+    const clusterCount = await clusters.count();
+
+    if (clusterCount > 0) {
+      const firstCluster = clusters.first();
+      const text = await firstCluster.textContent();
+      expect(text).toMatch(/\d+/);
+    }
+  });
+});

--- a/e2e/src/ui/specs/map/utils.ts
+++ b/e2e/src/ui/specs/map/utils.ts
@@ -1,0 +1,127 @@
+import { ConsoleMessage, expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Map testing utilities for e2e tests
+ */
+
+export const mapUtils = {
+  /**
+   * Get all visible cluster on the map
+   */
+  getClusters(page: Page) {
+    return page.locator('[class*="rounded-full"][class*="bg-immich-primary"]').filter({ hasText: /\d+/ });
+  },
+
+  /**
+   * Get the first visible cluster button
+   */
+  getFirstCluster(page: Page) {
+    return this.getClusters(page).first();
+  },
+
+  /**
+   * Get asset count of a cluster
+   */
+  async getClusterCount(page: Page, clusterElement?: Locator) {
+    const element = clusterElement || this.getFirstCluster(page);
+    await expect(element).toBeVisible();
+    await expect(element).toHaveText(/\d+/);
+    const text = await element.textContent();
+    return Number.parseInt((text ?? '').replaceAll(/[^\d]/g, ''), 10);
+  },
+
+  /**
+   * Verify map is visible and loaded
+   */
+  async expectMapVisible(page: Page) {
+    const mapContainer = page.locator('.rounded-none.h-full');
+    await expect(mapContainer).toBeVisible();
+  },
+
+  /**
+   * Verify clusters exist on map
+   */
+  async expectClustersVisible(page: Page, minCount = 1) {
+    const clusters = this.getClusters(page);
+    const count = await clusters.count();
+    expect(count).toBeGreaterThanOrEqual(minCount);
+  },
+
+  /**
+   * Get map control buttons
+   */
+  getZoomInButton(page: Page) {
+    return page.getByTitle(/zoom in/i);
+  },
+
+  getZoomOutButton(page: Page) {
+    return page.getByTitle(/zoom out/i);
+  },
+
+  getSettingsButton(page: Page) {
+    return page.getByTitle(/map settings/i);
+  },
+
+  /**
+   * Verify all standard map controls are visible
+   */
+  async expectMapControlsVisible(page: Page) {
+    await expect(this.getZoomInButton(page)).toBeVisible();
+    await expect(this.getZoomOutButton(page)).toBeVisible();
+    await expect(this.getSettingsButton(page)).toBeVisible();
+  },
+
+  /**
+   * Click zoom in button
+   */
+  async zoomIn(page: Page) {
+    await this.getZoomInButton(page).click();
+    await page.waitForTimeout(500);
+  },
+
+  /**
+   * Click zoom out button
+   */
+  async zoomOut(page: Page) {
+    await this.getZoomOutButton(page).click();
+    await page.waitForTimeout(500);
+  },
+
+  /**
+   * Wait for markers API to respond
+   */
+  async waitForMarkersAPI(page: Page) {
+    return page.waitForResponse((response) => response.url().includes('/api/map/markers') && response.status() === 200);
+  },
+
+  /**
+   * Navigate to map and wait for load
+   */
+  async navigateToMap(page: Page) {
+    await page.goto('/map');
+    await page.waitForLoadState('networkidle');
+  },
+
+  /**
+   * Check if map has any errors
+   */
+  async captureConsoleErrors(page: Page, callback: () => Promise<void>) {
+    const errors: string[] = [];
+    const handler = (msg: ConsoleMessage) => {
+      if (msg.type() === 'error') {
+        const text = msg.text();
+        // Ignore expected MapLibre external styles 401 in ci/cd
+        if (text.includes('401 (Unauthorized)')) {
+          return;
+        }
+        errors.push(text);
+      }
+    };
+
+    page.on('console', handler);
+    await callback();
+    page.off('console', handler);
+
+    return errors;
+  },
+};

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1072,6 +1072,8 @@
   "exif_bottom_sheet_description": "Add Description...",
   "exif_bottom_sheet_description_error": "Error updating description",
   "exif_bottom_sheet_no_description": "No description",
+  "exif_bottom_sheet_people": "PEOPLE",
+  "exif_bottom_sheet_person_add_person": "Add name",
   "exit_slideshow": "Exit Slideshow",
   "expand": "Expand",
   "expand_all": "Expand all",
@@ -1129,9 +1131,11 @@
   "free_up_space_settings_subtitle": "Free up device storage",
   "full_path": "Full path: {path}",
   "full_path_or_folder": "Full path or folder",
+  "fullscreen": "Fullscreen",
   "gcast_enabled": "Google Cast",
   "gcast_enabled_description": "This feature loads external resources from Google in order to work.",
   "general": "General",
+  "geolocate": "Geolocate",
   "geolocation_instruction_location": "Click on an asset with GPS coordinates to use its location, or select a location directly from the map",
   "get_help": "Get Help",
   "get_people_error": "Error getting people",
@@ -2036,6 +2040,8 @@
   "support_third_party_description": "Your Immich installation was packaged by a third-party. Issues you experience may be caused by that package, so please raise issues with them in the first instance using the links below.",
   "supporter": "Supporter",
   "swap_merge_direction": "Swap merge direction",
+  "switch_to_flat_map": "Switch to flat map",
+  "switch_to_globe_map": "Switch to globe map",
   "sync": "Sync",
   "sync_albums": "Sync albums",
   "sync_local": "Sync Local",
@@ -2246,5 +2252,7 @@
   "you_dont_have_any_shared_links": "You don't have any shared links",
   "your_wifi_name": "Your Wi-Fi name",
   "zero_to_clear_rating": "press 0 to clear asset rating",
-  "zoom_image": "Zoom Image"
+  "zoom_image": "Zoom Image",
+  "zoom_in": "Zoom in",
+  "zoom_out": "Zoom out"
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -178,3 +178,23 @@
     @apply bg-subtle rounded-lg;
   }
 }
+
+.maplibregl-ctrl-group {
+  @apply bg-white/70! shadow-lg! backdrop-blur-md dark:bg-immich-dark-gray/70! overflow-hidden border border-white/20 dark:border-white/10;
+}
+
+.maplibregl-ctrl-group {
+  @apply rounded-full!;
+}
+
+.maplibregl-ctrl-group:has(button:nth-child(2)) {
+  @apply rounded-2xl!;
+}
+
+.maplibregl-ctrl-group button {
+  @apply w-11! h-11! flex items-center justify-center text-black/80 transition-all hover:bg-white/90! dark:text-white/80 dark:hover:bg-immich-dark-gray/90!;
+}
+
+.maplibregl-ctrl-group button + button {
+  @apply border-t border-black/10 dark:border-white/10;
+}

--- a/web/src/lib/components/shared-components/map/Map.svelte
+++ b/web/src/lib/components/shared-components/map/Map.svelte
@@ -13,38 +13,45 @@
   import OnEvents from '$lib/components/OnEvents.svelte';
   import { serverConfigManager } from '$lib/managers/server-config-manager.svelte';
   import MapSettingsModal from '$lib/modals/MapSettingsModal.svelte';
-  import { mapSettings } from '$lib/stores/preferences.store';
+  import { mapSettings, mapShowHeatmap } from '$lib/stores/preferences.store';
   import { getAssetMediaUrl, handlePromiseError } from '$lib/utils';
   import { getMapMarkers, type MapMarkerResponseDto } from '@immich/sdk';
   import { Icon, modalManager, Theme, themeManager } from '@immich/ui';
-  import { mdiCog, mdiMap, mdiMapMarker } from '@mdi/js';
-  import type { Feature, GeoJsonProperties, Geometry, Point } from 'geojson';
-  import { isEqual, omit } from 'lodash-es';
+  import {
+    mdiCog,
+    mdiCrosshairsGps,
+    mdiImageMultiple,
+    mdiEarth,
+    mdiMap,
+    mdiMapMarker,
+    mdiMinus,
+    mdiPlus,
+  } from '@mdi/js';
+  import type { Feature, Point } from 'geojson';
+  import { isEqual } from 'lodash-es';
   import { DateTime, Duration } from 'luxon';
   import {
-    GlobeControl,
     LngLat,
     LngLatBounds,
     Marker,
+    type ExpressionSpecification,
     type GeoJSONSource,
     type LngLatLike,
+    type ProjectionSpecification,
     type Map,
     type MapMouseEvent,
   } from 'maplibre-gl';
   import { onDestroy, onMount, untrack } from 'svelte';
   import { t } from 'svelte-i18n';
   import {
-    AttributionControl,
-    Control,
-    ControlButton,
-    ControlGroup,
     GeoJSON,
-    GeolocateControl,
+    HeatmapLayer,
     MapLibre,
     MarkerLayer,
-    NavigationControl,
     Popup,
-    ScaleControl,
+    Control,
+    ControlGroup,
+    ControlButton,
   } from 'svelte-maplibre';
   import type { SelectionBBox } from './types';
 
@@ -63,6 +70,8 @@
     onClickPoint?: ({ lat, lng }: { lat: number; lng: number }) => void;
     popup?: import('svelte').Snippet<[{ marker: MapMarkerResponseDto }]>;
     rounded?: boolean;
+    isTimelineOpen?: boolean;
+    onToggleTimeline?: () => void;
     showSimpleControls?: boolean;
     autoFitBounds?: boolean;
   }
@@ -82,6 +91,8 @@
     onClickPoint = () => {},
     popup,
     rounded = false,
+    isTimelineOpen = false,
+    onToggleTimeline,
     showSimpleControls = true,
     autoFitBounds = true,
   }: Props = $props();
@@ -99,14 +110,18 @@
     return bounds;
   })();
 
-  let map: Map | undefined = $state();
+  let map: Map | undefined = $state.raw();
   let marker: Marker | null = null;
   let abortController: AbortController;
+  let isGlobeView = $state(false);
 
-  const mapTheme = $derived($mapSettings.allowDarkMode ? themeManager.value : Theme.Light);
+  const mapTheme = $derived(themeManager.value);
   const styleUrl = $derived(
     mapTheme === Theme.Dark ? serverConfigManager.value.mapDarkStyleUrl : serverConfigManager.value.mapLightStyleUrl,
   );
+  const mapProjection = $derived<ProjectionSpecification>({
+    type: isGlobeView ? 'globe' : 'mercator',
+  });
 
   export function addClipMapMarker(lng: number, lat: number) {
     if (map) {
@@ -188,7 +203,7 @@
     };
   };
 
-  const asMarker = (feature: Feature<Geometry, GeoJsonProperties>): MapMarkerResponseDto => {
+  const asMarker = (feature: Feature): MapMarkerResponseDto => {
     const featurePoint = feature as FeaturePoint;
     const coords = LngLat.convert(featurePoint.geometry.coordinates as [number, number]);
     return {
@@ -241,16 +256,18 @@
     );
   }
 
-  const handleSettingsClick = async () => {
-    const settings = await modalManager.show(MapSettingsModal);
-    if (settings) {
-      const shouldUpdate = !isEqual(omit(settings, 'allowDarkMode'), omit($mapSettings, 'allowDarkMode'));
-      $mapSettings = settings;
-
-      if (shouldUpdate) {
-        mapMarkers = await loadMapMarkers();
-      }
-    }
+  const handleSettingsClick = () => {
+    handlePromiseError(
+      modalManager.show(MapSettingsModal).then(async (settings) => {
+        if (settings) {
+          const shouldUpdate = !isEqual(settings, $mapSettings);
+          $mapSettings = settings;
+          if (shouldUpdate) {
+            mapMarkers = await loadMapMarkers();
+          }
+        }
+      }),
+    );
   };
 
   afterNavigate(() => {
@@ -309,8 +326,24 @@
     untrack(() => map?.jumpTo({ center, zoom }));
   });
 
-  const onAssetsDelete = async () => {
-    mapMarkers = await loadMapMarkers();
+  const onAssetsDelete = () => {
+    handlePromiseError(
+      loadMapMarkers().then((markers) => {
+        mapMarkers = markers;
+      }),
+    );
+  };
+
+  const handleLocate = () => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => map?.flyTo({ center: [pos.coords.longitude, pos.coords.latitude], zoom: 15 }),
+      (err) => handlePromiseError(Promise.reject(err)),
+      { enableHighAccuracy: true },
+    );
+  };
+
+  const toggleMapProjection = () => {
+    isGlobeView = !isGlobeView;
   };
 </script>
 
@@ -327,97 +360,164 @@
   fitBoundsOptions={{ padding: 50, maxZoom: 15 }}
   attributionControl={false}
   diffStyleUpdates={true}
+  projection={mapProjection}
   onload={(event: Map) => {
     event.setMaxZoom(18);
     event.on('click', handleMapClick);
-    if (!simplified) {
-      event.addControl(new GlobeControl(), 'top-left');
-    }
   }}
   bind:map
 >
   {#snippet children({ map }: { map: Map })}
     {#if showSimpleControls}
-      <NavigationControl position="top-left" showCompass={!simplified} />
-
-      {#if !simplified}
-        <GeolocateControl position="top-left" />
-        <ScaleControl />
-        <AttributionControl compact={false} />
-      {/if}
-    {/if}
-
-    {#if showSettings}
-      <Control>
-        <ControlGroup>
-          <ControlButton onclick={handleSettingsClick}>
-            <Icon icon={mdiCog} size="100%" class="text-black/80" />
-          </ControlButton>
-        </ControlGroup>
-      </Control>
-    {/if}
-
-    {#if onOpenInMapView && showSimpleControls}
       <Control position="top-right">
-        <ControlGroup>
-          <ControlButton onclick={() => onOpenInMapView()}>
-            <Icon title={$t('open_in_map_view')} icon={mdiMap} size="100%" class="text-black/80" />
-          </ControlButton>
-        </ControlGroup>
+        <div class="pointer-events-auto mt-3 mr-3 flex flex-col gap-3">
+          {#if showSettings}
+            <ControlGroup class="m-0!">
+              <ControlButton title={$t('map_settings')} onclick={handleSettingsClick}>
+                <Icon icon={mdiCog} size="24" />
+              </ControlButton>
+            </ControlGroup>
+          {/if}
+
+          {#if !simplified}
+            <ControlGroup class="m-0!">
+              <ControlButton
+                title={isGlobeView ? $t('switch_to_flat_map') : $t('switch_to_globe_map')}
+                onclick={toggleMapProjection}
+              >
+                <Icon icon={isGlobeView ? mdiMap : mdiEarth} size="24" />
+              </ControlButton>
+            </ControlGroup>
+          {/if}
+
+          {#if onOpenInMapView}
+            <ControlGroup class="m-0!">
+              <ControlButton title={$t('open_in_map_view')} onclick={() => void onOpenInMapView()}>
+                <Icon icon={mdiMap} size="24" />
+              </ControlButton>
+            </ControlGroup>
+          {/if}
+
+          {#if onToggleTimeline}
+            <ControlGroup class="m-0!">
+              <ControlButton title={$t('timeline')} onclick={() => onToggleTimeline?.()}>
+                <Icon
+                  icon={mdiImageMultiple}
+                  size="24"
+                  class={isTimelineOpen ? 'text-immich-primary dark:text-immich-primary' : ''}
+                />
+              </ControlButton>
+            </ControlGroup>
+          {/if}
+        </div>
+      </Control>
+
+      <Control position="bottom-right">
+        <div class="pointer-events-auto·mr-3·mb-3·flex·flex-col·gap-3">
+          {#if !simplified}
+            <ControlGroup class="m-0!">
+              <ControlButton title={$t('geolocate')} onclick={handleLocate}>
+                <Icon icon={mdiCrosshairsGps} size="24" />
+              </ControlButton>
+            </ControlGroup>
+          {/if}
+
+          <ControlGroup class="m-0!">
+            <ControlButton title={$t('zoom_in')} onclick={() => map?.zoomIn()}>
+              <Icon icon={mdiPlus} size="24" />
+            </ControlButton>
+            <ControlButton title={$t('zoom_out')} onclick={() => map?.zoomOut()}>
+              <Icon icon={mdiMinus} size="24" />
+            </ControlButton>
+          </ControlGroup>
+        </div>
+      </Control>
+
+      <Control position="bottom-left">
+        <div
+          class="mb-3 ml-4 rounded-sm bg-white/70 px-2 py-0.5 text-[11px] font-medium text-black/80 shadow-sm backdrop-blur-md transition-all duration-300 ease-out dark:bg-immich-dark-gray/70 dark:text-white/80"
+        >
+          © OpenStreetMap
+        </div>
       </Control>
     {/if}
-
     <GeoJSON
       data={{
         type: 'FeatureCollection',
         features: mapMarkers?.map((marker) => asFeature(marker)) ?? [],
       }}
       id="geojson"
-      cluster={{ radius: 35, maxZoom: 18 }}
+      cluster={{ radius: 35, maxZoom: 17 }}
     >
-      <MarkerLayer
-        applyToClusters
-        asButton
-        onclick={(event) => handlePromiseError(handleClusterClick(event.feature.properties?.cluster_id, map))}
-      >
-        {#snippet children({ feature })}
-          <div
-            class="flex size-10 items-center justify-center rounded-full bg-immich-primary font-mono font-bold text-white opacity-90 shadow-lg transition-all duration-200 hover:bg-immich-dark-primary hover:text-immich-dark-bg"
-          >
-            {feature.properties?.point_count?.toLocaleString()}
-          </div>
-        {/snippet}
-      </MarkerLayer>
-      <MarkerLayer
-        applyToClusters={false}
-        asButton
-        onclick={(event) => {
-          if (!popup) {
-            handleAssetClick(event.feature.properties?.id, map);
-          }
-        }}
-      >
-        {#snippet children({ feature }: { feature: Feature })}
-          {#if useLocationPin}
-            <Icon icon={mdiMapMarker} size="50px" class="translate-y-[calc(5px-50%)] text-primary" />
-          {:else}
-            <img
-              src={getAssetMediaUrl({ id: feature.properties?.id })}
-              class="size-15 rounded-full border-2 border-immich-primary bg-immich-primary object-cover shadow-lg transition-all duration-200 hover:scale-150 hover:border-immich-dark-primary"
-              alt={feature.properties?.city && feature.properties.country
-                ? $t('map_marker_for_image', {
-                    values: { city: feature.properties.city, country: feature.properties.country },
-                  })
-                : $t('map_marker_with_image')}
-            />
-          {/if}
-          {#if popup}
-            <Popup offset={[0, -30]} openOn="click" closeOnClickOutside>
-              {@render popup({ marker: asMarker(feature) })}
-            </Popup>
-          {/if}
-        {/snippet}
-      </MarkerLayer>
+      {#if $mapShowHeatmap}
+        <HeatmapLayer
+          id="asset-heatmap-layer"
+          paint={{
+            'heatmap-color': [
+              'interpolate',
+              ['linear'],
+              ['heatmap-density'],
+              0,
+              'rgba(255, 255, 255, 0)',
+              0.2,
+              'rgb(255, 235, 59)',
+              0.4,
+              'rgb(255, 152, 0)',
+              0.7,
+              'rgb(244, 67, 54)',
+              1,
+              'rgb(183, 28, 28)',
+            ] as ExpressionSpecification,
+            'heatmap-intensity': ['interpolate', ['linear'], ['zoom'], 0, 0.8, 15, 2] as ExpressionSpecification,
+            'heatmap-radius': ['interpolate', ['linear'], ['zoom'], 0, 20, 15, 40] as ExpressionSpecification,
+            'heatmap-opacity': 0.8,
+          }}
+        />
+      {:else}
+        <MarkerLayer
+          applyToClusters
+          asButton
+          onclick={(event) => handlePromiseError(handleClusterClick(event.feature.properties?.cluster_id, map))}
+        >
+          {#snippet children({ feature })}
+            <div
+              class="flex size-10 items-center justify-center rounded-full bg-immich-primary font-mono font-bold text-white opacity-90 shadow-lg transition-all duration-200 hover:bg-immich-dark-primary hover:text-immich-dark-bg"
+            >
+              {feature.properties?.point_count?.toLocaleString()}
+            </div>
+          {/snippet}
+        </MarkerLayer>
+        <MarkerLayer
+          applyToClusters={false}
+          asButton
+          onclick={(event) => {
+            if (!popup) {
+              handleAssetClick(event.feature.properties?.id, map);
+            }
+          }}
+        >
+          {#snippet children({ feature }: { feature: Feature })}
+            {#if useLocationPin}
+              <Icon icon={mdiMapMarker} size="50px" class="translate-y-[-50%] text-primary" />
+            {:else}
+              <img
+                src={getAssetMediaUrl({ id: feature.properties?.id })}
+                class="size-15 rounded-full border-2 border-immich-primary bg-immich-primary object-cover shadow-lg transition-all duration-200 hover:scale-150 hover:border-immich-dark-primary"
+                alt={feature.properties?.city && feature.properties.country
+                  ? $t('map_marker_for_image', {
+                      values: { city: feature.properties.city, country: feature.properties.country },
+                    })
+                  : $t('map_marker_with_image')}
+              />
+            {/if}
+            {#if popup}
+              <Popup offset={[0, -30]} openOn="click" closeOnClickOutside>
+                {@render popup?.({ marker: asMarker(feature) })}
+              </Popup>
+            {/if}
+          {/snippet}
+        </MarkerLayer>
+      {/if}
     </GeoJSON>
   {/snippet}
 </MapLibre>

--- a/web/src/lib/modals/MapSettingsModal.svelte
+++ b/web/src/lib/modals/MapSettingsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { mapSettings, type MapSettings } from '$lib/stores/preferences.store';
+  import { mapSettings, mapShowHeatmap, type MapSettings } from '$lib/stores/preferences.store';
   import { Button, DatePicker, Field, FormModal, Select, Stack, Switch } from '@immich/ui';
   import { DateTime, Duration } from 'luxon';
   import { t } from 'svelte-i18n';
@@ -11,30 +11,32 @@
 
   let { onClose }: Props = $props();
   let settings = $state({ ...$mapSettings });
+  let showHeatmap = $state($mapShowHeatmap);
 
   let customDateRange = $state(!!settings.dateAfter || !!settings.dateBefore);
 
   const onSubmit = () => {
+    $mapShowHeatmap = showHeatmap;
     onClose(settings);
   };
 </script>
 
 <FormModal title={$t('map_settings')} {onClose} {onSubmit} size="small">
   <Stack gap={4}>
-    <Field label={$t('allow_dark_mode')}>
-      <Switch bind:checked={settings.allowDarkMode} />
-    </Field>
-    <Field label={$t('only_favorites')}>
+    <Field label={$t('map_settings_only_show_favorites')}>
       <Switch bind:checked={settings.onlyFavorites} />
     </Field>
-    <Field label={$t('include_archived')}>
+    <Field label={$t('map_settings_include_show_archived')}>
       <Switch bind:checked={settings.includeArchived} />
     </Field>
-    <Field label={$t('include_shared_partner_assets')}>
+    <Field label={$t('map_settings_include_show_partners')}>
       <Switch bind:checked={settings.withPartners} />
     </Field>
     <Field label={$t('include_shared_albums')}>
       <Switch bind:checked={settings.withSharedAlbums} />
+    </Field>
+    <Field label="Show Heatmap">
+      <Switch bind:checked={showHeatmap} />
     </Field>
 
     {#if customDateRange}

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -20,7 +20,7 @@ export const lang = persisted<string>('lang', preferredLocale || defaultLang.cod
 });
 
 export interface MapSettings {
-  allowDarkMode: boolean;
+  theme: 'light' | 'dark' | 'system';
   includeArchived: boolean;
   onlyFavorites: boolean;
   withPartners: boolean;
@@ -30,8 +30,8 @@ export interface MapSettings {
   dateBefore?: string;
 }
 
-const defaultMapSettings = {
-  allowDarkMode: true,
+const defaultMapSettings: MapSettings = {
+  theme: 'system',
   includeArchived: false,
   onlyFavorites: false,
   withPartners: false,
@@ -39,15 +39,17 @@ const defaultMapSettings = {
   relativeDate: '',
 };
 
-const persistedObject = <T>(key: string, defaults: T) =>
-  persisted<T>(key, defaults, {
-    serializer: {
-      parse: (text) => ({ ...defaults, ...JSON.parse(text ?? null) }),
-      stringify: JSON.stringify,
-    },
-  });
+export const mapShowHeatmap = persisted<boolean>('map-show-heatmap', false, {});
 
-export const mapSettings = persistedObject<MapSettings>('map-settings', defaultMapSettings);
+export const mapSettings = persisted<MapSettings>('map-settings', defaultMapSettings, {
+  serializer: {
+    parse: (text) => {
+      const parsed = (JSON.parse(text ?? 'null') ?? {}) as Partial<MapSettings>;
+      return { ...defaultMapSettings, ...parsed };
+    },
+    stringify: JSON.stringify,
+  },
+});
 
 export interface AlbumViewSettings {
   view: string;
@@ -68,11 +70,6 @@ export interface PlacesViewSettings {
     // Grouping Option => Array<Group ID>
     [group: string]: string[];
   };
-}
-
-export interface SidebarSettings {
-  people: boolean;
-  sharing: boolean;
 }
 
 export enum SortOrder {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -69,7 +69,13 @@
             </div>
           {/await}
         {:then { default: Map }}
-          <Map hash onSelect={onViewAssets} {onClusterSelect} />
+          <Map
+            hash
+            onSelect={onViewAssets}
+            {onClusterSelect}
+            isTimelineOpen={isTimelinePanelVisible}
+            onToggleTimeline={() => (isTimelinePanelVisible = !isTimelinePanelVisible)}
+          />
         {/await}
       </div>
 


### PR DESCRIPTION
## Description
Improvements to the map UI and controls so the whole experience is more inline with the rest of the web app. This is part of a bigger improvements to UI and UX of the map and sidebar timeline. Separated in various pr as asked in #28676 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] The Map and new controls were extensively tested by hand.
- [X] End to End tests with Playwright to:
       - Verify panning, zooming, interactions and the buttons controls.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="2268" height="1885" alt="image" src="https://github.com/user-attachments/assets/c24bd5e6-14d4-47e8-9ff9-539513cc2ac2" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
GitHub Copilot was used to understand how the E2E Playwright test system functions, and to help translate some of Svelte's quirks (since we are more familiar with React). Also Gemini was used to correct some grammar erros on the pr and comments.
...
