### PR TITLE
fix(server): use VBR for QSV so the max bitrate is respected

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -2939,6 +2939,8 @@ describe(MediaService.name, () => {
             '7',
             '-global_quality:v',
             '23',
+            '-b:v',
+            '6897k',
             '-maxrate',
             '10000k',
             '-bufsize',

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -788,6 +788,12 @@ export class QsvSwDecodeConfig extends BaseHWConfig {
     const options = [`-${this.useCQP() ? 'q:v' : 'global_quality:v'}`, `${this.config.crf}`];
     const bitrates = this.getBitrateDistribution();
     if (bitrates.max > 0) {
+      // Workaround for https://github.com/immich-app/immich/issues/29220, to be revisited
+      // QSV seems to ignore -maxrate without -b:v
+      // -b:v alongside global_quality uses QVBR
+      if (!this.useCQP()) {
+        options.push('-b:v', `${bitrates.target}${bitrates.unit}`);
+      }
       options.push('-maxrate', `${bitrates.max}${bitrates.unit}`, '-bufsize', `${bitrates.max * 2}${bitrates.unit}`);
     }
     return options;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #29220
QSV with ICQ doesn't seem to respect the `-maxrate` arg. This adds `-b:v` for a target bitrate, which forces QVBR so the max bitrate is respected. According to @mertalev this is a workaround for the time being and should be revisited (https://github.com/immich-app/immich/issues/29220#issuecomment-4761168636). FWIW [Jellyfin also uses a target bitrate](https://github.com/immich-app/immich/issues/29220#issuecomment-4755669630) in their HLS implementation with QSV.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [Manually, checking the sizes of the output segments](https://github.com/immich-app/immich/issues/29220#issuecomment-4756338701)
- Built and ran an [image with the change](https://hub.docker.com/repository/docker/ant385525/immich-server/tags/qsv-target-bitrate/sha256:b7629cb3ad511484332513008f458d10891be7ca741289a86a00ee81b3329d88), verified the output ffmpeg command included the target bitrate and the segments sent to the browser were properly sized with realtime transcoding enabled
```
ffmpeg -hwaccel qsv -hwaccel_output_format qsv -async_depth 4 -noautorotate -qsv_device /dev/dri/renderD128 -threads 1 -ss 1.996735971524288 -nostdin -nostats -i /data/library/anthony/Recents/2026/06/IMG_0528.mov -c:v hevc_qsv -c:a aac -map 0:0 -map_metadata -1 -map 0:1 -bf 0 -refs 5 -g 240 -keyint_min 240 -preset 3 -global_quality:v 28 -b:v 3104k -maxrate 4500k -bufsize 9000k -idr_interval 0 -copyts -r 9552000/79636 -avoid_negative_ts disabled -f hls -hls_time 2 -hls_list_size 0 -hls_segment_type fmp4 -hls_fmp4_init_filename init.mp4 -hls_segment_options movflags=+frag_discont -hls_flags temp_file -hls_segment_filename /data/encoded-video/d5e4be30-b38f-4c6b-a7b1-0721a11992c5/7a/9e/7a9eacb2-6c29-4277-b1b1-20d173cfe8d4/7/seg_%d.m4s -start_number 1 -vf scale_qsv=-1:1080:async_depth=4:mode=hq,hwmap=derive_device=opencl,tonemap_opencl=desat=0:format=nv12:matrix=bt709:primaries=bt709:transfer=bt709:range=pc:tonemap=hable:tonemap_mode=lum:peak=100,hwmap=derive_device=qsv:reverse=1,format=qsv /data/encoded-video/d5e4be30-b38f-4c6b-a7b1-0721a11992c5/7a/9e/7a9eacb2-6c29-4277-b1b1-20d173cfe8d4/7/playlist.m3u8
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="757" height="463" alt="Screenshot 2026-06-21 at 8 47 44 AM" src="https://github.com/user-attachments/assets/1c288338-22b3-42b6-8966-3b11a4dbfc49" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
