### PR TITLE
fix(mobile): show memory and folder dates in local time

### DIFF
--- a/mobile/lib/pages/library/folder/folder.page.dart
+++ b/mobile/lib/pages/library/folder/folder.page.dart
@@ -197,7 +197,7 @@ class FolderContent extends HookConsumerWidget {
                           style: context.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                         ),
                         subtitle: Text(
-                          "${asset.exifInfo.fileSize != null ? formatBytes(asset.exifInfo.fileSize ?? 0) : ""} • ${DateFormat.yMMMd().format(asset.createdAt)}",
+                          "${asset.exifInfo.fileSize != null ? "${formatBytes(asset.exifInfo.fileSize ?? 0)} • " : ""}${DateFormat.yMMMd().format(asset.createdAt.toLocal())}",
                           style: context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary),
                         ),
                       ),

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -30,7 +30,7 @@ class DriftMemoryBottomInfo extends StatelessWidget {
                 style: TextStyle(color: Colors.grey[400], fontSize: 13.0, fontWeight: FontWeight.w500),
               ),
               Text(
-                df.format(fileCreatedDate),
+                df.format(fileCreatedDate.toLocal()),
                 style: const TextStyle(color: Colors.white, fontSize: 15.0, fontWeight: FontWeight.w500),
               ),
             ],
@@ -41,7 +41,7 @@ class DriftMemoryBottomInfo extends StatelessWidget {
               minWidth: 0,
               onPressed: () async {
                 await context.router.navigate(const TabShellRoute(children: [MainTimelineRoute()]));
-                EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate));
+                EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate.toLocal()));
               },
               shape: const CircleBorder(),
               color: Colors.white.withValues(alpha: 0.2),


### PR DESCRIPTION
## Description

memory cards and the folder list formatted `createdAt` (UTC) without `.toLocal()`, so early-morning photos showed a day early — e.g. taken 2025-06-09 02:00 at +06 showed "June 8". now matches the asset viewer/detail panel.

fixes #25318

tested on device at UTC+6: June 8 → June 9 after the fix.
