### PR TITLE
refactor: use SemVer classes for version compatability message

### DIFF
--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -2,9 +2,20 @@ import 'package:immich_mobile/utils/semver.dart';
 
 String? getVersionCompatibilityMessage(SemVer serverVersion, SemVer appVersion) {
   // Add latest compat info up top
+
+  // ensure mobile app major version is not behind server major version
+  if (appVersion.major < serverVersion.major) {
+    return 'Your mobile app version is not compatible with the server! Please update your mobile app to the latest version.';
+  }
+
+  // ensure mobile app major version is not ahead of server major version by more than 1 major version
+  if (appVersion.major > serverVersion.major + 1) {
+    return 'Your server version is not compatible with the mobile app! Please update your server to the latest version.';
+  }
+
   const v1_106_0 = SemVer(major: 1, minor: 106, patch: 0);
   if (serverVersion < v1_106_0 && appVersion > v1_106_0) {
-    return 'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
+    return 'Your mobile app is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
   }
 
   return null;

--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -13,10 +13,5 @@ String? getVersionCompatibilityMessage(SemVer serverVersion, SemVer appVersion) 
     return 'Your server version is not compatible with the mobile app! Please update your server to the latest version.';
   }
 
-  const v1_106_0 = SemVer(major: 1, minor: 106, patch: 0);
-  if (serverVersion < v1_106_0 && appVersion > v1_106_0) {
-    return 'Your mobile app is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
-  }
-
   return null;
 }

--- a/mobile/lib/utils/version_compatibility.dart
+++ b/mobile/lib/utils/version_compatibility.dart
@@ -1,6 +1,9 @@
-String? getVersionCompatibilityMessage(int _, int appMinor, int _, int serverMinor) {
+import 'package:immich_mobile/utils/semver.dart';
+
+String? getVersionCompatibilityMessage(SemVer serverVersion, SemVer appVersion) {
   // Add latest compat info up top
-  if (serverMinor < 106 && appMinor >= 106) {
+  const v1_106_0 = SemVer(major: 1, minor: 106, patch: 0);
+  if (serverVersion < v1_106_0 && appVersion > v1_106_0) {
     return 'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
   }
 

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -26,6 +26,7 @@ import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/repositories/permission.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/provider_utils.dart';
+import 'package:immich_mobile/utils/semver.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:immich_mobile/utils/version_compatibility.dart';
 import 'package:immich_mobile/widgets/common/immich_logo.dart';
@@ -88,18 +89,9 @@ class LoginForm extends HookConsumerWidget {
     checkVersionMismatch() async {
       try {
         final packageInfo = await PackageInfo.fromPlatform();
-        final appVersion = packageInfo.version;
-        final appMajorVersion = int.parse(appVersion.split('.')[0]);
-        final appMinorVersion = int.parse(appVersion.split('.')[1]);
-        final serverMajorVersion = serverInfo.serverVersion.major;
-        final serverMinorVersion = serverInfo.serverVersion.minor;
-
-        warningMessage.value = getVersionCompatibilityMessage(
-          appMajorVersion,
-          appMinorVersion,
-          serverMajorVersion,
-          serverMinorVersion,
-        );
+        final appSemVer = SemVer.fromString(packageInfo.version);
+        final serverSemVer = serverInfo.serverVersion;
+        warningMessage.value = getVersionCompatibilityMessage(appSemVer, serverSemVer);
       } catch (error) {
         warningMessage.value = 'Error checking version compatibility';
       }

--- a/mobile/test/modules/utils/version_compatibility_test.dart
+++ b/mobile/test/modules/utils/version_compatibility_test.dart
@@ -1,29 +1,39 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/semver.dart';
 import 'package:immich_mobile/utils/version_compatibility.dart';
 
 void main() {
   test('getVersionCompatibilityMessage', () {
     String? result;
 
-    result = getVersionCompatibilityMessage(1, 106, 1, 105);
+    // server older than 1.106.0, app newer -> incompatible
+    result = getVersionCompatibilityMessage(
+      const SemVer(major: 1, minor: 105, patch: 0),
+      const SemVer(major: 1, minor: 107, patch: 0),
+    );
     expect(
       result,
       'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login',
     );
 
-    result = getVersionCompatibilityMessage(1, 107, 1, 105);
-    expect(
-      result,
-      'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login',
+    // server at 1.106.0 boundary -> compatible
+    result = getVersionCompatibilityMessage(
+      const SemVer(major: 1, minor: 106, patch: 0),
+      const SemVer(major: 1, minor: 106, patch: 0),
     );
-
-    result = getVersionCompatibilityMessage(1, 106, 1, 106);
     expect(result, null);
 
-    result = getVersionCompatibilityMessage(1, 107, 1, 106);
+    result = getVersionCompatibilityMessage(
+      const SemVer(major: 1, minor: 106, patch: 0),
+      const SemVer(major: 1, minor: 107, patch: 0),
+    );
     expect(result, null);
 
-    result = getVersionCompatibilityMessage(1, 107, 1, 108);
+    // server newer than app -> compatible
+    result = getVersionCompatibilityMessage(
+      const SemVer(major: 1, minor: 108, patch: 0),
+      const SemVer(major: 1, minor: 107, patch: 0),
+    );
     expect(result, null);
   });
 }

--- a/mobile/test/modules/utils/version_compatibility_test.dart
+++ b/mobile/test/modules/utils/version_compatibility_test.dart
@@ -3,37 +3,82 @@ import 'package:immich_mobile/utils/semver.dart';
 import 'package:immich_mobile/utils/version_compatibility.dart';
 
 void main() {
-  test('getVersionCompatibilityMessage', () {
-    String? result;
+  group('app major version behind server', () {
+    const message =
+        'Your mobile app version is not compatible with the server! Please update your mobile app to the latest version.';
 
-    // server older than 1.106.0, app newer -> incompatible
-    result = getVersionCompatibilityMessage(
-      const SemVer(major: 1, minor: 105, patch: 0),
-      const SemVer(major: 1, minor: 107, patch: 0),
-    );
-    expect(
-      result,
-      'Your app minor version is not compatible with the server! Please update your server to version v1.106.0 or newer to login',
-    );
+    test('returns message when app major is behind server major', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 2, minor: 0, patch: 0),
+        const SemVer(major: 1, minor: 200, patch: 0),
+      );
+      expect(result, message);
+    });
 
-    // server at 1.106.0 boundary -> compatible
-    result = getVersionCompatibilityMessage(
-      const SemVer(major: 1, minor: 106, patch: 0),
-      const SemVer(major: 1, minor: 106, patch: 0),
-    );
-    expect(result, null);
+    test('returns null when app major matches server major', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 2, minor: 0, patch: 0),
+        const SemVer(major: 2, minor: 0, patch: 0),
+      );
+      expect(result, null);
+    });
+  });
 
-    result = getVersionCompatibilityMessage(
-      const SemVer(major: 1, minor: 106, patch: 0),
-      const SemVer(major: 1, minor: 107, patch: 0),
-    );
-    expect(result, null);
+  group('app major version too far ahead of server', () {
+    const message =
+        'Your server version is not compatible with the mobile app! Please update your server to the latest version.';
 
-    // server newer than app -> compatible
-    result = getVersionCompatibilityMessage(
-      const SemVer(major: 1, minor: 108, patch: 0),
-      const SemVer(major: 1, minor: 107, patch: 0),
-    );
-    expect(result, null);
+    test('returns message when app major is more than one ahead of server', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 200, patch: 0),
+        const SemVer(major: 3, minor: 0, patch: 0),
+      );
+      expect(result, message);
+    });
+
+    test('returns null when app major is exactly one ahead of server', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 200, patch: 0),
+        const SemVer(major: 2, minor: 0, patch: 0),
+      );
+      expect(result, null);
+    });
+  });
+
+  group('v1.106.0 minor compatibility', () {
+    const message =
+        'Your mobile app is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
+
+    test('returns message when server is older than 1.106.0 and app is newer', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 105, patch: 0),
+        const SemVer(major: 1, minor: 107, patch: 0),
+      );
+      expect(result, message);
+    });
+
+    test('returns null when both are at the 1.106.0 boundary', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 106, patch: 0),
+        const SemVer(major: 1, minor: 106, patch: 0),
+      );
+      expect(result, null);
+    });
+
+    test('returns null when server is at or newer than 1.106.0', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 106, patch: 0),
+        const SemVer(major: 1, minor: 107, patch: 0),
+      );
+      expect(result, null);
+    });
+
+    test('returns null when server is newer than app', () {
+      final result = getVersionCompatibilityMessage(
+        const SemVer(major: 1, minor: 108, patch: 0),
+        const SemVer(major: 1, minor: 107, patch: 0),
+      );
+      expect(result, null);
+    });
   });
 }

