### PR TITLE
feat: implement straightening tool for image editing

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1026,6 +1026,8 @@
   "editor_reset_all_changes": "Reset changes",
   "editor_rotate_left": "Rotate 90° counterclockwise",
   "editor_rotate_right": "Rotate 90° clockwise",
+  "editor_straighten": "Straighten",
+  "editor_straighten_reset": "Reset angle",
   "email": "Email",
   "email_notifications": "Email notifications",
   "empty_folder": "This folder is empty",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -17463,15 +17463,15 @@
             "type": "integer"
           },
           "x": {
-            "description": "Top-Left X coordinate of crop",
+            "description": "Top-Left X coordinate of crop. Can be negative for straightened crops before bounds validation",
             "maximum": 9007199254740991,
-            "minimum": 0,
+            "minimum": -9007199254740991,
             "type": "integer"
           },
           "y": {
-            "description": "Top-Left Y coordinate of crop",
+            "description": "Top-Left Y coordinate of crop. Can be negative for straightened crops before bounds validation",
             "maximum": 9007199254740991,
-            "minimum": 0,
+            "minimum": -9007199254740991,
             "type": "integer"
           }
         },
@@ -20823,6 +20823,8 @@
         "properties": {
           "angle": {
             "description": "Rotation angle in degrees",
+            "maximum": 360,
+            "minimum": -360,
             "type": "number"
           }
         },

--- a/server/src/controllers/asset.controller.spec.ts
+++ b/server/src/controllers/asset.controller.spec.ts
@@ -440,6 +440,31 @@ describe(AssetController.name, () => {
       );
     });
 
