### PR TITLE
fix(web): correctly handle person search with more than 100 results

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -69,7 +69,7 @@ export enum OpenQueryParam {
   PURCHASE_SETTINGS = 'user-purchase-settings',
 }
 
-export const maximumLengthSearchPeople = 1000;
+export const maximumLengthSearchPeople = 100;
 
 // time to load the map before displaying the loading spinner
 export const timeToLoadTheMap: number = 100;


### PR DESCRIPTION
## Description

When a search returns more than 100 results for the first character, it didn't return all results when typing more characters. This was because the frontend assumed the backend returns up to 1000 results but it returns just 100 results. The PR fixed this inconsistency by setting the `maximumLengthSearchPeople` constant to 100.

Fixes #28294

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I created 10000 sample people in the database with the names 'Person 1' to 'Person 10000'. Before applying the searching for 'person 200' on the people page did not return any results. After applying the fix it returns all 11 matching results.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used in creating this PR
