### PR TITLE
fix(server): de-duplicate integity checks missing paths

### DIFF
--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -399,7 +399,10 @@ export class IntegrityService extends BaseService {
       await this.integrityRepository.deleteByIds(outdatedReports);
     }
 
-    const missingFiles = results.filter(({ exists }) => !exists);
+    const missingFiles = Object.values(
+      Object.fromEntries(results.filter(({ exists }) => !exists).map((file) => [file.path, file])),
+    );
+
     if (missingFiles.length > 0) {
       await this.integrityRepository.create(
         missingFiles.map(({ path, assetId, fileAssetId }) => ({

--- a/server/test/medium/specs/services/integrity.service.spec.ts
+++ b/server/test/medium/specs/services/integrity.service.spec.ts
@@ -512,6 +512,82 @@ describe(IntegrityService.name, () => {
         nextCursor: undefined,
       });
     });
+
+    it('should not fail when the same path is duplicated within a batch', async () => {
+      const { sut, ctx } = setup();
+      const storage = ctx.getMock(StorageRepository);
+
+      const {
+        result: { id: ownerId },
+      } = await ctx.newUser();
+
+      const {
+        result: { id: assetId1 },
+      } = await ctx.newAsset({ ownerId, originalPath: '/path/to/duplicate' });
+
+      const {
+        result: { id: assetId2 },
+      } = await ctx.newAsset({ ownerId, originalPath: '/path/to/duplicate' });
+
+      const fileAssetId1 = randomUUID();
+      await ctx.newAssetFile({
+        id: fileAssetId1,
+        assetId: assetId1,
+        type: AssetFileType.Thumbnail,
+        path: '/path/to/duplicate-file',
+      });
+
+      const fileAssetId2 = randomUUID();
+      await ctx.newAssetFile({
+        id: fileAssetId2,
+        assetId: assetId1,
+        type: AssetFileType.Preview,
+        path: '/path/to/duplicate-file',
+      });
+
+      const {
+        result: { id: assetId3 },
+      } = await ctx.newAsset({ ownerId, originalPath: '/path/to/duplicate-cross' });
+
+      const fileAssetId3 = randomUUID();
+      await ctx.newAssetFile({
+        id: fileAssetId3,
+        assetId: assetId3,
+        type: AssetFileType.Thumbnail,
+        path: '/path/to/duplicate-cross',
+      });
+
+      storage.stat.mockRejectedValue(new Error('ENOENT'));
+
+      await expect(
+        sut.handleMissingFiles({
+          items: [
+            { path: '/path/to/duplicate', assetId: assetId1, fileAssetId: null, reportId: null },
+            { path: '/path/to/duplicate', assetId: assetId2, fileAssetId: null, reportId: null },
+            { path: '/path/to/duplicate-file', assetId: null, fileAssetId: fileAssetId1, reportId: null },
+            { path: '/path/to/duplicate-file', assetId: null, fileAssetId: fileAssetId2, reportId: null },
+            { path: '/path/to/duplicate-cross', assetId: assetId3, fileAssetId: null, reportId: null },
+            { path: '/path/to/duplicate-cross', assetId: null, fileAssetId: fileAssetId3, reportId: null },
+          ],
+        }),
+      ).resolves.toBe(JobStatus.Success);
+
+      await expect(
+        ctx.get(IntegrityRepository).getIntegrityReport(
+          {
+            limit: 100,
+          },
+          IntegrityReport.MissingFile,
+        ),
+      ).resolves.toEqual({
+        items: expect.arrayContaining([
+          expect.objectContaining({ path: '/path/to/duplicate' }),
+          expect.objectContaining({ path: '/path/to/duplicate-file' }),
+          expect.objectContaining({ path: '/path/to/duplicate-cross' }),
+        ]),
+        nextCursor: undefined,
+      });
+    });
   });
 
   describe('handleMissingRefresh', () => {
@@ -683,6 +759,40 @@ describe(IntegrityService.name, () => {
         ),
       ).resolves.toEqual({
         items: [],
+        nextCursor: undefined,
+      });
+    });
+
+    it('should not fail when the same path is duplicated across assets', async () => {
+      const { sut, ctx } = setup();
+      const storage = ctx.getMock(StorageRepository);
+      const job = ctx.getMock(JobRepository);
+      job.queue.mockResolvedValue(void 0);
+
+      const {
+        result: { id: ownerId },
+      } = await ctx.newUser();
+
+      await ctx.newAsset({ ownerId, originalPath: '/path/to/duplicate', checksum: Buffer.from('mismatch-a') });
+      await ctx.newAsset({ ownerId, originalPath: '/path/to/duplicate', checksum: Buffer.from('mismatch-b') });
+
+      storage.createPlainReadStream.mockImplementation(() => Readable.from('garbage data'));
+
+      await expect(sut.handleChecksumFiles({ refreshOnly: false })).resolves.toBe(JobStatus.Success);
+
+      await expect(
+        ctx.get(IntegrityRepository).getIntegrityReport(
+          {
+            limit: 100,
+          },
+          IntegrityReport.ChecksumFail,
+        ),
+      ).resolves.toEqual({
+        items: [
+          expect.objectContaining({
+            path: '/path/to/duplicate',
+          }),
+        ],
         nextCursor: undefined,
       });
     });


### PR DESCRIPTION
## Bug description

There is no guarantee that paths generated for the missing files job are unique from one another.
- `asset.originalPath` has no unique constraints (despite the comment on L63)
- `asset_file.path` has no unique constraints
- `asset.originalPath` and `asset_file.path` together have no unique constraint

So, whether through database corruption or some intentional action, these values may produce duplicate paths.
Resulting in the following error where a batch of missing files is processed together:

```
[Nest] 32710  - 06/16/2026, 11:07:21 AM   ERROR [Microservices:{"items":[{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":"33ddf664-4eeb-4cfb-9932-217a2d4de11d","fileAssetId":null,"reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":"0bd26978-b7ad-474d-b73d-d4e46b79f834","fileAssetId":null,"reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"35ca62ab-e65f-4dfb-8477-e6f0e82cf188","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"8a2555dc-b88f-4f72-9b47-ae1cd03148c1","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"5018cff4-d62c-4667-8e6f-853d62dda008","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"d2f1b8a6-435c-457c-81f6-bb7ba504d119","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"216c1902-3753-4c26-84c0-fc71070e323e","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"c6b7af59-402b-4b35-9136-6f14b20db1fc","reportId":null},{"path":"/data/upload/0dbbbebd-024a-493b-8a2c-3820f4c57858/52/d4/52d487df-e890-43d1-9f71-cbfb2e092209.jpg","assetId":null,"fileAssetId":"ee54a88a-6ec7-477f-b3c0-21653f2a2800","reportId":null}]}] Unable to run job handler (IntegrityMissingFiles): PostgresError: ON CONFLICT DO UPDATE command cannot affect row a second time
PostgresError: ON CONFLICT DO UPDATE command cannot affect row a second time
    at ErrorResponse (file:///usr/src/app/node_modules/.pnpm/postgres@3.4.9/node_modules/postgres/src/connection.js:815:30)
    at handle (file:///usr/src/app/node_modules/.pnpm/postgres@3.4.9/node_modules/postgres/src/connection.js:489:6)
    at Socket.data (file:///usr/src/app/node_modules/.pnpm/postgres@3.4.9/node_modules/postgres/src/connection.js:324:9)
    at Socket.emit (node:events:509:28)
    at addChunk (node:internal/streams/readable:563:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
    at Readable.push (node:internal/streams/readable:394:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
```

In this scenario, all assets / asset files point at the same source file.

## Fix

De-duplicate the missing files by the `path`, first asset / asset file wins as being tied to the report item.

This does mean that clean up (deleting the asset / asset file) and doing further runs will produce the same report item again (as the item is still missing for other asset / asset files).

Note: I did also consider using `DISTINCT ON` in the query, but I don't know what impact that will have on the performance of the query so I decided to not touch that.

## How Has This Been Tested?

- [x] Test for missing files covering each case listed above
- [x] Test for checksum files covering duplicate `originalPath` case

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Test scaffold