### PR TITLE
fix(server): do not merge metadata when multiple duplicates are kept

### DIFF
--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -369,6 +369,26 @@ describe(DuplicateService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.SidecarWrite, data: { id: asset1.id } }]);
     });
 
+    it('should not merge metadata when multiple assets are kept', async () => {
+      const asset1 = { ...AssetFactory.create(), isFavorite: true };
+      const asset2 = { ...AssetFactory.create(), isFavorite: false };
+      mocks.access.duplicate.checkOwnerAccess.mockResolvedValue(new Set(['group-1']));
+      mocks.duplicateRepository.get.mockResolvedValue({
+        duplicateId: 'group-1',
+        assets: [asset1 as unknown as MapAsset, asset2 as unknown as MapAsset],
+      });
+
+      const result = await sut.resolve(authStub.admin, {
+        groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id, asset2.id], trashAssetIds: [] }],
+      });
+
+      expect(result[0].success).toBe(true);
+      expect(mocks.album.addAssetIdsToAlbums).not.toHaveBeenCalled();
+      expect(mocks.tag.replaceAssetTags).not.toHaveBeenCalled();
+      expect(mocks.asset.updateAllExif).not.toHaveBeenCalled();
+      expect(mocks.asset.updateAll).toHaveBeenCalledWith([asset1.id, asset2.id], { duplicateId: null });
+    });
+
     // NOTE: The following integration-style tests are covered by E2E tests instead
     // to avoid complex mock setup. The validation and error-handling logic above
     // is thoroughly unit tested.

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -370,8 +370,8 @@ describe(DuplicateService.name, () => {
     });
 
     it('should not merge metadata when multiple assets are kept', async () => {
-      const asset1 = { ...AssetFactory.create(), isFavorite: true };
-      const asset2 = { ...AssetFactory.create(), isFavorite: false };
+      const asset1 = AssetFactory.create({ isFavorite: true });
+      const asset2 = AssetFactory.create();
       mocks.access.duplicate.checkOwnerAccess.mockResolvedValue(new Set(['group-1']));
       mocks.duplicateRepository.get.mockResolvedValue({
         duplicateId: 'group-1',

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -156,51 +156,51 @@ export class DuplicateService extends BaseService {
       }
     }
 
-    const assetAlbumMap = await this.albumRepository.getByAssetIds(auth.user.id, [...groupAssetIds]);
+    // Only merge metadata into the keeper when exactly one asset can absorb trashed duplicates.
+    if (idsToKeep.length === 1 && idsToTrash.length > 0) {
+      const assetAlbumMap = await this.albumRepository.getByAssetIds(auth.user.id, [...groupAssetIds]);
 
-    const { assetUpdate, exifUpdate, mergedAlbumIds, mergedTagIds, mergedTagValues } = this.getSyncMergeResult(
-      duplicateGroup.assets,
-      assetAlbumMap,
-    );
+      const { assetUpdate, exifUpdate, mergedAlbumIds, mergedTagIds, mergedTagValues } = this.getSyncMergeResult(
+        duplicateGroup.assets,
+        assetAlbumMap,
+      );
 
-    if (mergedAlbumIds.length > 0) {
-      const allowedAlbumIds = await this.checkAccess({
-        auth,
-        permission: Permission.AlbumAssetCreate,
-        ids: mergedAlbumIds,
-      });
+      if (mergedAlbumIds.length > 0) {
+        const allowedAlbumIds = await this.checkAccess({
+          auth,
+          permission: Permission.AlbumAssetCreate,
+          ids: mergedAlbumIds,
+        });
 
-      const allowedShareIds = await this.checkAccess({
-        auth,
-        permission: Permission.AssetShare,
-        ids: idsToKeep,
-      });
+        const allowedShareIds = await this.checkAccess({
+          auth,
+          permission: Permission.AssetShare,
+          ids: idsToKeep,
+        });
 
-      if (allowedAlbumIds.size > 0 && allowedShareIds.size > 0) {
-        await this.albumRepository.addAssetIdsToAlbums(
-          [...allowedAlbumIds].flatMap((albumId) => [...allowedShareIds].map((assetId) => ({ albumId, assetId }))),
-        );
+        if (allowedAlbumIds.size > 0 && allowedShareIds.size > 0) {
+          await this.albumRepository.addAssetIdsToAlbums(
+            [...allowedAlbumIds].flatMap((albumId) => [...allowedShareIds].map((assetId) => ({ albumId, assetId }))),
+          );
+        }
       }
-    }
 
-    if (mergedTagIds.length > 0) {
-      const allowedTagIds = await this.checkAccess({
-        auth,
-        permission: Permission.TagAsset,
-        ids: mergedTagIds,
-      });
+      if (mergedTagIds.length > 0) {
+        const allowedTagIds = await this.checkAccess({
+          auth,
+          permission: Permission.TagAsset,
+          ids: mergedTagIds,
+        });
 
-      if (allowedTagIds.size > 0) {
-        // Replace tags for each keeper asset to ensure all merged tags are applied
-        await Promise.all(idsToKeep.map((assetId) => this.tagRepository.replaceAssetTags(assetId, [...allowedTagIds])));
+        if (allowedTagIds.size > 0) {
+          await Promise.all(
+            idsToKeep.map((assetId) => this.tagRepository.replaceAssetTags(assetId, [...allowedTagIds])),
+          );
 
-        // Update asset_exif.tags so the subsequent SidecarWrite + MetadataExtraction
-        // cycle preserves the merged tags (updateAllExif locks the property automatically)
-        await this.assetRepository.updateAllExif(idsToKeep, { tags: mergedTagValues });
+          await this.assetRepository.updateAllExif(idsToKeep, { tags: mergedTagValues });
+        }
       }
-    }
 
-    if (idsToKeep.length > 0) {
       const hasExifUpdate = Object.keys(exifUpdate).length > 0;
       const hasTagUpdate = mergedTagIds.length > 0;
 
@@ -213,6 +213,8 @@ export class DuplicateService extends BaseService {
       }
 
       await this.assetRepository.updateAll(idsToKeep, { duplicateId: null, ...assetUpdate });
+    } else if (idsToKeep.length > 0) {
+      await this.assetRepository.updateAll(idsToKeep, { duplicateId: null });
     }
 
     if (idsToTrash.length > 0) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix duplicate resolution incorrectly merging metadata across surviving assets when the user chooses to keep more than one.

Fixes #27687

> [!NOTE]
> The diff is tiny, but github's diff makes it look bigger. VSC works good 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] new unit test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
