### PR TITLE
fix(web): Prevent face editor from closing when dismissing tag confirmation

### DIFF
--- a/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
@@ -326,9 +326,9 @@
       });
 
       await assetViewerManager.setAssetId(assetId);
+      onClose();
     } catch (error) {
       handleError(error, 'Error tagging face');
-    } finally {
       onClose();
     }
   };


### PR DESCRIPTION
## Description

When tagging a face on an asset, the "confirm tag" dialog appears after selecting a person. If the user cancels this dialog, the entire face editor closes — forcing them to re-draw the bounding box and re-search for the person.

The root cause was `onClose()` being placed in the `finally` block of `tagFace()`. In JavaScript, `finally` always executes, including after an early `return` from cancelling the confirmation dialog. This caused the editor to tear down even though the user explicitly chose not to proceed.

The fix moves `onClose()` out of `finally` and into the success and error paths only. On cancel, the function returns early without calling `onClose()`, leaving the face editor open so the user can try a different person.

## How Has This Been Tested?

- [x] `pnpm run lint` — ESLint, 0 errors
- [x] `pnpm run format` — Prettier, all files match code style
- [x] `pnpm run check:svelte` — svelte-check, 0 errors, 0 warnings
- [x] `pnpm run check:typescript` — tsc, all errors are pre-existing (`Cannot find module '@immich/sdk'` in unrelated files, none from this change)
- [x] `pnpm test` — 14 test files pass (238 tests), 39 fail with the same pre-existing `@immich/sdk` resolution issue; 0 failures related to this change
- [x] Manual testing: opened face editor, selected a person, cancelled the confirmation dialog — editor stays open, can select a different person
- [x] Manual testing: pressed Escape / Cancel button — editor closes as expected

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was implemented with assistance from an LLM under close human supervision. Validation was done manually by the human contributor.