### PR TITLE
fix(mobile): add album picker to archive bottom sheet

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
@@ -1,6 +1,8 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
@@ -14,21 +16,68 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/stack_action_b
 import 'package:immich_mobile/presentation/widgets/action_buttons/trash_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unarchive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unstack_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
-class ArchiveBottomSheet extends ConsumerWidget {
+class ArchiveBottomSheet extends ConsumerStatefulWidget {
   const ArchiveBottomSheet({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ArchiveBottomSheet> createState() => _ArchiveBottomSheetState();
+}
+
+class _ArchiveBottomSheetState extends ConsumerState<ArchiveBottomSheet> {
+  late final DraggableScrollableController sheetController;
+
+  @override
+  void initState() {
+    super.initState();
+    sheetController = DraggableScrollableController();
+  }
+
+  @override
+  void dispose() {
+    sheetController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final multiselect = ref.watch(multiSelectProvider);
     final isTrashEnable = ref.watch(serverInfoProvider.select((state) => state.serverFeatures.trash));
 
+    Future<void> addToAlbum(RemoteAlbum album) async {
+      final result = await ref.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, album);
+
+      if (!context.mounted) {
+        return;
+      }
+
+      if (!result.success) {
+        ImmichToast.show(context: context, msg: 'scaffold_body_error_occurred'.tr(), toastType: ToastType.error);
+        return;
+      }
+
+      ImmichToast.show(
+        context: context,
+        msg: result.count == 0
+            ? 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name})
+            : 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name}),
+      );
+    }
+
+    Future<void> onKeyboardExpand() {
+      return sheetController.animateTo(0.85, duration: const Duration(milliseconds: 200), curve: Curves.easeInOut);
+    }
+
     return BaseBottomSheet(
+      controller: sheetController,
       initialChildSize: 0.25,
-      maxChildSize: 0.4,
+      maxChildSize: 0.85,
       shouldCloseOnMinExtent: false,
       actions: [
         const ShareActionButton(source: ActionSource.timeline),
@@ -47,6 +96,10 @@ class ArchiveBottomSheet extends ConsumerWidget {
           if (multiselect.hasStacked) const UnStackActionButton(source: ActionSource.timeline),
         ],
         if (multiselect.hasMerged) const DeleteLocalActionButton(source: ActionSource.timeline),
+      ],
+      slivers: [
+        const AddToAlbumHeader(),
+        AlbumSelector(onAlbumSelected: addToAlbum, onKeyboardExpanded: onKeyboardExpand),
       ],
     );
   }


### PR DESCRIPTION
## Description

the archive bottom sheet never passed `slivers` to `BaseBottomSheet`, so the album picker doesn't show there like it does on the other sheets. added the picker mirroring the local album sheet, add goes through the shared `actionProvider.addToAlbum`.

fixes #23011

tested on device: archived photo → pick album → added toast, photo shows in the album and stays archived.