### PR TITLE
fix: update datetimeRelative description to minutes instead of seconds

### DIFF
--- a/mobile/openapi/lib/model/asset_bulk_update_dto.dart
+++ b/mobile/openapi/lib/model/asset_bulk_update_dto.dart
@@ -35,7 +35,7 @@ class AssetBulkUpdateDto {
   ///
   Optional<String?> dateTimeOriginal;
 
-  /// Relative time offset in seconds
+  /// Relative time offset in minutes
   ///
   /// Minimum value: -9007199254740991
   /// Maximum value: 9007199254740991

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16868,7 +16868,7 @@
             "type": "string"
           },
           "dateTimeRelative": {
-            "description": "Relative time offset in seconds",
+            "description": "Relative time offset in minutes",
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -673,7 +673,7 @@ export type AssetMediaResponseDto = {
 export type AssetBulkUpdateDto = {
     /** Original date and time */
     dateTimeOriginal?: string;
-    /** Relative time offset in seconds */
+    /** Relative time offset in minutes */
     dateTimeRelative?: number;
     /** Asset description */
     description?: string;

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -41,7 +41,7 @@ const UpdateAssetBaseSchema = z
 const AssetBulkUpdateBaseSchema = UpdateAssetBaseSchema.extend({
   ids: z.array(z.uuidv4()).describe('Asset IDs to update'),
   duplicateId: z.string().nullish().describe('Duplicate ID'),
-  dateTimeRelative: z.int().optional().describe('Relative time offset in seconds'),
+  dateTimeRelative: z.int().optional().describe('Relative time offset in minutes'),
   timeZone: z.string().optional().describe('Time zone (IANA timezone)'),
 });
 


### PR DESCRIPTION
The offset is in fact a number of minutes, not, as the API docs stated, a number of seconds. We can support an offset in seconds for v4.