### PR TITLE
fix(server): skip existing members when adding users to album

### DIFF
--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -480,8 +480,8 @@ describe(AlbumService.name, () => {
       mocks.album.getById.mockResolvedValue(getForAlbum(album));
       await expect(
         sut.addUsers(AuthFactory.create(owner), album.id, { albumUsers: [{ userId }] }),
-      ).rejects.toBeInstanceOf(BadRequestException);
-      expect(mocks.album.update).not.toHaveBeenCalled();
+      ).resolves.toBeDefined();
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
       expect(mocks.user.get).not.toHaveBeenCalled();
     });
 
@@ -505,11 +505,10 @@ describe(AlbumService.name, () => {
       mocks.album.getById.mockResolvedValue(getForAlbum(album));
       await expect(
         sut.addUsers(AuthFactory.create(owner), album.id, {
-          albumUsers: [{ userId: owner.id }],
+          albumUsers: [{ userId: newUuid(), role: AlbumUserRole.Owner }],
         }),
       ).rejects.toBeInstanceOf(BadRequestException);
-      expect(mocks.album.update).not.toHaveBeenCalled();
-      expect(mocks.user.get).not.toHaveBeenCalled();
+      expect(mocks.albumUser.create).not.toHaveBeenCalled();
     });
 
     it('should add valid shared users', async () => {
@@ -532,6 +531,28 @@ describe(AlbumService.name, () => {
         id: album.id,
         userId: user.id,
         senderName: owner.name,
+      });
+    });
+
+    it('should add the remaining users when one is already a member', async () => {
+      const existingId = newUuid();
+      const album = AlbumFactory.from().albumUser({ userId: existingId }).build();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      const newUser = UserFactory.create();
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.album.update.mockResolvedValue(getForAlbum(album));
+      mocks.user.get.mockResolvedValue(newUser);
+      mocks.albumUser.create.mockResolvedValue(AlbumUserFactory.from().album(album).user(newUser).build());
+
+      await sut.addUsers(AuthFactory.create(owner), album.id, {
+        albumUsers: [{ userId: existingId }, { userId: newUser.id }],
+      });
+
+      expect(mocks.albumUser.create).toHaveBeenCalledTimes(1);
+      expect(mocks.albumUser.create).toHaveBeenCalledWith({
+        userId: newUser.id,
+        albumId: album.id,
       });
     });
   });

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -290,7 +290,7 @@ export class AlbumService extends BaseService {
 
       const exists = album.albumUsers.find(({ user: { id } }) => id === userId);
       if (exists) {
-        throw new BadRequestException('User already added');
+        continue; // skip, already a member
       }
 
       const user = await this.userRepository.get(userId, {});


### PR DESCRIPTION
## Description

`addUsers` previously threw `BadRequestException('User already added')` as soon as it encountered a user who was already a member of the album. Because this happened mid-loop, the entire request failed and **no** users were added — including valid, new ones in the same batch.

This changes the already-a-member case to skip that user and continue, so the remaining users are still added. Adding a user with `role: owner` is still rejected, as before.

Fixes #28880

## How Has This Been Tested?

Server unit tests (`server/src/services/album.service.spec.ts`):

- [x] Updated the existing "already added" test to assert the duplicate user is **skipped** (request resolves, no `albumUser.create` / `user.get` call for that user).
- [x] Reworked the owner test to actually exercise the `role === owner` guard (passing `role: AlbumUserRole.Owner`), since the old test was implicitly relying on the duplicate-member check.
- [x] Added a test confirming that when a batch contains one existing member and one new user, the new user **is** added (`albumUser.create` called exactly once for the new user).

```bash
cd server && pnpm test --run src/services/album.service.spec.ts
# 64 passed
```

Also verified `tsc --noEmit` and ESLint pass clean on the changed files.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

N/A — server-only logic change.

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude Code) assisted me with navigating the codebase to locate the relevant service and tests, and with drafting the unit-test changes. I reviewed, understood, and verified all changes myself, ran the test suite and lint locally, and wrote/edited this description. No code was committed that I did not read and understand.
