### PR TITLE
fix(web): respect local timezone when building date range for search

### DIFF
--- a/web/src/lib/modals/SearchFilterModal.svelte
+++ b/web/src/lib/modals/SearchFilterModal.svelte
@@ -11,7 +11,7 @@
   import { MediaType, QueryType, validQueryTypes } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import type { SearchFilter } from '$lib/types';
-  import { parseUtcDate } from '$lib/utils/date-time';
+  import { asLocalTimeISO, parseUtcDate } from '$lib/utils/date-time';
   import { generateId } from '$lib/utils/generate-id';
   import { AssetTypeEnum, AssetVisibility, type MetadataSearchDto, type SmartSearchDto } from '@immich/sdk';
   import { Button, HStack, Modal, ModalBody, ModalFooter } from '@immich/ui';
@@ -27,7 +27,6 @@
 
   let { searchQuery, onClose }: Props = $props();
 
-  const parseOptionalDate = (dateString?: DateTime) => (dateString ? parseUtcDate(dateString.toString()) : undefined);
   const toStartOfDayDate = (dateString: string) => parseUtcDate(dateString)?.startOf('day') || undefined;
   const formId = generateId();
 
@@ -144,8 +143,12 @@
       make: filter.camera.make,
       model: filter.camera.model,
       lensModel: filter.camera.lensModel,
-      takenAfter: parseOptionalDate(filter.date.takenAfter)?.startOf('day').toISO() || undefined,
-      takenBefore: parseOptionalDate(filter.date.takenBefore)?.endOf('day').toISO() || undefined,
+      takenAfter: filter.date.takenAfter
+        ? asLocalTimeISO(filter.date.takenAfter.startOf('day') as DateTime<true>)
+        : undefined,
+      takenBefore: filter.date.takenBefore
+        ? asLocalTimeISO(filter.date.takenBefore.endOf('day') as DateTime<true>)
+        : undefined,
       visibility: filter.display.isArchive ? AssetVisibility.Archive : undefined,
       isFavorite: filter.display.isFavorite || undefined,
       isNotInAlbum: filter.display.isNotInAlbum || undefined,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Date range search was returning results one day early for users in timezones ahead of UTC. The DatePicker returns a Luxon DateTime in local time, but it was going through `parseUtcDate` which re-interpreted the local offset as UTC, shifting the date back by hours.

Switched to `asLocalTimeISO` (already in the codebase) which keeps the wall-clock time and labels it UTC — correct for calendar-day queries.

Fixes #28705

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

- Set browser timezone to UTC+5:30, searched by date — results no longer include assets from the previous day

## Screenshots (if appropriate)

<details><summary>N/A — logic fix, no visual change</summary></details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.