### PR TITLE
fix(album): skip users already in album when adding members

### DIFF
--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -472,17 +472,41 @@ describe(AlbumService.name, () => {
       expect(mocks.album.update).not.toHaveBeenCalled();
     });
 
-    it('should throw an error if the userId is already added', async () => {
+    it('should skip users that are already members', async () => {
       const userId = newUuid();
       const album = AlbumFactory.from().albumUser({ userId }).build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
       mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
       mocks.album.getById.mockResolvedValue(getForAlbum(album));
-      await expect(
-        sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] }),
-      ).rejects.toBeInstanceOf(BadRequestException);
-      expect(mocks.album.update).not.toHaveBeenCalled();
-      expect(mocks.user.get).not.toHaveBeenCalled();
+      mocks.album.update.mockResolvedValue(getForAlbum(album));
+      await sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] });
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
+      expect(mocks.event.emit).not.toHaveBeenCalled();
+    });
+
+    it('should add new users and skip already-existing members in the same request', async () => {
+      const existingUserId = newUuid();
+      const album = AlbumFactory.from().albumUser({ userId: existingUserId }).build();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      const newUser = UserFactory.create();
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.album.update.mockResolvedValue(getForAlbum(album));
+      mocks.user.get.mockResolvedValue(newUser);
+      mocks.albumUser.create.mockResolvedValue(AlbumUserFactory.from().album(album).user(newUser).build());
+
+      await sut.addUsers(AuthFactory.create(owner), album.id, {
+        albumUsers: [{ userId: existingUserId }, { userId: newUser.id }],
+      });
+
+      expect(mocks.albumUser.create).toHaveBeenCalledTimes(1);
+      expect(mocks.albumUser.create).toHaveBeenCalledWith({ userId: newUser.id, albumId: album.id });
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
+        id: album.id,
+        userId: newUser.id,
+        senderName: owner.name,
+      });
     });
 
     it('should throw an error if the userId does not exist', async () => {

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -290,7 +290,7 @@ export class AlbumService extends BaseService {
 
       const exists = album.albumUsers.find(({ user: { id } }) => id === userId);
       if (exists) {
-        throw new BadRequestException('User already added');
+        continue;
       }
 
       const user = await this.userRepository.get(userId, {});


### PR DESCRIPTION
## Description

When calling `PUT /api/albums/{albumId}/users` with a batch of users where one or more are already album members, the endpoint would throw `400 Bad Request` on the first duplicate encountered. This aborted the entire request, leaving any new users in the same batch unadded.

Changed the `throw new BadRequestException('User already added')` to a `continue` in `album.service.ts` so existing members are silently skipped and the rest of the batch is still processed.

Fixes #28880

## How Has This Been Tested?

- Updated the existing "should throw when user already exists" test to assert the skip behavior: no `albumUser.create` call is made for the duplicate, no error is thrown
- Added a new test for the mixed case: one existing member + one new user in the same batch — verifies only the new user is inserted and invited, duplicate is silently skipped

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.