### PR TITLE
refactor(web): move keyboard state into a store

### DIFF
--- a/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
@@ -44,7 +44,7 @@
     brokenAssetClass?: ClassValue;
     dimmed?: boolean;
     albumUsers?: UserResponseDto[];
-    onClick?: (asset: TimelineAsset, event?: MouseEvent) => void;
+    onClick?: (asset: TimelineAsset) => void;
     onPreview?: (asset: TimelineAsset) => void;
     onSelect?: (asset: TimelineAsset) => void;
     onMouseEvent?: (event: { isMouseOver: boolean; selectedGroupIndex: number }) => void;
@@ -93,12 +93,12 @@
     }
   };
 
-  const callClickHandlers = (e?: MouseEvent) => {
+  const callClickHandlers = () => {
     if (selected) {
-      onIconClickedHandler(e);
+      onIconClickedHandler();
       return;
     }
-    onClick?.($state.snapshot(asset), e);
+    onClick?.($state.snapshot(asset));
   };
 
   const handleClick = (e: MouseEvent) => {
@@ -109,7 +109,7 @@
 
     e.stopPropagation();
     e.preventDefault();
-    callClickHandlers(e);
+    callClickHandlers();
   };
 
   const onMouseEnter = () => {

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -13,6 +13,7 @@
   import AssetDeleteConfirmModal from '$lib/modals/AssetDeleteConfirmModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Route } from '$lib/route';
+  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { handlePromiseError } from '$lib/utils';
   import { deleteAssets } from '$lib/utils/actions';
@@ -85,7 +86,6 @@
     return top + pageHeaderOffset < window.bottom && top + geometry.getHeight(index) > window.top;
   };
 
-  let shiftKeyIsDown = $state(false);
   let lastAssetMouseEvent: TimelineAsset | null = $state(null);
   let scrollTop = $state(0);
 
@@ -122,21 +122,6 @@
     assetInteraction.selectAssets(assets.map((a) => toTimelineAsset(a)));
   };
 
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Shift') {
-      event.preventDefault();
-
-      shiftKeyIsDown = true;
-    }
-  };
-
-  const onKeyUp = (event: KeyboardEvent) => {
-    if (event.key === 'Shift') {
-      event.preventDefault();
-      shiftKeyIsDown = false;
-    }
-  };
-
   const handleSelectAssets = (asset: TimelineAsset) => {
     if (!asset) {
       return;
@@ -168,7 +153,7 @@
   };
 
   const selectAssetCandidates = (endAsset: TimelineAsset) => {
-    if (!shiftKeyIsDown) {
+    if (!keyboardModifier.shift) {
       return;
     }
 
@@ -188,7 +173,7 @@
   };
 
   const onSelectStart = (event: Event) => {
-    if (assetInteraction.selectionActive && shiftKeyIsDown) {
+    if (assetInteraction.selectionActive && keyboardModifier.shift) {
       event.preventDefault();
     }
   };
@@ -333,13 +318,13 @@
   });
 
   $effect(() => {
-    if (!shiftKeyIsDown) {
+    if (!keyboardModifier.shift) {
       assetInteraction.clearCandidates();
     }
   });
 
   $effect(() => {
-    if (shiftKeyIsDown && lastAssetMouseEvent) {
+    if (keyboardModifier.shift && lastAssetMouseEvent) {
       selectAssetCandidates(lastAssetMouseEvent);
     }
   });
@@ -351,13 +336,7 @@
   });
 </script>
 
-<svelte:document
-  onkeydown={onKeyDown}
-  onkeyup={onKeyUp}
-  onselectstart={onSelectStart}
-  use:shortcuts={shortcutList}
-  onscroll={() => updateSlidingWindow()}
-/>
+<svelte:document onselectstart={onSelectStart} use:shortcuts={shortcutList} onscroll={() => updateSlidingWindow()} />
 
 {#if assets.length > 0}
   <div

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -13,7 +13,7 @@
   import AssetDeleteConfirmModal from '$lib/modals/AssetDeleteConfirmModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Route } from '$lib/route';
-  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
+  import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { handlePromiseError } from '$lib/utils';
   import { deleteAssets } from '$lib/utils/actions';
@@ -153,7 +153,7 @@
   };
 
   const selectAssetCandidates = (endAsset: TimelineAsset) => {
-    if (!keyboardModifier.shift) {
+    if (!keyboardManager.shift) {
       return;
     }
 
@@ -173,7 +173,7 @@
   };
 
   const onSelectStart = (event: Event) => {
-    if (assetInteraction.selectionActive && keyboardModifier.shift) {
+    if (assetInteraction.selectionActive && keyboardManager.shift) {
       event.preventDefault();
     }
   };
@@ -318,13 +318,13 @@
   });
 
   $effect(() => {
-    if (!keyboardModifier.shift) {
+    if (!keyboardManager.shift) {
       assetInteraction.clearCandidates();
     }
   });
 
   $effect(() => {
-    if (keyboardModifier.shift && lastAssetMouseEvent) {
+    if (keyboardManager.shift && lastAssetMouseEvent) {
       selectAssetCandidates(lastAssetMouseEvent);
     }
   });

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -19,7 +19,7 @@
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineAsset, TimelineManagerOptions, ViewportTopMonth } from '$lib/managers/timeline-manager/types';
   import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
-  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
+  import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { isAssetViewerRoute, navigate } from '$lib/utils/navigation';
   import { getTimes, type ScrubberListener } from '$lib/utils/timeline-util';
@@ -471,7 +471,7 @@
   };
 
   const selectAssetCandidates = async (endAsset: TimelineAsset) => {
-    if (!keyboardModifier.shift) {
+    if (!keyboardManager.shift) {
       return;
     }
 
@@ -491,13 +491,13 @@
   });
 
   $effect(() => {
-    if (!keyboardModifier.shift) {
+    if (!keyboardManager.shift) {
       assetInteraction.clearCandidates();
     }
   });
 
   $effect(() => {
-    if (keyboardModifier.shift && lastAssetMouseEvent) {
+    if (keyboardManager.shift && lastAssetMouseEvent) {
       void selectAssetCandidates(lastAssetMouseEvent);
     }
   });
@@ -583,12 +583,12 @@
     onScrubKeyDown={(evt) => {
       evt.preventDefault();
       let amount = 50;
-      if (keyboardModifier.shift) {
+      if (keyboardManager.shift) {
         amount = 500;
       }
       if (evt.key === 'ArrowUp') {
         amount = -amount;
-        if (keyboardModifier.shift) {
+        if (keyboardManager.shift) {
           scrollableElement?.scrollBy({ top: amount, behavior: 'smooth' });
         }
       } else if (evt.key === 'ArrowDown') {

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -19,6 +19,7 @@
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineAsset, TimelineManagerOptions, ViewportTopMonth } from '$lib/managers/timeline-manager/types';
   import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
+  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { isAssetViewerRoute, navigate } from '$lib/utils/navigation';
   import { getTimes, type ScrubberListener } from '$lib/utils/timeline-util';
@@ -59,7 +60,6 @@
         groupTitle: string,
         asset: TimelineAsset,
       ) => void,
-      event?: MouseEvent,
     ) => void;
   }
 
@@ -371,21 +371,6 @@
 
   let lastAssetMouseEvent: TimelineAsset | null = $state(null);
 
-  let shiftKeyIsDown = $state(false);
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Shift') {
-      event.preventDefault();
-      shiftKeyIsDown = true;
-    }
-  };
-
-  const onKeyUp = (event: KeyboardEvent) => {
-    if (event.key === 'Shift') {
-      event.preventDefault();
-      shiftKeyIsDown = false;
-    }
-  };
   const handleSelectAssetCandidates = (asset: TimelineAsset | null) => {
     if (asset) {
       void selectAssetCandidates(asset);
@@ -486,7 +471,7 @@
   };
 
   const selectAssetCandidates = async (endAsset: TimelineAsset) => {
-    if (!shiftKeyIsDown) {
+    if (!keyboardModifier.shift) {
       return;
     }
 
@@ -506,13 +491,13 @@
   });
 
   $effect(() => {
-    if (!shiftKeyIsDown) {
+    if (!keyboardModifier.shift) {
       assetInteraction.clearCandidates();
     }
   });
 
   $effect(() => {
-    if (shiftKeyIsDown && lastAssetMouseEvent) {
+    if (keyboardModifier.shift && lastAssetMouseEvent) {
       void selectAssetCandidates(lastAssetMouseEvent);
     }
   });
@@ -561,8 +546,6 @@
   };
 </script>
 
-<svelte:document onkeydown={onKeyDown} onkeyup={onKeyUp} />
-
 <HotModuleReload
   onAfterUpdate={() => {
     const asset = page.url.searchParams.get('at');
@@ -600,12 +583,12 @@
     onScrubKeyDown={(evt) => {
       evt.preventDefault();
       let amount = 50;
-      if (shiftKeyIsDown) {
+      if (keyboardModifier.shift) {
         amount = 500;
       }
       if (evt.key === 'ArrowUp') {
         amount = -amount;
-        if (shiftKeyIsDown) {
+        if (keyboardModifier.shift) {
           scrollableElement?.scrollBy({ top: amount, behavior: 'smooth' });
         }
       } else if (evt.key === 'ArrowDown') {
@@ -686,9 +669,9 @@
                 {asset}
                 {albumUsers}
                 {groupIndex}
-                onClick={(asset, event) => {
+                onClick={(asset) => {
                   if (typeof onThumbnailClick === 'function') {
-                    onThumbnailClick(asset, timelineManager, timelineDay, _onClick, event);
+                    onThumbnailClick(asset, timelineManager, timelineDay, _onClick);
                   } else {
                     _onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
                   }

--- a/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
+++ b/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
@@ -15,6 +15,7 @@
   import NavigateToDateModal from '$lib/modals/NavigateToDateModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Route } from '$lib/route';
+  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { searchStore } from '$lib/stores/search.svelte';
   import { handlePromiseError } from '$lib/utils';
@@ -73,32 +74,8 @@
     assetInteraction.clear();
   };
 
-  let shiftKeyIsDown = $state(false);
-
-  const onKeyDown = (event: KeyboardEvent) => {
-    if (searchStore.isSearchEnabled) {
-      return;
-    }
-
-    if (event.key === 'Shift') {
-      event.preventDefault();
-      shiftKeyIsDown = true;
-    }
-  };
-
-  const onKeyUp = (event: KeyboardEvent) => {
-    if (searchStore.isSearchEnabled) {
-      return;
-    }
-
-    if (event.key === 'Shift') {
-      event.preventDefault();
-      shiftKeyIsDown = false;
-    }
-  };
-
   const onSelectStart = (e: Event) => {
-    if (assetInteraction.selectionActive && shiftKeyIsDown) {
+    if (!searchStore.isSearchEnabled && assetInteraction.selectionActive && keyboardModifier.shift) {
       e.preventDefault();
     }
   };
@@ -171,4 +148,4 @@
   });
 </script>
 
-<svelte:document onkeydown={onKeyDown} onkeyup={onKeyUp} onselectstart={onSelectStart} use:shortcuts={shortcutList} />
+<svelte:document onselectstart={onSelectStart} use:shortcuts={shortcutList} />

--- a/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
+++ b/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
@@ -15,7 +15,7 @@
   import NavigateToDateModal from '$lib/modals/NavigateToDateModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Route } from '$lib/route';
-  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
+  import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { searchStore } from '$lib/stores/search.svelte';
   import { handlePromiseError } from '$lib/utils';
@@ -75,7 +75,7 @@
   };
 
   const onSelectStart = (e: Event) => {
-    if (!searchStore.isSearchEnabled && assetInteraction.selectionActive && keyboardModifier.shift) {
+    if (!searchStore.isSearchEnabled && assetInteraction.selectionActive && keyboardManager.shift) {
       e.preventDefault();
     }
   };

--- a/web/src/lib/stores/keyboard-manager.svelte.ts
+++ b/web/src/lib/stores/keyboard-manager.svelte.ts
@@ -1,30 +1,46 @@
 class KeyboardManager {
-  shift = $state(false);
-  ctrl = $state(false);
-  meta = $state(false);
-  alt = $state(false);
+  #shift = $state(false);
+  #ctrl = $state(false);
+  #meta = $state(false);
+  #alt = $state(false);
 
   constructor() {
     if (globalThis.window === undefined) {
       return;
     }
-    globalThis.addEventListener('keydown', this.update);
-    globalThis.addEventListener('keyup', this.update);
-    globalThis.addEventListener('blur', this.clear);
+    globalThis.addEventListener('keydown', this.#update);
+    globalThis.addEventListener('keyup', this.#update);
+    globalThis.addEventListener('blur', this.#clear);
   }
 
-  private update = (event: KeyboardEvent) => {
-    this.shift = event.shiftKey;
-    this.ctrl = event.ctrlKey;
-    this.meta = event.metaKey;
-    this.alt = event.altKey;
+  get shift() {
+    return this.#shift;
+  }
+
+  get ctrl() {
+    return this.#ctrl;
+  }
+
+  get meta() {
+    return this.#meta;
+  }
+
+  get alt() {
+    return this.#alt;
+  }
+
+  #update = (event: KeyboardEvent) => {
+    this.#shift = event.shiftKey;
+    this.#ctrl = event.ctrlKey;
+    this.#meta = event.metaKey;
+    this.#alt = event.altKey;
   };
 
-  private clear = () => {
-    this.shift = false;
-    this.ctrl = false;
-    this.meta = false;
-    this.alt = false;
+  #clear = () => {
+    this.#shift = false;
+    this.#ctrl = false;
+    this.#meta = false;
+    this.#alt = false;
   };
 }
 

--- a/web/src/lib/stores/keyboard-manager.svelte.ts
+++ b/web/src/lib/stores/keyboard-manager.svelte.ts
@@ -1,4 +1,4 @@
-class KeyboardModifierStore {
+class KeyboardManager {
   shift = $state(false);
   ctrl = $state(false);
   meta = $state(false);
@@ -28,4 +28,4 @@ class KeyboardModifierStore {
   };
 }
 
-export const keyboardModifier = new KeyboardModifierStore();
+export const keyboardManager = new KeyboardManager();

--- a/web/src/lib/stores/keyboard-modifier.svelte.ts
+++ b/web/src/lib/stores/keyboard-modifier.svelte.ts
@@ -5,12 +5,12 @@ class KeyboardModifierStore {
   alt = $state(false);
 
   constructor() {
-    if (typeof window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
-    window.addEventListener('keydown', this.update);
-    window.addEventListener('keyup', this.update);
-    window.addEventListener('blur', this.clear);
+    globalThis.addEventListener('keydown', this.update);
+    globalThis.addEventListener('keyup', this.update);
+    globalThis.addEventListener('blur', this.clear);
   }
 
   private update = (event: KeyboardEvent) => {

--- a/web/src/lib/stores/keyboard-modifier.svelte.ts
+++ b/web/src/lib/stores/keyboard-modifier.svelte.ts
@@ -1,0 +1,31 @@
+class KeyboardModifierStore {
+  shift = $state(false);
+  ctrl = $state(false);
+  meta = $state(false);
+  alt = $state(false);
+
+  constructor() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.addEventListener('keydown', this.update);
+    window.addEventListener('keyup', this.update);
+    window.addEventListener('blur', this.clear);
+  }
+
+  private update = (event: KeyboardEvent) => {
+    this.shift = event.shiftKey;
+    this.ctrl = event.ctrlKey;
+    this.meta = event.metaKey;
+    this.alt = event.altKey;
+  };
+
+  private clear = () => {
+    this.shift = false;
+    this.ctrl = false;
+    this.meta = false;
+    this.alt = false;
+  };
+}
+
+export const keyboardModifier = new KeyboardModifierStore();

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -11,7 +11,7 @@
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import GeolocationPointPickerModal from '$lib/modals/GeolocationPointPickerModal.svelte';
   import GeolocationUpdateConfirmModal from '$lib/modals/GeolocationUpdateConfirmModal.svelte';
-  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
+  import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import type { LatLng } from '$lib/types';
   import { setQueryValue } from '$lib/utils/navigation';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
@@ -120,7 +120,7 @@
       asset: TimelineAsset,
     ) => void,
   ) => {
-    if (keyboardModifier.shift) {
+    if (keyboardManager.shift) {
       onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
     } else if (hasGps(asset)) {
       locationUpdated = true;

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -11,6 +11,7 @@
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import GeolocationPointPickerModal from '$lib/modals/GeolocationPointPickerModal.svelte';
   import GeolocationUpdateConfirmModal from '$lib/modals/GeolocationUpdateConfirmModal.svelte';
+  import { keyboardModifier } from '$lib/stores/keyboard-modifier.svelte';
   import type { LatLng } from '$lib/types';
   import { setQueryValue } from '$lib/utils/navigation';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
@@ -118,13 +119,10 @@
       groupTitle: string,
       asset: TimelineAsset,
     ) => void,
-    event?: MouseEvent,
   ) => {
-    if (event?.shiftKey) {
+    if (keyboardModifier.shift) {
       onClick(timelineManager, timelineDay.getAssets(), timelineDay.groupTitle, asset);
-      return;
-    }
-    if (hasGps(asset)) {
+    } else if (hasGps(asset)) {
       locationUpdated = true;
       setTimeout(() => {
         locationUpdated = false;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Introduces a single reactive `keyboardModifier` store for global key state, and migrates the three places that each tracked Shift independently:

- `Timeline.svelte`
- `GalleryViewer.svelte`
- `TimelineKeyboardActions.svelte`

These three components each duplicated the same `shiftKeyIsDown` plus a `<svelte:document>` keydown/keyup pair. One store removes that duplication and gives selection logic a primitive to build on.

It also lets the geolocation utility read modifier state directly, so the callback-signature threading from #29022 is reverted.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Main timeline: shift+click range select still works as expected
- [x] Gallery viewer (album): shift+click range select still works as expected
- [x] Geolocation utility: the PR #29022 behavior, now via the store

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
