### PR TITLE
refactor(server): use zod time validation

### DIFF
--- a/mobile/openapi/lib/model/system_config_nightly_tasks_dto.dart
+++ b/mobile/openapi/lib/model/system_config_nightly_tasks_dto.dart
@@ -33,7 +33,7 @@ class SystemConfigNightlyTasksDto {
   /// Missing thumbnails
   bool missingThumbnails;
 
-  /// Start time
+  /// Start time (HH:MM)
   String startTime;
 
   /// Sync quota usage

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -26144,8 +26144,8 @@
             "type": "boolean"
           },
           "startTime": {
-            "description": "Start time",
-            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "description": "Start time (HH:MM)",
+            "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
             "type": "string"
           },
           "syncQuotaUsage": {

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2501,7 +2501,7 @@ export type SystemConfigNightlyTasksDto = {
     generateMemories: boolean;
     /** Missing thumbnails */
     missingThumbnails: boolean;
-    /** Start time */
+    /** Start time (HH:MM) */
     startTime: string;
     /** Sync quota usage */
     syncQuotaUsage: boolean;

--- a/server/src/controllers/system-config.controller.spec.ts
+++ b/server/src/controllers/system-config.controller.spec.ts
@@ -70,7 +70,7 @@ describe(SystemConfigController.name, () => {
           errorDto.validationError([
             {
               path: ['nightlyTasks', 'startTime'],
-              message: 'Invalid input: expected string in HH:mm format, received string',
+              message: 'Invalid input: expected string in HH:MM format, received string',
             },
           ]),
         );

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -20,7 +20,6 @@ import {
   VideoCodecSchema,
   VideoContainerSchema,
 } from 'src/enum';
-import { isValidTime } from 'src/validation';
 import z from 'zod';
 
 /** Coerces 'true'/'false' strings to boolean, but also allows booleans. */
@@ -204,7 +203,12 @@ const SystemConfigNewVersionCheckSchema = z
 
 const SystemConfigNightlyTasksSchema = z
   .object({
-    startTime: isValidTime.describe('Start time'),
+    startTime: z.iso
+      .time({
+        precision: -1,
+        error: (iss) => `Invalid input: expected string in HH:MM format, received ${typeof iss.input}`,
+      })
+      .describe('Start time (HH:MM)'),
     databaseCleanup: configBool.describe('Database cleanup'),
     missingThumbnails: configBool.describe('Missing thumbnails'),
     clusterNewFaces: configBool.describe('Cluster new faces'),

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -188,10 +188,6 @@ export const isoDateToDate = z
   )
   .meta({ example: '2024-01-01' });
 
-export const isValidTime = z
-  .string()
-  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid input: expected string in HH:mm format, received string');
-
 /**
  * Latitude in range [-90, 90]. Reuse for body or query params.
  *


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

use zod instead of a custom regex. not pulling into a reusable const as a) we only use it once and b) is more explict avoiding sync drifts between logic and documentation.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
