### PR TITLE
refactor(server): use uuids in schemas

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16972,8 +16972,6 @@
           },
           "id": {
             "description": "Asset ID",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16508,7 +16508,9 @@
           },
           "albumThumbnailAssetId": {
             "description": "Thumbnail asset ID",
+            "format": "uuid",
             "nullable": true,
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "albumUsers": {
@@ -16551,6 +16553,8 @@
           },
           "id": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isActivityEnabled": {
@@ -16793,6 +16797,8 @@
           },
           "id": {
             "description": "API key ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "name": {
@@ -16966,6 +16972,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -17001,6 +17009,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isTrashed": {
@@ -17379,6 +17389,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "error": {
@@ -17494,6 +17506,8 @@
         "properties": {
           "id": {
             "description": "Asset media ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "status": {
@@ -17562,6 +17576,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "key": {
@@ -17809,7 +17825,9 @@
           },
           "duplicateId": {
             "description": "Duplicate group ID",
+            "format": "uuid",
             "nullable": true,
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "duration": {
@@ -17845,6 +17863,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isArchived": {
@@ -17923,6 +17943,8 @@
           },
           "ownerId": {
             "description": "Owner user ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "people": {
@@ -18020,10 +18042,14 @@
           },
           "id": {
             "description": "Stack ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "primaryAssetId": {
             "description": "Primary asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -18159,6 +18185,8 @@
           },
           "id": {
             "description": "ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "success": {
@@ -18337,6 +18365,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -18441,6 +18471,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -18601,6 +18633,8 @@
           "assetIds": {
             "description": "Asset IDs in this archive",
             "items": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
               "type": "string"
             },
             "type": "array"
@@ -18786,6 +18820,8 @@
           },
           "duplicateId": {
             "description": "Duplicate group ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "suggestedKeepAssetIds": {
@@ -19102,6 +19138,8 @@
               "properties": {
                 "id": {
                   "description": "Integrity report item id",
+                  "format": "uuid",
+                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
                   "type": "string"
                 },
                 "path": {
@@ -19276,6 +19314,8 @@
           },
           "id": {
             "description": "Library ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "importPaths": {
@@ -19291,6 +19331,8 @@
           },
           "ownerId": {
             "description": "Owner user ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "refreshedAt": {
@@ -19445,6 +19487,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -19635,6 +19679,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "lat": {
@@ -19835,6 +19881,8 @@
           },
           "id": {
             "description": "Memory ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isSaved": {
@@ -19850,6 +19898,8 @@
           },
           "ownerId": {
             "description": "Owner user ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "seenAt": {
@@ -20311,6 +20361,8 @@
           },
           "id": {
             "description": "Notification ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "level": {
@@ -20755,6 +20807,8 @@
           },
           "id": {
             "description": "Person ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isFavorite": {
@@ -20990,6 +21044,8 @@
           },
           "id": {
             "description": "Person ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isFavorite": {
@@ -21245,6 +21301,8 @@
           },
           "id": {
             "description": "Plugin ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "methods": {
@@ -22640,6 +22698,8 @@
           },
           "id": {
             "description": "Version history entry ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "version": {
@@ -22744,6 +22804,8 @@
           },
           "id": {
             "description": "Session ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isPendingSyncReset": {
@@ -22801,6 +22863,8 @@
           },
           "id": {
             "description": "Session ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isPendingSyncReset": {
@@ -23023,6 +23087,8 @@
           },
           "id": {
             "description": "Shared link ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "key": {
@@ -23048,6 +23114,8 @@
           },
           "userId": {
             "description": "Owner user ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23389,10 +23457,14 @@
           },
           "id": {
             "description": "Stack ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "primaryAssetId": {
             "description": "Primary asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23666,6 +23738,8 @@
         "properties": {
           "albumId": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23678,10 +23752,14 @@
         "properties": {
           "albumId": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23695,10 +23773,14 @@
         "properties": {
           "albumId": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23712,10 +23794,14 @@
         "properties": {
           "albumId": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23729,6 +23815,8 @@
         "properties": {
           "albumId": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "role": {
@@ -23736,6 +23824,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23761,6 +23851,8 @@
           },
           "id": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isActivityEnabled": {
@@ -23776,6 +23868,8 @@
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "thumbnailAssetId": {
@@ -23819,6 +23913,8 @@
           },
           "id": {
             "description": "Album ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isActivityEnabled": {
@@ -23861,6 +23957,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23873,6 +23971,8 @@
         "properties": {
           "editId": {
             "description": "Edit ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -23888,10 +23988,14 @@
           },
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "id": {
             "description": "Edit ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "parameters": {
@@ -23919,6 +24023,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "city": {
@@ -24096,6 +24202,8 @@
         "properties": {
           "assetFaceId": {
             "description": "Asset face ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -24108,6 +24216,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "boundingBoxX1": {
@@ -24136,6 +24246,8 @@
           },
           "id": {
             "description": "Asset face ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "imageHeight": {
@@ -24178,6 +24290,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "boundingBoxX1": {
@@ -24214,6 +24328,8 @@
           },
           "id": {
             "description": "Asset face ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "imageHeight": {
@@ -24262,6 +24378,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "key": {
@@ -24279,6 +24397,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "key": {
@@ -24327,6 +24447,8 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "boxScore": {
@@ -24336,6 +24458,8 @@
           },
           "id": {
             "description": "OCR entry ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isVisible": {
@@ -24462,6 +24586,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isEdited": {
@@ -24496,6 +24622,8 @@
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "stackId": {
@@ -24600,6 +24728,8 @@
           },
           "id": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isEdited": {
@@ -24634,6 +24764,8 @@
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "stackId": {
@@ -24712,6 +24844,8 @@
           },
           "id": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isAdmin": {
@@ -24846,10 +24980,14 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "memoryId": {
             "description": "Memory ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -24863,10 +25001,14 @@
         "properties": {
           "assetId": {
             "description": "Asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "memoryId": {
             "description": "Memory ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -24880,6 +25022,8 @@
         "properties": {
           "memoryId": {
             "description": "Memory ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -24920,6 +25064,8 @@
           },
           "id": {
             "description": "Memory ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isSaved": {
@@ -24935,6 +25081,8 @@
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "seenAt": {
@@ -24984,10 +25132,14 @@
         "properties": {
           "sharedById": {
             "description": "Shared by ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "sharedWithId": {
             "description": "Shared with ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25005,10 +25157,14 @@
           },
           "sharedById": {
             "description": "Shared by ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "sharedWithId": {
             "description": "Shared with ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25023,6 +25179,8 @@
         "properties": {
           "personId": {
             "description": "Person ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25060,6 +25218,8 @@
           },
           "id": {
             "description": "Person ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "isFavorite": {
@@ -25076,6 +25236,8 @@
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "updatedAt": {
@@ -25141,6 +25303,8 @@
         "properties": {
           "stackId": {
             "description": "Stack ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25160,14 +25324,20 @@
           },
           "id": {
             "description": "Stack ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "ownerId": {
             "description": "Owner ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "primaryAssetId": {
             "description": "Primary asset ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "updatedAt": {
@@ -25210,6 +25380,8 @@
         "properties": {
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25225,6 +25397,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           }
         },
@@ -25241,6 +25415,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "value": {
@@ -25284,6 +25460,8 @@
           },
           "id": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "name": {
@@ -26470,6 +26648,8 @@
           },
           "id": {
             "description": "Tag ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "name": {
@@ -26993,6 +27173,8 @@
           },
           "userId": {
             "description": "User ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "userName": {
@@ -27635,6 +27817,8 @@
           },
           "id": {
             "description": "Workflow ID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
           "name": {

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -100,21 +100,21 @@ const AlbumUserResponseSchema = z
 
 const ContributorCountResponseSchema = z
   .object({
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     assetCount: z.int().min(0).describe('Number of assets contributed'),
   })
   .meta({ id: 'ContributorCountResponseDto' });
 
 export const AlbumResponseSchema = z
   .object({
-    id: z.string().describe('Album ID'),
+    id: z.uuidv4().describe('Album ID'),
     albumName: z.string().describe('Album name'),
     description: z.string().describe('Album description'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     createdAt: z.string().meta({ format: 'date-time' }).describe('Creation date'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     updatedAt: z.string().meta({ format: 'date-time' }).describe('Last update date'),
-    albumThumbnailAssetId: z.string().nullable().describe('Thumbnail asset ID'),
+    albumThumbnailAssetId: z.uuidv4().nullable().describe('Thumbnail asset ID'),
     shared: z.boolean().describe('Is shared album'),
     albumUsers: z
       .array(AlbumUserResponseSchema)

--- a/server/src/dtos/api-key.dto.ts
+++ b/server/src/dtos/api-key.dto.ts
@@ -21,7 +21,7 @@ const ApiKeyUpdateSchema = z
 
 const ApiKeyResponseSchema = z
   .object({
-    id: z.string().describe('API key ID'),
+    id: z.uuidv4().describe('API key ID'),
     name: z.string().describe('API key name'),
     createdAt: isoDatetimeToDate.describe('Creation date'),
     updatedAt: isoDatetimeToDate.describe('Last update date'),

--- a/server/src/dtos/asset-ids.response.dto.ts
+++ b/server/src/dtos/asset-ids.response.dto.ts
@@ -16,7 +16,7 @@ const AssetIdErrorReasonSchema = z
 /** @deprecated Use `BulkIdResponseDto` instead */
 const AssetIdsResponseSchema = z
   .object({
-    assetId: z.string().describe('Asset ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     success: z.boolean().describe('Whether operation succeeded'),
     error: AssetIdErrorReasonSchema.optional(),
   })
@@ -43,7 +43,7 @@ export const BulkIdsSchema = z
 
 const BulkIdResponseSchema = z
   .object({
-    id: z.string().describe('ID'),
+    id: z.uuidv4().describe('ID'),
     success: z.boolean().describe('Whether operation succeeded'),
     error: BulkIdErrorReasonSchema.optional(),
     errorMessage: z.string().optional(),

--- a/server/src/dtos/asset-media-response.dto.ts
+++ b/server/src/dtos/asset-media-response.dto.ts
@@ -11,7 +11,7 @@ const AssetMediaStatusSchema = z.enum(AssetMediaStatus).describe('Upload status'
 const AssetMediaResponseSchema = z
   .object({
     status: AssetMediaStatusSchema,
-    id: z.string().describe('Asset media ID'),
+    id: z.uuidv4().describe('Asset media ID'),
   })
   .meta({ id: 'AssetMediaResponseDto' });
 
@@ -34,7 +34,7 @@ const AssetRejectReasonSchema = z
 
 const AssetBulkUploadCheckResultSchema = z
   .object({
-    id: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Asset ID'),
     action: AssetUploadActionSchema,
     reason: AssetRejectReasonSchema.optional(),
     assetId: z.string().optional().describe('Existing asset ID if duplicate'),

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -58,7 +58,7 @@ const AssetMediaCreateSchema = AssetMediaBaseSchema.extend({
 
 const AssetBulkUploadCheckItemSchema = z
   .object({
-    id: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Asset ID'),
     checksum: z.string().describe('Base64 or hex encoded SHA1 hash'),
   })
   .meta({ id: 'AssetBulkUploadCheckItem' });

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -58,7 +58,7 @@ const AssetMediaCreateSchema = AssetMediaBaseSchema.extend({
 
 const AssetBulkUploadCheckItemSchema = z
   .object({
-    id: z.uuidv4().describe('Asset ID'),
+    id: z.string().describe('Asset ID'),
     checksum: z.string().describe('Base64 or hex encoded SHA1 hash'),
   })
   .meta({ id: 'AssetBulkUploadCheckItem' });

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -24,7 +24,7 @@ import z from 'zod';
 
 const SanitizedAssetResponseSchema = z
   .object({
-    id: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Asset ID'),
     type: AssetTypeSchema,
     thumbhash: z
       .string()
@@ -52,8 +52,8 @@ export class SanitizedAssetResponseDto extends createZodDto(SanitizedAssetRespon
 
 const AssetStackResponseSchema = z
   .object({
-    id: z.string().describe('Stack ID'),
-    primaryAssetId: z.string().describe('Primary asset ID'),
+    id: z.uuidv4().describe('Stack ID'),
+    primaryAssetId: z.uuidv4().describe('Primary asset ID'),
     assetCount: z.int().min(0).describe('Number of assets in stack'),
   })
   .meta({ id: 'AssetStackResponseDto' });
@@ -65,7 +65,7 @@ export const AssetResponseSchema = SanitizedAssetResponseSchema.extend(
       .string()
       .meta({ format: 'date-time' })
       .describe('The UTC timestamp when the asset was originally uploaded to Immich.'),
-    ownerId: z.string().describe('Owner user ID'),
+    ownerId: z.uuidv4().describe('Owner user ID'),
     owner: UserResponseSchema.optional(),
     libraryId: z
       .uuidv4()
@@ -103,7 +103,7 @@ export const AssetResponseSchema = SanitizedAssetResponseSchema.extend(
     people: z.array(PersonResponseSchema).optional(),
     checksum: z.string().describe('Base64 encoded SHA1 hash'),
     stack: AssetStackResponseSchema.nullish(),
-    duplicateId: z.string().nullish().describe('Duplicate group ID'),
+    duplicateId: z.uuidv4().nullish().describe('Duplicate group ID'),
     resized: z
       .boolean()
       .optional()

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -148,7 +148,7 @@ const AssetMetadataResponseSchema = z
   .meta({ id: 'AssetMetadataResponseDto' });
 
 const AssetMetadataBulkResponseSchema = AssetMetadataResponseSchema.extend({
-  assetId: z.string().describe('Asset ID'),
+  assetId: z.uuidv4().describe('Asset ID'),
 }).meta({ id: 'AssetMetadataBulkResponseDto' });
 
 const AssetCopySchema = z

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -29,7 +29,7 @@ const LoginCredentialSchema = z
 const LoginResponseSchema = z
   .object({
     accessToken: z.string().describe('Access token'),
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     userEmail: toEmail.describe('User email'),
     name: z.string().describe('User name'),
     profileImagePath: z.string().describe('Profile image path'),

--- a/server/src/dtos/download.dto.ts
+++ b/server/src/dtos/download.dto.ts
@@ -14,7 +14,7 @@ const DownloadInfoSchema = z
 const DownloadArchiveInfoSchema = z
   .object({
     size: z.int().describe('Archive size in bytes'),
-    assetIds: z.array(z.string()).describe('Asset IDs in this archive'),
+    assetIds: z.array(z.uuidv4()).describe('Asset IDs in this archive'),
   })
   .meta({ id: 'DownloadArchiveInfo' });
 

--- a/server/src/dtos/duplicate.dto.ts
+++ b/server/src/dtos/duplicate.dto.ts
@@ -4,7 +4,7 @@ import z from 'zod';
 
 const DuplicateResponseSchema = z
   .object({
-    duplicateId: z.string().describe('Duplicate group ID'),
+    duplicateId: z.uuidv4().describe('Duplicate group ID'),
     assets: z.array(AssetResponseSchema).describe('Duplicate assets'),
     suggestedKeepAssetIds: z.array(z.uuidv4()).describe('Suggested asset IDs to keep based on file size and EXIF data'),
   })

--- a/server/src/dtos/integrity.dto.ts
+++ b/server/src/dtos/integrity.dto.ts
@@ -27,7 +27,7 @@ const IntegrityDeleteReportSchema = z.object({ type: IntegrityReport }).meta({ i
 export class IntegrityDeleteReportDto extends createZodDto(IntegrityDeleteReportSchema) {}
 
 const IntegrityReportResponseItemSchema = z.object({
-  id: z.string().describe('Integrity report item id'),
+  id: z.uuidv4().describe('Integrity report item id'),
   type: IntegrityReportSchema,
   path: z.string().describe('Integrity report item path'),
 });

--- a/server/src/dtos/library.dto.ts
+++ b/server/src/dtos/library.dto.ts
@@ -62,8 +62,8 @@ const ValidateLibraryResponseSchema = z
 
 const LibraryResponseSchema = z
   .object({
-    id: z.string().describe('Library ID'),
-    ownerId: z.string().describe('Owner user ID'),
+    id: z.uuidv4().describe('Library ID'),
+    ownerId: z.uuidv4().describe('Owner user ID'),
     name: z.string().describe('Library name'),
     assetCount: z.int().describe('Number of assets'),
     importPaths: z.array(z.string()).describe('Import paths'),

--- a/server/src/dtos/map.dto.ts
+++ b/server/src/dtos/map.dto.ts
@@ -30,7 +30,7 @@ const MapMarkerSchema = z
 
 const MapMarkerResponseSchema = z
   .object({
-    id: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Asset ID'),
     lat: z.number().meta({ format: 'double' }).describe('Latitude'),
     lon: z.number().meta({ format: 'double' }).describe('Longitude'),
     city: z.string().nullable().describe('City name'),

--- a/server/src/dtos/memory.dto.ts
+++ b/server/src/dtos/memory.dto.ts
@@ -59,7 +59,7 @@ const MemoryStatisticsResponseSchema = z
 
 const MemoryResponseSchema = z
   .object({
-    id: z.string().describe('Memory ID'),
+    id: z.uuidv4().describe('Memory ID'),
     createdAt: isoDatetimeToDate.describe('Creation date'),
     updatedAt: isoDatetimeToDate.describe('Last update date'),
     deletedAt: isoDatetimeToDate.optional().describe('Deletion date'),
@@ -67,7 +67,7 @@ const MemoryResponseSchema = z
     seenAt: isoDatetimeToDate.optional().describe('Date when memory was seen'),
     showAt: isoDatetimeToDate.optional().describe('Date when memory should be shown'),
     hideAt: isoDatetimeToDate.optional().describe('Date when memory should be hidden'),
-    ownerId: z.string().describe('Owner user ID'),
+    ownerId: z.uuidv4().describe('Owner user ID'),
     type: MemoryTypeSchema,
     data: OnThisDaySchema,
     isSaved: z.boolean().describe('Is memory saved'),

--- a/server/src/dtos/notification.dto.ts
+++ b/server/src/dtos/notification.dto.ts
@@ -24,7 +24,7 @@ const TemplateSchema = z
 
 const NotificationSchema = z
   .object({
-    id: z.string().describe('Notification ID'),
+    id: z.uuidv4().describe('Notification ID'),
     createdAt: isoDatetimeToDate.describe('Creation date'),
     level: NotificationLevelSchema,
     type: NotificationTypeSchema,

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -33,7 +33,7 @@ const PersonUpdateSchema = PersonCreateSchema.extend({
 }).meta({ id: 'PersonUpdateDto' });
 
 const PeopleUpdateItemSchema = PersonUpdateSchema.extend({
-  id: z.string().describe('Person ID'),
+  id: z.uuidv4().describe('Person ID'),
 }).meta({ id: 'PeopleUpdateItem' });
 
 const PeopleUpdateSchema = z
@@ -60,7 +60,7 @@ const PersonSearchSchema = z
 
 export const PersonResponseSchema = z
   .object({
-    id: z.string().describe('Person ID'),
+    id: z.uuidv4().describe('Person ID'),
     name: z.string().describe('Person name'),
     // TODO: use `isoDateToDate` when using `ZodSerializerDto` on the controllers.
     birthDate: z.string().meta({ format: 'date' }).describe('Person date of birth').nullable(),

--- a/server/src/dtos/plugin.dto.ts
+++ b/server/src/dtos/plugin.dto.ts
@@ -32,7 +32,7 @@ const PluginMethodResponseSchema = z
 
 const PluginResponseSchema = z
   .object({
-    id: z.string().describe('Plugin ID'),
+    id: z.uuidv4().describe('Plugin ID'),
     name: z.string().describe('Plugin name'),
     title: z.string().describe('Plugin title'),
     description: z.string().describe('Plugin description'),

--- a/server/src/dtos/server.dto.ts
+++ b/server/src/dtos/server.dto.ts
@@ -73,7 +73,7 @@ const ServerVersionResponseSchema = z
 
 const ServerVersionHistoryResponseSchema = z
   .object({
-    id: z.string().describe('Version history entry ID'),
+    id: z.uuidv4().describe('Version history entry ID'),
     createdAt: isoDatetimeToDate.describe('When this version was first seen'),
     version: z.string().describe('Version string'),
   })
@@ -81,7 +81,7 @@ const ServerVersionHistoryResponseSchema = z
 
 const UsageByUserSchema = z
   .object({
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     userName: z.string().describe('User name'),
     photos: z.int().describe('Number of photos'),
     videos: z.int().describe('Number of videos'),

--- a/server/src/dtos/session.dto.ts
+++ b/server/src/dtos/session.dto.ts
@@ -18,7 +18,7 @@ const SessionUpdateSchema = z
 
 const SessionResponseSchema = z
   .object({
-    id: z.string().describe('Session ID'),
+    id: z.uuidv4().describe('Session ID'),
     createdAt: z.string().describe('Creation date'),
     updatedAt: z.string().describe('Last update date'),
     expiresAt: z.string().optional().describe('Expiration date'),

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -53,10 +53,10 @@ const SharedLinkLoginSchema = z
 
 const SharedLinkResponseSchema = z
   .object({
-    id: z.string().describe('Shared link ID'),
+    id: z.uuidv4().describe('Shared link ID'),
     description: z.string().nullable().describe('Link description'),
     password: z.string().nullable().describe('Has password'),
-    userId: z.string().describe('Owner user ID'),
+    userId: z.uuidv4().describe('Owner user ID'),
     key: z.string().describe('Encryption key (base64url)'),
     type: SharedLinkTypeSchema,
     createdAt: isoDatetimeToDate.describe('Creation date'),

--- a/server/src/dtos/stack.dto.ts
+++ b/server/src/dtos/stack.dto.ts
@@ -24,8 +24,8 @@ const StackUpdateSchema = z
 
 const StackResponseSchema = z
   .object({
-    id: z.string().describe('Stack ID'),
-    primaryAssetId: z.string().describe('Primary asset ID'),
+    id: z.uuidv4().describe('Stack ID'),
+    primaryAssetId: z.uuidv4().describe('Primary asset ID'),
     assets: z.array(AssetResponseSchema),
   })
   .describe('Stack response')

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -19,7 +19,7 @@ import z from 'zod';
 
 const SyncUserV1Schema = z
   .object({
-    id: z.string().describe('User ID'),
+    id: z.uuidv4().describe('User ID'),
     name: z.string().describe('User name'),
     email: z.string().describe('User email'),
     avatarColor: UserAvatarColorSchema.nullish(),
@@ -40,27 +40,27 @@ const SyncAuthUserV1Schema = SyncUserV1Schema.merge(
   }),
 ).meta({ id: 'SyncAuthUserV1' });
 
-const SyncUserDeleteV1Schema = z.object({ userId: z.string().describe('User ID') }).meta({ id: 'SyncUserDeleteV1' });
+const SyncUserDeleteV1Schema = z.object({ userId: z.uuidv4().describe('User ID') }).meta({ id: 'SyncUserDeleteV1' });
 
 const SyncPartnerV1Schema = z
   .object({
-    sharedById: z.string().describe('Shared by ID'),
-    sharedWithId: z.string().describe('Shared with ID'),
+    sharedById: z.uuidv4().describe('Shared by ID'),
+    sharedWithId: z.uuidv4().describe('Shared with ID'),
     inTimeline: z.boolean().describe('In timeline'),
   })
   .meta({ id: 'SyncPartnerV1' });
 
 const SyncPartnerDeleteV1Schema = z
   .object({
-    sharedById: z.string().describe('Shared by ID'),
-    sharedWithId: z.string().describe('Shared with ID'),
+    sharedById: z.uuidv4().describe('Shared by ID'),
+    sharedWithId: z.uuidv4().describe('Shared with ID'),
   })
   .meta({ id: 'SyncPartnerDeleteV1' });
 
 const SyncAssetV1Schema = z
   .object({
-    id: z.string().describe('Asset ID'),
-    ownerId: z.string().describe('Owner ID'),
+    id: z.uuidv4().describe('Asset ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
     originalFileName: z.string().describe('Original file name'),
     thumbhash: z.string().nullable().describe('Thumbhash'),
     checksum: z.string().describe('Checksum'),
@@ -84,8 +84,8 @@ const SyncAssetV1Schema = z
 
 const SyncAssetV2Schema = z
   .object({
-    id: z.string().describe('Asset ID'),
-    ownerId: z.string().describe('Owner ID'),
+    id: z.uuidv4().describe('Asset ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
     originalFileName: z.string().describe('Original file name'),
     thumbhash: z.string().nullable().describe('Thumbhash'),
     checksum: z.string().describe('Checksum'),
@@ -123,12 +123,12 @@ export class SyncAssetV1 extends createZodDto(SyncAssetV1Schema) {}
 export class SyncAssetV2 extends createZodDto(SyncAssetV2Schema) {}
 
 const SyncAssetDeleteV1Schema = z
-  .object({ assetId: z.string().describe('Asset ID') })
+  .object({ assetId: z.uuidv4().describe('Asset ID') })
   .meta({ id: 'SyncAssetDeleteV1' });
 
 const SyncAssetExifV1Schema = z
   .object({
-    assetId: z.string().describe('Asset ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     description: z.string().nullable().describe('Description'),
     exifImageWidth: z.int().nullable().describe('Exif image width'),
     exifImageHeight: z.int().nullable().describe('Exif image height'),
@@ -158,7 +158,7 @@ const SyncAssetExifV1Schema = z
 
 const SyncAssetMetadataV1Schema = z
   .object({
-    assetId: z.string().describe('Asset ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     key: z.string().describe('Key'),
     value: z.record(z.string(), z.unknown()).describe('Value'),
   })
@@ -166,15 +166,15 @@ const SyncAssetMetadataV1Schema = z
 
 const SyncAssetMetadataDeleteV1Schema = z
   .object({
-    assetId: z.string().describe('Asset ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     key: z.string().describe('Key'),
   })
   .meta({ id: 'SyncAssetMetadataDeleteV1' });
 
 const SyncAssetEditV1Schema = z
   .object({
-    id: z.string().describe('Edit ID'),
-    assetId: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Edit ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     action: AssetEditActionSchema,
     parameters: z.record(z.string(), z.unknown()).describe('Edit parameters'),
     sequence: z.int().describe('Edit sequence'),
@@ -182,7 +182,7 @@ const SyncAssetEditV1Schema = z
   .meta({ id: 'SyncAssetEditV1' });
 
 const SyncAssetEditDeleteV1Schema = z
-  .object({ editId: z.string().describe('Edit ID') })
+  .object({ editId: z.uuidv4().describe('Edit ID') })
   .meta({ id: 'SyncAssetEditDeleteV1' });
 
 @ExtraModel()
@@ -199,28 +199,28 @@ export class SyncAssetEditV1 extends createZodDto(SyncAssetEditV1Schema) {}
 class SyncAssetEditDeleteV1 extends createZodDto(SyncAssetEditDeleteV1Schema) {}
 
 const SyncAlbumDeleteV1Schema = z
-  .object({ albumId: z.string().describe('Album ID') })
+  .object({ albumId: z.uuidv4().describe('Album ID') })
   .meta({ id: 'SyncAlbumDeleteV1' });
 
 const SyncAlbumUserDeleteV1Schema = z
   .object({
-    albumId: z.string().describe('Album ID'),
-    userId: z.string().describe('User ID'),
+    albumId: z.uuidv4().describe('Album ID'),
+    userId: z.uuidv4().describe('User ID'),
   })
   .meta({ id: 'SyncAlbumUserDeleteV1' });
 
 const SyncAlbumUserV1Schema = z
   .object({
-    albumId: z.string().describe('Album ID'),
-    userId: z.string().describe('User ID'),
+    albumId: z.uuidv4().describe('Album ID'),
+    userId: z.uuidv4().describe('User ID'),
     role: AlbumUserRoleSchema,
   })
   .meta({ id: 'SyncAlbumUserV1' });
 
 const SyncAlbumV1Schema = z
   .object({
-    id: z.string().describe('Album ID'),
-    ownerId: z.string().describe('Owner ID'),
+    id: z.uuidv4().describe('Album ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
     name: z.string().describe('Album name'),
     description: z.string().describe('Album description'),
     createdAt: isoDatetimeToDate.describe('Created at'),
@@ -233,7 +233,7 @@ const SyncAlbumV1Schema = z
 
 const SyncAlbumV2Schema = z
   .object({
-    id: z.string().describe('Album ID'),
+    id: z.uuidv4().describe('Album ID'),
     name: z.string().describe('Album name'),
     description: z.string().describe('Album description'),
     createdAt: isoDatetimeToDate.describe('Created at'),
@@ -246,15 +246,15 @@ const SyncAlbumV2Schema = z
 
 const SyncAlbumToAssetV1Schema = z
   .object({
-    albumId: z.string().describe('Album ID'),
-    assetId: z.string().describe('Asset ID'),
+    albumId: z.uuidv4().describe('Album ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
   })
   .meta({ id: 'SyncAlbumToAssetV1' });
 
 const SyncAlbumToAssetDeleteV1Schema = z
   .object({
-    albumId: z.string().describe('Album ID'),
-    assetId: z.string().describe('Asset ID'),
+    albumId: z.uuidv4().describe('Album ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
   })
   .meta({ id: 'SyncAlbumToAssetDeleteV1' });
 
@@ -284,11 +284,11 @@ export function syncAlbumV2ToV1(
 
 const SyncMemoryV1Schema = z
   .object({
-    id: z.string().describe('Memory ID'),
+    id: z.uuidv4().describe('Memory ID'),
     createdAt: isoDatetimeToDate.describe('Created at'),
     updatedAt: isoDatetimeToDate.describe('Updated at'),
     deletedAt: isoDatetimeToDate.nullable().describe('Deleted at'),
-    ownerId: z.string().describe('Owner ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
     type: MemoryTypeSchema,
     data: z.record(z.string(), z.unknown()).describe('Data'),
     isSaved: z.boolean().describe('Is saved'),
@@ -300,43 +300,43 @@ const SyncMemoryV1Schema = z
   .meta({ id: 'SyncMemoryV1' });
 
 const SyncMemoryDeleteV1Schema = z
-  .object({ memoryId: z.string().describe('Memory ID') })
+  .object({ memoryId: z.uuidv4().describe('Memory ID') })
   .meta({ id: 'SyncMemoryDeleteV1' });
 
 const SyncMemoryAssetV1Schema = z
   .object({
-    memoryId: z.string().describe('Memory ID'),
-    assetId: z.string().describe('Asset ID'),
+    memoryId: z.uuidv4().describe('Memory ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
   })
   .meta({ id: 'SyncMemoryAssetV1' });
 
 const SyncMemoryAssetDeleteV1Schema = z
   .object({
-    memoryId: z.string().describe('Memory ID'),
-    assetId: z.string().describe('Asset ID'),
+    memoryId: z.uuidv4().describe('Memory ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
   })
   .meta({ id: 'SyncMemoryAssetDeleteV1' });
 
 const SyncStackV1Schema = z
   .object({
-    id: z.string().describe('Stack ID'),
+    id: z.uuidv4().describe('Stack ID'),
     createdAt: isoDatetimeToDate.describe('Created at'),
     updatedAt: isoDatetimeToDate.describe('Updated at'),
-    primaryAssetId: z.string().describe('Primary asset ID'),
-    ownerId: z.string().describe('Owner ID'),
+    primaryAssetId: z.uuidv4().describe('Primary asset ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
   })
   .meta({ id: 'SyncStackV1' });
 
 const SyncStackDeleteV1Schema = z
-  .object({ stackId: z.string().describe('Stack ID') })
+  .object({ stackId: z.uuidv4().describe('Stack ID') })
   .meta({ id: 'SyncStackDeleteV1' });
 
 const SyncPersonV1Schema = z
   .object({
-    id: z.string().describe('Person ID'),
+    id: z.uuidv4().describe('Person ID'),
     createdAt: isoDatetimeToDate.describe('Created at'),
     updatedAt: isoDatetimeToDate.describe('Updated at'),
-    ownerId: z.string().describe('Owner ID'),
+    ownerId: z.uuidv4().describe('Owner ID'),
     name: z.string().describe('Person name'),
     birthDate: isoDatetimeToDate.nullable().describe('Birth date'),
     isHidden: z.boolean().describe('Is hidden'),
@@ -347,13 +347,13 @@ const SyncPersonV1Schema = z
   .meta({ id: 'SyncPersonV1' });
 
 const SyncPersonDeleteV1Schema = z
-  .object({ personId: z.string().describe('Person ID') })
+  .object({ personId: z.uuidv4().describe('Person ID') })
   .meta({ id: 'SyncPersonDeleteV1' });
 
 const SyncAssetFaceV1Schema = z
   .object({
-    id: z.string().describe('Asset face ID'),
-    assetId: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('Asset face ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
     personId: z.string().nullable().describe('Person ID'),
     imageWidth: z.int().describe('Image width'),
     imageHeight: z.int().describe('Image height'),
@@ -371,12 +371,12 @@ const SyncAssetFaceV2Schema = SyncAssetFaceV1Schema.extend({
 }).meta({ id: 'SyncAssetFaceV2' });
 
 const SyncAssetFaceDeleteV1Schema = z
-  .object({ assetFaceId: z.string().describe('Asset face ID') })
+  .object({ assetFaceId: z.uuidv4().describe('Asset face ID') })
   .meta({ id: 'SyncAssetFaceDeleteV1' });
 
 const SyncUserMetadataV1Schema = z
   .object({
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     key: UserMetadataKeySchema,
     value: z.record(z.string(), z.unknown()).describe('User metadata value'),
   })
@@ -384,7 +384,7 @@ const SyncUserMetadataV1Schema = z
 
 const SyncUserMetadataDeleteV1Schema = z
   .object({
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     key: UserMetadataKeySchema,
   })
   .meta({ id: 'SyncUserMetadataDeleteV1' });
@@ -404,8 +404,8 @@ class SyncMemoryAssetDeleteV1 extends createZodDto(SyncMemoryAssetDeleteV1Schema
 
 const SyncAssetOcrV1Schema = z
   .object({
-    id: z.string().describe('OCR entry ID'),
-    assetId: z.string().describe('Asset ID'),
+    id: z.uuidv4().describe('OCR entry ID'),
+    assetId: z.uuidv4().describe('Asset ID'),
 
     x1: z.number().meta({ format: 'double' }).describe('Top-left X coordinate (normalized 0–1)'),
     y1: z.number().meta({ format: 'double' }).describe('Top-left Y coordinate (normalized 0–1)'),

--- a/server/src/dtos/tag.dto.ts
+++ b/server/src/dtos/tag.dto.ts
@@ -40,7 +40,7 @@ const TagBulkAssetsResponseSchema = z
 
 export const TagResponseSchema = z
   .object({
-    id: z.string().describe('Tag ID'),
+    id: z.uuidv4().describe('Tag ID'),
     parentId: z.string().optional().describe('Parent tag ID'),
     name: z.string().describe('Tag name'),
     value: z.string().describe('Tag value (full path)'),

--- a/server/src/dtos/user-profile.dto.ts
+++ b/server/src/dtos/user-profile.dto.ts
@@ -11,7 +11,7 @@ export class CreateProfileImageDto {
 
 const CreateProfileImageResponseSchema = z
   .object({
-    userId: z.string().describe('User ID'),
+    userId: z.uuidv4().describe('User ID'),
     profileChangedAt: isoDatetimeToDate.describe('Profile image change date'),
     profileImagePath: z.string().describe('Profile image file path'),
   })

--- a/server/src/dtos/workflow.dto.ts
+++ b/server/src/dtos/workflow.dto.ts
@@ -58,7 +58,7 @@ const WorkflowUpdateSchema = z
 
 const WorkflowResponseSchema = z
   .object({
-    id: z.string().describe('Workflow ID'),
+    id: z.uuidv4().describe('Workflow ID'),
     trigger: WorkflowTriggerSchema.describe('Workflow trigger type'),
     name: z.string().nullable().describe('Workflow name'),
     description: z.string().nullable().describe('Workflow description'),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

search by regex pattern including all fields that end with ID. manually filtered out false-positives by inspecting there database definition (e.g. oauth client id, email msg id, oauthId, ack id)

Clients profit from this more accurate type definition, values are validated by zod against the uuid v4 shape, so might raise on bad inputs that passed the validation stage beforehand. However not breaking in the sense that such request would have failed on db level anyways.

Note: we use uuid v4 and v7 inconsistently on the db level. I used `z.uuidv4` consistently in the dtos, since the regex pattern in the output does not differ.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none
