### PR TITLE
chore(web): add switch case exhaustiveness lint

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -129,6 +129,7 @@ export default typescriptEslint.config(
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': ['error', { considerDefaultExhaustiveForUnions: true }],
       'object-shorthand': ['error', 'always'],
       'svelte/no-navigation-without-resolve': 'off',
     },

--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -351,6 +351,7 @@
         closeViewer();
         break;
       }
+      // no default
     }
 
     onAction?.(action);

--- a/web/src/lib/components/share-page/IndividualSharedViewer.svelte
+++ b/web/src/lib/components/share-page/IndividualSharedViewer.svelte
@@ -69,6 +69,7 @@
         await goto(Route.photos());
         break;
       }
+      // no default
     }
   };
 </script>

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -316,6 +316,7 @@
         }
         break;
       }
+      // no default
     }
   };
 

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -140,6 +140,7 @@
 
         break;
       }
+      // no default
     }
   };
   const handleAction = (action: Action) => {
@@ -195,6 +196,7 @@
         });
         break;
       }
+      // no default
     }
   };
   const handleUndoDelete = async (assets: TimelineAsset[]) => {

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -667,6 +667,7 @@ class TransformManager implements EditToolManager {
         desiredWidth = Math.max(minSize, Math.max(mouseX, 0) - x);
         break;
       }
+      // no default
     }
 
     // Height
@@ -683,10 +684,14 @@ class TransformManager implements EditToolManager {
         desiredHeight = Math.max(minSize, Math.max(mouseY, 0) - y);
         break;
       }
+      // no default
     }
 
     // Old
     switch (this.resizeSide) {
+      case ResizeBoundary.None: {
+        break;
+      }
       case ResizeBoundary.Left: {
         const { newWidth: w, newHeight: h } = this.keepAspectRatio(desiredWidth, height);
         const finalWidth = clamp(w, minSize, canvas.clientWidth);

--- a/web/src/lib/managers/timeline-manager/types.ts
+++ b/web/src/lib/managers/timeline-manager/types.ts
@@ -72,12 +72,7 @@ export interface TrashAssets {
   values: string[];
 }
 
-export interface UpdateStackAssets {
-  type: 'update_stack_assets';
-  values: string[];
-}
-
-export type PendingChange = AddAsset | UpdateAsset | DeleteAsset | TrashAssets | UpdateStackAssets;
+export type PendingChange = AddAsset | UpdateAsset | DeleteAsset | TrashAssets;
 
 export type ScrubberMonth = {
   height: number;

--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -105,6 +105,7 @@
         }
         break;
       }
+      // no default
     }
 
     selectedRowIndex = -1;

--- a/web/src/lib/stores/upload.ts
+++ b/web/src/lib/stores/upload.ts
@@ -98,6 +98,13 @@ function createUploadStore() {
             case UploadState.DONE: {
               break;
             }
+
+            case UploadState.PENDING:
+            case UploadState.STARTED:
+            case undefined: {
+              console.error('Cannot remove uploads in progress');
+              break;
+            }
           }
 
           return stats;

--- a/web/src/lib/utils/cast/gcast-destination.svelte.ts
+++ b/web/src/lib/utils/cast/gcast-destination.svelte.ts
@@ -171,6 +171,7 @@ export class GCastDestination implements ICastDestination {
   ///
   private onSessionStateChanged(event: cast.framework.SessionStateEventData) {
     switch (event.sessionState) {
+      case cast.framework.SessionState.NO_SESSION:
       case cast.framework.SessionState.SESSION_ENDED: {
         this.session = null;
         break;
@@ -180,6 +181,11 @@ export class GCastDestination implements ICastDestination {
         this.session = event.session.getSessionObj();
         break;
       }
+      case cast.framework.SessionState.SESSION_START_FAILED: {
+        console.error('Google Cast failed to start session:', event.errorCode);
+        break;
+      }
+      // no default
     }
   }
 

--- a/web/src/routes/admin/queues/QueuePanel.svelte
+++ b/web/src/routes/admin/queues/QueuePanel.svelte
@@ -104,6 +104,7 @@
           break;
         }
       }
+      // no default
     }
 
     try {
@@ -115,6 +116,7 @@
           toastManager.primary($t('admin.cleared_jobs', { values: { job: item.title } }));
           break;
         }
+        // no default
       }
     } catch (error) {
       handleError(error, $t('admin.failed_job_command', { values: { command: dto.command, job: item.title } }));


### PR DESCRIPTION
## Description
Add `@typescript-eslint/switch-exhaustiveness-check` to the web src. Inspired by #28992 (although that one had a default case so wouldn't have been caught).

I think this can be very useful to catch missed cases, especially when new union/enum variants are added later on.

A comment `// no default` means not all cases are covered, and we're fine not having a `default`. I used this in most places, because the switch there is used for handling e.g. a few actions or commands specific to that component.

If merged I'll do the server part too.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None