### PR TITLE
fix(web): correct date search timezone handling for UTC+ users

### DIFF
--- a/web/src/lib/modals/SearchFilterModal.svelte
+++ b/web/src/lib/modals/SearchFilterModal.svelte
@@ -11,7 +11,7 @@
   import { MediaType, QueryType, validQueryTypes } from '$lib/constants';
   import { preferences } from '$lib/stores/user.store';
   import type { SearchFilter } from '$lib/types';
-  import { parseUtcDate } from '$lib/utils/date-time';
+  import { asLocalTimeISO, parseUtcDate } from '$lib/utils/date-time';
   import { generateId } from '$lib/utils/generate-id';
   import { AssetTypeEnum, AssetVisibility, type MetadataSearchDto, type SmartSearchDto } from '@immich/sdk';
   import { Button, HStack, Modal, ModalBody, ModalFooter } from '@immich/ui';
@@ -139,8 +139,8 @@
       make: filter.camera.make,
       model: filter.camera.model,
       lensModel: filter.camera.lensModel,
-      takenAfter: parseOptionalDate(filter.date.takenAfter)?.startOf('day').toISO() || undefined,
-      takenBefore: parseOptionalDate(filter.date.takenBefore)?.endOf('day').toISO() || undefined,
+      takenAfter: filter.date.takenAfter ? asLocalTimeISO(filter.date.takenAfter.startOf('day')) : undefined,
+      takenBefore: filter.date.takenBefore ? asLocalTimeISO(filter.date.takenBefore.endOf('day')) : undefined,
       visibility: filter.display.isArchive ? AssetVisibility.Archive : undefined,
       isFavorite: filter.display.isFavorite || undefined,
       isNotInAlbum: filter.display.isNotInAlbum || undefined,


### PR DESCRIPTION
## Description

Fixes #28705

Search by date returns results from the wrong day for users in UTC+ timezones. Selecting June 12 in Europe/Madrid (UTC+2) produces `takenAfter=2026-06-11T00:00:00.000Z` in the URL instead of June 12.

**Root cause:** `parseOptionalDate` calls `parseUtcDate(dateString.toString())`, which reinterprets the local-timezone `DateTime` as UTC, shifting midnight local time back by the UTC offset. For UTC+2, `2026-06-12T00:00:00.000+02:00` becomes `2026-06-11T22:00:00.000Z`, and `.startOf('day')` snaps to `2026-06-11T00:00:00.000Z`.

**Fix:** Replace with `asLocalTimeISO` (already in `date-time.ts`), which preserves the wall-clock date using `keepLocalTime: true`.

## How Has This Been Tested?

Tested locally against a v2.7.5 backend with system timezone set to Europe/Madrid (UTC+2).

- [x] Selecting June 12 now produces `takenAfter=2026-06-12T00:00:00.000Z` in the URL
- [x] Search results correctly show photos from the selected date

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code (claude.ai/code) was used to identify the root cause and suggest the fix. The fix itself uses an existing utility function (`asLocalTimeISO`) already present in the codebase. Testing and verification were done manually.