### PR TITLE
feat(web): indicate partial selection on paginated search

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1856,6 +1856,7 @@
   "select_trash_all": "Select trash all",
   "selected": "Selected",
   "selected_count": "{count, plural, other {# selected}}",
+  "selected_count_with_more": "{count, plural, other {Only # selected}}",
   "selected_gps_coordinates": "Selected GPS Coordinates",
   "send_message": "Send message",
   "send_welcome_email": "Send welcome email",

--- a/web/src/lib/components/timeline/AssetSelectControlBar.svelte
+++ b/web/src/lib/components/timeline/AssetSelectControlBar.svelte
@@ -20,7 +20,13 @@
   {#snippet leading()}
     <div class="font-medium text-primary">
       <p class="block sm:hidden">{assets.length}</p>
-      <p class="hidden sm:block">{$t('selected_count', { values: { count: assets.length } })}</p>
+      <p class="hidden sm:block">
+        {#if assetMultiSelectManager.hasMoreAssets}
+          {$t('selected_count_with_more', { values: { count: assets.length } })}
+        {:else}
+          {$t('selected_count', { values: { count: assets.length } })}
+        {/if}
+      </p>
     </div>
   {/snippet}
   {#snippet trailing()}

--- a/web/src/lib/managers/asset-multi-select-manager.svelte.spec.ts
+++ b/web/src/lib/managers/asset-multi-select-manager.svelte.spec.ts
@@ -44,4 +44,13 @@ describe('AssetMultiSelectManager', () => {
     cleanup();
     authManager.reset();
   });
+
+  it('resets hasMoreAssets when cleared', () => {
+    sut.setHasMoreAssets(true);
+    expect(sut.hasMoreAssets).toBe(true);
+
+    sut.clear();
+
+    expect(sut.hasMoreAssets).toBe(false);
+  });
 });

--- a/web/src/lib/managers/asset-multi-select-manager.svelte.ts
+++ b/web/src/lib/managers/asset-multi-select-manager.svelte.ts
@@ -17,6 +17,8 @@ export class AssetMultiSelectManager {
 
   candidates = $state<TimelineAsset[]>([]);
 
+  hasMoreAssets = $state(false);
+
   selectionActive = $derived(this.#selectedMap.size > 0);
 
   assets = $derived(Array.from(this.#selectedMap.values()));
@@ -88,6 +90,10 @@ export class AssetMultiSelectManager {
     this.candidates = assets;
   }
 
+  setHasMoreAssets(hasMore: boolean) {
+    this.hasMoreAssets = hasMore;
+  }
+
   clearCandidates() {
     this.candidates = [];
   }
@@ -102,6 +108,7 @@ export class AssetMultiSelectManager {
     // Range selection
     this.candidates = [];
     this.startAsset = null;
+    this.hasMoreAssets = false;
   }
 }
 

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -122,6 +122,7 @@
     nextPage = 1;
     searchResultAssets = [];
     searchResultAlbums = [];
+    assetMultiSelectManager.setHasMoreAssets(false);
     await loadNextPage(true);
   }
 
@@ -146,6 +147,7 @@
 
       searchResultAlbums.push(...albums.items);
       searchResultAssets.push(...assets.items);
+      assetMultiSelectManager.setHasMoreAssets(!!assets.nextPage);
 
       nextPage = Number(assets.nextPage) || 0;
     } catch (error) {


### PR DESCRIPTION
## Description

This PR tracks whether the active search has additional pages and updates the selection bar label accordingly:

- Added `hasMoreAssets` to `AssetMultiSelectManager`, set from the search page when assets.nextPage is present 
- Updated `AssetSelectControlBar` to use a separate i18n key (`selected_count_with_more`) when more results are available
- Reset `hasMoreAssets` when clearing selection or starting a new search, so the label does not linger between queries

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #28365 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Search for anything that returns more than 1 page of results, press Ctrl+A to select all, it should show `Only X selected`
- Either filter or search for something else that returns only 1 page, press Ctrl+A, it shows `X selected`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
### Select all with paginated results
<img width="2001" height="1080" alt="Screenshot 2026-06-22 at 6 30 21 PM" src="https://github.com/user-attachments/assets/49b408b8-030f-49b1-8869-9c3dc6967ba0" />

### Select all without paginated results

<img width="1905" height="525" alt="image" src="https://github.com/user-attachments/assets/56ac4f6c-83a3-48d1-b122-c8a80fd8cbc5" />

</details>



## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Unit test
