### PR TITLE
fix(web): expand stacked assets when adding to album

### DIFF
--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -4,6 +4,7 @@ import {
   AssetTypeEnum,
   AssetVisibility,
   getAssetInfo,
+  getStack,
   runAssetJobs,
   updateAsset,
   type AssetJobsDto,
@@ -58,8 +59,21 @@ export const getAssetBulkActions = ($t: MessageFormatter) => {
     title: $t('add_to_album'),
     icon: mdiPlus,
     shortcuts: [{ key: 'l' }],
-    onAction: () =>
-      modalManager.show(AssetAddToAlbumModal, { assetIds: assetMultiSelectManager.assets.map((asset) => asset.id) }),
+    onAction: async () => {
+      const selectedAssets = assetMultiSelectManager.assets;
+      const ids = new Set(selectedAssets.map(({ id }) => id));
+      for (const asset of selectedAssets) {
+        if (asset.stack) {
+          try {
+            const { assets } = await getStack({ id: asset.stack.id });
+            assets.forEach(({ id }) => ids.add(id));
+          } catch {
+            // ignore failed stack fetches
+          }
+        }
+      }
+      modalManager.show(AssetAddToAlbumModal, { assetIds: [...ids] });
+    },
   };
 
   const RefreshFacesJob: ActionItem = {


### PR DESCRIPTION
## Description

When selecting a stacked cover photo in the timeline and using the bulk action "Add to Album", only the selected cover asset is added. Stack children are silently omitted because `assetMultiSelectManager` only tracks explicitly selected asset IDs, and the `AddToAlbum` action passes these IDs directly to the modal without expanding stacked assets.

This changes `AddToAlbum.onAction` in `getAssetBulkActions` to call `getStack()` for each selected stacked asset and include all sibling IDs.

## How Has This Been Tested?

- Select a stacked cover photo in the timeline
- Click "Add to Album" from the bulk action bar
- Select an album
- Verify all stack children are added to the album, not just the cover

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code assisted in tracing the full code path from `handleSelectAsset` → `AssetMultiSelectManager` → `getAssetBulkActions` → `AssetAddToAlbumModal` → `addAssetsToAlbums` API call, and in identifying the correct location for the fix. The code change follows existing patterns in the codebase and was manually reviewed.
