### PR TITLE
fix(web): refresh album order state after updating in options modal

### DIFF
--- a/web/src/lib/modals/AlbumOptionsModal.svelte
+++ b/web/src/lib/modals/AlbumOptionsModal.svelte
@@ -26,9 +26,10 @@
     album: AlbumResponseDto;
     readOnly?: boolean;
     onClose: () => void;
+    onUpdate?: (album: AlbumResponseDto) => void;
   };
 
-  let { album, readOnly = false, onClose }: Props = $props();
+  let { album, readOnly = false, onClose, onUpdate }: Props = $props();
 
   const handleRoleSelect = async (user: UserResponseDto, role: AlbumUserRole | 'none') => {
     if (role === 'none') {
@@ -70,7 +71,10 @@
   onAlbumShare={refreshAlbum}
   {onSharedLinkCreate}
   {onSharedLinkDelete}
-  onAlbumUpdate={(newAlbum) => (album = newAlbum)}
+  onAlbumUpdate={(newAlbum) => {
+    album = newAlbum;
+    onUpdate?.(newAlbum);
+  }}
 />
 
 <Modal title={readOnly ? $t('album') : $t('options')} {onClose} size="small">

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -206,7 +206,11 @@
     }
   });
 
-  let album = $derived(data.album);
+  let album: AlbumResponseDto = $state(data.album);
+
+  $effect(() => {
+    album = data.album;
+  });
   let albumId = $derived(album.id);
 
   const containsEditors = $derived(album?.shared && album.albumUsers.some(({ role }) => role === AlbumUserRole.Editor));
@@ -376,7 +380,7 @@
                   <button
                     class="flex gap-x-1"
                     type="button"
-                    onclick={() => modalManager.show(AlbumOptionsModal, { album, readOnly: !isOwned })}
+                    onclick={() => modalManager.show(AlbumOptionsModal, { album, readOnly: !isOwned, onUpdate: (updated) => (album = updated) })}
                   >
                     <!-- owner & users with write access (collaborators) -->
                     {#each album.albumUsers.filter(({ role }) => role === AlbumUserRole.Editor || role === AlbumUserRole.Owner) as { user } (user.id)}
@@ -570,7 +574,7 @@
                   <MenuOption
                     icon={mdiCogOutline}
                     text={$t('options')}
-                    onClick={() => modalManager.show(AlbumOptionsModal, { album })}
+                    onClick={() => modalManager.show(AlbumOptionsModal, { album, onUpdate: (updated) => (album = updated) })}
                   />
                 {/if}
 


### PR DESCRIPTION
## Description

Fixes #28383

When a user changes album display order in the options modal, the change is saved to the server correctly but the parent page's reactive `album` state isn't updated. After closing the asset viewer (which triggers a re-render), the stale `data.album` reference causes the order to appear to reset.

**Root cause:** `album` was declared as `$derived(data.album)`, making it read-only in Svelte 5. Assignments like `album = newAlbum` in event handlers were silently dropped. The async `invalidate('album:data')` call would eventually sync state, but if the user opened the asset viewer before it resolved, the subsequent navigation on Escape re-used the stale `data.album`.

**Fix:** Two minimal changes:
1. Convert `album` to `$state(data.album)` with a `$effect` to stay in sync when route data changes, so local assignments actually stick.
2. Add an `onUpdate` callback prop to `AlbumOptionsModal` and pass it from the parent, so the fresh server response is applied to local state immediately — without waiting for the async invalidate cycle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, where necessary
- [x] My changes do not break existing tests

## LLM-Generated Code

None.