### PR TITLE
fix(mobile): show error when creating an album fails

### DIFF
--- a/mobile/lib/presentation/pages/drift_create_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_create_album.page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart'
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/album/album_action_filled_button.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 @RoutePage()
 class DriftCreateAlbumPage extends ConsumerStatefulWidget {
@@ -47,7 +48,7 @@ class _DriftCreateAlbumPageState extends ConsumerState<DriftCreateAlbumPage> {
     super.dispose();
   }
 
-  bool get _canCreateAlbum => albumTitleController.text.isNotEmpty;
+  bool get _canCreateAlbum => albumTitleController.text.trim().isNotEmpty;
 
   String _getEffectiveTitle() {
     return albumTitleController.text.isNotEmpty
@@ -169,25 +170,23 @@ class _DriftCreateAlbumPageState extends ConsumerState<DriftCreateAlbumPage> {
     onBackgroundTapped();
 
     final title = _getEffectiveTitle().trim();
-    if (title.isEmpty) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('create_album_title_required'.t()), backgroundColor: context.colorScheme.error),
-        );
+
+    try {
+      final album = await ref
+          .read(remoteAlbumProvider.notifier)
+          .createAlbumWithAssets(
+            title: title,
+            description: albumDescriptionController.text.trim(),
+            assets: selectedAssets,
+          );
+
+      if (album != null && context.mounted) {
+        unawaited(context.replaceRoute(RemoteAlbumRoute(album: album)));
       }
-      return;
-    }
-
-    final album = await ref
-        .read(remoteAlbumProvider.notifier)
-        .createAlbumWithAssets(
-          title: title,
-          description: albumDescriptionController.text.trim(),
-          assets: selectedAssets,
-        );
-
-    if (album != null && context.mounted) {
-      unawaited(context.replaceRoute(RemoteAlbumRoute(album: album)));
+    } catch (_) {
+      if (context.mounted) {
+        ImmichToast.show(context: context, toastType: ToastType.error, msg: 'errors.failed_to_create_album'.t());
+      }
     }
   }
 


### PR DESCRIPTION
## Description

creating an album failed silently when the server was down — now shows an error toast. also disables Create for blank titles.

fixes #10357
