### PR TITLE
chore: remove incompatibility message warning

### DIFF
--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -1,4 +1,4 @@
-String? getVersionCompatibilityMessage(int appMajor, int appMinor, int serverMajor, int serverMinor) {
+String? getVersionCompatibilityMessage(int _, int appMinor, int _, int serverMinor) {
   // Add latest compat info up top
   if (serverMinor < 106 && appMinor >= 106) {
     return 'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login';

--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -1,8 +1,4 @@
 String? getVersionCompatibilityMessage(int appMajor, int appMinor, int serverMajor, int serverMinor) {
-  if (serverMajor != appMajor) {
-    return 'Your app major version is not compatible with the server!';
-  }
-
   // Add latest compat info up top
   if (serverMinor < 106 && appMinor >= 106) {
     return 'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login';

--- a/mobile/test/modules/utils/version_compatibility_test.dart
+++ b/mobile/test/modules/utils/version_compatibility_test.dart
@@ -5,9 +5,6 @@ void main() {
   test('getVersionCompatibilityMessage', () {
     String? result;
 
-    result = getVersionCompatibilityMessage(1, 0, 2, 0);
-    expect(result, 'Your app major version is not compatible with the server!');
-
     result = getVersionCompatibilityMessage(1, 106, 1, 105);
     expect(
       result,


### PR DESCRIPTION
There is no incompability for the next major version release, so remove it to avoid scaring the users
