### PR TITLE
fix(web): stacked asset scrollbar not draggable

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -629,7 +629,7 @@
   {#if stack && withStacked && !assetViewerManager.isShowEditor}
     {@const stackedAssets = stack.assets}
     <div id="stack-slideshow" class="pointer-events-none absolute bottom-0 col-span-4 col-start-1 w-full">
-      <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">
+      <div class="no-wrap horizontal-scrollbar pointer-events-auto relative flex flex-row overflow-x-auto overflow-y-hidden">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div
             class={['pointer-events-auto relative inline-block px-1 pb-2 transition-all']}


### PR DESCRIPTION
## Description

The stacked asset slideshow horizontal scrollbar is not draggable because the parent div `stack-slideshow` has `pointer-events-none`. This prevents mouse events from reaching the scrollbar element below it.

This adds `pointer-events-auto` to the scrollbar container div to restore dragging behavior.

## How Has This Been Tested?

- Open an asset that is part of a stack
- Verify the horizontal scrollbar at the bottom of the viewer is draggable

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code was used to locate the relevant file and confirm the fix approach, but the code change itself was manually written and reviewed.
