### PR TITLE
docs(mobile): point users towards shared setup docs

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -4,20 +4,7 @@ The Immich mobile app is a Flutter-based solution leveraging the Isar Database f
 
 ## Setup
 
-1. [Install mise](https://mise.jdx.dev/installing-mise.html).
-2. Change to the immich directory and trust the mise config with `mise trust`.
-3. Install tools with mise: `mise install`.
-4. Run `flutter pub get` to install the dependencies.
-5. Run `make translation` to generate the translation file.
-6. Run `flutter run` to start the app.
-
-## Translation
-
-To add a new translation text, enter the key-value pair in the `i18n/en.json` in the root of the immich project. Then, from the `mobile/` directory, run
-
-```bash
-make translation
-```
+See [setup](https://docs.immich.app/developer/setup) for how to set up the mobile build environment.
 
 ## Static Analysis
 


### PR DESCRIPTION
## Description

The mobile README.md now contains duplicated and outdated setup information against `docs/docs/developer/setup.md`. Point the reader to the deployed version of those docs instead.

## How Has This Been Tested?

N/A

## API Changes

N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None