### PR TITLE
fix(web): refresh album order state after updating in options modal

### DIFF
--- a/web/src/lib/modals/AlbumOptionsModal.svelte
+++ b/web/src/lib/modals/AlbumOptionsModal.svelte
@@ -26,9 +26,10 @@
     album: AlbumResponseDto;
     readOnly?: boolean;
     onClose: () => void;
+    onUpdate?: (album: AlbumResponseDto) => void;
   };
 
-  let { album, readOnly = false, onClose }: Props = $props();
+  let { album, readOnly = false, onClose, onUpdate }: Props = $props();
 
   const handleRoleSelect = async (user: UserResponseDto, role: AlbumUserRole | 'none') => {
     if (role === 'none') {
@@ -70,7 +71,10 @@
   onAlbumShare={refreshAlbum}
   {onSharedLinkCreate}
   {onSharedLinkDelete}
-  onAlbumUpdate={(newAlbum) => (album = newAlbum)}
+  onAlbumUpdate={(newAlbum) => {
+    album = newAlbum;
+    onUpdate?.(newAlbum);
+  }}
 />
 
 <Modal title={readOnly ? $t('album') : $t('options')} {onClose} size="small">

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -206,7 +206,11 @@
     }
   });
 
-  let album = $derived(data.album);
+  let album: AlbumResponseDto = $state(data.album);
+
+  $effect(() => {
+    album = data.album;
+  });
   let albumId = $derived(album.id);
 
   const containsEditors = $derived(album?.shared && album.albumUsers.some(({ role }) => role === AlbumUserRole.Editor));
@@ -376,7 +380,7 @@
                   <button
                     class="flex gap-x-1"
                     type="button"
-                    onclick={() => modalManager.show(AlbumOptionsModal, { album, readOnly: !isOwned })}
+                    onclick={() => modalManager.show(AlbumOptionsModal, { album, readOnly: !isOwned, onUpdate: (updated) => (album = updated) })}
                   >
                     <!-- owner & users with write access (collaborators) -->
                     {#each album.albumUsers.filter(({ role }) => role === AlbumUserRole.Editor || role === AlbumUserRole.Owner) as { user } (user.id)}
@@ -570,7 +574,7 @@
                   <MenuOption
                     icon={mdiCogOutline}
                     text={$t('options')}
-                    onClick={() => modalManager.show(AlbumOptionsModal, { album })}
+                    onClick={() => modalManager.show(AlbumOptionsModal, { album, onUpdate: (updated) => (album = updated) })}
                   />
                 {/if}
 


### PR DESCRIPTION
## Description

The album page declared `album` as `derived(data.album)`, making it read-only in Svelte 5. Assignments like `album = newAlbum` inside event handlers were silently dropped, so the sort order appeared to reset after updating via the options modal.

Fix: convert `album` to `state` with an effect to sync from route data, and add an `onUpdate` callback to `AlbumOptionsModal` so the parent applies the server response immediately without waiting for the async invalidate cycle.

Fixes #28383

## How Has This Been Tested?

- [x] Manually verified the fix in a local dev environment - updated album sort order now persists immediately after closing the modal

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.