### PR TITLE
chore: do not optimize on cleanup

### DIFF
--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -104,6 +104,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   Future<void> onAndroidUpload(int? maxMinutes) async {
     final hashTimeout = Duration(minutes: _isBackupEnabled ? 3 : 6);
     final backupTimeout = maxMinutes != null ? Duration(minutes: maxMinutes - 1) : null;
+    await _optimizeDB();
     return _backgroundLoop(
       hashTimeout: hashTimeout,
       backupTimeout: backupTimeout,
@@ -121,6 +122,11 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       final sync = _ref?.read(backgroundSyncProvider);
       if (sync == null) {
         return;
+      }
+
+      // Only for Background Processing tasks
+      if (maxSeconds == null) {
+        await _optimizeDB();
       }
 
       // Run sync local, sync remote, hash and backup concurrently so the bg
@@ -193,6 +199,14 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
     }
   }
 
+  Future<void> _optimizeDB() async {
+    try {
+      await (_drift.optimize(allTables: true), _driftLogger.optimize()).wait;
+    } catch (error, stack) {
+      dPrint(() => "Error during background worker optimize: $error, $stack");
+    }
+  }
+
   Future<void> _cleanup() async {
     await runZonedGuarded(_handleCleanup, (error, stack) {
       dPrint(() => "Error during background worker cleanup: $error, $stack");
@@ -221,7 +235,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         if (nativeSyncApi != null) nativeSyncApi.cancelHashing(),
       ]);
       await workerManagerPatch.dispose().catchError((_) async {});
-      await Future.wait([LogService.I.dispose(), Store.dispose(), _drift.optimize(allTables: true)]);
+      await Future.wait([LogService.I.dispose(), Store.dispose()]);
       await _drift.close();
       await _driftLogger.close();
 

--- a/mobile/lib/infrastructure/repositories/logger_db.repository.dart
+++ b/mobile/lib/infrastructure/repositories/logger_db.repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:drift_sqlite_async/drift_sqlite_async.dart';
 import 'package:immich_mobile/infrastructure/entities/log.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/logger_db.repository.drift.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
 @DriftDatabase(tables: [LogMessageEntity])
@@ -12,6 +13,14 @@ class DriftLogger extends $DriftLogger {
 
   @override
   int get schemaVersion => 1;
+
+  Future<void> optimize() async {
+    try {
+      await customStatement('PRAGMA optimize=0x10002');
+    } catch (error) {
+      dPrint(() => 'Failed to optimize logger database: $error');
+    }
+  }
 
   @override
   MigrationStrategy get migration => MigrationStrategy(


### PR DESCRIPTION
Changes the `optimize` PRAGMA call to be executed only on Android / iOS Processing tasks. Doing this during the cleanup, especially in refresh tasks on iOS is risky as the engine might be disposed while the optimization is still in progress