### PR TITLE
fix(web): shift+click on GPS asset extends range selection in geolocation utility

### DIFF
--- a/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
@@ -44,7 +44,7 @@
     brokenAssetClass?: ClassValue;
     dimmed?: boolean;
     albumUsers?: UserResponseDto[];
-    onClick?: (asset: TimelineAsset) => void;
+    onClick?: (asset: TimelineAsset, event?: MouseEvent) => void;
     onPreview?: (asset: TimelineAsset) => void;
     onSelect?: (asset: TimelineAsset) => void;
     onMouseEvent?: (event: { isMouseOver: boolean; selectedGroupIndex: number }) => void;
@@ -93,12 +93,12 @@
     }
   };
 
-  const callClickHandlers = () => {
+  const callClickHandlers = (e?: MouseEvent) => {
     if (selected) {
-      onIconClickedHandler();
+      onIconClickedHandler(e);
       return;
     }
-    onClick?.($state.snapshot(asset));
+    onClick?.($state.snapshot(asset), e);
   };
 
   const handleClick = (e: MouseEvent) => {
@@ -109,7 +109,7 @@
 
     e.stopPropagation();
     e.preventDefault();
-    callClickHandlers();
+    callClickHandlers(e);
   };
 
   const onMouseEnter = () => {

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -59,6 +59,7 @@
         groupTitle: string,
         asset: TimelineAsset,
       ) => void,
+      event?: MouseEvent,
     ) => void;
   }
 
@@ -685,9 +686,9 @@
                 {asset}
                 {albumUsers}
                 {groupIndex}
-                onClick={(asset) => {
+                onClick={(asset, event) => {
                   if (typeof onThumbnailClick === 'function') {
-                    onThumbnailClick(asset, timelineManager, timelineDay, _onClick);
+                    onThumbnailClick(asset, timelineManager, timelineDay, _onClick, event);
                   } else {
                     _onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
                   }

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -118,7 +118,12 @@
       groupTitle: string,
       asset: TimelineAsset,
     ) => void,
+    event?: MouseEvent,
   ) => {
+    if (event?.shiftKey) {
+      onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
+      return;
+    }
     if (hasGps(asset)) {
       locationUpdated = true;
       setTimeout(() => {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #29021

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested locally (see recording below)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/bd90439c-cc6b-45b3-810e-e6e36b83b59a



</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
