### PR TITLE
fix(web): use deterministic version name in svelte config

### DIFF
--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -16,7 +16,7 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     version: {
-      name: process.env.IMMICH_BUILD || Date.now().toString(),
+     name: process.env.IMMICH_BUILD || process.env.npm_package_version || 'local',
     },
     paths: {
       relative: false,

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -16,7 +16,7 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     version: {
-     name: process.env.IMMICH_BUILD || process.env.npm_package_version || 'local',
+      name: process.env.IMMICH_BUILD || process.env.npm_package_version || 'local',
     },
     paths: {
       relative: false,


### PR DESCRIPTION
## Description
Replace `Date.now().toString()` with `process.env.npm_package_version || 'local'` 
to ensure a deterministic version name for correct hash generation in Svelte config.

`Date.now()` changes on every build causing non-deterministic hashes which breaks 
the web UI in local prod builds.

Fixes #29169

## How Has This Been Tested?
- [ ] Verified the svelte.config.js now uses a deterministic value

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None. Fix was identified by reading the Svelte documentation and the issue description.