### PR TITLE
fix(mobile): give android notification channels proper names

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -69,7 +69,7 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
 
     val notificationChannel = NotificationChannel(
       NOTIFICATION_CHANNEL_ID,
-      NOTIFICATION_CHANNEL_ID,
+      ctx.getString(R.string.background_worker_notification_channel_name),
       NotificationManager.IMPORTANCE_LOW
     )
     notificationManager.createNotificationChannel(notificationChannel)

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
 
   <string name="memory_widget_description">See memories from Immich.</string>
   <string name="random_widget_description">View a random image from your library or a specific album.</string>
+
+  <string name="bg_downloader_notification_channel_name">Uploads and downloads</string>
+  <string name="bg_downloader_notification_channel_description">Progress updates for uploads and downloads</string>
+
+  <string name="background_worker_notification_channel_name">Background backup</string>
 </resources>


### PR DESCRIPTION
## Description

backup upload notifications show up under a channel called "Downloads" — that's the background_downloader plugin's default channel name, and the plugin only has one channel for everything, so the fix is overriding its string resources with a neutral name (the documented way). also gave our background worker channel a real name — it was literally showing as `immich::background_worker::notif` in android settings.

fixes #21460

channel ids don't change, so existing notification preferences survive and the names update in place. verified on a pixel: "Downloads" → "Uploads and downloads", raw id → "Background backup".

note: the comments on the issue about the "Backing up your assets…" notification not clearing is a different bug, not touched here.