### PR TITLE
fix(web): prevent upload status panel from overlapping album action bar

### DIFF
--- a/web/src/routes/UploadPanel.svelte
+++ b/web/src/routes/UploadPanel.svelte
@@ -37,7 +37,7 @@
       }
       uploadAssetsStore.reset();
     }}
-    class="fixed inset-e-16 bottom-6"
+    class="fixed inset-e-16 bottom-6 z-60"
   >
     {#if showDetail}
       <div


### PR DESCRIPTION
## Description

When uploading to a shared album, the upload status panel had no `z-index` set. The album activity bar uses an `absolute`-positioned element that painted on top of the upload panel's `fixed` container, making the duplicate/error action buttons in the upload panel unclickable.

Added `z-60` to the upload panel's outer `fixed` container in `UploadPanel.svelte`, matching `DownloadPanel.svelte` which already uses `z-60`. Both floating panels now have consistent stacking priority above page chrome.

Fixes #27794

## How Has This Been Tested?

- Opened a shared album and uploaded an image that already exists
- Confirmed the duplicate warning buttons in the upload panel are no longer blocked by the like/comment bar
- Verified `DownloadPanel.svelte` already uses `z-60` — consistent behavior across both panels

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.