### PR TITLE
chore(web): make login page email and password required

### DIFF
--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -141,11 +141,11 @@
           <Alert color="danger" title={errorMessage} closable />
         {/if}
 
-        <Field label={$t('email')}>
+        <Field label={$t('email')} required="indicator">
           <Input id="email" name="email" type="email" autocomplete="email" bind:value={email} />
         </Field>
 
-        <Field label={$t('password')}>
+        <Field label={$t('password')} required="indicator">
           <PasswordInput id="password" bind:value={password} autocomplete="current-password" />
         </Field>
 


### PR DESCRIPTION
To prevent posting an empty body. Afaict empty passwords are not allowed/supported. If they are, it should ofc not be required.