### PR TITLE
fix(web): distorted aspect ratio for images without dimensions

### DIFF
--- a/web/src/lib/components/AdaptiveImage.svelte
+++ b/web/src/lib/components/AdaptiveImage.svelte
@@ -146,6 +146,9 @@
     if (width && width > 0 && height && height > 0) {
       return { width, height };
     }
+    if (imgRef?.naturalWidth && imgRef.naturalWidth > 0 && imgRef?.naturalHeight && imgRef.naturalHeight > 0) {
+      return { width: imgRef.naturalWidth, height: imgRef.naturalHeight };
+    }
     return { width: 1, height: 1 };
   });
 


### PR DESCRIPTION
## Description

When an image asset lacks width/height metadata the AdaptiveImage component falls back to a 1:1 square aspect ratio, causing images to appear stretched in the viewer.

This fix uses the loaded image naturalWidth/naturalHeight as a fallback before defaulting to 1:1.

## How Has This Been Tested?

- [x] Opened an image without dimensions, confirmed correct aspect ratio after load
- [x] Verified images with proper metadata still work

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have followed naming conventions in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The bug was manually discovered during use of Immich. The fix was applied using Claude Code.