+    it('should reject rotate angles outside the supported range', async () => {
+      const { status, body } = await request(ctx.getHttpServer())
+        .put(`/assets/${factory.uuid()}/edits`)
+        .send({
+          edits: [
+            {
+              action: 'rotate',
+              parameters: {
+                angle: 361,
+              },
+            },
+          ],
+        });
+
+      expect(status).toBe(400);
+      expect(body).toEqual(
+        factory.responses.validationError([
+          {
+            path: ['edits', 0, 'parameters', 'angle'],
+            message: 'Too big: expected number to be <=360',
+          },
+        ]),
+      );
+    });
+
     it('should require at least one edit', async () => {
       const { status, body } = await request(ctx.getHttpServer())
         .put(`/assets/${factory.uuid()}/edits`)

--- a/server/src/dtos/editing.dto.ts
+++ b/server/src/dtos/editing.dto.ts
@@ -17,12 +17,18 @@ export enum MirrorAxis {
   Vertical = 'vertical',
 }
 
+const MAX_ROTATION_DEGREES = 360;
+
 const MirrorAxisSchema = z.enum(['horizontal', 'vertical']).describe('Axis to mirror along').meta({ id: 'MirrorAxis' });
 
 const CropParametersSchema = z
   .object({
-    x: z.int().min(0).describe('Top-Left X coordinate of crop'),
-    y: z.int().min(0).describe('Top-Left Y coordinate of crop'),
+    x: z
+      .int()
+      .describe('Top-Left X coordinate of crop. Can be negative for straightened crops before bounds validation'),
+    y: z
+      .int()
+      .describe('Top-Left Y coordinate of crop. Can be negative for straightened crops before bounds validation'),
     width: z.int().min(1).describe('Width of the crop'),
     height: z.int().min(1).describe('Height of the crop'),
   })
@@ -30,12 +36,7 @@ const CropParametersSchema = z
 
 const RotateParametersSchema = z
   .object({
-    angle: z
-      .number()
-      .refine((v) => [0, 90, 180, 270].includes(v), {
-        error: 'Angle must be one of the following values: 0, 90, 180, 270',
-      })
-      .describe('Rotation angle in degrees'),
+    angle: z.number().min(-MAX_ROTATION_DEGREES).max(MAX_ROTATION_DEGREES).describe('Rotation angle in degrees'),
   })
   .meta({ id: 'RotateParameters' });
 

--- a/server/src/repositories/media.repository.spec.ts
+++ b/server/src/repositories/media.repository.spec.ts
@@ -2,7 +2,7 @@ import sharp from 'sharp';
 import { AssetFace } from 'src/database';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
-import { SourceType } from 'src/enum';
+import { Colorspace, SourceType } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { BoundingBox } from 'src/repositories/machine-learning.repository';
 import { MediaRepository } from 'src/repositories/media.repository';
@@ -268,6 +268,124 @@ describe(MediaRepository.name, () => {
 
       expect(await getPixelColor(buffer, 10, 10)).toEqual({ r: 0, g: 0, b: 255 });
       expect(await getPixelColor(buffer, 990, 10)).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it('should swap straighten crop dimensions for 90° rotation', async () => {
+      const result = sut['applyEdits'](
+        sharp({
+          create: {
+            width: 1000,
+            height: 800,
+            channels: 4,
+            background: { r: 255, g: 0, b: 0, alpha: 1 },
+          },
+        }).png(),
+        [
+          { action: AssetEditAction.Crop, parameters: { x: 200, y: 250, width: 600, height: 450 } },
+          { action: AssetEditAction.Rotate, parameters: { angle: 100 } },
+        ],
+        { width: 1000, height: 800 },
+      );
+
+      const metadata = await result
+        .png()
+        .toBuffer()
+        .then((buffer) => sharp(buffer).metadata());
+      expect(metadata.width).toBeLessThan(metadata.height!);
+      expect(metadata.width! / metadata.height!).toBeCloseTo(450 / 600, 1);
+    });
+
+    it('should invert straighten rotation for a single mirror', async () => {
+      const image = sharp({
+        create: {
+          width: 100,
+          height: 80,
+          channels: 4,
+          background: { r: 255, g: 255, b: 255, alpha: 1 },
+        },
+      }).png();
+
+      const result = sut['applyEdits'](
+        image,
+        [
+          { action: AssetEditAction.Crop, parameters: { x: 20, y: 20, width: 60, height: 40 } },
+          { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+          { action: AssetEditAction.Rotate, parameters: { angle: 43 } },
+        ],
+        { width: 100, height: 80 },
+      );
+
+      const metadata = await result
+        .png()
+        .toBuffer()
+        .then((buffer) => sharp(buffer).metadata());
+      expect(metadata.width).toBe(38);
+      expect(metadata.height).toBe(25);
+    });
+
+    it('should require source dimensions for straighten extraction', () => {
+      const image = sharp({
+        create: {
+          width: 100,
+          height: 80,
+          channels: 4,
+          background: { r: 255, g: 255, b: 255, alpha: 1 },
+        },
+      }).png();
+
+      expect(() =>
+        sut['applyEdits'](image, [
+          { action: AssetEditAction.Crop, parameters: { x: 20, y: 20, width: 60, height: 40 } },
+          { action: AssetEditAction.Rotate, parameters: { angle: 43 } },
+        ]),
+      ).toThrow('Image dimensions are required for straighten edits');
+    });
+
+    it('should decode encoded images with straighten edits', async () => {
+      const imageBuffer = await sharp({
+        create: {
+          width: 100,
+          height: 80,
+          channels: 4,
+          background: { r: 255, g: 255, b: 255, alpha: 1 },
+        },
+      })
+        .png()
+        .toBuffer();
+
+      await expect(
+        sut.decodeImage(imageBuffer, {
+          colorspace: Colorspace.Srgb,
+          processInvalidImages: false,
+          edits: [
+            { action: AssetEditAction.Crop, parameters: { x: 20, y: 20, width: 60, height: 40 } },
+            { action: AssetEditAction.Rotate, parameters: { angle: 10 } },
+          ],
+        }),
+      ).resolves.toMatchObject({
+        info: expect.objectContaining({
+          width: expect.any(Number),
+          height: expect.any(Number),
+        }),
+      });
+    });
+
+    it('should treat floating-point quarter turns as right-angle rotations', () => {
+      const image = sharp({
+        create: {
+          width: 100,
+          height: 80,
+          channels: 4,
+          background: { r: 255, g: 255, b: 255, alpha: 1 },
+        },
+      }).png();
+
+      expect(() =>
+        sut['applyEdits'](image, [
+          { action: AssetEditAction.Crop, parameters: { x: 20, y: 20, width: 60, height: 40 } },
+          { action: AssetEditAction.Rotate, parameters: { angle: 90.000_000_000_000_01 } },
+        ]),
+      ).not.toThrow();
     });
 
     it('should apply vertical mirror then horizontal mirror then rotate 90°', async () => {

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -36,6 +36,7 @@ import {
   VideoInfo,
   VideoPacketInfo,
 } from 'src/types';
+import { getEffectiveStraightenRotation, getStraightenExtractRectangle, splitRotation } from 'src/utils/editor';
 import { handlePromiseError } from 'src/utils/misc';
 import { createAffineMatrix } from 'src/utils/transform';
 
@@ -148,35 +149,70 @@ export class MediaRepository {
     }
   }
 
-  decodeImage(input: string | Buffer, options: DecodeToBufferOptions) {
-    return this.getImageDecodingPipeline(input, options).raw().toBuffer({ resolveWithObject: true });
+  async decodeImage(input: string | Buffer, options: DecodeToBufferOptions) {
+    const pipeline = await this.getImageDecodingPipeline(input, options);
+    return pipeline.raw().toBuffer({ resolveWithObject: true });
   }
 
-  private applyEdits(pipeline: sharp.Sharp, edits: AssetEditActionItem[]): sharp.Sharp {
-    const crop = edits.find((edit) => edit.action === 'crop');
-    if (crop) {
-      pipeline = pipeline.extract({
-        left: Math.round(crop.parameters.x),
-        top: Math.round(crop.parameters.y),
-        width: Math.round(crop.parameters.width),
-        height: Math.round(crop.parameters.height),
-      });
-    }
+  private applyEdits(
+    pipeline: sharp.Sharp,
+    edits: AssetEditActionItem[],
+    dimensions?: { width: number; height: number },
+  ): sharp.Sharp {
+    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
+    const straightenActive = rotateEdit && splitRotation(rotateEdit.parameters.angle).straightenAngle !== 0;
 
-    const affineEditOperations = edits.filter((edit) => edit.action !== 'crop');
-    if (affineEditOperations.length > 0) {
-      const { a, b, c, d } = createAffineMatrix(affineEditOperations);
-      pipeline = pipeline.affine([
-        [a, b],
-        [c, d],
-      ]);
+    if (straightenActive) {
+      const mirrorEdits = edits.filter((edit) => edit.action === 'mirror');
+      const effectiveRotation = getEffectiveStraightenRotation(rotateEdit.parameters.angle, mirrorEdits);
+
+      pipeline = pipeline.rotate(effectiveRotation);
+
+      for (const mirror of mirrorEdits) {
+        if (mirror.parameters.axis === 'horizontal') {
+          pipeline = pipeline.flop();
+        } else if (mirror.parameters.axis === 'vertical') {
+          pipeline = pipeline.flip();
+        }
+      }
+
+      const crop = edits.find((edit) => edit.action === 'crop');
+      if (crop) {
+        if (!dimensions?.width || !dimensions.height) {
+          throw new Error('Image dimensions are required for straighten edits');
+        }
+
+        pipeline = pipeline.extract(
+          getStraightenExtractRectangle(crop.parameters, dimensions, rotateEdit.parameters.angle, edits),
+        );
+      }
+    } else {
+      const crop = edits.find((edit) => edit.action === 'crop');
+      if (crop) {
+        pipeline = pipeline.extract({
+          left: Math.round(crop.parameters.x),
+          top: Math.round(crop.parameters.y),
+          width: Math.round(crop.parameters.width),
+          height: Math.round(crop.parameters.height),
+        });
+      }
+
+      const affineEditOperations = edits.filter((edit) => edit.action !== 'crop');
+      if (affineEditOperations.length > 0) {
+        const { a, b, c, d } = createAffineMatrix(affineEditOperations);
+        pipeline = pipeline.affine([
+          [a, b],
+          [c, d],
+        ]);
+      }
     }
 
     return pipeline;
   }
 
   async generateThumbnail(input: string | Buffer, options: GenerateThumbnailOptions, output: string): Promise<void> {
-    await this.getImageDecodingPipeline(input, options)
+    const pipeline = await this.getImageDecodingPipeline(input, options);
+    await pipeline
       .toFormat(options.format, {
         quality: options.quality,
         // this is default in libvips (except the threshold is 90), but we need to set it manually in sharp
@@ -186,7 +222,37 @@ export class MediaRepository {
       .toFile(output);
   }
 
-  private getImageDecodingPipeline(input: string | Buffer, options: DecodeToBufferOptions) {
+  private requiresStraightenDimensions(edits: AssetEditActionItem[]) {
+    const crop = edits.find((edit) => edit.action === 'crop');
+    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
+    return Boolean(crop && rotateEdit && splitRotation(rotateEdit.parameters.angle).straightenAngle !== 0);
+  }
+
+  private async getDecodedDimensions(
+    input: string | Buffer,
+    options: DecodeToBufferOptions,
+  ): Promise<ImageDimensions | undefined> {
+    if (options.raw) {
+      return options.raw;
+    }
+
+    const metadata = await sharp(input, {
+      failOn: options.processInvalidImages ? 'none' : 'error',
+      limitInputPixels: false,
+      unlimited: true,
+    }).metadata();
+
+    if (!metadata.width || !metadata.height) {
+      return;
+    }
+
+    const { angle } = options.orientation ? ORIENTATION_TO_SHARP_ROTATION[options.orientation] : {};
+    return angle === 90 || angle === 270
+      ? { width: metadata.height, height: metadata.width }
+      : { width: metadata.width, height: metadata.height };
+  }
+
+  private async getImageDecodingPipeline(input: string | Buffer, options: DecodeToBufferOptions) {
     let pipeline = sharp(input, {
       // some invalid images can still be processed by sharp, but we want to fail on them by default to avoid crashes
       failOn: options.processInvalidImages ? 'none' : 'error',
@@ -210,7 +276,10 @@ export class MediaRepository {
     }
 
     if (options.edits && options.edits.length > 0) {
-      pipeline = this.applyEdits(pipeline, options.edits);
+      const dimensions = this.requiresStraightenDimensions(options.edits)
+        ? await this.getDecodedDimensions(input, options)
+        : options.raw;
+      pipeline = this.applyEdits(pipeline, options.edits, dimensions);
     }
 
     if (options.size !== undefined) {
@@ -222,12 +291,13 @@ export class MediaRepository {
   async generateThumbhash(input: string | Buffer, options: GenerateThumbhashOptions): Promise<Buffer> {
     const { rgbaToThumbHash } = await import('thumbhash');
 
-    const { data, info } = await this.getImageDecodingPipeline(input, {
+    const pipeline = await this.getImageDecodingPipeline(input, {
       colorspace: options.colorspace,
       processInvalidImages: options.processInvalidImages,
       raw: options.raw,
       edits: options.edits,
-    })
+    });
+    const { data, info } = await pipeline
       .resize(100, 100, { fit: 'inside', withoutEnlargement: true })
       .raw()
       .ensureAlpha()

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -158,11 +158,11 @@ export class MediaRepository {
     pipeline: sharp.Sharp,
     edits: AssetEditActionItem[],
     dimensions?: { width: number; height: number },
+    analysis = this.analyzeEdits(edits),
   ): sharp.Sharp {
-    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
-    const straightenActive = rotateEdit && splitRotation(rotateEdit.parameters.angle).straightenAngle !== 0;
+    const { crop, rotateEdit, straightenActive } = analysis;
 
-    if (straightenActive) {
+    if (straightenActive && rotateEdit) {
       const mirrorEdits = edits.filter((edit) => edit.action === 'mirror');
       const effectiveRotation = getEffectiveStraightenRotation(rotateEdit.parameters.angle, mirrorEdits);
 
@@ -176,7 +176,6 @@ export class MediaRepository {
         }
       }
 
-      const crop = edits.find((edit) => edit.action === 'crop');
       if (crop) {
         if (!dimensions?.width || !dimensions.height) {
           throw new Error('Image dimensions are required for straighten edits');
@@ -187,7 +186,6 @@ export class MediaRepository {
         );
       }
     } else {
-      const crop = edits.find((edit) => edit.action === 'crop');
       if (crop) {
         pipeline = pipeline.extract({
           left: Math.round(crop.parameters.x),
@@ -210,6 +208,21 @@ export class MediaRepository {
     return pipeline;
   }
 
+  private analyzeEdits(edits: AssetEditActionItem[]) {
+    const crop = edits.find((edit) => edit.action === 'crop');
+    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
+    const { straightenAngle } = rotateEdit ? splitRotation(rotateEdit.parameters.angle) : { straightenAngle: 0 };
+    const straightenActive = Boolean(rotateEdit) && straightenAngle !== 0;
+
+    return {
+      crop,
+      rotateEdit,
+      straightenAngle,
+      straightenActive,
+      needsDimensions: straightenActive && Boolean(crop),
+    };
+  }
+
   async generateThumbnail(input: string | Buffer, options: GenerateThumbnailOptions, output: string): Promise<void> {
     const pipeline = await this.getImageDecodingPipeline(input, options);
     await pipeline
@@ -220,12 +233,6 @@ export class MediaRepository {
         progressive: options.progressive,
       })
       .toFile(output);
-  }
-
-  private requiresStraightenDimensions(edits: AssetEditActionItem[]) {
-    const crop = edits.find((edit) => edit.action === 'crop');
-    const rotateEdit = edits.find((edit) => edit.action === 'rotate');
-    return Boolean(crop && rotateEdit && splitRotation(rotateEdit.parameters.angle).straightenAngle !== 0);
   }
 
   private async getDecodedDimensions(
@@ -276,10 +283,9 @@ export class MediaRepository {
     }
 
     if (options.edits && options.edits.length > 0) {
-      const dimensions = this.requiresStraightenDimensions(options.edits)
-        ? await this.getDecodedDimensions(input, options)
-        : options.raw;
-      pipeline = this.applyEdits(pipeline, options.edits, dimensions);
+      const analysis = this.analyzeEdits(options.edits);
+      const dimensions = analysis.needsDimensions ? await this.getDecodedDimensions(input, options) : options.raw;
+      pipeline = this.applyEdits(pipeline, options.edits, dimensions, analysis);
     }
 
     if (options.size !== undefined) {

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -744,5 +744,115 @@ describe(AssetService.name, () => {
 
       expect(mocks.assetEdit.replaceAll).not.toHaveBeenCalled();
     });
+
+    it('should reject out-of-bounds non-straighten crops', async () => {
+      const asset = {
+        ...AssetFactory.from({ id: 'asset-1' }).build(),
+        exifImageWidth: 1000,
+        exifImageHeight: 800,
+        orientation: '1',
+        projectionType: null,
+      };
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForEdit.mockResolvedValue(asset);
+
+      await expect(
+        sut.editAsset(authStub.admin, asset.id, {
+          edits: [{ action: AssetEditAction.Crop, parameters: { x: -50, y: 0, width: 500, height: 300 } }],
+        }),
+      ).rejects.toThrow('Crop parameters are out of bounds');
+
+      expect(mocks.assetEdit.replaceAll).not.toHaveBeenCalled();
+    });
+
+    it('should allow straighten crops that extend beyond the unrotated image bounds', async () => {
+      const asset = {
+        ...AssetFactory.from({ id: 'asset-1' }).build(),
+        exifImageWidth: 1000,
+        exifImageHeight: 800,
+        orientation: '1',
+        projectionType: null,
+      };
+      const edits = [
+        { action: AssetEditAction.Crop, parameters: { x: -53, y: 89, width: 1106, height: 622 } },
+        { action: AssetEditAction.Rotate, parameters: { angle: 10 } },
+      ];
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForEdit.mockResolvedValue(asset);
+      mocks.assetEdit.replaceAll.mockResolvedValue(edits as any);
+
+      await expect(sut.editAsset(authStub.admin, asset.id, { edits })).resolves.toEqual({
+        assetId: asset.id,
+        edits,
+      });
+
+      expect(mocks.assetEdit.replaceAll).toHaveBeenCalledWith(asset.id, edits);
+    });
+
+    it('should allow straighten crops with tiny negative transformed bounds', async () => {
+      const asset = {
+        ...AssetFactory.from({ id: 'asset-1' }).build(),
+        exifImageWidth: 1000,
+        exifImageHeight: 800,
+        orientation: '1',
+        projectionType: null,
+      };
+      const edits = [
+        { action: AssetEditAction.Crop, parameters: { x: -176.4, y: 89, width: 1106, height: 622 } },
+        { action: AssetEditAction.Rotate, parameters: { angle: 10 } },
+      ];
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForEdit.mockResolvedValue(asset);
+      mocks.assetEdit.replaceAll.mockResolvedValue(edits as any);
+
+      await expect(sut.editAsset(authStub.admin, asset.id, { edits })).resolves.toEqual({
+        assetId: asset.id,
+        edits,
+      });
+
+      expect(mocks.assetEdit.replaceAll).toHaveBeenCalledWith(asset.id, edits);
+    });
+
+    it('should reject crops when asset dimensions are missing', async () => {
+      const asset = {
+        ...AssetFactory.from({ id: 'asset-1' }).build(),
+        exifImageWidth: null,
+        exifImageHeight: null,
+        orientation: null,
+        projectionType: null,
+      };
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForEdit.mockResolvedValue(asset);
+
+      await expect(
+        sut.editAsset(authStub.admin, asset.id, {
+          edits: [{ action: AssetEditAction.Crop, parameters: { x: 0, y: 0, width: 500, height: 300 } }],
+        }),
+      ).rejects.toThrow('Asset dimensions are not available for editing');
+
+      expect(mocks.assetEdit.replaceAll).not.toHaveBeenCalled();
+    });
+
+    it('should reject out-of-bounds straighten crops', async () => {
+      const asset = {
+        ...AssetFactory.from({ id: 'asset-1' }).build(),
+        exifImageWidth: 1000,
+        exifImageHeight: 800,
+        orientation: '1',
+        projectionType: null,
+      };
+      const edits = [
+        { action: AssetEditAction.Crop, parameters: { x: -1000, y: 89, width: 1106, height: 622 } },
+        { action: AssetEditAction.Rotate, parameters: { angle: 10 } },
+      ];
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForEdit.mockResolvedValue(asset);
+
+      await expect(sut.editAsset(authStub.admin, asset.id, { edits })).rejects.toThrow(
+        'Crop parameters are out of bounds',
+      );
+
+      expect(mocks.assetEdit.replaceAll).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -46,7 +46,10 @@ import {
 } from 'src/utils/asset.util';
 import { updateLockedColumns } from 'src/utils/database';
 import { extractTimeZone } from 'src/utils/date';
+import { getRotatedCanvasDimensions, getStraightenExtractRectangle, splitRotation } from 'src/utils/editor';
 import { transformOcrBoundingBox } from 'src/utils/transform';
+
+const STRAIGHTEN_BOUNDS_EPSILON = 1;
 
 @Injectable()
 export class AssetService extends BaseService {
@@ -581,15 +584,36 @@ export class AssetService extends BaseService {
       }
 
       // check that crop parameters will not go out of bounds
-      const { width: assetWidth, height: assetHeight } = getDimensions(asset);
+      const rotateEdit = edits.find((e) => e.action === AssetEditAction.Rotate);
+      const straightenActive = rotateEdit && splitRotation(rotateEdit.parameters.angle).straightenAngle !== 0;
 
-      if (!assetWidth || !assetHeight) {
-        throw new BadRequestException('Asset dimensions are not available for editing');
-      }
-
-      const { x, y, width, height } = crop.parameters;
-      if (x + width > assetWidth || y + height > assetHeight) {
-        throw new BadRequestException('Crop parameters are out of bounds');
+      if (straightenActive) {
+        const extract = getStraightenExtractRectangle(
+          crop.parameters,
+          { width: assetWidth, height: assetHeight },
+          rotateEdit.parameters.angle,
+          edits,
+          false,
+        );
+        const target = getRotatedCanvasDimensions(
+          { width: assetWidth, height: assetHeight },
+          rotateEdit.parameters.angle,
+        );
+        if (
+          extract.width < 1 ||
+          extract.height < 1 ||
+          extract.left < -STRAIGHTEN_BOUNDS_EPSILON ||
+          extract.top < -STRAIGHTEN_BOUNDS_EPSILON ||
+          extract.left + extract.width > target.width + STRAIGHTEN_BOUNDS_EPSILON ||
+          extract.top + extract.height > target.height + STRAIGHTEN_BOUNDS_EPSILON
+        ) {
+          throw new BadRequestException('Crop parameters are out of bounds');
+        }
+      } else {
+        const { x, y, width, height } = crop.parameters;
+        if (x < 0 || y < 0 || x + width > assetWidth || y + height > assetHeight) {
+          throw new BadRequestException('Crop parameters are out of bounds');
+        }
       }
     }
 

--- a/server/src/utils/editor.spec.ts
+++ b/server/src/utils/editor.spec.ts
@@ -1,8 +1,210 @@
 import { AssetFace } from 'src/database';
+import { AssetEditAction, MirrorAxis, type AssetEditActionItem } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
 import { SourceType } from 'src/enum';
-import { boundingBoxOverlap, checkFaceVisibility, checkOcrVisibility } from 'src/utils/editor';
+import {
+  boundingBoxOverlap,
+  checkFaceVisibility,
+  checkOcrVisibility,
+  getEffectiveStraightenRotation,
+  getRotatedCanvasDimensions,
+  getStraightenExtractRectangle,
+  splitRotation,
+} from 'src/utils/editor';
 import { describe, expect, it } from 'vitest';
+
+describe('straighten crop geometry', () => {
+  it('splits total rotation into quarter turn and straighten angle', () => {
+    expect(splitRotation(12)).toEqual({ quarterTurn: 0, straightenAngle: 12 });
+    expect(splitRotation(100)).toEqual({ quarterTurn: 90, straightenAngle: 10 });
+    expect(splitRotation(263)).toEqual({ quarterTurn: 270, straightenAngle: -7 });
+    expect(splitRotation(45)).toEqual({ quarterTurn: 0, straightenAngle: 45 });
+    expect(splitRotation(-45)).toEqual({ quarterTurn: 0, straightenAngle: -45 });
+  });
+
+  it('snaps floating point residue around quarter turns', () => {
+    expect(splitRotation(-90.000_000_000_000_01)).toEqual({ quarterTurn: 270, straightenAngle: 0 });
+    expect(splitRotation(90.000_000_000_000_01)).toEqual({ quarterTurn: 90, straightenAngle: 0 });
+  });
+
+  it('inverts straighten rotation for a single mirror', () => {
+    expect(
+      getEffectiveStraightenRotation(43, [
+        { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+      ]),
+    ).toBe(-43);
+    expect(
+      getEffectiveStraightenRotation(43, [
+        { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+        { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } },
+      ]),
+    ).toBe(43);
+    expect(
+      getEffectiveStraightenRotation(100, [
+        { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+      ]),
+    ).toBe(80);
+  });
+
+  it('extracts a centered straighten crop inside the rotated canvas', () => {
+    const rect = getStraightenExtractRectangle(
+      { x: 250, y: 200, width: 500, height: 400 },
+      { width: 1000, height: 800 },
+      10,
+    );
+    const target = getRotatedCanvasDimensions({ width: 1000, height: 800 }, 10);
+
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+    expect(rect.left).toBeGreaterThanOrEqual(0);
+    expect(rect.top).toBeGreaterThanOrEqual(0);
+    expect(rect.left + rect.width).toBeLessThanOrEqual(target.width);
+    expect(rect.top + rect.height).toBeLessThanOrEqual(target.height);
+  });
+
+  it('extracts an unclamped crop when clamp = false', () => {
+    const rect = getStraightenExtractRectangle(
+      { x: -500, y: -500, width: 500, height: 400 },
+      { width: 1000, height: 800 },
+      10,
+      [],
+      false,
+    );
+
+    expect(rect.left).toBeLessThan(0);
+    expect(rect.top).toBeLessThan(0);
+  });
+
+  it('preserves an off-center crop by moving the extract center', () => {
+    const centered = getStraightenExtractRectangle(
+      { x: 250, y: 200, width: 500, height: 400 },
+      { width: 1000, height: 800 },
+      10,
+    );
+    const moved = getStraightenExtractRectangle(
+      { x: 100, y: 200, width: 500, height: 400 },
+      { width: 1000, height: 800 },
+      10,
+    );
+
+    expect(moved.left).toBeLessThan(centered.left);
+  });
+
+  it('does not rotate straightened crop-center movement a second time', () => {
+    const upper = getStraightenExtractRectangle(
+      { x: 100, y: 40, width: 800, height: 500 },
+      { width: 1000, height: 800 },
+      10,
+    );
+    const lower = getStraightenExtractRectangle(
+      { x: 100, y: 200, width: 800, height: 500 },
+      { width: 1000, height: 800 },
+      10,
+    );
+
+    expect(lower.left).toBe(upper.left);
+    expect(lower.top).toBeGreaterThan(upper.top);
+  });
+
+  it('swaps crop dimensions for quarter-turn straighten edits', () => {
+    const rect = getStraightenExtractRectangle(
+      { x: 250, y: 200, width: 500, height: 300 },
+      { width: 1000, height: 800 },
+      100,
+    );
+
+    expect(rect.width).toBeLessThan(rect.height);
+  });
+
+  it('maps mirrored straighten crop coordinates after the mirror transform', () => {
+    const unmirrored = getStraightenExtractRectangle(
+      { x: 100, y: 200, width: 300, height: 300 },
+      { width: 1000, height: 800 },
+      10,
+    );
+    const mirrored = getStraightenExtractRectangle(
+      { x: 100, y: 200, width: 300, height: 300 },
+      { width: 1000, height: 800 },
+      10,
+      [{ action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } }],
+    );
+
+    expect(mirrored.left).not.toBe(unmirrored.left);
+    expect(mirrored.top).toBe(unmirrored.top);
+  });
+
+  it('keeps mirrored straighten crop-center movement in crop space', () => {
+    const imageSize = { width: 1000, height: 800 };
+
+    const horizontal = getStraightenExtractRectangle({ x: 100, y: 240, width: 300, height: 300 }, imageSize, 10, [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+    ]);
+    const horizontalMoved = getStraightenExtractRectangle({ x: 200, y: 240, width: 300, height: 300 }, imageSize, 10, [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+    ]);
+
+    expect(horizontalMoved.left).toBeLessThan(horizontal.left);
+    expect(horizontalMoved.top).toBe(horizontal.top);
+
+    const vertical = getStraightenExtractRectangle({ x: 200, y: 140, width: 300, height: 300 }, imageSize, 10, [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } },
+    ]);
+    const verticalMoved = getStraightenExtractRectangle({ x: 200, y: 240, width: 300, height: 300 }, imageSize, 10, [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } },
+    ]);
+
+    expect(verticalMoved.left).toBe(vertical.left);
+    expect(verticalMoved.top).toBeLessThan(vertical.top);
+  });
+
+  it('uses mirrored quarter-turn direction for crop movement after a single mirror', () => {
+    const imageSize = { width: 1000, height: 800 };
+    const mirror: AssetEditActionItem[] = [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } },
+    ];
+
+    const upper = getStraightenExtractRectangle({ x: 350, y: 100, width: 300, height: 300 }, imageSize, 240, mirror);
+    const lower = getStraightenExtractRectangle({ x: 350, y: 300, width: 300, height: 300 }, imageSize, 240, mirror);
+
+    expect(lower.left).toBeLessThan(upper.left);
+    expect(lower.top).toBe(upper.top);
+  });
+
+  it('maps mirrored straighten crop coordinates across quarter-turn rotation', () => {
+    const mirrored = getStraightenExtractRectangle(
+      { x: 600, y: 200, width: 300, height: 300 },
+      { width: 1000, height: 800 },
+      100,
+      [{ action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } }],
+    );
+    const target = getRotatedCanvasDimensions({ width: 1000, height: 800 }, 100);
+
+    expect(mirrored.left).toBeGreaterThanOrEqual(0);
+    expect(mirrored.top).toBeGreaterThanOrEqual(0);
+    expect(mirrored.left + mirrored.width).toBeLessThanOrEqual(target.width);
+    expect(mirrored.top + mirrored.height).toBeLessThanOrEqual(target.height);
+  });
+
+  it('maps both mirrored axes with quarter-turn straighten rotation', () => {
+    const imageSize = { width: 1000, height: 800 };
+    const bothMirrors: AssetEditActionItem[] = [
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } },
+      { action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } },
+    ];
+
+    const rect = getStraightenExtractRectangle(
+      { x: 350, y: 220, width: 360, height: 280 },
+      imageSize,
+      100,
+      bothMirrors,
+    );
+    const target = getRotatedCanvasDimensions(imageSize, 100);
+
+    expect(rect).toEqual({ left: 331, top: 387, width: 233, height: 300 });
+    expect(rect.left + rect.width).toBeLessThanOrEqual(target.width);
+    expect(rect.top + rect.height).toBeLessThanOrEqual(target.height);
+  });
+});
 
 describe('boundingBoxOverlap', () => {
   it('should return 1 for identical boxes', () => {

--- a/server/src/utils/editor.ts
+++ b/server/src/utils/editor.ts
@@ -1,4 +1,5 @@
 import { AssetFace } from 'src/database';
+import { AssetEditActionItem, CropParameters, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
 import { ImageDimensions } from 'src/types';
 
@@ -7,6 +8,110 @@ type BoundingBox = {
   y1: number;
   x2: number;
   y2: number;
+};
+
+export type ExtractRectangle = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export const splitRotation = (angle: number) => {
+  let straightenAngle = angle % 90;
+  if (straightenAngle > 45) {
+    straightenAngle -= 90;
+  }
+  if (straightenAngle < -45) {
+    straightenAngle += 90;
+  }
+  if (Math.abs(straightenAngle) < 1e-10) {
+    straightenAngle = 0;
+  }
+
+  const quarterTurn = (((Math.round((angle - straightenAngle) / 90) * 90) % 360) + 360) % 360;
+  return { quarterTurn, straightenAngle };
+};
+
+export const getEffectiveStraightenRotation = (angle: number, edits: AssetEditActionItem[] = []) => {
+  const { quarterTurn, straightenAngle } = splitRotation(angle);
+  const mirrorCount = edits.filter((edit) => edit.action === 'mirror').length;
+  return quarterTurn + (mirrorCount % 2 === 1 ? -straightenAngle : straightenAngle);
+};
+
+export const getStraightenScale = ({ width, height }: ImageDimensions, straightenAngle: number) => {
+  if (straightenAngle === 0 || !Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return 1;
+  }
+
+  const radians = (Math.abs(straightenAngle) * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const newWidthRatio = (width * cos + height * sin) / width;
+  const newHeightRatio = (width * sin + height * cos) / height;
+  return Math.max(newWidthRatio, newHeightRatio, 1);
+};
+
+export const getRotatedCanvasDimensions = ({ width, height }: ImageDimensions, angle: number): ImageDimensions => {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.abs(Math.cos(radians));
+  const sin = Math.abs(Math.sin(radians));
+
+  return {
+    width: Math.round(width * cos + height * sin),
+    height: Math.round(width * sin + height * cos),
+  };
+};
+
+export const getStraightenExtractRectangle = (
+  crop: CropParameters,
+  imageSize: ImageDimensions,
+  angle: number,
+  edits: AssetEditActionItem[] = [],
+  clamp = true,
+): ExtractRectangle => {
+  const { quarterTurn, straightenAngle } = splitRotation(angle);
+  const mirrorEdits = edits.filter((edit) => edit.action === 'mirror');
+  const effectiveAngle = getEffectiveStraightenRotation(angle, edits);
+  const target = getRotatedCanvasDimensions(imageSize, effectiveAngle);
+  const straightenScale = getStraightenScale(imageSize, straightenAngle);
+  const centerRotation = mirrorEdits.length % 2 === 1 ? (360 - quarterTurn) % 360 : quarterTurn;
+  const centerRotationRadians = (centerRotation * Math.PI) / 180;
+  const centerRotationCos = Math.cos(centerRotationRadians);
+  const centerRotationSin = Math.sin(centerRotationRadians);
+
+  const cropWidth = crop.width / straightenScale;
+  const cropHeight = crop.height / straightenScale;
+  const finalWidth = quarterTurn === 90 || quarterTurn === 270 ? cropHeight : cropWidth;
+  const finalHeight = quarterTurn === 90 || quarterTurn === 270 ? cropWidth : cropHeight;
+
+  const centerX = imageSize.width / 2;
+  const centerY = imageSize.height / 2;
+  const cropCenterX = crop.x + crop.width / 2;
+  const cropCenterY = crop.y + crop.height / 2;
+  const dx = (cropCenterX - centerX) / straightenScale;
+  const dy = (cropCenterY - centerY) / straightenScale;
+
+  let left = target.width / 2 + (dx * centerRotationCos - dy * centerRotationSin) - finalWidth / 2;
+  let top = target.height / 2 + (dx * centerRotationSin + dy * centerRotationCos) - finalHeight / 2;
+
+  for (const edit of mirrorEdits) {
+    if (edit.parameters.axis === MirrorAxis.Horizontal) {
+      left = target.width - left - finalWidth;
+    } else if (edit.parameters.axis === MirrorAxis.Vertical) {
+      top = target.height - top - finalHeight;
+    }
+  }
+
+  const width = clamp ? Math.max(1, Math.min(Math.round(finalWidth), target.width)) : finalWidth;
+  const height = clamp ? Math.max(1, Math.min(Math.round(finalHeight), target.height)) : finalHeight;
+
+  return {
+    left: clamp ? Math.max(0, Math.min(Math.round(left), target.width - width)) : left,
+    top: clamp ? Math.max(0, Math.min(Math.round(top), target.height - height)) : top,
+    width,
+    height,
+  };
 };
 
 export const boundingBoxOverlap = (boxA: BoundingBox, boxB: BoundingBox) => {

--- a/server/src/utils/transform.spec.ts
+++ b/server/src/utils/transform.spec.ts
@@ -1,7 +1,32 @@
 import { AssetEditAction, AssetEditActionItem, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
-import { transformFaceBoundingBox, transformOcrBoundingBox } from 'src/utils/transform';
+import { getOutputDimensions, transformFaceBoundingBox, transformOcrBoundingBox } from 'src/utils/transform';
 import { describe, expect, it } from 'vitest';
+
+describe('getOutputDimensions', () => {
+  it('swaps crop dimensions for a quarter-turn crop without applying straighten scale', () => {
+    const edits: AssetEditActionItem[] = [
+      { action: AssetEditAction.Crop, parameters: { x: 200, y: 250, width: 600, height: 450 } },
+      { action: AssetEditAction.Rotate, parameters: { angle: 90 } },
+    ];
+
+    const dimensions = getOutputDimensions(edits, { width: 1000, height: 800 });
+
+    expect(dimensions).toEqual({ width: 450, height: 600 });
+  });
+
+  it('should swap crop dimensions for a quarter-turn straighten edit', () => {
+    const edits: AssetEditActionItem[] = [
+      { action: AssetEditAction.Crop, parameters: { x: 200, y: 250, width: 600, height: 450 } },
+      { action: AssetEditAction.Rotate, parameters: { angle: 100 } },
+    ];
+
+    const dimensions = getOutputDimensions(edits, { width: 1000, height: 800 });
+
+    expect(dimensions.width).toBeLessThan(dimensions.height);
+    expect(dimensions.width / dimensions.height).toBeCloseTo(450 / 600, 1);
+  });
+});
 
 describe('transformFaceBoundingBox', () => {
   const baseFace = {
@@ -269,6 +294,20 @@ describe('transformOcrBoundingBox', () => {
 
       expect(result.id).toBe(baseOcr.id);
       expect(result.text).toBe(baseOcr.text);
+      expect(result.x1).toBeCloseTo(0.1, 5);
+      expect(result.y1).toBeCloseTo(0.8, 5);
+      expect(result.x2).toBeCloseTo(0.2, 5);
+      expect(result.y2).toBeCloseTo(0.8, 5);
+      expect(result.x3).toBeCloseTo(0.2, 5);
+      expect(result.y3).toBeCloseTo(0.9, 5);
+      expect(result.x4).toBeCloseTo(0.1, 5);
+      expect(result.y4).toBeCloseTo(0.9, 5);
+    });
+
+    it('should rotate -90 degrees as a 270 degree turn and reorder points', () => {
+      const edits: AssetEditActionItem[] = [{ action: AssetEditAction.Rotate, parameters: { angle: -90 } }];
+      const result = transformOcrBoundingBox(baseOcr, edits, baseDimensions);
+
       expect(result.x1).toBeCloseTo(0.1, 5);
       expect(result.y1).toBeCloseTo(0.8, 5);
       expect(result.x2).toBeCloseTo(0.2, 5);

--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -1,6 +1,7 @@
 import { AssetEditAction, AssetEditActionItem } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
 import { ImageDimensions } from 'src/types';
+import { getStraightenScale, splitRotation } from 'src/utils/editor';
 import { applyToPoint, compose, flipX, flipY, identity, Matrix, rotate, scale, translate } from 'transformation-matrix';
 
 export const getOutputDimensions = (
@@ -18,7 +19,15 @@ export const getOutputDimensions = (
   for (const edit of edits) {
     if (edit.action === AssetEditAction.Rotate) {
       const angleDegrees = edit.parameters.angle;
-      if (angleDegrees === 90 || angleDegrees === 270) {
+      const { quarterTurn, straightenAngle } = splitRotation(angleDegrees);
+
+      if (straightenAngle !== 0 && crop) {
+        const straightenScale = getStraightenScale(startingDimensions, straightenAngle);
+        width = Math.round(crop.parameters.width / straightenScale);
+        height = Math.round(crop.parameters.height / straightenScale);
+      }
+
+      if (quarterTurn === 90 || quarterTurn === 270) {
         [width, height] = [height, width];
       }
     }
@@ -103,9 +112,10 @@ export const transformPoints = (
     let matrix: Matrix = identity();
     if (edit.action === 'rotate') {
       const angleDegrees = edit.parameters.angle;
+      const { quarterTurn } = splitRotation(angleDegrees);
       const angleRadians = (angleDegrees * Math.PI) / 180;
-      const newWidth = angleDegrees === 90 || angleDegrees === 270 ? currentHeight : currentWidth;
-      const newHeight = angleDegrees === 90 || angleDegrees === 270 ? currentWidth : currentHeight;
+      const newWidth = quarterTurn === 90 || quarterTurn === 270 ? currentHeight : currentWidth;
+      const newHeight = quarterTurn === 90 || quarterTurn === 270 ? currentWidth : currentHeight;
 
       matrix = compose(
         translate(newWidth / 2, newHeight / 2),
@@ -225,8 +235,9 @@ export const transformOcrBoundingBox = (
   const { points: transformedPoints, currentWidth, currentHeight } = transformPoints(points, edits, imageDimensions);
 
   // Reorder points to maintain semantic ordering (topLeft, topRight, bottomRight, bottomLeft)
-  const netRotation = edits.find((e) => e.action == AssetEditAction.Rotate)?.parameters.angle ?? 0 % 360;
-  const reorderedPoints = reorderQuadPointsForRotation(transformedPoints, netRotation);
+  const netRotation = edits.find((e) => e.action === AssetEditAction.Rotate)?.parameters.angle ?? 0;
+  const { quarterTurn } = splitRotation(netRotation);
+  const reorderedPoints = reorderQuadPointsForRotation(transformedPoints, quarterTurn);
 
   const [p1, p2, p3, p4] = reorderedPoints;
   return {

--- a/web/src/lib/components/asset-viewer/editor/transform-tool/CropArea.svelte
+++ b/web/src/lib/components/asset-viewer/editor/transform-tool/CropArea.svelte
@@ -26,11 +26,20 @@
   let imageTransform = $derived.by(() => {
     const transforms: string[] = [];
 
+    // Translate image only while straightening, normal crop/rotate/flip moves the grid.
+    if (transformManager.straightenAngle !== 0 && (transformManager.offsetX !== 0 || transformManager.offsetY !== 0)) {
+      transforms.push(`translate(${transformManager.offsetX}px, ${transformManager.offsetY}px)`);
+    }
+
     if (transformManager.mirrorHorizontal) {
       transforms.push('scaleX(-1)');
     }
     if (transformManager.mirrorVertical) {
       transforms.push('scaleY(-1)');
+    }
+
+    if (transformManager.straightenAngle !== 0) {
+      transforms.push(`rotate(${transformManager.straightenAngle}deg)`, `scale(${transformManager.straightenScale})`);
     }
 
     return transforms.join(' ');
@@ -62,27 +71,33 @@
 
 <div class="flex size-full flex-col items-center justify-center p-8" bind:this={canvasContainer}>
   <div
-    class="crop-area max-h-full max-w-full transition-transform motion-reduce:transition-none"
+    class={[
+      'crop-area max-h-full max-w-full',
+      !transformManager.isInteracting && 'transition-transform motion-reduce:transition-none',
+    ]}
     class:rotated={transformManager.normalizedRotation % 180 > 0}
     style:rotate={transformManager.imageRotation + 'deg'}
     bind:this={transformManager.cropAreaEl}
     aria-label="Crop area"
   >
     <img
+      bind:this={transformManager.imgElement}
       draggable="false"
       src={imageSrc}
       alt={$getAltText(toTimelineAsset(asset))}
-      class="h-full transition-transform select-none motion-reduce:transition-none"
+      class={[
+        'h-full select-none',
+        !transformManager.isInteracting && 'transition-transform motion-reduce:transition-none',
+      ]}
       style:transform={imageTransform}
     />
     <div
-      class={[
-        'overlay pointer-events-none absolute top-0 size-full transition-colors motion-reduce:transition-none',
-        transformManager.isInteracting ? 'bg-black/30' : 'bg-black/56',
-      ]}
-      bind:this={transformManager.overlayEl}
-    ></div>
-    <div class="crop-frame absolute border-2 border-white" bind:this={transformManager.cropFrame}>
+      class="crop-frame absolute border-2 border-white"
+      style:box-shadow={transformManager.isInteracting
+        ? '0 0 0 9999px rgba(0, 0, 0, 0.3)'
+        : '0 0 0 9999px rgba(0, 0, 0, 0.56)'}
+      bind:this={transformManager.cropFrame}
+    >
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class={[
@@ -119,6 +134,10 @@
 </div>
 
 <style>
+  .crop-area {
+    position: relative;
+  }
+
   .crop-frame.transition {
     transition: all 0.15s ease;
   }

--- a/web/src/lib/components/asset-viewer/editor/transform-tool/TransformTool.svelte
+++ b/web/src/lib/components/asset-viewer/editor/transform-tool/TransformTool.svelte
@@ -3,6 +3,8 @@
   import { transformManager } from '$lib/managers/edit/transform-manager.svelte';
   import { Button, HStack, IconButton } from '@immich/ui';
   import { mdiFlipHorizontal, mdiFlipVertical, mdiRotateLeft, mdiRotateRight } from '@mdi/js';
+  import { clamp } from 'lodash-es';
+  import { tick } from 'svelte';
   import { t } from 'svelte-i18n';
 
   interface AspectRatioOption {
@@ -28,9 +30,14 @@
   ];
 
   let isRotated = $derived(transformManager.normalizedRotation % 180 !== 0);
+  let isLeftHanded = $derived(transformManager.mirrorHorizontal !== transformManager.mirrorVertical);
+  let visualAngle = $derived(isLeftHanded ? -transformManager.straightenAngle : transformManager.straightenAngle);
+  let isEditingStraightenAngle = $state(false);
+  let straightenAngleInput = $state('');
+  let straightenAngleInputElement = $state<HTMLInputElement>();
 
   function rotatedRatio(ratio: AspectRatioOption): string {
-    if (ratio.value === 'free') {
+    if (ratio.value === 'free' || ratio.value === 'original') {
       return ratio.value;
     }
 
@@ -66,6 +73,31 @@
 
   function mirrorImage(axis: 'horizontal' | 'vertical') {
     transformManager.mirror(axis);
+  }
+
+  async function editStraightenAngle() {
+    straightenAngleInput = visualAngle.toFixed(1);
+    isEditingStraightenAngle = true;
+    await tick();
+    straightenAngleInputElement?.focus();
+    straightenAngleInputElement?.select();
+  }
+
+  function applyStraightenAngleInput() {
+    const angle = Number(straightenAngleInput);
+
+    isEditingStraightenAngle = false;
+
+    if (!Number.isFinite(angle)) {
+      return;
+    }
+
+    const clampedAngle = clamp(angle, -45, 45);
+    transformManager.setStraightenAngle(isLeftHanded ? -clampedAngle : clampedAngle);
+  }
+
+  function cancelStraightenAngleInput() {
+    isEditingStraightenAngle = false;
   }
 </script>
 
@@ -110,6 +142,100 @@
       onclick={() => mirrorImage('vertical')}
     />
   </HStack>
+
+  <div class="mt-6 flex h-10 w-full items-center justify-between text-sm">
+    <h2>{$t('editor_straighten')}</h2>
+    {#if transformManager.straightenAngle !== 0}
+      <button
+        onclick={() => transformManager.setStraightenAngle(0)}
+        class="text-xs text-primary hover:underline"
+        type="button"
+      >
+        {$t('editor_straighten_reset')}
+      </button>
+    {/if}
+  </div>
+  <div class="mb-4 flex flex-col items-center px-2">
+    <div class="mb-2 flex justify-center text-sm font-semibold text-primary">
+      {#if isEditingStraightenAngle}
+        <div class="relative">
+          <input
+            bind:this={straightenAngleInputElement}
+            bind:value={straightenAngleInput}
+            type="number"
+            min="-45"
+            max="45"
+            step="0.1"
+            aria-label={$t('editor_straighten')}
+            class="w-16 rounded-sm border border-primary bg-transparent px-1 py-0 text-center text-sm font-semibold text-primary outline-none"
+            onblur={applyStraightenAngleInput}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                applyStraightenAngleInput();
+              }
+
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelStraightenAngleInput();
+              }
+            }}
+          />
+          <span class="absolute top-0 left-full">°</span>
+        </div>
+      {:else}
+        <button
+          class="relative cursor-text"
+          type="button"
+          onclick={editStraightenAngle}
+          aria-label={$t('editor_straighten')}
+        >
+          {visualAngle > 0 ? '+' : ''}{visualAngle.toFixed(1)}<span class="absolute top-0 left-full">°</span>
+        </button>
+      {/if}
+    </div>
+    <div class="relative flex w-full items-center">
+      <div class="pointer-events-none absolute top-1/2 left-1/2 h-4 w-0.5 -translate-1/2 bg-white/20"></div>
+
+      <input
+        type="range"
+        min="-45"
+        max="45"
+        step="0.5"
+        value={visualAngle}
+        oninput={(e) => {
+          transformManager.isInteracting = true;
+          const val = Number((e.target as HTMLInputElement).value);
+          transformManager.setStraightenAngle(isLeftHanded ? -val : val);
+        }}
+        onchange={() => {
+          transformManager.isInteracting = false;
+        }}
+        onmousedown={() => {
+          transformManager.isInteracting = true;
+        }}
+        onmouseup={() => {
+          transformManager.isInteracting = false;
+        }}
+        ontouchstart={() => {
+          transformManager.isInteracting = true;
+        }}
+        ontouchend={() => {
+          transformManager.isInteracting = false;
+        }}
+        class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-700 accent-primary focus:outline-none"
+      />
+    </div>
+    <div class="mt-1 grid w-full grid-cols-3 text-[10px] text-gray-400">
+      <span class="text-left">-45°</span>
+      <span class="text-center">
+        <span class="relative inline-block">
+          0<span class="absolute top-0 left-full">°</span>
+        </span>
+      </span>
+      <span class="text-right">+45°</span>
+    </div>
+  </div>
 
   <div class="mt-6 flex h-10 w-full items-center justify-between text-sm">
     <h2>{$t('crop')}</h2>

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -4,8 +4,9 @@ import { tick } from 'svelte';
 import { type EditActions, type EditToolManager } from '$lib/managers/edit/edit-manager.svelte';
 import { getAssetMediaUrl } from '$lib/utils';
 import { getDimensions } from '$lib/utils/asset-utils';
-import { normalizeTransformEdits } from '$lib/utils/editor';
+import { normalizeTransformEdits, splitRotation } from '$lib/utils/editor';
 import { handleError } from '$lib/utils/handle-error';
+import { calculateLargestInscribedRect, calculateStraightenScale } from '$lib/utils/straighten';
 
 export type CropAspectRatio =
   | '1:1'
@@ -38,6 +39,9 @@ type RegionConvertParams = {
   to: ImageDimensions;
 };
 
+const CROP_INTERSECTION_STEPS = 8;
+const CROP_RESIZE_INTERSECTION_STEPS = 16;
+
 export enum ResizeBoundary {
   None = 'none',
   TopLeft = 'top-left',
@@ -51,6 +55,9 @@ export enum ResizeBoundary {
 }
 
 class TransformManager implements EditToolManager {
+  private handleWindowMouseMove = (event: MouseEvent) => this.handleMouseMove(event);
+  private loadToken = 0;
+
   canReset: boolean = $derived.by(() => this.checkEdits());
   hasChanges: boolean = $state(false);
 
@@ -58,14 +65,28 @@ class TransformManager implements EditToolManager {
   isDragging = $state(false);
   animationFrame = $state<ReturnType<typeof requestAnimationFrame> | null>(null);
   dragAnchor = $state({ x: 0, y: 0 });
+  dragStartRegion = $state({ x: 0, y: 0, width: 0, height: 0 });
+  offsetX = $derived.by(() => {
+    const W = this.previewImageSize.width;
+    const cx = W / 2;
+    const cropCenterX = this.region.x + this.region.width / 2;
+    return cx - cropCenterX;
+  });
+  offsetY = $derived.by(() => {
+    const H = this.previewImageSize.height;
+    const cy = H / 2;
+    const cropCenterY = this.region.y + this.region.height / 2;
+    return cy - cropCenterY;
+  });
   resizeSide = $state(ResizeBoundary.None);
   imgElement = $state<HTMLImageElement | null>(null);
   cropAreaEl = $state<HTMLElement | null>(null);
-  overlayEl = $state<HTMLElement | null>(null);
   cropFrame = $state<HTMLElement | null>(null);
   cropImageSize = $state<ImageDimensions>({ width: 1000, height: 1000 });
   cropImageScale = $state(1);
   cropAspectRatio = $state('free');
+  // Initial edit import waits for the preview image to load; later resizes reuse the current region.
+  pendingInitialEdits = $state<EditActions | null>(null);
   originalImageSize = $state<ImageDimensions>({ width: 1000, height: 1000 });
   region = $state({ x: 0, y: 0, width: 100, height: 100 });
   previewImageSize = $derived({
@@ -74,6 +95,18 @@ class TransformManager implements EditToolManager {
   });
 
   imageRotation = $state(0);
+  straightenAngle = $state(0);
+  getStraightenScaleFor(): number {
+    if (this.previewImageSize.width === 0 || this.previewImageSize.height === 0) {
+      return 1;
+    }
+
+    return calculateStraightenScale(this.previewImageSize, this.straightenAngle);
+  }
+
+  straightenScale = $derived.by(() => {
+    return this.getStraightenScaleFor();
+  });
   mirrorHorizontal = $state(false);
   mirrorVertical = $state(false);
   normalizedRotation = $derived.by(() => {
@@ -104,7 +137,8 @@ class TransformManager implements EditToolManager {
       Math.abs(this.previewImageSize.height - this.region.height) > 2 ||
       this.mirrorHorizontal ||
       this.mirrorVertical ||
-      this.normalizedRotation !== 0
+      this.normalizedRotation !== 0 ||
+      this.straightenAngle !== 0
     );
   }
 
@@ -118,24 +152,26 @@ class TransformManager implements EditToolManager {
   getEdits(): EditActions {
     const edits: EditActions = [];
 
-    if (this.checkCropEdits()) {
-      // Convert from display coordinates to loaded preview image coordinates
-      let cropRegion = this.getRegionInPreviewCoords(this.region);
+    if (this.checkCropEdits() || this.straightenAngle !== 0) {
+      // Convert from display coordinates to preview image coordinates
+      let cropRegionPreview = this.getRegionInPreviewCoords(this.region);
 
       // Transform crop coordinates to account for mirroring
       // The preview shows the mirrored image, but crop is applied before mirror on the server
       // So we need to "unmirror" the crop coordinates
-      cropRegion = this.applyMirrorToCoords(cropRegion, this.cropImageSize);
+      cropRegionPreview = this.applyMirrorToCoords(cropRegionPreview, this.cropImageSize);
 
       // Convert from preview image coordinates to original image coordinates
-      cropRegion = this.convertRegion({
-        region: cropRegion,
+      let cropRegion = this.convertRegion({
+        region: cropRegionPreview,
         from: this.cropImageSize,
         to: this.originalImageSize,
       });
 
-      // Constrain to original image bounds (fixes possible rounding errors)
-      cropRegion = this.constrainToBounds(cropRegion, this.originalImageSize);
+      if (this.straightenAngle === 0) {
+        // Constrain non-straighten crops to the original image bounds to absorb rounding error.
+        cropRegion = this.constrainToBounds(cropRegion, this.originalImageSize);
+      }
 
       edits.push({
         action: AssetEditAction.Crop,
@@ -163,11 +199,12 @@ class TransformManager implements EditToolManager {
       });
     }
 
-    if (this.normalizedRotation !== 0) {
+    const totalRotation = this.normalizedRotation + this.straightenAngle;
+    if (totalRotation !== 0) {
       edits.push({
         action: AssetEditAction.Rotate,
         parameters: {
-          angle: this.normalizedRotation,
+          angle: totalRotation,
         },
       });
     }
@@ -177,6 +214,7 @@ class TransformManager implements EditToolManager {
 
   async resetAllChanges() {
     this.imageRotation = 0;
+    this.straightenAngle = 0;
     this.mirrorHorizontal = false;
     this.mirrorVertical = false;
     await tick();
@@ -197,20 +235,34 @@ class TransformManager implements EditToolManager {
       size: AssetMediaSize.Preview,
     });
 
-    this.imgElement.src = imageURL;
-    this.imgElement.addEventListener('load', () => transformManager.onImageLoad(edits), { passive: true });
-    this.imgElement.addEventListener('error', (error) => handleError(error, 'ErrorLoadingImage'), {
+    this.pendingInitialEdits = edits;
+    const imgElement = this.imgElement;
+    const loadToken = ++this.loadToken;
+    imgElement.addEventListener(
+      'load',
+      () => {
+        if (this.loadToken === loadToken) {
+          this.onImageLoad(this.pendingInitialEdits);
+        }
+      },
+      { passive: true },
+    );
+    imgElement.addEventListener('error', (error) => handleError(error, 'ErrorLoadingImage'), {
       passive: true,
     });
+    imgElement.src = imageURL;
 
-    globalThis.addEventListener('mousemove', (e: MouseEvent) => transformManager.handleMouseMove(e), { passive: true });
+    globalThis.addEventListener('mousemove', this.handleWindowMouseMove, { passive: true });
 
     const transformEdits = edits.filter((e) => e.action === 'rotate' || e.action === 'mirror');
-
-    // Normalize rotation and mirror edits to single rotation and mirror state
+    // Normalize rotation and mirror edits into a quarter-turn rotation, straighten angle, and mirror state
     // This allows edits to be imported in any order and still produce correct state
     const normalizedTransformation = normalizeTransformEdits(transformEdits);
-    this.imageRotation = normalizedTransformation.rotation;
+    const rawRotation = normalizedTransformation.rotation;
+
+    const { quarterTurn, straightenAngle } = splitRotation(rawRotation);
+    this.imageRotation = quarterTurn;
+    this.straightenAngle = straightenAngle;
     this.mirrorHorizontal = normalizedTransformation.mirrorHorizontal;
     this.mirrorVertical = normalizedTransformation.mirrorVertical;
 
@@ -220,7 +272,7 @@ class TransformManager implements EditToolManager {
   }
 
   onDeactivate() {
-    globalThis.removeEventListener('mousemove', transformManager.handleMouseMove);
+    globalThis.removeEventListener('mousemove', this.handleWindowMouseMove);
 
     this.reset();
   }
@@ -233,8 +285,8 @@ class TransformManager implements EditToolManager {
     this.imgElement = null;
     this.cropAreaEl = null;
     this.isDragging = false;
-    this.overlayEl = null;
     this.imageRotation = 0;
+    this.straightenAngle = 0;
     this.mirrorHorizontal = false;
     this.mirrorVertical = false;
     this.region = { x: 0, y: 0, width: 100, height: 100 };
@@ -242,6 +294,7 @@ class TransformManager implements EditToolManager {
     this.originalImageSize = { width: 1000, height: 1000 };
     this.cropImageScale = 1;
     this.cropAspectRatio = 'free';
+    this.pendingInitialEdits = null;
     this.hasChanges = false;
   }
 
@@ -254,9 +307,23 @@ class TransformManager implements EditToolManager {
 
     if (axis === 'horizontal') {
       this.mirrorHorizontal = !this.mirrorHorizontal;
+      if (this.straightenAngle !== 0) {
+        const W = this.previewImageSize.width;
+        if (W > 0) {
+          this.region.x = W - this.region.x - this.region.width;
+        }
+      }
     } else {
       this.mirrorVertical = !this.mirrorVertical;
+      if (this.straightenAngle !== 0) {
+        const H = this.previewImageSize.height;
+        if (H > 0) {
+          this.region.y = H - this.region.y - this.region.height;
+        }
+      }
     }
+
+    this.draw();
   }
 
   async rotate(angle: number) {
@@ -267,13 +334,71 @@ class TransformManager implements EditToolManager {
     this.onImageLoad();
   }
 
+  ensureCropInsideImageAfterRotation() {
+    if (this.straightenAngle === 0) {
+      const bounds = {
+        width: this.cropImageSize.width * this.cropImageScale,
+        height: this.cropImageSize.height * this.cropImageScale,
+      };
+      this.region = this.constrainToBounds(this.region, bounds);
+      return;
+    }
+
+    const W = this.cropImageSize.width * this.cropImageScale;
+    const H = this.cropImageSize.height * this.cropImageScale;
+
+    const targetX = W / 2 - this.region.width / 2;
+    const targetY = H / 2 - this.region.height / 2;
+
+    const centerRegion = { ...this.region, x: targetX, y: targetY };
+    this.region = this.getIntersectingStep(centerRegion, this.region);
+  }
+
+  setStraightenAngle(angle: number) {
+    this.hasChanges = true;
+    this.straightenAngle = angle;
+
+    this.resizeCanvas();
+
+    const newCrop = this.recalculateCrop(this.cropAspectRatio);
+    if (newCrop) {
+      this.region = newCrop;
+    }
+
+    this.ensureCropInsideImageAfterRotation();
+    this.draw();
+  }
+
   recalculateCrop(aspectRatio: string = this.cropAspectRatio): Region {
     if (!this.cropAreaEl) {
       return this.region;
     }
 
-    const canvasW = this.cropAreaEl.clientWidth;
-    const canvasH = this.cropAreaEl.clientHeight;
+    if (this.straightenAngle !== 0) {
+      const scale = this.straightenScale;
+      const displaySize = {
+        width: this.cropImageSize.width * this.cropImageScale * scale,
+        height: this.cropImageSize.height * this.cropImageScale * scale,
+      };
+
+      let targetRatio = aspectRatio;
+      if (aspectRatio === 'free' || aspectRatio === 'reset') {
+        targetRatio = `${this.region.width}:${this.region.height}`;
+      }
+
+      const inscribed = calculateLargestInscribedRect(displaySize, this.straightenAngle, targetRatio);
+      const W = this.cropImageSize.width * this.cropImageScale;
+      const H = this.cropImageSize.height * this.cropImageScale;
+      return {
+        x: W / 2 - inscribed.width / 2,
+        y: H / 2 - inscribed.height / 2,
+        width: inscribed.width,
+        height: inscribed.height,
+      };
+    }
+
+    const canvasW = this.previewImageSize.width;
+    const canvasH = this.previewImageSize.height;
 
     // Calculate new dimensions with aspect ratio
     const { newWidth: w, newHeight: h } = this.keepAspectRatio(this.region.width, this.region.height, aspectRatio);
@@ -396,34 +521,104 @@ class TransformManager implements EditToolManager {
     return { newWidth: w, newHeight: h };
   }
 
+  getTransformedOverlayPoint(x: number, y: number, W: number, H: number, S: number): { x: number; y: number } {
+    let px = x;
+    let py = y;
+
+    if (this.mirrorHorizontal) {
+      px = W - px;
+    }
+    if (this.mirrorVertical) {
+      py = H - py;
+    }
+
+    if (this.straightenAngle !== 0) {
+      const angle = -this.straightenAngle;
+      const rad = (angle * Math.PI) / 180;
+      const cos = Math.cos(rad);
+      const sin = Math.sin(rad);
+
+      const cx = W / 2;
+      const cy = H / 2;
+
+      const xRel = px - cx;
+      const yRel = py - cy;
+
+      const rx = (xRel * cos - yRel * sin) / S;
+      const ry = (xRel * sin + yRel * cos) / S;
+
+      px = rx + cx;
+      py = ry + cy;
+    }
+
+    return { x: px, y: py };
+  }
+
+  isCropInsideImage(crop: Region): boolean {
+    const width = this.cropImageSize.width * this.cropImageScale;
+    const height = this.cropImageSize.height * this.cropImageScale;
+    const straightenScale = this.getStraightenScaleFor();
+
+    const corners = [
+      { x: crop.x, y: crop.y },
+      { x: crop.x + crop.width, y: crop.y },
+      { x: crop.x + crop.width, y: crop.y + crop.height },
+      { x: crop.x, y: crop.y + crop.height },
+    ];
+
+    for (const corner of corners) {
+      const pLocal = this.getTransformedOverlayPoint(corner.x, corner.y, width, height, straightenScale);
+      if (pLocal.x < 0 || pLocal.x > width || pLocal.y < 0 || pLocal.y > height) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  getIntersectingStep(startRegion: Region, targetRegion: Region, steps = CROP_INTERSECTION_STEPS): Region {
+    let low = 0;
+    let high = 1;
+    for (let i = 0; i < steps; i++) {
+      const mid = (low + high) / 2;
+      const testRegion = {
+        x: startRegion.x + (targetRegion.x - startRegion.x) * mid,
+        y: startRegion.y + (targetRegion.y - startRegion.y) * mid,
+        width: startRegion.width + (targetRegion.width - startRegion.width) * mid,
+        height: startRegion.height + (targetRegion.height - startRegion.height) * mid,
+      };
+      if (this.isCropInsideImage(testRegion)) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+    return {
+      x: startRegion.x + (targetRegion.x - startRegion.x) * low,
+      y: startRegion.y + (targetRegion.y - startRegion.y) * low,
+      width: startRegion.width + (targetRegion.width - startRegion.width) * low,
+      height: startRegion.height + (targetRegion.height - startRegion.height) * low,
+    };
+  }
+
   draw(crop: Region = this.region) {
     if (!this.cropFrame) {
       return;
     }
 
-    this.cropFrame.style.left = `${crop.x}px`;
-    this.cropFrame.style.top = `${crop.y}px`;
+    if (this.straightenAngle === 0) {
+      this.cropFrame.style.left = `${crop.x}px`;
+      this.cropFrame.style.top = `${crop.y}px`;
+    } else {
+      const W = this.cropImageSize.width * this.cropImageScale;
+      const H = this.cropImageSize.height * this.cropImageScale;
+
+      // The crop frame selection viewport stays stationary and visually centered in the crop area
+      this.cropFrame.style.left = `${W / 2 - crop.width / 2}px`;
+      this.cropFrame.style.top = `${H / 2 - crop.height / 2}px`;
+    }
     this.cropFrame.style.width = `${crop.width}px`;
     this.cropFrame.style.height = `${crop.height}px`;
-
-    if (!this.overlayEl) {
-      return;
-    }
-
-    this.overlayEl.style.clipPath = `
-    polygon(
-      0% 0%,
-      0% 100%,
-      100% 100%,
-      100% 0%,
-      0% 0%,
-      ${crop.x}px ${crop.y}px,
-      ${crop.x + crop.width}px ${crop.y}px,
-      ${crop.x + crop.width}px ${crop.y + crop.height}px,
-      ${crop.x}px ${crop.y + crop.height}px,
-      ${crop.x}px ${crop.y}px
-    )
-  `;
   }
 
   onImageLoad(edits: EditActions | null = null) {
@@ -431,17 +626,32 @@ class TransformManager implements EditToolManager {
     if (!this.cropAreaEl || !img) {
       return;
     }
+    if (!img.naturalWidth || !img.naturalHeight) {
+      return;
+    }
 
-    this.cropImageSize = { width: img.width, height: img.height };
+    this.cropImageSize = { width: img.naturalWidth, height: img.naturalHeight };
     const scale = this.calculateScale();
+    const oldScale = this.cropImageScale;
+
+    let nextRegion;
 
     if (edits === null) {
-      const cropFrameEl = this.cropFrame;
-      cropFrameEl?.classList.add('transition');
-      this.region = this.normalizeCropArea(scale);
-      cropFrameEl?.addEventListener('transitionend', () => cropFrameEl?.classList.remove('transition'), {
-        passive: true,
-      });
+      const scaleRatio = scale / oldScale;
+      const scaledRegion = {
+        x: this.region.x * scaleRatio,
+        y: this.region.y * scaleRatio,
+        width: this.region.width * scaleRatio,
+        height: this.region.height * scaleRatio,
+      };
+
+      nextRegion =
+        this.straightenAngle === 0
+          ? this.constrainToBounds(scaledRegion, {
+              width: img.naturalWidth * scale,
+              height: img.naturalHeight * scale,
+            })
+          : scaledRegion;
     } else {
       const cropEdit = edits.find((e) => e.action === AssetEditAction.Crop);
 
@@ -456,36 +666,44 @@ class TransformManager implements EditToolManager {
           to: this.cropImageSize,
         });
 
-        // Transform crop coordinates to account for mirroring
-        // The stored coordinates are for the original image, but we display mirrored
-        // So we need to mirror the crop coordinates to match the preview
         if (this.mirrorHorizontal) {
-          x = img.width - x - width;
+          x = img.naturalWidth - x - width;
         }
         if (this.mirrorVertical) {
-          y = img.height - y - height;
+          y = img.naturalHeight - y - height;
         }
 
-        // Convert from absolute pixel coordinates to display coordinates
-        this.region = {
+        nextRegion = {
           x: x * scale,
           y: y * scale,
           width: width * scale,
           height: height * scale,
         };
       } else {
-        this.region = {
+        nextRegion = {
           x: 0,
           y: 0,
-          width: img.width * scale,
-          height: img.height * scale,
+          width: img.naturalWidth * scale,
+          height: img.naturalHeight * scale,
         };
       }
     }
     this.cropImageScale = scale;
+    this.region = nextRegion;
+    if (edits !== null) {
+      this.pendingInitialEdits = null;
+    }
 
-    img.style.width = `${img.width * scale}px`;
-    img.style.height = `${img.height * scale}px`;
+    img.style.width = `${img.naturalWidth * scale}px`;
+    img.style.height = `${img.naturalHeight * scale}px`;
+
+    if (edits === null) {
+      const cropFrameEl = this.cropFrame;
+      cropFrameEl?.classList.add('transition');
+      cropFrameEl?.addEventListener('transitionend', () => cropFrameEl?.classList.remove('transition'), {
+        passive: true,
+      });
+    }
 
     this.draw();
   }
@@ -498,37 +716,33 @@ class TransformManager implements EditToolManager {
       return 1;
     }
 
-    const containerWidth = cropArea.clientWidth;
-    const containerHeight = cropArea.clientHeight;
+    const container = cropArea.parentElement;
+    if (!container) {
+      return 1;
+    }
+
+    const style = getComputedStyle(container);
+    const paddingX = Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight);
+    const paddingY = Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom);
+
+    const containerWidth = container.clientWidth - paddingX;
+    const containerHeight = container.clientHeight - paddingY;
+
+    const isQuarterTurn = this.normalizedRotation === 90 || this.normalizedRotation === 270;
+    const fitWidth = isQuarterTurn ? img.naturalHeight : img.naturalWidth;
+    const fitHeight = isQuarterTurn ? img.naturalWidth : img.naturalHeight;
 
     // Fit image to container while maintaining aspect ratio
-    let scale = containerWidth / img.width;
-    if (img.height * scale > containerHeight) {
-      scale = containerHeight / img.height;
+    let scale = containerWidth / fitWidth;
+    if (fitHeight * scale > containerHeight) {
+      scale = containerHeight / fitHeight;
+    }
+
+    if (this.straightenAngle !== 0) {
+      scale /= this.straightenScale;
     }
 
     return scale;
-  }
-
-  normalizeCropArea(scale: number) {
-    const img = this.imgElement;
-    if (!img) {
-      return this.region;
-    }
-
-    const scaleRatio = scale / this.cropImageScale;
-    const scaledRegion = {
-      x: this.region.x * scaleRatio,
-      y: this.region.y * scaleRatio,
-      width: this.region.width * scaleRatio,
-      height: this.region.height * scaleRatio,
-    };
-
-    // Constrain to scaled image bounds
-    return this.constrainToBounds(scaledRegion, {
-      width: img.width * scale,
-      height: img.height * scale,
-    });
   }
 
   resizeCanvas() {
@@ -538,13 +752,39 @@ class TransformManager implements EditToolManager {
     if (!cropArea || !img) {
       return;
     }
+    if (!img.naturalWidth || !img.naturalHeight) {
+      return;
+    }
+    if (this.pendingInitialEdits !== null) {
+      this.onImageLoad(this.pendingInitialEdits);
+      return;
+    }
 
     const scale = this.calculateScale();
-    this.region = this.normalizeCropArea(scale);
-    this.cropImageScale = scale;
+    const oldScale = this.cropImageScale;
 
-    img.style.width = `${img.width * scale}px`;
-    img.style.height = `${img.height * scale}px`;
+    const scaleRatio = scale / oldScale;
+    const scaledRegion = {
+      x: this.region.x * scaleRatio,
+      y: this.region.y * scaleRatio,
+      width: this.region.width * scaleRatio,
+      height: this.region.height * scaleRatio,
+    };
+
+    // Constrain to scaled image bounds
+    const nextRegion =
+      this.straightenAngle === 0
+        ? this.constrainToBounds(scaledRegion, {
+            width: img.naturalWidth * scale,
+            height: img.naturalHeight * scale,
+          })
+        : scaledRegion;
+
+    this.cropImageScale = scale;
+    this.region = nextRegion;
+
+    img.style.width = `${img.naturalWidth * scale}px`;
+    img.style.height = `${img.naturalHeight * scale}px`;
 
     this.draw();
   }
@@ -556,14 +796,27 @@ class TransformManager implements EditToolManager {
 
     this.isInteracting = true;
     this.resizeSide = resizeBoundary;
+
+    const { mouseX, mouseY } = this.getMousePosition(e);
+    this.dragStartRegion = {
+      x: this.region.x,
+      y: this.region.y,
+      width: this.region.width,
+      height: this.region.height,
+    };
+
     if (resizeBoundary === ResizeBoundary.None) {
       this.isDragging = true;
-      const { mouseX, mouseY } = this.getMousePosition(e);
-      this.dragAnchor = { x: mouseX - this.region.x, y: mouseY - this.region.y };
+      this.dragAnchor =
+        this.straightenAngle === 0
+          ? { x: mouseX - this.region.x, y: mouseY - this.region.y }
+          : { x: mouseX, y: mouseY };
+    } else {
+      this.dragAnchor = { x: mouseX, y: mouseY };
     }
 
     document.body.style.userSelect = 'none';
-    globalThis.addEventListener('mouseup', () => this.handleMouseUp(), { passive: true });
+    globalThis.addEventListener('mouseup', () => this.handleMouseUp(), { passive: true, once: true });
   }
 
   handleMouseMove(e: MouseEvent) {
@@ -581,7 +834,6 @@ class TransformManager implements EditToolManager {
   }
 
   handleMouseUp() {
-    globalThis.removeEventListener('mouseup', this.handleMouseUp);
     document.body.style.userSelect = '';
 
     this.isInteracting = false;
@@ -631,94 +883,140 @@ class TransformManager implements EditToolManager {
     }
 
     this.hasChanges = true;
-    this.region.x = clamp(mouseX - this.dragAnchor.x, 0, cropArea.clientWidth - this.region.width);
-    this.region.y = clamp(mouseY - this.dragAnchor.y, 0, cropArea.clientHeight - this.region.height);
+
+    if (this.straightenAngle === 0) {
+      this.region.x = clamp(mouseX - this.dragAnchor.x, 0, cropArea.clientWidth - this.region.width);
+      this.region.y = clamp(mouseY - this.dragAnchor.y, 0, cropArea.clientHeight - this.region.height);
+    } else {
+      const deltaX = mouseX - this.dragAnchor.x;
+      const deltaY = mouseY - this.dragAnchor.y;
+      const newX = this.dragStartRegion.x - deltaX;
+      const newY = this.dragStartRegion.y - deltaY;
+      const targetRegion = { ...this.region, x: newX, y: newY };
+      if (this.isCropInsideImage(targetRegion)) {
+        this.region = targetRegion;
+      } else {
+        const horizRegion = { ...this.region, x: newX };
+        this.region = this.getIntersectingStep(this.region, horizRegion);
+
+        const vertRegion = { ...this.region, y: newY };
+        this.region = this.getIntersectingStep(this.region, vertRegion);
+      }
+    }
 
     this.draw();
   }
 
   resizeCrop(mouseX: number, mouseY: number) {
     const canvas = this.cropAreaEl;
-    const currentCrop = this.region;
     if (!canvas) {
       return;
     }
     this.isInteracting = true;
-
     this.hasChanges = true;
-    const { x, y, width, height } = currentCrop;
+
+    const canvasWidth = this.previewImageSize.width;
+    const canvasHeight = this.previewImageSize.height;
+
+    const deltaX = mouseX - this.dragAnchor.x;
+    const deltaY = mouseY - this.dragAnchor.y;
+
+    const startX = this.dragStartRegion.x;
+    const startY = this.dragStartRegion.y;
+    const startW = this.dragStartRegion.width;
+    const startH = this.dragStartRegion.height;
+
     const minSize = 50;
-    let newRegion = { ...currentCrop };
+    let newRegion = { ...this.region };
 
-    let desiredWidth = width;
-    let desiredHeight = height;
+    const maxW = this.straightenAngle === 0 ? canvasWidth : canvasWidth * this.straightenScale;
+    const maxH = this.straightenAngle === 0 ? canvasHeight : canvasHeight * this.straightenScale;
+    const leftLimit = this.straightenAngle === 0 ? Math.min(maxW, startX + startW) : maxW;
+    const rightLimit = this.straightenAngle === 0 ? Math.min(maxW, canvasWidth - startX) : maxW;
+    const topLimit = this.straightenAngle === 0 ? Math.min(maxH, startY + startH) : maxH;
+    const bottomLimit = this.straightenAngle === 0 ? Math.min(maxH, canvasHeight - startY) : maxH;
 
-    // Width
+    let desiredWidth = startW;
+    let desiredHeight = startH;
+
     switch (this.resizeSide) {
       case ResizeBoundary.Left:
       case ResizeBoundary.TopLeft:
       case ResizeBoundary.BottomLeft: {
-        desiredWidth = Math.max(minSize, width + (x - Math.max(mouseX, 0)));
+        desiredWidth = clamp(startW - deltaX, minSize, maxW);
         break;
       }
       case ResizeBoundary.Right:
       case ResizeBoundary.TopRight:
       case ResizeBoundary.BottomRight: {
-        desiredWidth = Math.max(minSize, Math.max(mouseX, 0) - x);
+        desiredWidth = clamp(startW + deltaX, minSize, maxW);
         break;
       }
     }
 
-    // Height
     switch (this.resizeSide) {
       case ResizeBoundary.Top:
       case ResizeBoundary.TopLeft:
       case ResizeBoundary.TopRight: {
-        desiredHeight = Math.max(minSize, height + (y - Math.max(mouseY, 0)));
+        desiredHeight = clamp(startH - deltaY, minSize, maxH);
         break;
       }
       case ResizeBoundary.Bottom:
       case ResizeBoundary.BottomLeft:
       case ResizeBoundary.BottomRight: {
-        desiredHeight = Math.max(minSize, Math.max(mouseY, 0) - y);
+        desiredHeight = clamp(startH + deltaY, minSize, maxH);
         break;
       }
     }
 
-    // Old
     switch (this.resizeSide) {
       case ResizeBoundary.Left: {
-        const { newWidth: w, newHeight: h } = this.keepAspectRatio(desiredWidth, height);
-        const finalWidth = clamp(w, minSize, canvas.clientWidth);
+        const { newWidth: w, newHeight: h } = this.adjustDimensions(
+          desiredWidth,
+          startH,
+          this.cropAspectRatio,
+          leftLimit,
+          maxH,
+          minSize,
+        );
         newRegion = {
-          x: Math.max(0, x + width - finalWidth),
-          y,
-          width: finalWidth,
-          height: clamp(h, minSize, canvas.clientHeight),
+          x: startX + startW - w,
+          y: startY + (startH - h) / 2,
+          width: w,
+          height: h,
         };
         break;
       }
       case ResizeBoundary.Right: {
-        const { newWidth: w, newHeight: h } = this.keepAspectRatio(desiredWidth, height);
+        const { newWidth: w, newHeight: h } = this.adjustDimensions(
+          desiredWidth,
+          startH,
+          this.cropAspectRatio,
+          rightLimit,
+          maxH,
+          minSize,
+        );
         newRegion = {
           ...newRegion,
-          width: clamp(w, minSize, canvas.clientWidth - x),
-          height: clamp(h, minSize, canvas.clientHeight),
+          x: startX,
+          y: startY + (startH - h) / 2,
+          width: w,
+          height: h,
         };
         break;
       }
       case ResizeBoundary.Top: {
         const { newWidth: w, newHeight: h } = this.adjustDimensions(
-          desiredWidth,
+          startW,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth,
-          canvas.clientHeight,
+          maxW,
+          topLimit,
           minSize,
         );
         newRegion = {
-          x,
-          y: Math.max(0, y + height - h),
+          x: startX + (startW - w) / 2,
+          y: startY + startH - h,
           width: w,
           height: h,
         };
@@ -726,15 +1024,16 @@ class TransformManager implements EditToolManager {
       }
       case ResizeBoundary.Bottom: {
         const { newWidth: w, newHeight: h } = this.adjustDimensions(
-          desiredWidth,
+          startW,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth,
-          canvas.clientHeight - y,
+          maxW,
+          bottomLimit,
           minSize,
         );
         newRegion = {
           ...newRegion,
+          x: startX + (startW - w) / 2,
           width: w,
           height: h,
         };
@@ -745,13 +1044,13 @@ class TransformManager implements EditToolManager {
           desiredWidth,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth,
-          canvas.clientHeight,
+          leftLimit,
+          topLimit,
           minSize,
         );
         newRegion = {
-          x: Math.max(0, x + width - w),
-          y: Math.max(0, y + height - h),
+          x: startX + startW - w,
+          y: startY + startH - h,
           width: w,
           height: h,
         };
@@ -762,13 +1061,13 @@ class TransformManager implements EditToolManager {
           desiredWidth,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth - x,
-          y + height,
+          rightLimit,
+          topLimit,
           minSize,
         );
         newRegion = {
-          x,
-          y: Math.max(0, y + height - h),
+          x: startX,
+          y: startY + startH - h,
           width: w,
           height: h,
         };
@@ -779,13 +1078,13 @@ class TransformManager implements EditToolManager {
           desiredWidth,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth,
-          canvas.clientHeight - y,
+          leftLimit,
+          bottomLimit,
           minSize,
         );
         newRegion = {
-          x: Math.max(0, x + width - w),
-          y,
+          x: startX + startW - w,
+          y: startY,
           width: w,
           height: h,
         };
@@ -796,8 +1095,8 @@ class TransformManager implements EditToolManager {
           desiredWidth,
           desiredHeight,
           this.cropAspectRatio,
-          canvas.clientWidth - x,
-          canvas.clientHeight - y,
+          rightLimit,
+          bottomLimit,
           minSize,
         );
         newRegion = {
@@ -810,23 +1109,43 @@ class TransformManager implements EditToolManager {
     }
 
     // Constrain the region to canvas bounds
-    this.region = {
-      ...newRegion,
-      x: Math.max(0, Math.min(newRegion.x, canvas.clientWidth - newRegion.width)),
-      y: Math.max(0, Math.min(newRegion.y, canvas.clientHeight - newRegion.height)),
-    };
+    this.region =
+      this.straightenAngle === 0
+        ? {
+            ...newRegion,
+            x: Math.max(0, Math.min(newRegion.x, canvasWidth - newRegion.width)),
+            y: Math.max(0, Math.min(newRegion.y, canvasHeight - newRegion.height)),
+          }
+        : this.getIntersectingStep(this.dragStartRegion, newRegion, CROP_RESIZE_INTERSECTION_STEPS);
 
     this.draw();
   }
 
   resetCrop() {
     this.cropAspectRatio = 'free';
-    this.region = {
-      x: 0,
-      y: 0,
-      width: this.cropImageSize.width * this.cropImageScale - 1,
-      height: this.cropImageSize.height * this.cropImageScale - 1,
-    };
+    if (this.straightenAngle === 0) {
+      this.region = {
+        x: 0,
+        y: 0,
+        width: this.cropImageSize.width * this.cropImageScale - 1,
+        height: this.cropImageSize.height * this.cropImageScale - 1,
+      };
+    } else {
+      const scale = this.straightenScale;
+      const displaySize = {
+        width: this.cropImageSize.width * this.cropImageScale * scale,
+        height: this.cropImageSize.height * this.cropImageScale * scale,
+      };
+      const inscribed = calculateLargestInscribedRect(displaySize, this.straightenAngle, 'free');
+      const W = this.cropImageSize.width * this.cropImageScale;
+      const H = this.cropImageSize.height * this.cropImageScale;
+      this.region = {
+        x: W / 2 - inscribed.width / 2,
+        y: H / 2 - inscribed.height / 2,
+        width: inscribed.width,
+        height: inscribed.height,
+      };
+    }
   }
 
   rotateAspectRatio() {

--- a/web/src/lib/utils/editor.spec.ts
+++ b/web/src/lib/utils/editor.spec.ts
@@ -1,6 +1,6 @@
 import { AssetEditAction, MirrorAxis } from '@immich/sdk';
 import type { EditActions } from '$lib/managers/edit/edit-manager.svelte';
-import { buildAffineFromEdits, normalizeTransformEdits } from '$lib/utils/editor';
+import { buildAffineFromEdits, normalizeTransformEdits, splitRotation } from '$lib/utils/editor';
 
 type NormalizedParameters = {
   rotation: number;
@@ -90,6 +90,7 @@ describe('edit normalization', () => {
     const result = normalizeTransformEdits(edits);
     const normalizedEdits = normalizedToEdits(result);
 
+    expect(result).toEqual({ rotation: 0, mirrorHorizontal: true, mirrorVertical: false });
     expect(compareEditAffines(normalizedEdits, edits)).toBe(true);
   });
 
@@ -99,6 +100,7 @@ describe('edit normalization', () => {
     const result = normalizeTransformEdits(edits);
     const normalizedEdits = normalizedToEdits(result);
 
+    expect(result).toEqual({ rotation: 0, mirrorHorizontal: false, mirrorVertical: true });
     expect(compareEditAffines(normalizedEdits, edits)).toBe(true);
   });
 
@@ -322,5 +324,22 @@ describe('edit normalization', () => {
     const normalizedEdits = normalizedToEdits(result);
 
     expect(compareEditAffines(normalizedEdits, edits)).toBe(true);
+  });
+});
+
+describe('splitRotation', () => {
+  it('removes floating point residue from quarter-turn rotations', () => {
+    expect(splitRotation(-90.000_000_000_000_01)).toEqual({ quarterTurn: 270, straightenAngle: 0 });
+    expect(splitRotation(90.000_000_000_000_01)).toEqual({ quarterTurn: 90, straightenAngle: 0 });
+  });
+
+  it('keeps real straighten angles', () => {
+    expect(splitRotation(100)).toEqual({ quarterTurn: 90, straightenAngle: 10 });
+    expect(splitRotation(263)).toEqual({ quarterTurn: 270, straightenAngle: -7 });
+  });
+
+  it('keeps exact 45 degree boundaries as straighten angles', () => {
+    expect(splitRotation(45)).toEqual({ quarterTurn: 0, straightenAngle: 45 });
+    expect(splitRotation(-45)).toEqual({ quarterTurn: 0, straightenAngle: -45 });
   });
 });

--- a/web/src/lib/utils/editor.ts
+++ b/web/src/lib/utils/editor.ts
@@ -1,23 +1,103 @@
-import type { MirrorParameters, RotateParameters } from '@immich/sdk';
+import { AssetEditAction, MirrorAxis, type MirrorParameters, type RotateParameters } from '@immich/sdk';
 import { compose, flipX, flipY, identity, rotate } from 'transformation-matrix';
 import type { EditActions } from '$lib/managers/edit/edit-manager.svelte';
 
 const isCloseToZero = (x: number, epsilon: number = 1e-15) => Math.abs(x) < epsilon;
+const isClose = (a: number, b: number, epsilon: number = 1e-10) => Math.abs(a - b) < epsilon;
 
-export const normalizeTransformEdits = (
-  edits: EditActions,
-): {
+type NormalizedTransform = {
   rotation: number;
   mirrorHorizontal: boolean;
   mirrorVertical: boolean;
-} => {
-  const { a, b, c, d } = buildAffineFromEdits(edits);
-  const rotation = ((isCloseToZero(a) ? Math.asin(c) : Math.acos(a)) * 180) / Math.PI;
+};
+
+const normalizeAngle = (angle: number) => (isCloseToZero(angle) ? 0 : angle);
+
+const areAffinesClose = (
+  affineA: ReturnType<typeof buildAffineFromEdits>,
+  affineB: ReturnType<typeof buildAffineFromEdits>,
+): boolean =>
+  isClose(affineA.a, affineB.a) &&
+  isClose(affineA.b, affineB.b) &&
+  isClose(affineA.c, affineB.c) &&
+  isClose(affineA.d, affineB.d);
+
+const candidateToEdits = ({ rotation, mirrorHorizontal, mirrorVertical }: NormalizedTransform): EditActions => {
+  const edits: EditActions = [];
+
+  if (mirrorHorizontal) {
+    edits.push({ action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Horizontal } });
+  }
+
+  if (mirrorVertical) {
+    edits.push({ action: AssetEditAction.Mirror, parameters: { axis: MirrorAxis.Vertical } });
+  }
+
+  if (rotation !== 0) {
+    edits.push({ action: AssetEditAction.Rotate, parameters: { angle: rotation } });
+  }
+
+  return edits;
+};
+
+export const splitRotation = (angle: number) => {
+  let straightenAngle = angle % 90;
+  if (straightenAngle > 45) {
+    straightenAngle -= 90;
+  }
+  if (straightenAngle < -45) {
+    straightenAngle += 90;
+  }
+  if (Math.abs(straightenAngle) < 1e-10) {
+    straightenAngle = 0;
+  }
+
+  const quarterTurn = (((Math.round((angle - straightenAngle) / 90) * 90) % 360) + 360) % 360;
+  return { quarterTurn, straightenAngle };
+};
+
+export const normalizeTransformEdits = (edits: EditActions): NormalizedTransform => {
+  const target = buildAffineFromEdits(edits);
+  const preferredMirrorHorizontal =
+    edits.filter(
+      (edit) =>
+        edit.action === AssetEditAction.Mirror && (edit.parameters as MirrorParameters).axis === MirrorAxis.Horizontal,
+    ).length %
+      2 ===
+    1;
+  const preferredMirrorVertical =
+    edits.filter(
+      (edit) =>
+        edit.action === AssetEditAction.Mirror && (edit.parameters as MirrorParameters).axis === MirrorAxis.Vertical,
+    ).length %
+      2 ===
+    1;
+
+  const mirrorCandidates = [
+    { mirrorHorizontal: preferredMirrorHorizontal, mirrorVertical: preferredMirrorVertical },
+    { mirrorHorizontal: false, mirrorVertical: false },
+    { mirrorHorizontal: true, mirrorVertical: false },
+    { mirrorHorizontal: false, mirrorVertical: true },
+    { mirrorHorizontal: true, mirrorVertical: true },
+  ];
+
+  for (const { mirrorHorizontal, mirrorVertical } of mirrorCandidates) {
+    const rotationRadians = mirrorHorizontal ? Math.atan2(-target.c, -target.a) : Math.atan2(target.c, target.a);
+    const candidate = {
+      rotation: normalizeAngle((rotationRadians * 180) / Math.PI),
+      mirrorHorizontal,
+      mirrorVertical,
+    };
+
+    if (areAffinesClose(buildAffineFromEdits(candidateToEdits(candidate)), target)) {
+      return candidate;
+    }
+  }
 
   return {
-    rotation: rotation < 0 ? 360 + rotation : rotation,
+    rotation: normalizeAngle((Math.atan2(target.c, target.a) * 180) / Math.PI),
     mirrorHorizontal: false,
-    mirrorVertical: isCloseToZero(a) ? b === c : a === -d,
+    mirrorVertical: isCloseToZero(target.a) ? target.b === target.c : target.a === -target.d,
   };
 };
 

--- a/web/src/lib/utils/straighten.spec.ts
+++ b/web/src/lib/utils/straighten.spec.ts
@@ -1,0 +1,70 @@
+import { calculateLargestInscribedRect, calculateStraightenScale } from './straighten';
+
+describe('calculateStraightenScale', () => {
+  it('should return 1 at 0 degrees', () => {
+    expect(calculateStraightenScale({ width: 1000, height: 800 }, 0)).toBe(1);
+  });
+
+  it('should scale a rotated image enough to cover its original bounds', () => {
+    expect(calculateStraightenScale({ width: 1000, height: 800 }, 10)).toBeCloseTo(1.201);
+  });
+
+  it('should return 1 for invalid image dimensions', () => {
+    expect(calculateStraightenScale({ width: 0, height: 800 }, 10)).toBe(1);
+    expect(calculateStraightenScale({ width: 1000, height: Number.NaN }, 10)).toBe(1);
+  });
+});
+
+describe('calculateLargestInscribedRect', () => {
+  const image16_9 = { width: 1920, height: 1080 };
+  const image4_3 = { width: 1440, height: 1080 };
+  const image1_1 = { width: 1000, height: 1000 };
+
+  it('should return the original bounds at 0 degrees for a matching aspect ratio', () => {
+    const result = calculateLargestInscribedRect(image16_9, 0, '16:9');
+    expect(result.width).toBeCloseTo(1920, -1);
+    expect(result.height).toBeCloseTo(1080, -1);
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+  });
+
+  it('should return correct square bounds inside square image at 45 degrees', () => {
+    const result = calculateLargestInscribedRect(image1_1, 45, '1:1');
+    // For a 1000x1000 square rotated by 45 degrees, max square width/height is 1000 / sqrt(2) ≈ 707
+    expect(result.width).toBe(707);
+    expect(result.height).toBe(result.width);
+    // Center alignment check
+    expect(result.x).toBe(Math.floor((1000 - result.width) / 2));
+    expect(result.y).toBe(Math.floor((1000 - result.height) / 2));
+  });
+
+  it('should handle positive and negative angles identically', () => {
+    const resultPositive = calculateLargestInscribedRect(image16_9, 15, '16:9');
+    const resultNegative = calculateLargestInscribedRect(image16_9, -15, '16:9');
+    expect(resultPositive).toEqual(resultNegative);
+  });
+
+  it('should support various aspect ratios (16:9, 4:3, 1:1)', () => {
+    const ratios = ['16:9', '4:3', '1:1', 'free'];
+    for (const ratio of ratios) {
+      const result = calculateLargestInscribedRect(image16_9, 20, ratio);
+      expect(result.width).toBeGreaterThan(0);
+      expect(result.height).toBeGreaterThan(0);
+      expect(result.x + result.width).toBeLessThanOrEqual(1920);
+      expect(result.y + result.height).toBeLessThanOrEqual(1080);
+    }
+  });
+
+  it('should handle edge cases like large angles close to 45 degrees', () => {
+    const result = calculateLargestInscribedRect(image4_3, 44.9, '4:3');
+    expect(result.width).toBeGreaterThan(0);
+    expect(result.height).toBeGreaterThan(0);
+    expect(result.x + result.width).toBeLessThanOrEqual(1440);
+    expect(result.y + result.height).toBeLessThanOrEqual(1080);
+  });
+
+  it('should handle invalid or zero-size images gracefully', () => {
+    const result = calculateLargestInscribedRect({ width: 0, height: 100 }, 15, '16:9');
+    expect(result).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+});

--- a/web/src/lib/utils/straighten.ts
+++ b/web/src/lib/utils/straighten.ts
@@ -1,0 +1,73 @@
+export type Size = {
+  width: number;
+  height: number;
+};
+
+export type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export function calculateStraightenScale(imageSize: Size, angleDegrees: number): number {
+  if (
+    angleDegrees === 0 ||
+    !Number.isFinite(imageSize.width) ||
+    !Number.isFinite(imageSize.height) ||
+    imageSize.width <= 0 ||
+    imageSize.height <= 0
+  ) {
+    return 1;
+  }
+
+  const radians = (Math.abs(angleDegrees) * Math.PI) / 180;
+  const cosA = Math.cos(radians);
+  const sinA = Math.sin(radians);
+  const widthRatio = (imageSize.width * cosA + imageSize.height * sinA) / imageSize.width;
+  const heightRatio = (imageSize.width * sinA + imageSize.height * cosA) / imageSize.height;
+
+  return Math.max(widthRatio, heightRatio, 1);
+}
+
+export function calculateLargestInscribedRect(imageSize: Size, angleDegrees: number, aspectRatioStr: string): Rect {
+  const { width, height } = imageSize;
+
+  if (width <= 0 || height <= 0) {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+
+  const radians = (Math.abs(angleDegrees % 180) * Math.PI) / 180;
+
+  let r: number;
+  if (aspectRatioStr === 'free' || aspectRatioStr === 'reset') {
+    r = width / height;
+  } else {
+    const [wRatio, hRatio] = aspectRatioStr.split(':').map(Number);
+    r = wRatio && hRatio && hRatio > 0 ? wRatio / hRatio : width / height;
+  }
+
+  const cosA = Math.cos(radians);
+  const sinA = Math.sin(radians);
+
+  const hLimit1 = width / (r * cosA + sinA);
+  const hLimit2 = height / (r * sinA + cosA);
+
+  const h = Math.min(hLimit1, hLimit2);
+  const w = h * r;
+
+  const x = (width - w) / 2;
+  const y = (height - h) / 2;
+
+  const roundedWidth = Math.max(1, Math.min(width, Math.floor(w)));
+  const roundedHeight = Math.max(1, Math.min(height, Math.floor(h)));
+  const roundedX = Math.max(0, Math.min(width - roundedWidth, Math.floor(x)));
+  const roundedY = Math.max(0, Math.min(height - roundedHeight, Math.floor(y)));
+
+  return {
+    x: roundedX,
+    y: roundedY,
+    width: roundedWidth,
+    height: roundedHeight,
+  };
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a Straighten tool to the image editor, letting users rotate an image by an arbitrary angle (not just 90° steps) to level horizons and correct tilt.

  Web
  - New straighten control (slider + "Reset angle") in TransformTool.svelte.
  - New web/src/lib/utils/straighten.ts with calculateStraightenScale (how much to scale the canvas so the rotated image still fills the frame) and calculateLargestInscribedRect (largest crop rectangle that stays inside the rotated image for a given aspect ratio).

  Server
  - New helpers in server/src/utils/editor.ts: splitRotation (decomposes an arbitrary angle into a quarter-turn + a residual straighten angle), getStraightenScale, getRotatedCanvasDimensions, getEffectiveStraightenRotation, and getStraightenExtractRectangle. 
  - OCR bounding-box transforms (transform.ts) account for the straighten rotation.

  DTO / validation
  - RotateParameters.angle is now a continuous number constrained to [-360, 360] (previously restricted to the enum 0 | 90 | 180 | 270).
  - CropParameters.x / .y may now be negative (intermediate straightened crops before bounds clamping). 

Fixes #27060

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

  - [x] Web unit tests all passing, including new straighten.spec.ts and editor.spec.ts coverage.
  - [x] Server unit tests for editor.ts, media.repository.ts, asset.service.ts, transform.ts, editing.dto.
  - [x] Manual: straighten an image in the editor, confirm preview + saved output match and crop stays within bounds.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
https://www.youtube.com/watch?v=i0ZOKabpJGg

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
An LLM was used to summarize the code changes for this PR description, to double-check code quality (verifying naming conventions and architectural fit with the project's patterns) and to assist in generating tests that verify the desired behavior.