### PR TITLE
docs(server): clarify AssetBulkUploadCheckItem.id is a correlation token

### DIFF
--- a/mobile/openapi/lib/model/asset_bulk_upload_check_item.dart
+++ b/mobile/openapi/lib/model/asset_bulk_upload_check_item.dart
@@ -20,7 +20,7 @@ class AssetBulkUploadCheckItem {
   /// Base64 or hex encoded SHA1 hash
   String checksum;
 
-  /// Asset ID
+  /// Client-side identifier echoed in the response to match results to inputs (e.g. filename)
   String id;
 
   @override

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16965,7 +16965,7 @@
             "type": "string"
           },
           "id": {
-            "description": "Asset ID",
+            "description": "Client-side identifier echoed in the response to match results to inputs (e.g. filename)",
             "type": "string"
           }
         },

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -696,7 +696,7 @@ export type AssetBulkUpdateDto = {
 export type AssetBulkUploadCheckItem = {
     /** Base64 or hex encoded SHA1 hash */
     checksum: string;
-    /** Asset ID */
+    /** Client-side identifier echoed in the response to match results to inputs (e.g. filename) */
     id: string;
 };
 export type AssetBulkUploadCheckDto = {

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -58,7 +58,7 @@ const AssetMediaCreateSchema = AssetMediaBaseSchema.extend({
 
 const AssetBulkUploadCheckItemSchema = z
   .object({
-    id: z.string().describe('Asset ID'),
+    id: z.string().describe('Client-side identifier echoed in the response to match results to inputs (e.g. filename)'),
     checksum: z.string().describe('Base64 or hex encoded SHA1 hash'),
   })
   .meta({ id: 'AssetBulkUploadCheckItem' });


### PR DESCRIPTION
Reword the `id` field description. [`bulkUploadCheck`](https://github.com/immich-app/immich/blob/main/server/src/services/asset-media.service.ts#L314:L315) only echoes it back. The web caller passes `assetFile.name` purely for response correlation ([`file-uploader.ts:200`](https://github.com/immich-app/immich/blob/main/web/src/lib/utils/file-uploader.ts#L200:L201)).