### PR TITLE
fix(server): skip already-added users in addUsersToAlbum instead of failing

### DIFF
--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -472,7 +472,7 @@ describe(AlbumService.name, () => {
       expect(mocks.album.update).not.toHaveBeenCalled();
     });
 
-    it('should throw an error if the userId is already added', async () => {
+    it('should skip if the userId is already added', async () => {
       const userId = newUuid();
       const album = AlbumFactory.from().albumUser({ userId }).build();
       const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
@@ -480,9 +480,8 @@ describe(AlbumService.name, () => {
       mocks.album.getById.mockResolvedValue(getForAlbum(album));
       await expect(
         sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] }),
-      ).rejects.toBeInstanceOf(BadRequestException);
-      expect(mocks.album.update).not.toHaveBeenCalled();
-      expect(mocks.user.get).not.toHaveBeenCalled();
+      ).resolves.toBeDefined();
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
     });
 
     it('should throw an error if the userId does not exist', async () => {

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -290,7 +290,8 @@ export class AlbumService extends BaseService {
 
       const exists = album.albumUsers.find(({ user: { id } }) => id === userId);
       if (exists) {
-        throw new BadRequestException('User already added');
+        this.logger.debug(`Skipping user ${userId}: already a member of album ${id}`);
+        continue;
       }
 
       const user = await this.userRepository.get(userId, {});


### PR DESCRIPTION
## Description

When adding multiple users to an album via `addUsersToAlbum`, if any user is already a member, the entire request fails with a 400 error (`"User already added"`) and no users are added. This is unexpected behavior — the API should skip already-existing members and add the remaining users.

**Root cause:** In `album.service.ts`, the `addUsers` method throws a `BadRequestException` when it encounters an already-added user, which aborts the entire loop.

**Fix:** Replace the `throw` with a `continue` statement, logging the skip at debug level. This allows the remaining users in the request to be added successfully.

Fixes #28880

## How Has This Been Tested

- [x] Updated existing unit test: changed `"should throw an error if the userId is already added"` to `"should skip if the userId is already added"` — now expects the call to succeed (resolve) instead of throwing, and verifies `albumUser.create` was not called for the duplicate.
- [x] Existing tests for adding new users and invalid users still pass.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM was used to help understand the codebase and draft the PR description. The code changes and testing strategy were designed by me.