### PR TITLE
fix(mobile): keep toasts off the dynamic island when keyboard is open

### DIFF
--- a/mobile/lib/widgets/common/immich_toast.dart
+++ b/mobile/lib/widgets/common/immich_toast.dart
@@ -50,9 +50,10 @@ class ImmichToast {
         ),
       ),
       positionedToastBuilder: (context, child, gravity) {
+        final isTop = gravity == ToastGravity.TOP;
         return Positioned(
-          top: gravity == ToastGravity.TOP ? 150 : null,
-          bottom: gravity == ToastGravity.BOTTOM ? 150 : null,
+          top: isTop ? 150 : null,
+          bottom: isTop ? null : 150 + MediaQuery.of(context).viewInsets.bottom,
           left: MediaQuery.of(context).size.width / 2 - 150,
           right: MediaQuery.of(context).size.width / 2 - 150,
           child: IgnorePointer(child: child),


### PR DESCRIPTION
## Description

when the keyboard is open, the "added to album" toast jumps to the top over the dynamic island instead of showing at the bottom.

fluttertoast moves bottom toasts to center while the keyboard's up and our builder didn't handle that case, so it landed at the top. now any non-top toast stays at the bottom, just above the keyboard. not just album either, it hit any bottom toast shown with the keyboard open.

tested on iphone 15 pro max.
