### PR TITLE
fix(mobile): hide video thumbnail when video is ready

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -260,7 +260,7 @@ class _NativeVideoViewerState extends ConsumerState<NativeVideoViewer> with Widg
     return IgnorePointer(
       child: Stack(
         children: [
-          Center(child: widget.image),
+          if (!_isVideoReady || widget.asset.isMotionPhoto || isCasting) Center(child: widget.image),
           if (!isCasting) ...[
             Visibility.maintain(
               visible: _isVideoReady,


### PR DESCRIPTION
## Description

Fixes #28731

Same bug as #18701 — the thumbnail is painted under the video and the player surface comes up ~1px short on Android, so a line of the thumbnail shows along the bottom. #19328 fixed it in the old viewer, but the new viewer was forked from the old file before that fix merged, so the gate never came along.

This ports the same gate. Also keeps the image while casting, since the player view isn't built in that case.

Tested on a Galaxy Tab A9 with a probe video (bright thumbnail, black tail): without the gate the line shows in every dark frame, with it none across repeated cold starts. No black flash when opening a video, motion photos unchanged.