### PR TITLE
fix(server): include all partner assets in map side panel regardless of timeline setting

### DIFF
--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -2,6 +2,8 @@ import { BadRequestException } from '@nestjs/common';
 import { AssetVisibility } from 'src/enum';
 import { TimelineService } from 'src/services/timeline.service';
 import { authStub } from 'test/fixtures/auth.stub';
+import { PartnerFactory } from 'test/factories/partner.factory';
+import { getForPartner } from 'test/mappers';
 import { newTestService, ServiceMocks } from 'test/utils';
 
 describe(TimelineService.name, () => {
@@ -203,6 +205,31 @@ describe(TimelineService.name, () => {
           userId: authStub.admin.user.id,
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should include partner assets with inTimeline=false when bbox is set', async () => {
+      const json = `[{ id: ['asset-id'] }]`;
+      mocks.asset.getTimeBucket.mockResolvedValue({ assets: json });
+      const partner = PartnerFactory.create({ sharedWithId: authStub.admin.user.id, inTimeline: false });
+      mocks.partner.getAll.mockResolvedValue([getForPartner(partner)]);
+
+      await expect(
+        sut.getTimeBucket(authStub.admin, {
+          timeBucket: 'bucket',
+          visibility: AssetVisibility.Timeline,
+          userId: authStub.admin.user.id,
+          withPartners: true,
+          bbox: { west: -10, south: -10, east: 10, north: 10 },
+        }),
+      ).resolves.toEqual(json);
+      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+        'bucket',
+        expect.objectContaining({
+          withPartners: true,
+          userIds: expect.arrayContaining([authStub.admin.user.id, partner.sharedById]),
+        }),
+        authStub.admin,
+      );
     });
 
     it('should throw an error if withPartners is true and visibility is locked', async () => {

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -32,10 +32,13 @@ export class TimelineService extends BaseService {
     if (userId) {
       userIds = [userId];
       if (dto.withPartners) {
+        // When filtering by bounding box (map side panel), include all partners regardless
+        // of their "Show in timeline" setting — the map markers are drawn using all partners,
+        // so the side panel must use the same set to avoid count/content mismatches.
         const partnerIds = await getMyPartnerIds({
           userId: auth.user.id,
           repository: this.partnerRepository,
-          timelineEnabled: true,
+          timelineEnabled: !dto.bbox,
         });
         userIds.push(...partnerIds);
       }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Map markers count all partners regardless of timeline setting, but the side panel only fetches partners with timeline enabled. So the cluster badge says 5 assets but the panel shows 2, or nothing at all.

Fixed by passing `timelineEnabled: false` when fetching partner IDs in the bbox path, matching what `getMapMarkers` does.

Fixes #28851

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

- Enabled a partner without "Show in timeline", added assets to the map — cluster count now matches the side panel

## Screenshots (if appropriate)

<details><summary>N/A — logic fix, no visual change</summary></details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.