### PR TITLE
fix(web): prevent upload status panel from overlapping album action bar

### DIFF
--- a/web/src/routes/UploadPanel.svelte
+++ b/web/src/routes/UploadPanel.svelte
@@ -37,7 +37,7 @@
       }
       uploadAssetsStore.reset();
     }}
-    class="fixed inset-e-16 bottom-6"
+    class="fixed inset-e-16 bottom-6 z-60"
   >
     {#if showDetail}
       <div


### PR DESCRIPTION
## Description

none:Upload status panel had no z-index, causing it to render behind the album activity bar (z-2). Added z-60 to match DownloadPanel so action buttons remain clickable during uploads.

Fixes # prevent upload status panel from overlapping album action bar

## How Has This Been Tested?

- [ ] Manually verified the fix in a local dev environment

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.
