### PR TITLE
fix(server): handle string coordinates in face region bounding box calculation

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -862,10 +862,10 @@ export class MetadataService extends BaseService {
         assetId: asset.id,
         imageWidth,
         imageHeight,
-        boundingBoxX1: Math.floor((region.Area.X - region.Area.W / 2) * imageWidth),
-        boundingBoxY1: Math.floor((region.Area.Y - region.Area.H / 2) * imageHeight),
-        boundingBoxX2: Math.floor((region.Area.X + region.Area.W / 2) * imageWidth),
-        boundingBoxY2: Math.floor((region.Area.Y + region.Area.H / 2) * imageHeight),
+        boundingBoxX1: Math.floor((Number(region.Area.X) - Number(region.Area.W) / 2) * imageWidth),
+        boundingBoxY1: Math.floor((Number(region.Area.Y) - Number(region.Area.H) / 2) * imageHeight),
+        boundingBoxX2: Math.floor((Number(region.Area.X) + Number(region.Area.W) / 2) * imageWidth),
+        boundingBoxY2: Math.floor((Number(region.Area.Y) + Number(region.Area.H) / 2) * imageHeight),
         sourceType: SourceType.Exif,
       };
 


### PR DESCRIPTION
## Description

Fixes #28991

When exiftool serializes a float with more than 16 significant digits, it writes it as a **string** instead of a number in the JSON output. This is documented behavior: https://github.com/exiftool/exiftool/blob/13.58/exiftool#L3808-L3809

The problem is JavaScript's `+` operator: it does **string concatenation** when either operand is a string. The `-`, `*`, and `/` operators always coerce strings to numbers first, so:

- `boundingBoxX1 = (X - W/2) * width` → `-` coerces X, always works
- `boundingBoxY1 = (Y - H/2) * height` → same, always works
- `boundingBoxX2 = (X + W/2) * width` → if X is a string, `+` concatenates: `"0.9876543210987654321" + 0.125 = "0.9876543210987654321 0.125"` → `Math.floor(...)` = `NaN`
- `boundingBoxY2 = (Y + H/2) * height` → same issue

`NaN` then fails PostgreSQL's integer type check with:
`PostgresError: invalid input syntax for type integer: "NaN"`

The fix wraps all four area coordinates with `Number()` before any arithmetic, which correctly parses strings like `"0.98765432109876543"` into a float. For coordinates that are already numbers (the normal case), `Number(x)` is a no-op.

**Note on where to apply the fix:** The `ImmichTags` type already lists `RegionInfo` in `TagsWithWrongTypes` (`metadata.repository.ts:14`), and `readTags` does a raw cast (`as Promise<ImmichTags>`) without transforming the exiftool output. The `Area` coordinates are typed as `number` but can be `string` at runtime — a known imprecision following the same pattern as `Description?: StringOrNumber`. Fixing the type to `number | string` would require the `Number()` call at the usage site anyway, so the result is identical. I kept the change to a single file to minimize diff size.

## How Has This Been Tested?

- All 87 server unit test files pass (2131 tests) with no regressions
- TypeScript type check (`tsc --noEmit`) passes clean

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude (claude.ai) was used to identify the root cause and draft the fix. The fix itself was verified by reading the exiftool source and confirming JavaScript operator coercion behavior.