### PR TITLE
fix(mobile): force AssetViewerPage recreation on repeated view intents

### DIFF
--- a/mobile/lib/providers/view_intent/view_intent_handler_android.dart
+++ b/mobile/lib/providers/view_intent/view_intent_handler_android.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
@@ -97,12 +98,6 @@ class AndroidViewIntentHandler implements ViewIntentHandler {
 
     await _router.replaceAll([
       const TabShellRoute(),
-      // UniqueKey forces the AssetViewerPage widget to be fully recreated
-      // each time a "View in Immich" intent is handled. Without it, auto_route
-      // may reuse the existing route when the stack already contains an
-      // AssetViewerRoute, which preserves the old ConsumerState (and its
-      // PageController) and causes the viewer to stay frozen on the previous
-      // asset instead of loading the new one.
       AssetViewerRoute(key: UniqueKey(), initialIndex: 0, timelineService: timelineService),
     ]);
   }

--- a/mobile/lib/providers/view_intent/view_intent_handler_android.dart
+++ b/mobile/lib/providers/view_intent/view_intent_handler_android.dart
@@ -97,7 +97,13 @@ class AndroidViewIntentHandler implements ViewIntentHandler {
 
     await _router.replaceAll([
       const TabShellRoute(),
-      AssetViewerRoute(initialIndex: 0, timelineService: timelineService),
+      // UniqueKey forces the AssetViewerPage widget to be fully recreated
+      // each time a "View in Immich" intent is handled. Without it, auto_route
+      // may reuse the existing route when the stack already contains an
+      // AssetViewerRoute, which preserves the old ConsumerState (and its
+      // PageController) and causes the viewer to stay frozen on the previous
+      // asset instead of loading the new one.
+      AssetViewerRoute(key: UniqueKey(), initialIndex: 0, timelineService: timelineService),
     ]);
   }
 }


### PR DESCRIPTION
## Description

When **View in Immich** is triggered a second time while the asset viewer is already open, the viewer stays frozen on the previous asset instead of loading the new one. The only workaround is to manually close the viewer first.

**Root cause:**

`_openAssetViewer` calls `_router.replaceAll([TabShellRoute, AssetViewerRoute(...)])`. When the stack already contains an `AssetViewerRoute` with `key: null`, auto_route considers it the same route and Flutter reuses the existing widget element — meaning `_AssetViewerState.initState` is never called again.

`_AssetViewerState` has two `late final` fields initialised only in `initState`:

```dart
late final _pageController = PageController(initialPage: widget.initialIndex);
late final _preloader = AssetPreloader(timelineService: ref.read(timelineServiceProvider), ...);
```

These never reset. The `ProviderScope` override for `timelineServiceProvider` changes (new timeline for the new asset), but the preloader still holds a reference to the old service. The `PageController` is stuck on page 0 of the old timeline. The viewer can't show the new asset.

**Fix:**

Pass `UniqueKey()` to `AssetViewerRoute` so each view intent creates a genuinely new widget element. Flutter then calls `initState` fresh, the `PageController` and `AssetPreloader` are created with the correct new `TimelineService`, and the viewer loads the right asset.

This only affects the view intent path — normal in-app navigation to the viewer is unchanged.

Fixes #29230

## How Has This Been Tested?

- [ ] Manually verified: open photo A via View in Immich, press back to file manager, open photo B via View in Immich — viewer now loads photo B correctly instead of staying on photo A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.