### PR TITLE
fix(mobile): refresh memories on resume and day change

### DIFF
--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/permission.provider.dart';
@@ -69,6 +70,8 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     }
     _wasPaused = false;
 
+    _ref.invalidate(driftMemoryFutureProvider);
+
     final isAuthenticated = _ref.read(authProvider).isAuthenticated;
 
     // Needs to be logged in
@@ -82,6 +85,7 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
 
     _ref.read(websocketProvider.notifier).connect();
     await _handleBetaTimelineResume();
+    _ref.invalidate(driftMemoryFutureProvider);
 
     await _ref.read(notificationPermissionProvider.notifier).getNotificationPermission();
 

--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -70,8 +70,6 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     }
     _wasPaused = false;
 
-    _ref.invalidate(driftMemoryFutureProvider);
-
     final isAuthenticated = _ref.read(authProvider).isAuthenticated;
 
     // Needs to be logged in
@@ -85,7 +83,6 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
 
     _ref.read(websocketProvider.notifier).connect();
     await _handleBetaTimelineResume();
-    _ref.invalidate(driftMemoryFutureProvider);
 
     await _ref.read(notificationPermissionProvider.notifier).getNotificationPermission();
 
@@ -119,6 +116,7 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
         _safeRun(backgroundManager.syncLocal(full: CurrentPlatform.isAndroid ? true : false), "syncLocal"),
         _safeRun(backgroundManager.syncRemote().then((success) => syncSuccess = success), "syncRemote"),
       ]);
+      _ref.invalidate(driftMemoryFutureProvider);
       if (syncSuccess) {
         await Future.wait([
           _safeRun(backgroundManager.hashAssets(), "hashAssets").then((_) {

--- a/mobile/lib/providers/infrastructure/memory.provider.dart
+++ b/mobile/lib/providers/infrastructure/memory.provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/services/memory.service.dart';
@@ -18,6 +20,11 @@ final driftMemoryFutureProvider = FutureProvider.autoDispose<List<DriftMemory>>(
   if (userId == null || !enabled) {
     return const [];
   }
+
+  final now = DateTime.now();
+  final nextMidnight = DateTime(now.year, now.month, now.day + 1);
+  final timer = Timer(nextMidnight.difference(now) + const Duration(seconds: 5), ref.invalidateSelf);
+  ref.onDispose(timer.cancel);
 
   final service = ref.watch(driftMemoryServiceProvider);
   return service.getMemoryLane(userId);

--- a/mobile/test/providers/infrastructure/memory_provider_test.dart
+++ b/mobile/test/providers/infrastructure/memory_provider_test.dart
@@ -1,0 +1,96 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/memory.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockDriftMemoryService extends Mock implements DriftMemoryService {}
+
+class MockUserService extends Mock implements UserService {}
+
+void main() {
+  late MockDriftMemoryService memoryService;
+  late MockUserService userService;
+
+  UserDto user({bool memoryEnabled = true}) => UserDto(
+    id: 'user-1',
+    email: 'user@test.dev',
+    name: 'user',
+    memoryEnabled: memoryEnabled,
+    profileChangedAt: DateTime(2026),
+  );
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        driftMemoryServiceProvider.overrideWithValue(memoryService),
+        currentUserProvider.overrideWith((ref) => CurrentUserProvider(userService)),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  setUp(() {
+    memoryService = MockDriftMemoryService();
+    userService = MockUserService();
+
+    when(() => memoryService.getMemoryLane('user-1')).thenAnswer((_) async => []);
+    when(() => userService.tryGetMyUser()).thenReturn(user());
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+  });
+
+  group('driftMemoryFutureProvider', () {
+    test('re-queries after local midnight', () {
+      fakeAsync((async) {
+        final container = makeContainer();
+        container.listen(driftMemoryFutureProvider, (_, __) {});
+        async.flushMicrotasks();
+
+        verify(() => memoryService.getMemoryLane('user-1')).called(1);
+
+        async.elapse(const Duration(seconds: 4));
+        async.flushMicrotasks();
+        verifyNever(() => memoryService.getMemoryLane('user-1'));
+
+        async.elapse(const Duration(hours: 25));
+        async.flushMicrotasks();
+        verify(() => memoryService.getMemoryLane('user-1')).called(greaterThanOrEqualTo(1));
+      });
+    });
+
+    test('cancels the midnight timer when disposed', () {
+      fakeAsync((async) {
+        final container = makeContainer();
+        final subscription = container.listen(driftMemoryFutureProvider, (_, __) {});
+        async.flushMicrotasks();
+        verify(() => memoryService.getMemoryLane('user-1')).called(1);
+
+        subscription.close();
+        async.elapse(const Duration(hours: 25));
+        async.flushMicrotasks();
+
+        verifyNever(() => memoryService.getMemoryLane('user-1'));
+      });
+    });
+
+    test('does not query or arm the timer when memories are disabled', () {
+      when(() => userService.tryGetMyUser()).thenReturn(user(memoryEnabled: false));
+
+      fakeAsync((async) {
+        final container = makeContainer();
+        container.listen(driftMemoryFutureProvider, (_, __) {});
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(hours: 25));
+        async.flushMicrotasks();
+
+        verifyNever(() => memoryService.getMemoryLane(any()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

the memory lane caches its query for the whole app session — the only refresh was tapping the photos tab (#21623), so opening the app in the morning showed yesterday's memories. now it invalidates on app resume (before and after sync, rows are usually pre-synced anyway) and a small timer re-runs it just after local midnight in case the app stays foregrounded. web fixed the same bug with a timer in #28114.

fixes #21765

added fake_async tests for the timer. tested on a pixel by moving the clock: jump a day while backgrounded → resume shows the new day's memory instantly; set 23:58 and wait → lane swaps on its own right after midnight.