### PR TITLE
fix: realign badge icon

### DIFF
--- a/mobile/lib/widgets/common/immich_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/immich_sliver_app_bar.dart
@@ -141,7 +141,7 @@ class _ProfileIndicator extends ConsumerWidget {
             color: serverInfoState.versionStatus == VersionStatus.error
                 ? context.colorScheme.error
                 : context.primaryColor,
-            size: widgetSize / 2,
+            size: widgetSize / 2 - 3,
             semanticLabel: 'new_version_available'.tr(),
           ),
         ),


### PR DESCRIPTION
Looks like the new version of Flutter moves the badge positioning calculation around

| before | after |
| - | - |
| <img width="186" height="176" alt="image" src="https://github.com/user-attachments/assets/60d559d2-a53b-4e1a-ac25-898c013a5aed" /> | <img width="241" height="225" alt="image" src="https://github.com/user-attachments/assets/b13bf38f-afdf-4956-9506-bbf544006343" /> |
