### PR TITLE
fix(mobile): endless spinner on album selection when device has no albums

### DIFF
--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -251,23 +251,32 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
                     ],
                   ),
                 ),
-                SliverLayoutBuilder(
-                  builder: (context, constraints) {
-                    if (constraints.crossAxisExtent > 600) {
-                      return _AlbumSelectionGrid(
-                        filteredAlbums: filteredAlbums,
-                        searchQuery: _searchQuery,
-                        isLoading: isLoading,
-                      );
-                    } else {
-                      return _AlbumSelectionList(
-                        filteredAlbums: filteredAlbums,
-                        searchQuery: _searchQuery,
-                        isLoading: isLoading,
-                      );
-                    }
-                  },
-                ),
+                if (filteredAlbums.isEmpty)
+                  SliverToBoxAdapter(
+                    child: Center(
+                      child: _searchQuery.isNotEmpty
+                          ? Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: Text('album_search_not_found'.t(context: context)),
+                            )
+                          : isLoading
+                          ? const CircularProgressIndicator()
+                          : Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: Text('no_albums_found'.t(context: context)),
+                            ),
+                    ),
+                  )
+                else
+                  SliverLayoutBuilder(
+                    builder: (context, constraints) {
+                      if (constraints.crossAxisExtent > 600) {
+                        return _AlbumSelectionGrid(filteredAlbums: filteredAlbums);
+                      } else {
+                        return _AlbumSelectionList(filteredAlbums: filteredAlbums);
+                      }
+                    },
+                  ),
               ],
             ),
             if (_handleLinkedAlbumFuture != null)
@@ -304,39 +313,11 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
 
 class _AlbumSelectionList extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
-  final String searchQuery;
-  final bool isLoading;
 
