### PR TITLE
feat(web): new timeline sidebar, align design

### DIFF
--- a/e2e/src/ui/mock-network/map-network.ts
+++ b/e2e/src/ui/mock-network/map-network.ts
@@ -1,0 +1,32 @@
+import type { MapMarkerResponseDto } from '@immich/sdk';
+import { BrowserContext } from '@playwright/test';
+import { TimelineData } from 'src/ui/generators/timeline';
+
+export const setupMapMockApiRoutes = async (context: BrowserContext, timelineData: TimelineData) => {
+  await context.route('**/api/map/markers', async (route) => {
+    const markers: MapMarkerResponseDto[] = [];
+
+    for (const bucket of timelineData.buckets.values()) {
+      for (const asset of bucket) {
+        // Only include assets with GPS coordinates
+        if (asset.latitude !== null && asset.longitude !== null) {
+          markers.push({
+            id: asset.id,
+            lat: asset.latitude,
+            lon: asset.longitude,
+            city: asset.city,
+            state: null,
+            country: asset.country,
+          });
+        }
+      }
+    }
+    markers.sort((a, b) => a.id.localeCompare(b.id));
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      json: markers,
+    });
+  });
+};

--- a/e2e/src/ui/specs/map/map.e2e-spec.ts
+++ b/e2e/src/ui/specs/map/map.e2e-spec.ts
@@ -1,0 +1,44 @@
+import { faker } from '@faker-js/faker';
+import { expect, test } from '@playwright/test';
+import { createDefaultTimelineConfig, generateTimelineData, TimelineData } from 'src/ui/generators/timeline';
+import { setupBaseMockApiRoutes } from 'src/ui/mock-network/base-network';
+import { setupMapMockApiRoutes } from 'src/ui/mock-network/map-network';
+import { utils } from 'src/utils';
+import { mapUtils } from './utils';
+
+test.describe.configure({ mode: 'parallel' });
+test.describe('Map', () => {
+  let adminUserId: string;
+  let mapTestData: TimelineData;
+
+  test.beforeAll(async () => {
+    test.fail(
+      process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS !== '1',
+      'This test requires env var: PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1',
+    );
+    utils.initSdk();
+    adminUserId = faker.string.uuid();
+
+    // Generate timeline data with GPS coordinates
+    mapTestData = generateTimelineData({
+      ...createDefaultTimelineConfig(),
+      ownerId: adminUserId,
+    });
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await setupBaseMockApiRoutes(context, adminUserId);
+    await setupMapMockApiRoutes(context, mapTestData);
+  });
+
+  test('mobile viewport displays all controls', async ({ page }) => {
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await mapUtils.navigateToMap(page);
+    await mapUtils.expectMapVisible(page);
+
+    // Timeline toggle button should be visible on mobile
+    await expect(mapUtils.getTimelineButton(page)).toBeVisible();
+  });
+});

--- a/e2e/src/ui/specs/map/map.e2e-spec.ts
+++ b/e2e/src/ui/specs/map/map.e2e-spec.ts
@@ -32,13 +32,11 @@ test.describe('Map', () => {
   });
 
   test('mobile viewport displays all controls', async ({ page }) => {
-    // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
 
     await mapUtils.navigateToMap(page);
     await mapUtils.expectMapVisible(page);
 
-    // Timeline toggle button should be visible on mobile
     await expect(mapUtils.getTimelineButton(page)).toBeVisible();
   });
 });

--- a/e2e/src/ui/specs/map/utils.ts
+++ b/e2e/src/ui/specs/map/utils.ts
@@ -1,27 +1,14 @@
 import { ConsoleMessage, expect, Locator, Page } from '@playwright/test';
 
