### PR TITLE
fix(web): show album names in duplicate review

### DIFF
--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { locale } from '$lib/stores/preferences.store';
+  import { lang, locale } from '$lib/stores/preferences.store';
   import { getAssetMediaUrl } from '$lib/utils';
   import { getAllMetadataItems, type DifferingMetadataFields } from '$lib/utils/duplicate-utils';
   import { getAltText } from '$lib/utils/thumbnail-util';
@@ -30,7 +30,8 @@
     initialVisibleCount = 5,
   }: Props = $props();
 
-  let isFromExternalLibrary = $derived(!!asset.libraryId);
+  const listFormat = $derived(new Intl.ListFormat($lang));
+  const isFromExternalLibrary = $derived(!!asset.libraryId);
 
   const visibleMetadataItems = $derived(
     getAllMetadataItems(asset, $t, $locale)
@@ -116,7 +117,13 @@
       {#await getAllAlbums({ assetId: asset.id })}
         {$t('scanning_for_album')}
       {:then albums}
-        {$t('in_albums', { values: { count: albums.length } })}
+        {#if albums.length === 1}
+          {albums[0].albumName}
+        {:else}
+          <span title={listFormat.format(albums.map(({ albumName }) => albumName))}>
+            {$t('in_albums', { values: { count: albums.length } })}
+          </span>
+        {/if}
       {/await}
     </InfoRow>
   </div>


### PR DESCRIPTION
## Description
Show album name instead of "in 1 album" when in a single album and "in x albums" with a title of "Album1name, album2name, and album3name" when in mulitple albums.

Closes #10206

## How Has This Been Tested?

<img width="2071" height="460" alt="image" src="https://github.com/user-attachments/assets/c37efdc0-5eaa-4390-9bd0-9894c4e96fdb" />


## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