-  const _AlbumSelectionList({required this.filteredAlbums, required this.searchQuery, required this.isLoading});
+  const _AlbumSelectionList({required this.filteredAlbums});
 
   @override
   Widget build(BuildContext context) {
-    if (filteredAlbums.isEmpty && searchQuery.isNotEmpty) {
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('album_search_not_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
-    if (filteredAlbums.isEmpty) {
-      if (isLoading) {
-        return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
-      }
-
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('no_albums_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
     return SliverPadding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       sliver: SliverList(
@@ -350,39 +331,11 @@ class _AlbumSelectionList extends StatelessWidget {
 
 class _AlbumSelectionGrid extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
-  final String searchQuery;
-  final bool isLoading;
 
-  const _AlbumSelectionGrid({required this.filteredAlbums, required this.searchQuery, required this.isLoading});
+  const _AlbumSelectionGrid({required this.filteredAlbums});
 
   @override
   Widget build(BuildContext context) {
-    if (filteredAlbums.isEmpty && searchQuery.isNotEmpty) {
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('album_search_not_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
-    if (filteredAlbums.isEmpty) {
-      if (isLoading) {
-        return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
-      }
-
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('no_albums_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
     return SliverPadding(
       padding: const EdgeInsets.all(12.0),
       sliver: SliverGrid.builder(

--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -19,6 +19,11 @@ import 'package:immich_mobile/widgets/backup/drift_album_info_list_tile.dart';
 import 'package:immich_mobile/widgets/common/search_field.dart';
 import 'package:logging/logging.dart';
 
+final backupAlbumCountProvider = FutureProvider.autoDispose<int>((ref) async {
+  await ref.read(backupAlbumProvider.notifier).getAll();
+  return ref.read(backupAlbumProvider).length;
+});
+
 @RoutePage()
 class DriftBackupAlbumSelectionPage extends ConsumerStatefulWidget {
   const DriftBackupAlbumSelectionPage({super.key});
@@ -30,7 +35,6 @@ class DriftBackupAlbumSelectionPage extends ConsumerStatefulWidget {
 class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbumSelectionPage> {
   String _searchQuery = '';
   bool _isSearchMode = false;
-  bool _isLoading = true;
   int _initialTotalAssetCount = 0;
   late ValueNotifier<bool> _enableSyncUploadAlbum;
   late TextEditingController _searchController;
@@ -45,11 +49,6 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
     _searchFocusNode = FocusNode();
 
     _enableSyncUploadAlbum.value = ref.read(appConfigProvider).backup.syncAlbums;
-    ref.read(backupAlbumProvider.notifier).getAll().whenComplete(() {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      }
-    });
 
     _initialTotalAssetCount = ref.read(driftBackupProvider.select((p) => p.totalCount));
   }
@@ -84,6 +83,7 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = ref.watch(backupAlbumCountProvider).isLoading;
     final albums = ref.watch(backupAlbumProvider);
     final albumCount = albums.length;
     // Filter albums based on search query
@@ -257,13 +257,13 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
                       return _AlbumSelectionGrid(
                         filteredAlbums: filteredAlbums,
                         searchQuery: _searchQuery,
-                        isLoading: _isLoading,
+                        isLoading: isLoading,
                       );
                     } else {
                       return _AlbumSelectionList(
                         filteredAlbums: filteredAlbums,
                         searchQuery: _searchQuery,
-                        isLoading: _isLoading,
+                        isLoading: isLoading,
                       );
                     }
                   },

--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -30,6 +30,7 @@ class DriftBackupAlbumSelectionPage extends ConsumerStatefulWidget {
 class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbumSelectionPage> {
   String _searchQuery = '';
   bool _isSearchMode = false;
+  bool _isLoading = true;
   int _initialTotalAssetCount = 0;
   late ValueNotifier<bool> _enableSyncUploadAlbum;
   late TextEditingController _searchController;
@@ -44,7 +45,11 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
     _searchFocusNode = FocusNode();
 
     _enableSyncUploadAlbum.value = ref.read(appConfigProvider).backup.syncAlbums;
-    ref.read(backupAlbumProvider.notifier).getAll();
+    ref.read(backupAlbumProvider.notifier).getAll().whenComplete(() {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    });
 
     _initialTotalAssetCount = ref.read(driftBackupProvider.select((p) => p.totalCount));
   }
@@ -249,9 +254,17 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
                 SliverLayoutBuilder(
                   builder: (context, constraints) {
                     if (constraints.crossAxisExtent > 600) {
-                      return _AlbumSelectionGrid(filteredAlbums: filteredAlbums, searchQuery: _searchQuery);
+                      return _AlbumSelectionGrid(
+                        filteredAlbums: filteredAlbums,
+                        searchQuery: _searchQuery,
+                        isLoading: _isLoading,
+                      );
                     } else {
-                      return _AlbumSelectionList(filteredAlbums: filteredAlbums, searchQuery: _searchQuery);
+                      return _AlbumSelectionList(
+                        filteredAlbums: filteredAlbums,
+                        searchQuery: _searchQuery,
+                        isLoading: _isLoading,
+                      );
                     }
                   },
                 ),
@@ -292,8 +305,9 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
 class _AlbumSelectionList extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
   final String searchQuery;
+  final bool isLoading;
 
-  const _AlbumSelectionList({required this.filteredAlbums, required this.searchQuery});
+  const _AlbumSelectionList({required this.filteredAlbums, required this.searchQuery, required this.isLoading});
 
   @override
   Widget build(BuildContext context) {
@@ -309,7 +323,18 @@ class _AlbumSelectionList extends StatelessWidget {
     }
 
     if (filteredAlbums.isEmpty) {
-      return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
+      if (isLoading) {
+        return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
+      }
+
+      return SliverToBoxAdapter(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Text('no_albums_found'.t(context: context)),
+          ),
+        ),
+      );
     }
 
     return SliverPadding(
@@ -326,8 +351,9 @@ class _AlbumSelectionList extends StatelessWidget {
 class _AlbumSelectionGrid extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
   final String searchQuery;
+  final bool isLoading;
 
-  const _AlbumSelectionGrid({required this.filteredAlbums, required this.searchQuery});
+  const _AlbumSelectionGrid({required this.filteredAlbums, required this.searchQuery, required this.isLoading});
 
   @override
   Widget build(BuildContext context) {
@@ -343,7 +369,18 @@ class _AlbumSelectionGrid extends StatelessWidget {
     }
 
     if (filteredAlbums.isEmpty) {
-      return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
+      if (isLoading) {
+        return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
+      }
+
+      return SliverToBoxAdapter(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Text('no_albums_found'.t(context: context)),
+          ),
+        ),
+      );
     }
 
     return SliverPadding(


### PR DESCRIPTION
## Description

Fixes #15703

The backup album selection page shows a spinner whenever the album list is empty, so a device with no photos (or denied/limited photo permission) spins forever — the page can't tell loading apart from zero albums.

Track when the initial load finishes and show "No albums found" after that, same as the search empty state on the same page.

Tested on a Pixel 9a with an empty work profile: used to spin forever, now shows the message. Populated library loads as before.