### PR TITLE
fix: lock transcoding options

### DIFF
--- a/web/src/routes/admin/system-settings/FFmpegSettings.svelte
+++ b/web/src/routes/admin/system-settings/FFmpegSettings.svelte
@@ -88,6 +88,7 @@
               desc={$t('admin.transcoding_accepted_video_codecs_description')}
               bind:value={configToEdit.ffmpeg.acceptedVideoCodecs}
               name="videoCodecs"
+              lockedOptions={[configToEdit.ffmpeg.targetVideoCodec]}
               options={[
                 { value: VideoCodec.H264, text: 'H.264' },
                 { value: VideoCodec.Hevc, text: 'HEVC' },
@@ -106,6 +107,7 @@
               desc={$t('admin.transcoding_accepted_audio_codecs_description')}
               bind:value={configToEdit.ffmpeg.acceptedAudioCodecs}
               name="audioCodecs"
+              lockedOptions={[configToEdit.ffmpeg.targetAudioCodec]}
               options={[
                 { value: AudioCodec.Aac, text: 'AAC' },
                 { value: AudioCodec.Mp3, text: 'MP3' },

--- a/web/src/routes/admin/system-settings/SettingCheckboxes.svelte
+++ b/web/src/routes/admin/system-settings/SettingCheckboxes.svelte
@@ -1,17 +1,18 @@
-<script lang="ts">
+<script lang="ts" generics="T extends string">
   import { Checkbox, Label } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import { quintOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
 
   interface Props {
-    value: string[];
-    options: { value: string; text: string }[];
+    value: T[];
+    options: { value: T; text: string }[];
     label?: string;
     desc?: string;
     name?: string;
     isEdited?: boolean;
     disabled?: boolean;
+    lockedOptions?: T[];
   }
 
   let {
@@ -22,9 +23,10 @@
     name = '',
     isEdited = false,
     disabled = false,
+    lockedOptions = [],
   }: Props = $props();
 
-  function handleCheckboxChange(option: string) {
+  function handleCheckboxChange(option: T) {
     value = value.includes(option) ? value.filter((item) => item !== option) : [...value, option];
   }
 </script>
@@ -57,7 +59,7 @@
           size="tiny"
           id="{option.value}-checkbox"
           checked={value.includes(option.value)}
-          {disabled}
+          disabled={disabled || lockedOptions.includes(option.value)}
           onCheckedChange={() => handleCheckboxChange(option.value)}
         />
         <Label label={option.text} for="{option.value}-checkbox" size="small" />


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #27814, as [discussed on Discord](https://discord.com/channels/979116623879368755/979148343693422593/1515046282605891584). Made the component typesafe on value, options and the new prop. I thought about passing a callable to disabled instead of introducing a new prop, but this seemed to be less readable to me. 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] check that H.264 and AAC are locked in the UI

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
