### PR TITLE
fix(web): prevent partner assets from being selected in geolocation utility

### DIFF
--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -54,7 +54,7 @@
 
     await updateAssets({
       assetBulkUpdateDto: {
-        ids: assetMultiSelectManager.assets.map((asset) => asset.id),
+        ids: assetMultiSelectManager.assets.filter((asset) => asset.ownerId === authManager.user.id).map((asset) => asset.id),
         latitude: point.lat,
         longitude: point.lng,
       },
@@ -106,6 +106,8 @@
   const hasGps = (asset: TimelineAsset | AssetPoint): asset is AssetPoint =>
     isDefined(asset.latitude) && isDefined(asset.longitude);
 
+  const isOwnAsset = (asset: TimelineAsset) => asset.ownerId === authManager.user.id;
+
   const handleThumbnailClick = (
     asset: TimelineAsset,
     timelineManager: TimelineManager,
@@ -124,7 +126,7 @@
       }, 1500);
       point = { lat: asset.latitude, lng: asset.longitude };
       void setQueryValue('at', asset.id);
-    } else {
+    } else if (isOwnAsset(asset)) {
       onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
     }
   };
@@ -199,6 +201,9 @@
     onThumbnailClick={handleThumbnailClick}
   >
     {#snippet customThumbnailLayout(asset: TimelineAsset)}
+      {#if !isOwnAsset(asset)}
+        <div class="absolute inset-0 bg-black/40 pointer-events-none rounded" />
+      {/if}
       {#if hasGps(asset)}
         <div class="absolute inset-e-3 bottom-1 rounded-xl bg-success px-4 py-1 text-xs text-black transition-colors">
           {asset.city || $t('gps')}


### PR DESCRIPTION
## Description

19956:Assets shared by partners were selectable in the geolocation utility page and could be bulk-updated with GPS coordinates belonging to a different user. Fix: mark partner assets as readonly in the geolocation asset store so they are excluded from selection.

Fixes # prevent partner assets from being selected in geolocation utility

## How Has This Been Tested?

- [ ] Manually verified the fix in a local dev environment

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.
