### PR TITLE
fix(server): guard against NaN face region coordinates from EXIF tags

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -926,16 +926,25 @@ export class MetadataService extends BaseService {
       const loweredName = region.Name.toLowerCase();
       const personId = existingNameMap.get(loweredName) || this.cryptoRepository.randomUUID();
 
+      const x = Number(region.Area.X);
+      const y = Number(region.Area.Y);
+      const w = Number(region.Area.W);
+      const h = Number(region.Area.H);
+
+      if (![x, y, w, h, imageWidth, imageHeight].every((v) => Number.isFinite(v))) {
+        continue;
+      }
+
       const face = {
         id: this.cryptoRepository.randomUUID(),
         personId,
         assetId: asset.id,
         imageWidth,
         imageHeight,
-        boundingBoxX1: Math.floor((region.Area.X - region.Area.W / 2) * imageWidth),
-        boundingBoxY1: Math.floor((region.Area.Y - region.Area.H / 2) * imageHeight),
-        boundingBoxX2: Math.floor((region.Area.X + region.Area.W / 2) * imageWidth),
-        boundingBoxY2: Math.floor((region.Area.Y + region.Area.H / 2) * imageHeight),
+        boundingBoxX1: Math.floor((x - w / 2) * imageWidth),
+        boundingBoxY1: Math.floor((y - h / 2) * imageHeight),
+        boundingBoxX2: Math.floor((x + w / 2) * imageWidth),
+        boundingBoxY2: Math.floor((y + h / 2) * imageHeight),
         sourceType: SourceType.Exif,
       };
 


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

Fixes #28991

Face region coordinates from EXIF tags with excessive decimal precision (17+ digits past the decimal) are returned as strings by exiftool. When these strings enter arithmetic operations in `applyTaggedFaces`, they produce `NaN`, which causes PostgreSQL to reject the INSERT with `invalid input syntax for type integer: "NaN"`. This silently fails face import for approximately 20% of assets with externally-tagged faces.

## Root Cause

The `applyTaggedFaces` method in `server/src/services/metadata.service.ts` uses `region.Area.X/Y/W/H` directly in arithmetic without validating they are finite numbers. The `ImmichTags` interface declares these as `number`, but exiftool extracts values with more than 16 decimal places as strings (see https://github.com/exiftool/exiftool/blob/13.58/exiftool#L3808-L3809). When these string values participate in `Math.floor((string - number/2) * number)`, the result is `NaN`, which then fails the PostgreSQL integer column constraint.

## Fix

- Convert `region.Area.X/Y/W/H` to numbers explicitly via `Number()` before use
- Add a guard that skips the region if any coordinate or dimension is non-finite
- This follows the same pattern as the existing `validate()` function (line 86-100) that already guards other EXIF numeric values

## Changes

- `server/src/services/metadata.service.ts`: Added `Number()` conversion and `Number.isFinite()` guard for face region coordinates in `applyTaggedFaces` (`+9 -4` lines)

## Testing

- Region with normal float coordinates (e.g., `0.12345`): bounding boxes computed correctly ✅
- Region with string coordinates from exiftool (17+ decimal digits): `Number()` converts successfully, guard passes, bounding boxes computed correctly ✅
- Region with `undefined` or unparseable coordinate: `Number()` returns `NaN`, guard catches it, region is skipped with `continue` ✅
- Regions with valid coordinates continue to import correctly (regression check) ✅
