### PR TITLE
fix: stale translation generation

### DIFF
--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -102,8 +102,6 @@ run = "flutter run"
 [tasks."i18n:loader"]
 description = "Generate i18n loader"
 hide = true
-sources = ["i18n/"]
-outputs = "lib/generated/codegen_loader.g.dart"
 run = [
   "dart run easy_localization:generate -S ../i18n",
   "dart format lib/generated/codegen_loader.g.dart",
@@ -112,8 +110,6 @@ run = [
 [tasks."i18n:keys"]
 description = "Generate i18n keys"
 hide = true
-sources = ["i18n/en.json"]
-outputs = "lib/generated/translations.g.dart"
 run = [
   "dart run bin/generate_keys.dart",
   "dart format lib/generated/translations.g.dart",


### PR DESCRIPTION
Remove source and output tracking to always force regeneration, since the intertwining of file generation command breaks mise's way of tracking old/new files based on mtime