-/**
- * Map testing utilities for e2e tests
- */
-
 export const mapUtils = {
-  /**
-   * Get all visible cluster on the map
-   */
   getClusters(page: Page) {
     return page.locator('[class*="rounded-full"][class*="bg-immich-primary"]').filter({ hasText: /\d+/ });
   },
 
-  /**
-   * Get the first visible cluster button
-   */
   getFirstCluster(page: Page) {
     return this.getClusters(page).first();
   },
 
-  /**
-   * Get asset count of a cluster
-   */
   async getClusterCount(page: Page, clusterElement?: Locator) {
     const element = clusterElement || this.getFirstCluster(page);
     await expect(element).toBeVisible();
@@ -30,26 +17,17 @@ export const mapUtils = {
     return Number.parseInt((text ?? '').replaceAll(/[^\d]/g, ''), 10);
   },
 
-  /**
-   * Verify map is visible and loaded
-   */
   async expectMapVisible(page: Page) {
     const mapContainer = page.locator('.rounded-none.h-full');
     await expect(mapContainer).toBeVisible();
   },
 
-  /**
-   * Verify clusters exist on map
-   */
   async expectClustersVisible(page: Page, minCount = 1) {
     const clusters = this.getClusters(page);
     const count = await clusters.count();
     expect(count).toBeGreaterThanOrEqual(minCount);
   },
 
-  /**
-   * Get map control buttons
-   */
   getZoomInButton(page: Page) {
     return page.getByLabel(/zoom in/i);
   },
@@ -59,56 +37,38 @@ export const mapUtils = {
   },
 
   getSettingsButton(page: Page) {
-    return page.getByLabel(/map settings/i);
+    return page.getByRole('button', { name: /map settings/i });
   },
 
   getTimelineButton(page: Page) {
-    return page.getByLabel(/timeline/i);
+    return page.getByRole('button', { name: /timeline/i });
   },
 
-  /**
-   * Verify all standard map controls are visible
-   */
   async expectMapControlsVisible(page: Page) {
     await expect(this.getZoomInButton(page)).toBeVisible();
     await expect(this.getZoomOutButton(page)).toBeVisible();
     await expect(this.getSettingsButton(page)).toBeVisible();
   },
 
-  /**
-   * Click zoom in button
-   */
   async zoomIn(page: Page) {
     await this.getZoomInButton(page).click();
     await page.waitForTimeout(500);
   },
 
-  /**
-   * Click zoom out button
-   */
   async zoomOut(page: Page) {
     await this.getZoomOutButton(page).click();
     await page.waitForTimeout(500);
   },
 
-  /**
-   * Wait for markers API to respond
-   */
   async waitForMarkersAPI(page: Page) {
     return page.waitForResponse((response) => response.url().includes('/api/map/markers') && response.status() === 200);
   },
 
-  /**
-   * Navigate to map and wait for load
-   */
   async navigateToMap(page: Page) {
     await page.goto('/map');
     await page.waitForLoadState('networkidle');
   },
 
-  /**
-   * Check if map has any errors
-   */
   async captureConsoleErrors(page: Page, callback: () => Promise<void>) {
     const errors: string[] = [];
     const handler = (msg: ConsoleMessage) => {

--- a/e2e/src/ui/specs/map/utils.ts
+++ b/e2e/src/ui/specs/map/utils.ts
@@ -1,0 +1,133 @@
+import { ConsoleMessage, expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Map testing utilities for e2e tests
+ */
+
+export const mapUtils = {
+  /**
+   * Get all visible cluster on the map
+   */
+  getClusters(page: Page) {
+    return page.locator('[class*="rounded-full"][class*="bg-immich-primary"]').filter({ hasText: /\d+/ });
+  },
+
+  /**
+   * Get the first visible cluster button
+   */
+  getFirstCluster(page: Page) {
+    return this.getClusters(page).first();
+  },
+
+  /**
+   * Get asset count of a cluster
+   */
+  async getClusterCount(page: Page, clusterElement?: Locator) {
+    const element = clusterElement || this.getFirstCluster(page);
+    await expect(element).toBeVisible();
+    await expect(element).toHaveText(/\d+/);
+    const text = await element.textContent();
+    return Number.parseInt((text ?? '').replaceAll(/[^\d]/g, ''), 10);
+  },
+
+  /**
+   * Verify map is visible and loaded
+   */
+  async expectMapVisible(page: Page) {
+    const mapContainer = page.locator('.rounded-none.h-full');
+    await expect(mapContainer).toBeVisible();
+  },
+
+  /**
+   * Verify clusters exist on map
+   */
+  async expectClustersVisible(page: Page, minCount = 1) {
+    const clusters = this.getClusters(page);
+    const count = await clusters.count();
+    expect(count).toBeGreaterThanOrEqual(minCount);
+  },
+
+  /**
+   * Get map control buttons
+   */
+  getZoomInButton(page: Page) {
+    return page.getByLabel(/zoom in/i);
+  },
+
+  getZoomOutButton(page: Page) {
+    return page.getByLabel(/zoom out/i);
+  },
+
+  getSettingsButton(page: Page) {
+    return page.getByLabel(/map settings/i);
+  },
+
+  getTimelineButton(page: Page) {
+    return page.getByLabel(/timeline/i);
+  },
+
+
+
+  /**
+   * Verify all standard map controls are visible
+   */
+  async expectMapControlsVisible(page: Page) {
+    await expect(this.getZoomInButton(page)).toBeVisible();
+    await expect(this.getZoomOutButton(page)).toBeVisible();
+    await expect(this.getSettingsButton(page)).toBeVisible();
+  },
+
+  /**
+   * Click zoom in button
+   */
+  async zoomIn(page: Page) {
+    await this.getZoomInButton(page).click();
+    await page.waitForTimeout(500);
+  },
+
+  /**
+   * Click zoom out button
+   */
+  async zoomOut(page: Page) {
+    await this.getZoomOutButton(page).click();
+    await page.waitForTimeout(500);
+  },
+
+  /**
+   * Wait for markers API to respond
+   */
+  async waitForMarkersAPI(page: Page) {
+    return page.waitForResponse((response) => response.url().includes('/api/map/markers') && response.status() === 200);
+  },
+
+  /**
+   * Navigate to map and wait for load
+   */
+  async navigateToMap(page: Page) {
+    await page.goto('/map');
+    await page.waitForLoadState('networkidle');
+  },
+
+  /**
+   * Check if map has any errors
+   */
+  async captureConsoleErrors(page: Page, callback: () => Promise<void>) {
+    const errors: string[] = [];
+    const handler = (msg: ConsoleMessage) => {
+      if (msg.type() === 'error') {
+        const text = msg.text();
+        // Ignore expected MapLibre external styles 401 in ci/cd
+        if (text.includes('401 (Unauthorized)')) {
+          return;
+        }
+        errors.push(text);
+      }
+    };
+
+    page.on('console', handler);
+    await callback();
+    page.off('console', handler);
+
+    return errors;
+  },
+};

--- a/e2e/src/ui/specs/map/utils.ts
+++ b/e2e/src/ui/specs/map/utils.ts
@@ -66,8 +66,6 @@ export const mapUtils = {
     return page.getByLabel(/timeline/i);
   },
 
-
-
   /**
    * Verify all standard map controls are visible
    */

--- a/web/src/lib/components/shared-components/map/Map.svelte
+++ b/web/src/lib/components/shared-components/map/Map.svelte
@@ -17,9 +17,9 @@
   import { getAssetMediaUrl, handlePromiseError } from '$lib/utils';
   import { getMapMarkers, type MapMarkerResponseDto } from '@immich/sdk';
   import { Icon, modalManager, Theme, themeManager } from '@immich/ui';
-  import { mdiCog, mdiMap, mdiMapMarker } from '@mdi/js';
+  import { mdiCog, mdiMap, mdiMapMarker, mdiImageMultiple } from '@mdi/js';
   import type { Feature, GeoJsonProperties, Geometry, Point } from 'geojson';
-  import { isEqual, omit } from 'lodash-es';
+  import { debounce, isEqual, omit } from 'lodash-es';
   import { DateTime, Duration } from 'luxon';
   import {
     GlobeControl,
@@ -63,6 +63,10 @@
     onClickPoint?: ({ lat, lng }: { lat: number; lng: number }) => void;
     popup?: import('svelte').Snippet<[{ marker: MapMarkerResponseDto }]>;
     rounded?: boolean;
+    isTimelineOpen?: boolean;
+    onToggleTimeline?: () => void;
+    sheetHeight?: number;
+    isDraggingSheet?: boolean;
     showSimpleControls?: boolean;
     autoFitBounds?: boolean;
   }
@@ -82,6 +86,10 @@
     onClickPoint = () => {},
     popup,
     rounded = false,
+    isTimelineOpen = false,
+    onToggleTimeline,
+    sheetHeight = 50,
+    isDraggingSheet = false,
     showSimpleControls = true,
     autoFitBounds = true,
   }: Props = $props();
@@ -103,6 +111,9 @@
   let marker: Marker | null = null;
   let abortController: AbortController;
 
+  let innerWidth = $state(1024);
+  let isMobile = $derived(innerWidth < 768);
+
   const mapTheme = $derived($mapSettings.allowDarkMode ? themeManager.value : Theme.Light);
   const styleUrl = $derived(
     mapTheme === Theme.Dark ? serverConfigManager.value.mapDarkStyleUrl : serverConfigManager.value.mapLightStyleUrl,
@@ -118,6 +129,8 @@
       marker = new Marker().setLngLat([lng, lat]).addTo(map);
     }
   }
+
+  void addClipMapMarker;
 
   function handleAssetClick(assetId: string, map: Map | null) {
     if (!map) {
@@ -309,14 +322,33 @@
     untrack(() => map?.jumpTo({ center, zoom }));
   });
 
+  $effect(() => {
+    const currentMap = map;
+    if (!currentMap) {
+      return;
+    }
+
+    if (isMobile && isTimelineOpen) {
+      const bottomPadding = (sheetHeight / 100) * innerHeight;
+      untrack(() => {
+        currentMap.setPadding({ top: 0, left: 0, right: 0, bottom: bottomPadding });
+      });
+    } else {
+      untrack(() => {
+        currentMap.setPadding({ top: 0, left: 0, right: 0, bottom: 0 });
+      });
+    }
+  });
+
   const onAssetsDelete = async () => {
     mapMarkers = await loadMapMarkers();
   };
 </script>
 
+<svelte:window bind:innerWidth />
+
 <OnEvents {onAssetsDelete} />
 
-<!--  We handle style loading ourselves so we set style blank here -->
 <MapLibre
   {hash}
   style=""
@@ -344,6 +376,21 @@
         <GeolocateControl position="top-left" />
         <ScaleControl />
         <AttributionControl compact={false} />
+      {/if}
+
+      {#if onToggleTimeline}
+        <Control position="top-right">
+          <ControlGroup>
+            <ControlButton onclick={() => onToggleTimeline?.()}>
+              <Icon
+                title={$t('timeline')}
+                icon={mdiImageMultiple}
+                size="100%"
+                class={isTimelineOpen ? 'text-immich-primary dark:text-immich-primary' : 'text-black/80'}
+              />
+            </ControlButton>
+          </ControlGroup>
+        </Control>
       {/if}
     {/if}
 

--- a/web/src/lib/components/shared-components/map/Map.svelte
+++ b/web/src/lib/components/shared-components/map/Map.svelte
@@ -19,7 +19,7 @@
   import { Icon, modalManager, Theme, themeManager } from '@immich/ui';
   import { mdiCog, mdiMap, mdiMapMarker, mdiImageMultiple } from '@mdi/js';
   import type { Feature, GeoJsonProperties, Geometry, Point } from 'geojson';
-  import { debounce, isEqual, omit } from 'lodash-es';
+  import { isEqual, omit } from 'lodash-es';
   import { DateTime, Duration } from 'luxon';
   import {
     GlobeControl,
@@ -66,7 +66,6 @@
     isTimelineOpen?: boolean;
     onToggleTimeline?: () => void;
     sheetHeight?: number;
-    isDraggingSheet?: boolean;
     showSimpleControls?: boolean;
     autoFitBounds?: boolean;
   }
@@ -89,7 +88,6 @@
     isTimelineOpen = false,
     onToggleTimeline,
     sheetHeight = 50,
-    isDraggingSheet = false,
     showSimpleControls = true,
     autoFitBounds = true,
   }: Props = $props();
@@ -381,7 +379,7 @@
       {#if onToggleTimeline}
         <Control position="top-right">
           <ControlGroup>
-            <ControlButton onclick={() => onToggleTimeline?.()}>
+            <ControlButton title={$t('timeline')} onclick={() => onToggleTimeline?.()}>
               <Icon
                 title={$t('timeline')}
                 icon={mdiImageMultiple}

--- a/web/src/lib/components/timeline/Scrubber.svelte
+++ b/web/src/lib/components/timeline/Scrubber.svelte
@@ -589,12 +589,16 @@
     >
       {#if !usingMobileDevice}
         {#if segment.hasLabel}
-          <div class="absolute inset-e-5 bottom-0 font-mono text-[13px] dark:text-immich-dark-fg">
+          <div
+            class="absolute inset-e-6 bottom-0 z-10 origin-right -translate-y-1/2 scale-90 text-[11px] font-bold tracking-wider whitespace-nowrap text-gray-400 uppercase transition-all hover:scale-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+          >
             {segment.year}
           </div>
         {/if}
         {#if segment.hasDot}
-          <div class="absolute inset-e-3 bottom-0 size-1 rounded-full bg-gray-300"></div>
+          <div
+            class="absolute inset-e-3 bottom-0 size-1.5 rounded-full bg-gray-200 transition-colors hover:bg-immich-primary dark:bg-gray-800 dark:hover:bg-immich-dark-primary"
+          ></div>
         {/if}
       {/if}
     </div>

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -17,7 +17,12 @@
   import { isIntersecting } from '$lib/managers/timeline-manager/internal/intersection-support.svelte';
   import type { TimelineMonth } from '$lib/managers/timeline-manager/timeline-month.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
-  import type { TimelineAsset, TimelineManagerOptions, ViewportTopMonth } from '$lib/managers/timeline-manager/types';
+  import type {
+    TimelineAsset,
+    TimelineManagerLayoutOptions,
+    TimelineManagerOptions,
+    ViewportTopMonth,
+  } from '$lib/managers/timeline-manager/types';
   import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
   import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
@@ -37,6 +42,7 @@
     enableRouting: boolean;
     timelineManager?: TimelineManager;
     options?: TimelineManagerOptions;
+    layoutOptions?: Partial<TimelineManagerLayoutOptions>;
     assetInteraction: AssetMultiSelectManager;
     removeAction?: AssetAction.UNARCHIVE | AssetAction.ARCHIVE | AssetAction.SET_VISIBILITY_TIMELINE | null;
     withStacked?: boolean;
@@ -69,6 +75,7 @@
     enableRouting,
     timelineManager = $bindable(),
     options,
+    layoutOptions: layoutOptionsOverride = {},
     assetInteraction,
     removeAction = null,
     withStacked = false,
@@ -115,7 +122,7 @@
           rowHeight: 235,
           headerHeight: 48,
         };
-    timelineManager.setLayoutOptions(layoutOptions);
+    timelineManager.setLayoutOptions({ ...layoutOptions, ...layoutOptionsOverride });
   });
 
   $effect(() => {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -11,8 +11,11 @@
   import { handlePromiseError } from '$lib/utils';
   import { delay } from '$lib/utils/asset-utils';
   import { navigate } from '$lib/utils/navigation';
-  import { LoadingSpinner } from '@immich/ui';
+  import { Icon, LoadingSpinner } from '@immich/ui';
+  import { mdiDragHorizontal } from '@mdi/js';
   import { onDestroy } from 'svelte';
+  import { fly } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
   import type { PageData } from './$types';
 
   interface Props {
@@ -22,12 +25,68 @@
   let { data }: Props = $props();
   let selectedClusterIds = $state.raw(new Set<string>());
   let selectedClusterBBox = $state.raw<SelectionBBox>();
+
   let isTimelinePanelVisible = $state(false);
+
+  // Desktop Sidebar State
+  const DEFAULT_PANEL_WIDTH = 384;
+  const DESKTOP_PANEL_MIN_WIDTH = 320;
+  const DESKTOP_PANEL_MAX_WIDTH = 700;
+  let timelinePanelWidth = $state(DEFAULT_PANEL_WIDTH);
+
+  // Mobile Bottom Sheet State
+  let sheetHeight = $state(50);
+  let isDraggingSheet = $state(false);
+  let innerWidth = $state(1024);
+  let isMobile = $derived(innerWidth < 768);
+
+  const clampedTimelinePanelWidth = $derived(
+    Math.min(Math.max(timelinePanelWidth, DESKTOP_PANEL_MIN_WIDTH), DESKTOP_PANEL_MAX_WIDTH),
+  );
+
+
+
+  let isResizingPanel = $state(false);
+  let resizeStartX = $state(0);
+  let resizeStartWidth = $state(0);
+
+  function handleResizeStart(event: PointerEvent) {
+    if (!isMobile) {
+      event.preventDefault();
+      isResizingPanel = true;
+      resizeStartX = event.clientX;
+      resizeStartWidth = timelinePanelWidth;
+      if (event.currentTarget instanceof HTMLElement) {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+    }
+  }
+
+  function handleResizeMove(event: PointerEvent) {
+    if (!isResizingPanel) {
+      return;
+    }
+    const deltaX = resizeStartX - event.clientX;
+    const newWidth = resizeStartWidth + deltaX;
+    timelinePanelWidth = Math.min(Math.max(newWidth, DESKTOP_PANEL_MIN_WIDTH), DESKTOP_PANEL_MAX_WIDTH);
+  }
+
+  function handleResizeEnd() {
+    isResizingPanel = false;
+  }
 
   function closeTimelinePanel() {
     isTimelinePanelVisible = false;
     selectedClusterBBox = undefined;
     selectedClusterIds = new Set();
+    sheetHeight = 50; // Reset for next open
+  }
+
+  function toggleTimeline() {
+    isTimelinePanelVisible = !isTimelinePanelVisible;
+    if (!isTimelinePanelVisible) {
+      closeTimelinePanel();
+    }
   }
 
   onDestroy(() => {
@@ -50,38 +109,73 @@
     assetViewerManager.showAssetViewer(false);
     handlePromiseError(navigate({ targetRoute: 'current', assetId: null }));
   }
+
+
 </script>
+
+<svelte:window bind:innerWidth onpointermove={handleResizeMove} onpointerup={handleResizeEnd} />
 
 {#if featureFlagsManager.value.map}
   <UserPageLayout title={data.meta.title}>
-    <div class="isolate flex size-full flex-col sm:flex-row">
-      <div
-        class={[
-          'min-h-0',
-          isTimelinePanelVisible ? 'h-1/2 w-full pb-2 sm:h-full sm:w-2/3 sm:pe-2 sm:pb-0' : 'size-full',
-        ]}
-      >
-        {#await import('$lib/components/shared-components/map/Map.svelte')}
-          {#await delay(timeToLoadTheMap) then}
-            <!-- show the loading spinner only if loading the map takes too much time -->
-            <div class="flex size-full items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          {/await}
-        {:then { default: Map }}
-          <Map hash onSelect={onViewAssets} {onClusterSelect} />
+    <div class="relative flex size-full overflow-hidden">
+      <div class="min-w-0 flex-1 transition-all duration-300 ease-in-out">
+        {#await Promise.all([import('$lib/components/shared-components/map/Map.svelte'), delay(timeToLoadTheMap)])}
+          <div class="flex size-full items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        {:then [{ default: MapComponent }]}
+          <MapComponent
+            hash
+            onSelect={onViewAssets}
+            {onClusterSelect}
+            isTimelineOpen={isTimelinePanelVisible}
+            onToggleTimeline={toggleTimeline}
+            {sheetHeight}
+            {isDraggingSheet}
+          />
         {/await}
       </div>
 
-      {#if isTimelinePanelVisible && selectedClusterBBox}
-        <div class="h-1/2 min-h-0 w-full pt-2 sm:h-full sm:w-1/3 sm:ps-2 sm:pt-0">
+      {#if isTimelinePanelVisible}
+        {#if !isMobile}
+          <button
+            type="button"
+            class="pointer-events-auto absolute inset-y-0 z-20 flex w-6 cursor-col-resize items-center justify-center text-immich-primary transition-colors hover:text-immich-dark-primary"
+            onpointerdown={handleResizeStart}
+            aria-label="Drag to resize timeline panel"
+            style:right={`${clampedTimelinePanelWidth}px`}
+            title="Drag to resize timeline panel"
+          >
+            <span
+              class="flex h-14 w-3 items-center justify-center rounded-full border border-gray-200 bg-white/90 shadow-md dark:border-immich-dark-gray dark:bg-immich-dark-bg"
+            >
+              <Icon icon={mdiDragHorizontal} size="16" />
+            </span>
+          </button>
+        {/if}
+
+        <aside
+          class="absolute inset-x-0 bottom-0 z-30 flex w-full shrink-0 flex-col sm:relative sm:h-full sm:w-(--timeline-panel-width) sm:max-w-175 sm:min-w-[320px] sm:overflow-y-auto sm:border-s sm:border-gray-200 sm:bg-white sm:dark:border-immich-dark-gray sm:dark:bg-immich-dark-bg"
+          style:--timeline-panel-width={isMobile ? '100%' : `${clampedTimelinePanelWidth}px`}
+          transition:fly={{
+            x: isMobile ? 0 : 400,
+            y: isMobile ? 800 : 0,
+            duration: 400,
+            easing: cubicOut,
+          }}
+        >
           <MapTimelinePanel
             bbox={selectedClusterBBox}
             {selectedClusterIds}
+            panelWidth={isMobile ? innerWidth : clampedTimelinePanelWidth}
+            {isMobile}
             assetCount={selectedClusterIds.size}
             onClose={closeTimelinePanel}
+            onSelect={onViewAssets}
+            bind:sheetHeight
+            bind:isDraggingSheet
           />
-        </div>
+        </aside>
       {/if}
     </div>
   </UserPageLayout>

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -44,8 +44,6 @@
     Math.min(Math.max(timelinePanelWidth, DESKTOP_PANEL_MIN_WIDTH), DESKTOP_PANEL_MAX_WIDTH),
   );
 
-
-
   let isResizingPanel = $state(false);
   let resizeStartX = $state(0);
   let resizeStartWidth = $state(0);
@@ -109,8 +107,6 @@
     assetViewerManager.showAssetViewer(false);
     handlePromiseError(navigate({ targetRoute: 'current', assetId: null }));
   }
-
-
 </script>
 
 <svelte:window bind:innerWidth onpointermove={handleResizeMove} onpointerup={handleResizeEnd} />
@@ -131,7 +127,6 @@
             isTimelineOpen={isTimelinePanelVisible}
             onToggleTimeline={toggleTimeline}
             {sheetHeight}
-            {isDraggingSheet}
           />
         {/await}
       </div>

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -28,13 +28,11 @@
 
   let isTimelinePanelVisible = $state(false);
 
-  // Desktop Sidebar State
   const DEFAULT_PANEL_WIDTH = 384;
   const DESKTOP_PANEL_MIN_WIDTH = 320;
   const DESKTOP_PANEL_MAX_WIDTH = 700;
   let timelinePanelWidth = $state(DEFAULT_PANEL_WIDTH);
 
-  // Mobile Bottom Sheet State
   let sheetHeight = $state(50);
   let isDraggingSheet = $state(false);
   let innerWidth = $state(1024);
@@ -77,7 +75,7 @@
     isTimelinePanelVisible = false;
     selectedClusterBBox = undefined;
     selectedClusterIds = new Set();
-    sheetHeight = 50; // Reset for next open
+    sheetHeight = 50;
   }
 
   function toggleTimeline() {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -65,7 +65,6 @@
 
   let timelineManager = $state<TimelineManager>();
 
-  // Mobile Swipe Logic
   const SHEET_MIN_HEIGHT = 15;
   const SHEET_COLLAPSED_HEIGHT = 30;
   const SHEET_DEFAULT_HEIGHT = 50;
@@ -102,9 +101,8 @@
     }
     isDraggingSheet = false;
 
-    // Snap states
     if (sheetHeight < SHEET_DISMISS_THRESHOLD) {
-      onClose(); // Swipe to dismiss
+      onClose();
     } else if (sheetHeight < SHEET_COLLAPSE_THRESHOLD) {
       sheetHeight = SHEET_COLLAPSED_HEIGHT;
     } else if (sheetHeight > SHEET_EXPAND_THRESHOLD) {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -20,9 +20,12 @@
   import Portal from '$lib/elements/Portal.svelte';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { isIntersecting } from '$lib/managers/timeline-manager/internal/intersection-support.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { mapSettings } from '$lib/stores/preferences.store';
+  import EmptyPlaceholder from '$lib/components/shared-components/EmptyPlaceholder.svelte';
   import {
     updateStackedAssetInTimeline,
     updateUnstackedAssetInTimeline,
@@ -30,21 +33,108 @@
     type OnUnlink,
   } from '$lib/utils/actions';
   import { AssetVisibility } from '@immich/sdk';
-  import { ActionButton, CloseButton, CommandPaletteDefaultProvider, Icon } from '@immich/ui';
+  import { ActionButton, CloseButton, CommandPaletteDefaultProvider, Icon, LoadingSpinner } from '@immich/ui';
   import { mdiDotsVertical, mdiImageMultiple } from '@mdi/js';
-  import { ceil, floor } from 'lodash-es';
+  import { ceil, floor, clamp } from 'lodash-es';
   import { t } from 'svelte-i18n';
+  import { SvelteSet } from 'svelte/reactivity';
+  import { fade } from 'svelte/transition';
 
   interface Props {
-    bbox: SelectionBBox;
+    bbox?: SelectionBBox;
     selectedClusterIds: Set<string>;
+    panelWidth?: number;
     assetCount: number;
     onClose: () => void;
+    onSelect?: (assetIds: string[]) => void;
+    sheetHeight?: number;
+    isDraggingSheet?: boolean;
+    isMobile: boolean;
   }
 
-  let { bbox, selectedClusterIds, assetCount, onClose }: Props = $props();
+  let {
+    bbox,
+    selectedClusterIds,
+    panelWidth = 384,
+    assetCount,
+    onClose,
+    onSelect,
+    sheetHeight = $bindable(50),
+    isDraggingSheet = $bindable(false),
+    isMobile,
+  }: Props = $props();
 
-  let timelineManager = $state<TimelineManager>() as TimelineManager;
+  let timelineManager = $state<TimelineManager>();
+
+  // Mobile Swipe Logic
+  const SHEET_MIN_HEIGHT = 15;
+  const SHEET_COLLAPSED_HEIGHT = 30;
+  const SHEET_DEFAULT_HEIGHT = 50;
+  const SHEET_EXPANDED_HEIGHT = 65;
+  const SHEET_DISMISS_THRESHOLD = 20;
+  const SHEET_COLLAPSE_THRESHOLD = 40;
+  const SHEET_EXPAND_THRESHOLD = 58;
+  const SHEET_STEP = 10;
+
+  let startY = 0;
+  let startHeight = 0;
+
+  function handlePointerDown(e: PointerEvent) {
+    startY = e.clientY;
+    startHeight = sheetHeight;
+    isDraggingSheet = true;
+    if (e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    }
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (!isDraggingSheet) {
+      return;
+    }
+    const deltaY = startY - e.clientY;
+    const deltaVh = (deltaY / globalThis.innerHeight) * 100;
+    sheetHeight = clamp(startHeight + deltaVh, SHEET_MIN_HEIGHT, SHEET_EXPANDED_HEIGHT);
+  }
+
+  function handlePointerUp() {
+    if (!isDraggingSheet) {
+      return;
+    }
+    isDraggingSheet = false;
+
+    // Snap states
+    if (sheetHeight < SHEET_DISMISS_THRESHOLD) {
+      onClose(); // Swipe to dismiss
+    } else if (sheetHeight < SHEET_COLLAPSE_THRESHOLD) {
+      sheetHeight = SHEET_COLLAPSED_HEIGHT;
+    } else if (sheetHeight > SHEET_EXPAND_THRESHOLD) {
+      sheetHeight = SHEET_EXPANDED_HEIGHT;
+    } else {
+      sheetHeight = SHEET_DEFAULT_HEIGHT;
+    }
+  }
+
+  function handleSheetKeydown(event: KeyboardEvent) {
+    if (!isMobile) {
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      sheetHeight = clamp(sheetHeight + SHEET_STEP, SHEET_MIN_HEIGHT, SHEET_EXPANDED_HEIGHT);
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      sheetHeight = clamp(sheetHeight - SHEET_STEP, SHEET_MIN_HEIGHT, SHEET_EXPANDED_HEIGHT);
+      if (sheetHeight <= SHEET_DISMISS_THRESHOLD) {
+        onClose();
+      }
+    }
+  }
+
   let selectedAssets = $derived(assetMultiSelectManager.assets);
   let isAssetStackSelected = $derived(selectedAssets.length === 1 && !!selectedAssets[0].stack);
   let isLinkActionAvailable = $derived.by(() => {
@@ -57,18 +147,22 @@
     return assetMultiSelectManager.isAllUserOwned && (isLivePhoto || isLivePhotoCandidate);
   });
 
+  const displayedAssetCount = $derived(
+    selectedClusterIds.size > 0 ? assetCount : (timelineManager?.assetCount ?? assetCount),
+  );
+
   const handleLink: OnLink = ({ still, motion }) => {
-    timelineManager.removeAssets([motion.id]);
-    timelineManager.upsertAssets([still]);
+    timelineManager!.removeAssets([motion.id]);
+    timelineManager!.upsertAssets([still]);
   };
 
   const handleUnlink: OnUnlink = ({ still, motion }) => {
-    timelineManager.upsertAssets([motion]);
-    timelineManager.upsertAssets([still]);
+    timelineManager!.upsertAssets([motion]);
+    timelineManager!.upsertAssets([still]);
   };
 
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    timelineManager!.removeAssets(assetIds);
     assetMultiSelectManager.clear();
   };
 
@@ -76,16 +170,37 @@
     assetMultiSelectManager.clear();
   };
 
-  const timelineBoundingBox = $derived(
-    `${floor(bbox.west, 6)},${floor(bbox.south, 6)},${ceil(bbox.east, 6)},${ceil(bbox.north, 6)}`,
-  );
+  const handleThumbnailClick = (asset: TimelineAsset) => {
+    onSelect?.([asset.id]);
+  };
 
-  const timelineOptions = $derived({
-    bbox: timelineBoundingBox,
-    visibility: $mapSettings.includeArchived ? undefined : AssetVisibility.Timeline,
-    isFavorite: $mapSettings.onlyFavorites || undefined,
-    withPartners: $mapSettings.withPartners || undefined,
-    assetFilter: selectedClusterIds,
+  const timelineBoundingBox = $derived.by(() => {
+    if (!bbox) {
+      return '';
+    }
+    return `${floor(bbox.west, 6)},${floor(bbox.south, 6)},${ceil(bbox.east, 6)},${ceil(bbox.north, 6)}`;
+  });
+
+  const timelineOptions = $derived.by(() => {
+    if (!timelineBoundingBox) {
+      return undefined;
+    }
+    const assetFilter = selectedClusterIds.size > 0 ? selectedClusterIds : undefined;
+    return {
+      bbox: timelineBoundingBox,
+      visibility: $mapSettings.includeArchived ? undefined : AssetVisibility.Timeline,
+      isFavorite: $mapSettings.onlyFavorites || undefined,
+      withPartners: $mapSettings.withPartners || undefined,
+      assetFilter,
+    };
+  });
+
+  const timelineLayoutOptions = $derived.by(() => {
+    const usableWidth = (panelWidth || 384) - 48;
+    const rowHeight = clamp(Math.round(usableWidth * 0.55), 180, 280);
+    const headerHeight = 36;
+    const gap = 4;
+    return { rowHeight, headerHeight, gap };
   });
 
   $effect.pre(() => {
@@ -94,28 +209,79 @@
   });
 </script>
 
-<aside class="flex size-full flex-col overflow-hidden bg-immich-bg contain-content dark:bg-immich-dark-bg">
-  <div class="flex items-center justify-between border-b border-gray-200 pe-1 pb-1 dark:border-immich-dark-gray">
-    <div class="flex items-center gap-2">
-      <Icon icon={mdiImageMultiple} size="20" />
-      <p class="text-sm font-medium text-immich-fg dark:text-immich-dark-fg">
-        {$t('assets_count', { values: { count: assetCount } })}
-      </p>
+<svelte:window onpointermove={handlePointerMove} onpointerup={handlePointerUp} />
+
+<div
+  class="flex min-w-0 flex-col overflow-hidden bg-white shadow-[0_-8px_30px_rgba(0,0,0,0.12)] ease-out sm:shadow-none dark:bg-immich-dark-bg"
+  class:transition-all={!isDraggingSheet}
+  class:duration-300={!isDraggingSheet}
+  style:height={isMobile ? `${sheetHeight}vh` : '100%'}
+  style:border-top-left-radius={isMobile ? '24px' : '0'}
+  style:border-top-right-radius={isMobile ? '24px' : '0'}
+>
+  {#if isMobile}
+    <div
+      class="flex cursor-grab touch-none justify-center pt-4 pb-2"
+      class:cursor-grabbing={isDraggingSheet}
+      onpointerdown={handlePointerDown}
+      onkeydown={handleSheetKeydown}
+      role="slider"
+      aria-orientation="vertical"
+      aria-label="Drag to resize"
+      aria-valuenow={sheetHeight}
+      aria-valuemin={SHEET_MIN_HEIGHT}
+      aria-valuemax={SHEET_EXPANDED_HEIGHT}
+      tabindex="0"
+    >
+      <div class="h-1.5 w-12 rounded-full bg-gray-300 dark:bg-gray-600"></div>
+    </div>
+  {/if}
+
+  <div class="flex items-center justify-between px-6 py-2 sm:pt-6">
+    <div class="flex items-center gap-3">
+      <Icon icon={mdiImageMultiple} size="24" class="text-immich-primary dark:text-immich-dark-primary" />
+      <h2 class="text-lg font-medium text-immich-primary dark:text-immich-dark-primary">
+        {$t('assets_count', { values: { count: displayedAssetCount } })}
+      </h2>
     </div>
     <CloseButton onclick={onClose} />
   </div>
 
-  <div class="min-h-0 flex-1">
-    <Timeline
-      bind:timelineManager
-      enableRouting={false}
-      options={timelineOptions}
-      onEscape={handleEscape}
-      assetInteraction={assetMultiSelectManager}
-      showArchiveIcon
-    />
+  <div class="relative min-h-0 min-w-0 flex-1 overflow-y-auto px-6">
+    <div class="size-full">
+      {#if timelineOptions}
+        <Timeline
+          bind:timelineManager
+          enableRouting={false}
+          options={timelineOptions}
+          layoutOptions={timelineLayoutOptions}
+          onEscape={handleEscape}
+          assetInteraction={assetMultiSelectManager}
+          showArchiveIcon
+          onSelect={handleThumbnailClick}
+        >
+          {#snippet empty()}
+            <div
+              in:fade={{ duration: 200 }}
+              class="flex h-full flex-col items-center justify-center text-center opacity-60"
+            >
+              <EmptyPlaceholder text="No photos in this area" />
+            </div>
+          {/snippet}
+        </Timeline>
+      {/if}
+    </div>
+
+    {#if !timelineManager?.isInitialized}
+      <div
+        transition:fade={{ duration: 200 }}
+        class="absolute inset-0 z-10 flex items-center justify-center bg-white/50 backdrop-blur-md dark:bg-immich-dark-bg/50"
+      >
+        <LoadingSpinner />
+      </div>
+    {/if}
   </div>
-</aside>
+</div>
 
 {#if assetMultiSelectManager.selectionActive}
   {@const Actions = getAssetBulkActions($t)}
@@ -124,13 +290,13 @@
   <Portal target="body">
     <AssetSelectControlBar>
       <CreateSharedLink />
-      <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+      <SelectAllAssets timelineManager={timelineManager!} assetInteraction={assetMultiSelectManager} />
       <ActionButton action={Actions.AddToAlbum} />
 
       {#if assetMultiSelectManager.isAllUserOwned}
         <FavoriteAction
           removeFavorite={assetMultiSelectManager.isAllFavorite}
-          onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
+          onFavorite={(ids, isFavorite) => timelineManager!.update(ids, (asset) => (asset.isFavorite = isFavorite))}
         />
 
         <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')}>
@@ -138,8 +304,8 @@
           {#if assetMultiSelectManager.assets.length > 1 || isAssetStackSelected}
             <StackAction
               unstack={isAssetStackSelected}
-              onStack={(result) => updateStackedAssetInTimeline(timelineManager, result)}
-              onUnstack={(assets) => updateUnstackedAssetInTimeline(timelineManager, assets)}
+              onStack={(result) => updateStackedAssetInTimeline(timelineManager!, result)}
+              onUnstack={(assets) => updateUnstackedAssetInTimeline(timelineManager!, assets)}
             />
           {/if}
           {#if isLinkActionAvailable}
@@ -156,15 +322,15 @@
           <ArchiveAction
             menuItem
             unarchive={assetMultiSelectManager.isAllArchived}
-            onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+            onArchive={(ids, visibility) => timelineManager!.update(ids, (asset) => (asset.visibility = visibility))}
           />
           {#if authManager.preferences.tags.enabled}
             <TagAction menuItem />
           {/if}
           <DeleteAssets
             menuItem
-            onAssetDelete={(assetIds) => timelineManager.removeAssets(assetIds)}
-            onUndoDelete={(assets) => timelineManager.upsertAssets(assets)}
+            onAssetDelete={(assetIds) => timelineManager!.removeAssets(assetIds)}
+            onUndoDelete={(assets) => timelineManager!.upsertAssets(assets)}
           />
           <SetVisibilityAction menuItem onVisibilitySet={handleSetVisibility} />
           <hr />

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -20,7 +20,7 @@
   import Portal from '$lib/elements/Portal.svelte';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
-  import { isIntersecting } from '$lib/managers/timeline-manager/internal/intersection-support.svelte';
+
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { getAssetBulkActions } from '$lib/services/asset.service';
@@ -37,7 +37,6 @@
   import { mdiDotsVertical, mdiImageMultiple } from '@mdi/js';
   import { ceil, floor, clamp } from 'lodash-es';
   import { t } from 'svelte-i18n';
-  import { SvelteSet } from 'svelte/reactivity';
   import { fade } from 'svelte/transition';
 
   interface Props {


### PR DESCRIPTION
## Description
New design of the sidebar timeline so it is on par with the normal timeline and the map timeline on mobile app, on the web desktop and the mobile version of the web app. Make it resizable both on mobile and on desktop.
This is part of a bigger improvements to UI and UX of the map and sidebar timeline. Separated in various pr as asked in #28676 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] The side Timeline features were extensively tested by hand, on desktop and mobile.
- [X] End to End tests with Playwright to:
       - Verify panning, zooming, interactions and ui controls on mobile.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="791" height="1786" alt="image" src="https://github.com/user-attachments/assets/ed12d909-ddb6-4bbd-aa02-1574a41dfe01" />
<img width="772" height="860" alt="CleanShot 2026-06-07 at 13 28 31" src="https://github.com/user-attachments/assets/9469dfab-afcb-4730-83c4-88402a63256d" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
GitHub Copilot was used to understand how the E2E Playwright test system functions, and to help translate some of Svelte's quirks (since we are more familiar with React). Also Gemini was used to correct some grammar erros on the pr and comments.
...
