### PR TITLE
fix!: document and validate AV1 parallelism

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -427,7 +427,7 @@
     "transcoding_temporal_aq": "Temporal AQ",
     "transcoding_temporal_aq_description": "Applies only to NVENC. Temporal Adaptive Quantization increases quality of high-detail, low-motion scenes. May not be compatible with older devices.",
     "transcoding_threads": "Threads",
-    "transcoding_threads_description": "Higher values lead to faster encoding, but leave less room for the server to process other tasks while active. This value should not be more than the number of CPU cores. Maximizes utilization if set to 0.",
+    "transcoding_threads_description": "Higher values lead to faster encoding, but leave less room for the server to process other tasks while active. This value should not be more than the number of CPU cores. Maximizes utilization if set to 0.{av1, select, true { The AV1 encoder uses a number between 1–6 describing the amount of parallelism, instead of limiting to a specific number of threads.} other {}}",
     "transcoding_tone_mapping": "Tone-mapping",
     "transcoding_tone_mapping_description": "Attempts to preserve the appearance of HDR videos when converted to SDR. Each algorithm makes different tradeoffs for color, detail and brightness. Hable preserves detail, Mobius preserves color, and Reinhard preserves brightness.",
     "transcoding_transcode_policy": "Transcode policy",

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -16,6 +16,7 @@ import {
   ToneMappingSchema,
   TranscodeHardwareAccelerationSchema,
   TranscodePolicySchema,
+  VideoCodec,
   VideoCodecSchema,
   VideoContainerSchema,
 } from 'src/enum';
@@ -108,6 +109,9 @@ const SystemConfigFFmpegSchema = z
         enabled: configBool.describe('Enable real-time HLS transcoding (alpha)'),
       })
       .meta({ id: 'SystemConfigFFmpegRealtimeDto' }),
+  })
+  .refine((ffmpeg) => (ffmpeg.targetVideoCodec === VideoCodec.Av1 ? ffmpeg.threads <= 6 : true), {
+    error: 'AV1 threads/parallelism must be 0 or 1–6',
   })
   .meta({ id: 'SystemConfigFFmpegDto' });
 

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -111,7 +111,7 @@ const SystemConfigFFmpegSchema = z
       .meta({ id: 'SystemConfigFFmpegRealtimeDto' }),
   })
   .refine((ffmpeg) => (ffmpeg.targetVideoCodec === VideoCodec.Av1 ? ffmpeg.threads <= 6 : true), {
-    error: 'AV1 threads/parallelism must be 0 or 1–6',
+    error: 'Threads: for AV1, parallelism must be 0–6',
   })
   .meta({ id: 'SystemConfigFFmpegDto' });
 

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -456,6 +456,11 @@ describe(SystemConfigService.name, () => {
       },
       { should: 'warn for top level unknown options', warn: true, config: { unknownOption: true } },
       { should: 'warn for nested unknown options', warn: true, config: { ffmpeg: { unknownOption: true } } },
+      {
+        should: 'validate av1 parallelism setting',
+        config: { ffmpeg: { targetVideoCodec: VideoCodec.Av1, threads: 7 } },
+        throws: '[ffmpeg] AV1 threads/parallelism must be 0 or 1–6',
+      },
     ];
 
     for (const test of tests) {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -459,7 +459,7 @@ describe(SystemConfigService.name, () => {
       {
         should: 'validate av1 parallelism setting',
         config: { ffmpeg: { targetVideoCodec: VideoCodec.Av1, threads: 7 } },
-        throws: '[ffmpeg] AV1 threads/parallelism must be 0 or 1–6',
+        throws: '[ffmpeg] Threads: for AV1, parallelism must be 0–6',
       },
     ];
 

--- a/web/src/routes/admin/system-settings/FFmpegSettings.svelte
+++ b/web/src/routes/admin/system-settings/FFmpegSettings.svelte
@@ -238,7 +238,9 @@
               inputType={SettingInputFieldType.NUMBER}
               {disabled}
               label={$t('admin.transcoding_threads')}
-              description={$t('admin.transcoding_threads_description')}
+              description={$t('admin.transcoding_threads_description', {
+                values: { av1: configToEdit.ffmpeg.targetVideoCodec === VideoCodec.Av1 },
+              })}
               bind:value={configToEdit.ffmpeg.threads}
               isEdited={configToEdit.ffmpeg.threads !== config.ffmpeg.threads}
             />


### PR DESCRIPTION
## Description
Document and validate behavior of `threads` setting when using AV1 encoder, which it doesn't really have (see issue).

I wasn't sure if it's better to append the setting's description or replace it completely when switching from e.g. h264 to AV1. It might be confusing if it's replaced.

Fixes #26929

## How Has This Been Tested?
- Manually
- Unit test

## API Changes
The added validation can be considered a breaking change, so I added the label

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
