### PR TITLE
fix(mobile): re-lock locked folder when the app is backgrounded

### DIFF
--- a/mobile/lib/presentation/pages/drift_locked_folder.page.dart
+++ b/mobile/lib/presentation/pages/drift_locked_folder.page.dart
@@ -49,7 +49,7 @@ class _DriftLockedFolderPageState extends ConsumerState<DriftLockedFolderPage> w
       return;
     }
     setState(() {
-      _showOverlay = _pendingClose || state != AppLifecycleState.resumed;
+      _showOverlay = state != AppLifecycleState.resumed;
     });
   }
 

--- a/mobile/lib/presentation/pages/drift_locked_folder.page.dart
+++ b/mobile/lib/presentation/pages/drift_locked_folder.page.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/mesmerizing_sliver_app_bar.dart';
 
 @RoutePage()
@@ -19,6 +20,7 @@ class DriftLockedFolderPage extends ConsumerStatefulWidget {
 
 class _DriftLockedFolderPageState extends ConsumerState<DriftLockedFolderPage> with WidgetsBindingObserver {
   bool _showOverlay = false;
+  bool _pendingClose = false;
 
   @override
   void initState() {
@@ -34,11 +36,21 @@ class _DriftLockedFolderPageState extends ConsumerState<DriftLockedFolderPage> w
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (mounted) {
-      setState(() {
-        _showOverlay = state != AppLifecycleState.resumed;
-      });
+    if (!mounted) {
+      return;
     }
+    if (state == AppLifecycleState.paused) {
+      _pendingClose = true;
+      ref.read(authProvider.notifier).lockPinCode();
+    }
+    if (state == AppLifecycleState.resumed && _pendingClose) {
+      _pendingClose = false;
+      context.navigateTo(const TabShellRoute());
+      return;
+    }
+    setState(() {
+      _showOverlay = _pendingClose || state != AppLifecycleState.resumed;
+    });
   }
 
   @override

--- a/mobile/lib/presentation/pages/drift_locked_folder.page.dart
+++ b/mobile/lib/presentation/pages/drift_locked_folder.page.dart
@@ -20,7 +20,6 @@ class DriftLockedFolderPage extends ConsumerStatefulWidget {
 
 class _DriftLockedFolderPageState extends ConsumerState<DriftLockedFolderPage> with WidgetsBindingObserver {
   bool _showOverlay = false;
-  bool _pendingClose = false;
 
   @override
   void initState() {
@@ -40,11 +39,7 @@ class _DriftLockedFolderPageState extends ConsumerState<DriftLockedFolderPage> w
       return;
     }
     if (state == AppLifecycleState.paused) {
-      _pendingClose = true;
       ref.read(authProvider.notifier).lockPinCode();
-    }
-    if (state == AppLifecycleState.resumed && _pendingClose) {
-      _pendingClose = false;
       context.navigateTo(const TabShellRoute());
       return;
     }


### PR DESCRIPTION
## Description

fixes #28999

the locked folder uses the servers "elevated" session to decide if it should ask for the pin, and that stays elevated for a while + survives the app being backgrounded/killed. so leaving the app while still inside the folder and coming back just opened it agian with no prompt.

now backgrounding while youre in the folder drops the elevated session and pops you back to the library, so reopening (warm or after a kill) you go back in and it asks for face id / pin again.. normal unlock still goes straight in, no double prompt.

tested on iphone, bg+reopen and swipe killing from the switcher both ask again now
