### PR TITLE
fix: toggle person visibility filters view instead of changing hidden state

### DIFF
--- a/web/src/routes/(user)/people/ManagePeopleVisibility.svelte
+++ b/web/src/routes/(user)/people/ManagePeopleVisibility.svelte
@@ -37,22 +37,22 @@
     }
   };
 
+  const isPersonVisible = (person: PersonResponseDto) => {
+    const isHidden = overrides.get(person.id) ?? person.isHidden;
+    if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
+      return false;
+    } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
+      return false;
+    }
+    return !isHidden;
+  };
+
+  let filteredPeople = $derived(
+    toggleVisibility === ToggleVisibility.SHOW_ALL ? people : people.filter((person) => isPersonVisible(person)),
+  );
+
   const handleToggleVisibility = () => {
     toggleVisibility = getNextVisibility(toggleVisibility);
-
-    for (const person of people) {
-      let isHidden = overrides.get(person.id) ?? person.isHidden;
-
-      if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
-        isHidden = true;
-      } else if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
-        isHidden = false;
-      } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
-        isHidden = true;
-      }
-
-      setHiddenOverride(person, isHidden);
-    }
   };
 
   const handleSaveVisibility = async () => {
@@ -147,7 +147,7 @@
   </div>
 
   <div class="flex flex-wrap gap-1 p-2 pb-8 md:px-8">
-    <PeopleInfiniteScroll {people} hasNextPage={true} {loadNextPage}>
+    <PeopleInfiniteScroll people={filteredPeople} hasNextPage={true} {loadNextPage}>
       {#snippet children({ person })}
         {@const hidden = overrides.get(person.id) ?? person.isHidden}
         <button


### PR DESCRIPTION
## Description

19956:The eye icon in Show and Hide People was writing to the overrides map, causing hidden-state changes to be persisted when clicking Done. Fix: toggle now only filters the visible list without touching overrides.

Fixes # toggle person visibility filters view instead of changing hidden state

## How Has This Been Tested?

- [ ] Manually verified the fix in a local dev environment

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.
