### PR TITLE
chore(e2e): remove vite-tsconfig-paths

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -54,7 +54,6 @@
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.28.0",
     "utimes": "^5.2.1",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.0.0"
   }
 }

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 const skipDockerSetup = process.env.VITEST_DISABLE_DOCKER_SETUP === 'true';
@@ -24,5 +23,7 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
   },
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
 });

--- a/e2e/vitest.maintenance.config.ts
+++ b/e2e/vitest.maintenance.config.ts
@@ -1,4 +1,3 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 const skipDockerSetup = process.env.VITEST_DISABLE_DOCKER_SETUP === 'true';
@@ -24,5 +23,7 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
   },
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ importers:
       utimes:
         specifier: ^5.2.1
         version: 5.2.1
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.0.0
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.3)(jsdom@26.1.0(canvas@3.2.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
## Description
I noticed this in a CI run:

`The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.`

Seems to work.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
