### PR TITLE
docs(mobile-app): add Play App Signing certificate hash

### DIFF
--- a/docs/docs/features/mobile-app.mdx
+++ b/docs/docs/features/mobile-app.mdx
@@ -13,7 +13,9 @@ import MobileAppBackup from '/docs/partials/_mobile-app-backup.md';
 :::info Android verification
 Below are the SHA-256 fingerprints for the certificates signing the android applications.
 
-- Playstore / Github releases:
+- Google Play releases:
+  `5A:22:C1:83:47:54:05:F5:49:C4:EB:9F:B2:6C:2E:93:A3:EF:9C:57:66:15:0A:7A:F3:8C:8D:3F:E5:15:CC:D6`
+- GitHub releases:
   `86:C5:C4:55:DF:AF:49:85:92:3A:8F:35:AD:B3:1D:0C:9E:0B:95:7D:7F:94:C2:D2:AF:6A:24:38:AA:96:00:20`
 - F-Droid releases:
   `FA:8B:43:95:F4:A6:47:71:A0:53:D1:C7:57:73:5F:A2:30:13:74:F5:3D:58:0D:D1:75:AA:F7:A1:35:72:9C:BF`


### PR DESCRIPTION
## Description

Installs from Play store have a different certificate hash than currently documented, presumably due to Play App Signing.

## How Has This Been Tested?

Fresh install from Play store produces this hash, however, please could you verify it (Google Play Console under Release > Setup > App integrity)?

(I also manually verified the GitHub releases hash, which successfully match. It might be also worthwhile adding this to the GitHub release notes, which can be useful for users installing from GitHub releases e.g. via Obtainium).

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.