### PR TITLE
fix: workflow asset type filter required

### DIFF
--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -199,7 +199,7 @@
             "enum": ["IMAGE", "VIDEO", "AUDIO", "OTHER"]
           }
         },
-        "required": ["types"]
+        "required": ["allowedTypes"]
       },
       "uiHints": ["Filter"]
     },


### PR DESCRIPTION
I should eventually revisit the zod schemas and see if I can prevent these kind of bugs