### PR TITLE
fix(web): stacked asset scrollbar not draggable

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -629,7 +629,7 @@
   {#if stack && withStacked && !assetViewerManager.isShowEditor}
     {@const stackedAssets = stack.assets}
     <div id="stack-slideshow" class="pointer-events-none absolute bottom-0 col-span-4 col-start-1 w-full">
-      <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">
+      <div class="no-wrap horizontal-scrollbar pointer-events-auto relative flex flex-row overflow-x-auto overflow-y-hidden">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div
             class={['pointer-events-auto relative inline-block px-1 pb-2 transition-all']}


### PR DESCRIPTION
## Description

The parent container of the stacked asset preview strip uses `pointer-events-none`, which prevents mouse interaction with the horizontal scrollbar. When a stack contains many photos the scrollbar thumb appears but cannot be dragged.

This fix adds `pointer-events-auto` to the scrollable container div.

## How Has This Been Tested?

- [x] Loaded a stack with 60+ assets, verified scrollbar can be dragged
- [x] Verified thumbnail clicks and navigation still work

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The bug was manually discovered during use of Immich. The fix was identified and code change applied using Claude Code.