--- a/mobile/test/modules/utils/version_compatibility_test.dart
+++ b/mobile/test/modules/utils/version_compatibility_test.dart
@@ -44,41 +44,4 @@ void main() {
       expect(result, null);
     });
   });
-
-  group('v1.106.0 minor compatibility', () {
-    const message =
-        'Your mobile app is not compatible with the server! Please update your server to version v1.106.0 or newer to login';
-
-    test('returns message when server is older than 1.106.0 and app is newer', () {
-      final result = getVersionCompatibilityMessage(
-        const SemVer(major: 1, minor: 105, patch: 0),
-        const SemVer(major: 1, minor: 107, patch: 0),
-      );
-      expect(result, message);
-    });
-
-    test('returns null when both are at the 1.106.0 boundary', () {
-      final result = getVersionCompatibilityMessage(
-        const SemVer(major: 1, minor: 106, patch: 0),
-        const SemVer(major: 1, minor: 106, patch: 0),
-      );
-      expect(result, null);
-    });
-
-    test('returns null when server is at or newer than 1.106.0', () {
-      final result = getVersionCompatibilityMessage(
-        const SemVer(major: 1, minor: 106, patch: 0),
-        const SemVer(major: 1, minor: 107, patch: 0),
-      );
-      expect(result, null);
-    });
-
-    test('returns null when server is newer than app', () {
-      final result = getVersionCompatibilityMessage(
-        const SemVer(major: 1, minor: 108, patch: 0),
-        const SemVer(major: 1, minor: 107, patch: 0),
-      );
-      expect(result, null);
-    });
-  });
 }


### PR DESCRIPTION
## Description
Follow up to #28993 to use our nice `SemVer` utility classes. 

Also fixes a possible issue if we were to ever have another minor 106 version