### PR TITLE
fix(mobile): prevent duplicate login pages for unauthenticated share intent warm start

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -355,14 +355,14 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
           onError: (exception) => {
             log.severe('Failed to update auth info with access token: $accessToken'),
             ref.read(authProvider.notifier).logout(),
-            context.replaceRoute(const LoginRoute()),
+            context.router.replaceAll([const LoginRoute()]),
           },
         ),
       );
     } else {
       log.severe('Missing crucial offline login info - Logging out completely');
       unawaited(ref.read(authProvider.notifier).logout());
-      unawaited(context.replaceRoute(const LoginRoute()));
+      unawaited(context.router.replaceAll([const LoginRoute()]));
       return;
     }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to #26134

The original auth bypass in #26134 was already fixed (TabShellRoute now has an auth guard). However, a related issue remains: when the app is running in the background and an unauthenticated user opens a share intent (warm start), Android's singleTask mode causes a auto_route to push a new SplashScreen on top of the existing login page. The SplashScreen calls replaceRoute(LoginRoute) which only replaces itself, leaving the original login page behind, resulting
in two stacked login pages requiring two back presses to exit.

Fixed by using replaceAll instead, so the stack always resolves to a single login page regardless of what was behind SplashScreen.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Logged out → shared image from Files app while app was in background → app came to foreground → only one login page visible → pressed back → app closed cleanly
- [x] Tested on Android emulator (Medium Phone, API 36)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/6decba48-78dd-4b00-8eca-b6f08f957342

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
