### PR TITLE
feat(ml): support running machine learning natively on Windows

### DIFF
--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -18,7 +18,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 ## Limitations
 
 - The instructions and configurations here are specific to Docker Compose. Other container engines may require different configuration.
-- Only Linux and Windows (through WSL2) servers are supported.
+- Only Linux and Windows (through WSL2) servers are supported for the containerized machine learning service. To use an NVIDIA GPU on Windows without Docker or WSL2, run the service [natively on Windows](/guides/windows-machine-learning) instead.
 - ARM NN is only supported on devices with Mali GPUs. Other Arm devices are not supported.
 - Some models may not be compatible with certain backends. CUDA is the most reliable.
 - Search latency isn't improved by ARM NN due to model compatibility issues preventing its use. However, smart search jobs do make use of ARM NN.
@@ -44,6 +44,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 - The server must have the official NVIDIA driver installed.
 - The installed driver must be >= 545 (it must support CUDA 12.3).
 - On Linux (except for WSL2), you also need to have [NVIDIA Container Toolkit][nvct] installed.
+- On Windows, you can run the machine learning service [natively](/guides/windows-machine-learning) to use an NVIDIA GPU directly, without Docker or WSL2.
 
 #### ROCm
 

--- a/docs/docs/guides/windows-machine-learning.md
+++ b/docs/docs/guides/windows-machine-learning.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 90
+---
+
+# Machine Learning on Windows (native)
+
+This guide explains how to run the Immich machine learning service **natively on Windows**, so it can use a local NVIDIA GPU without Docker or WSL. It is an alternative to [Remote Machine Learning](/guides/remote-machine-learning): the Immich server still runs wherever it normally does (for example on a NAS) and is simply pointed at the Windows machine for ML inference.
+
+This is useful when your server host has no GPU (or only a slow CPU) but you have a Windows PC with a capable NVIDIA GPU that can take over Smart Search and Face Detection.
+
+:::info
+Smart Search and Face Detection use the remote machine learning service, but Facial Recognition does not — it runs between the server and the database. See [Remote Machine Learning](/guides/remote-machine-learning) for details.
+:::
+
+:::danger
+The machine learning service has no authentication and receives image previews. Only run it on a trusted network and restrict access to the port (default `3003`).
+:::
+
+## Prerequisites
+
+- Windows 10/11 with a supported **NVIDIA GPU** and a recent driver.
+- **Python 3.11** (matching the version in `machine-learning/.python-version`).
+- **Visual Studio Build Tools** with the "Desktop development with C++" workload — `insightface` is built from source on Windows.
+- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`.
+
+## Setup
+
+1. Get the `machine-learning` source for your Immich version. Either clone the repo and check out the matching tag, or copy the `machine-learning` folder out of the `immich-machine-learning` image:
+
+   ```powershell
+   git clone https://github.com/immich-app/immich
+   cd immich/machine-learning
+   git checkout v1.xxx.x   # match your server version
+   ```
+
+2. Create a virtual environment and install the runtime with the CUDA extra:
+
+   ```powershell
+   uv sync --no-dev --extra cuda
+   ```
+
+   Or with `pip`:
+
+   ```powershell
+   py -3.11 -m venv .venv
+   .venv\Scripts\Activate.ps1
+   pip install -e ".[cuda]"
+   ```
+
+3. Install the CUDA 12 / cuDNN 9 runtime libraries that `onnxruntime-gpu` needs. On Linux these come from the base image; on Windows install them as wheels:
+
+   ```powershell
+   pip install nvidia-cudnn-cu12 nvidia-cublas-cu12 nvidia-cuda-runtime-cu12 nvidia-cufft-cu12 nvidia-curand-cu12 nvidia-cuda-nvrtc-cu12 nvidia-nvjitlink-cu12
+   ```
+
+   :::warning cuDNN DLLs must be on `PATH`
+   cuDNN 9 loads its sub-libraries (for example `cudnn_engines_tensor_ir64_9.dll`) **by name from `PATH` at runtime**. `onnxruntime.preload_dlls()` is not enough. If the wheel `bin` directories are not on `PATH`, inference fails with `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED` and silently falls back to the CPU. Add them before launching (see the start script below).
+   :::
+
+## Running the service
+
+Create a `start-ml.ps1` script:
+
+```powershell
+$ErrorActionPreference = "Stop"
+$venv = "$PSScriptRoot\.venv"
+
+# Put the NVIDIA wheel bin directories on PATH so cuDNN can load its sub-libraries.
+$nv = "$venv\Lib\site-packages\nvidia"
+$bins = "cudnn","cublas","cuda_runtime","cufft","curand","cuda_nvrtc","nvjitlink" |
+    ForEach-Object { "$nv\$_\bin" }
+$env:PATH = ($bins -join ";") + ";" + $env:PATH
+
+# Optional: keep downloaded models out of the user profile
+$env:MACHINE_LEARNING_CACHE_FOLDER = "$PSScriptRoot\cache"
+
+$env:IMMICH_HOST = "0.0.0.0"
+$env:IMMICH_PORT = "3003"
+
+& "$venv\Scripts\python.exe" -m immich_ml
+```
+
+`python -m immich_ml` detects Windows and starts `uvicorn` directly (gunicorn is Unix-only and is skipped automatically). On first use the required models are downloaded into the cache folder. Verify it is up:
+
+```powershell
+curl http://localhost:3003/ping   # -> pong
+```
+
+Allow the port through the Windows firewall so the server can reach it:
+
+```powershell
+New-NetFirewallRule -DisplayName "immich-ml" -Direction Inbound -Protocol TCP -LocalPort 3003 -Action Allow
+```
+
+## Point the server at the Windows machine
+
+In the Immich web UI, go to **Administration → Settings → Machine Learning Settings** and set the URL to `http://<windows-host-ip>:3003`. The server will now send Smart Search and Face Detection requests to the GPU on Windows.
+
+:::info
+The Windows process must be running (and the PC awake) for ML jobs to complete. To keep it running across reboots/logoffs, register `start-ml.ps1` as a scheduled task that runs at startup, or wrap it with a service manager such as [NSSM](https://nssm.cc/).
+:::

--- a/machine-learning/immich_ml/__main__.py
+++ b/machine-learning/immich_ml/__main__.py
@@ -26,33 +26,48 @@ if is_ipv6(bind_host):
     bind_host = f"[{bind_host}]"
 bind_address = f"{bind_host}:{non_prefixed_settings.immich_port}"
 
-try:
-    with subprocess.Popen(
-        [
-            "python",
-            "-m",
-            "gunicorn",
-            "immich_ml.main:app",
-            "-k",
-            "immich_ml.config.CustomUvicornWorker",
-            "-c",
-            module_dir / "gunicorn_conf.py",
-            "-b",
-            bind_address,
-            "-w",
-            str(settings.workers),
-            "-t",
-            str(settings.worker_timeout),
-            "--log-config-json",
-            module_dir / "log_conf.json",
-            "--keep-alive",
-            str(settings.http_keepalive_timeout_s),
-            "--graceful-timeout",
-            "10",
-            "--no-control-socket",
-        ],
-    ) as cmd:
-        cmd.wait()
-except KeyboardInterrupt:
-    cmd.send_signal(signal.SIGINT)
-exit(cmd.returncode)
+if os.name == "nt":
+    # gunicorn depends on the Unix-only `fcntl` module and cannot run on Windows,
+    # so launch uvicorn directly instead. See the "Running machine learning
+    # natively on Windows" guide in the docs.
+    import uvicorn
+
+    log.info("Running on Windows; starting uvicorn directly without gunicorn.")
+    uvicorn.run(
+        "immich_ml.main:app",
+        host=non_prefixed_settings.immich_host,
+        port=non_prefixed_settings.immich_port,
+        workers=settings.workers,
+        timeout_keep_alive=settings.http_keepalive_timeout_s,
+    )
+else:
+    try:
+        with subprocess.Popen(
+            [
+                "python",
+                "-m",
+                "gunicorn",
+                "immich_ml.main:app",
+                "-k",
+                "immich_ml.config.CustomUvicornWorker",
+                "-c",
+                module_dir / "gunicorn_conf.py",
+                "-b",
+                bind_address,
+                "-w",
+                str(settings.workers),
+                "-t",
+                str(settings.worker_timeout),
+                "--log-config-json",
+                module_dir / "log_conf.json",
+                "--keep-alive",
+                str(settings.http_keepalive_timeout_s),
+                "--graceful-timeout",
+                "10",
+                "--no-control-socket",
+            ],
+        ) as cmd:
+            cmd.wait()
+    except KeyboardInterrupt:
+        cmd.send_signal(signal.SIGINT)
+    exit(cmd.returncode)

--- a/machine-learning/immich_ml/config.py
+++ b/machine-learning/immich_ml/config.py
@@ -5,13 +5,22 @@ import sys
 from pathlib import Path
 from socket import socket
 
-from gunicorn.arbiter import Arbiter
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from rich.console import Console
 from rich.logging import RichHandler
 from uvicorn import Server
-from uvicorn.workers import UvicornWorker
+
+try:
+    from gunicorn.arbiter import Arbiter
+    from uvicorn.workers import UvicornWorker
+except ModuleNotFoundError:
+    # gunicorn depends on the Unix-only `fcntl` module and is unavailable on
+    # Windows (uvicorn's gunicorn worker imports it transitively). The service
+    # runs uvicorn directly there (see `__main__`), so `CustomUvicornWorker`
+    # below is never used.
+    Arbiter = None
+    UvicornWorker = object  # type: ignore[assignment,misc]
 
 from .schemas import ModelPrecision
 

--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 dependencies = [
     "aiocache>=0.12.1,<1.0",
     "fastapi>=0.95.2,<1.0",
-    "gunicorn>=21.1.0",
+    "gunicorn>=21.1.0; sys_platform != 'win32'",
     "huggingface-hub>=1.0,<2.0",
     "insightface>=0.7.3,<2.0",
     "numpy>=2.4.0,<3.0",

--- a/machine-learning/uv.lock
+++ b/machine-learning/uv.lock
@@ -979,7 +979,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiocache" },
     { name = "fastapi" },
-    { name = "gunicorn" },
+    { name = "gunicorn", marker = "sys_platform != 'win32'" },
     { name = "huggingface-hub" },
     { name = "insightface" },
     { name = "numpy" },
@@ -1060,7 +1060,7 @@ types = [
 requires-dist = [
     { name = "aiocache", specifier = ">=0.12.1,<1.0" },
     { name = "fastapi", specifier = ">=0.95.2,<1.0" },
-    { name = "gunicorn", specifier = ">=21.1.0" },
+    { name = "gunicorn", marker = "sys_platform != 'win32'", specifier = ">=21.1.0" },
     { name = "huggingface-hub", specifier = ">=1.0,<2.0" },
     { name = "insightface", specifier = ">=0.7.3,<2.0" },
     { name = "numpy", specifier = ">=2.4.0,<3.0" },


### PR DESCRIPTION
## Description

`gunicorn` depends on the Unix-only `fcntl` module, so the machine learning service currently cannot start on Windows. This adds native Windows support:

- **`config.py`** — guard the `gunicorn` / `uvicorn.workers` imports (only used by `CustomUvicornWorker`) so the module loads without gunicorn.
- **`__main__.py`** — on Windows (`os.name == "nt"`), launch `uvicorn` directly instead of the gunicorn subprocess.
- **`pyproject.toml` / `uv.lock`** — mark `gunicorn` as `sys_platform != 'win32'` so it isn't required on Windows.
- **Docs** — a new "Machine Learning on Windows (native)" guide plus cross-references from the hardware-acceleration page.

Behavior on Linux/Docker is unchanged. This lets users run the ML service natively on a Windows PC to use a local NVIDIA GPU — without Docker or WSL2 — e.g. as a remote machine learning target for a server on a GPU-less host.

Not linked to an existing issue.

## How Has This Been Tested?

- [x] Ran natively on Windows 11 (Python 3.11, `onnxruntime-gpu` + CUDA 12 / cuDNN 9, NVIDIA GPU) serving a live Immich server's Smart Search + Face Detection backlog over an extended run; stable.
- [x] Verified `config.py` imports successfully with `gunicorn` absent — it falls back to `Arbiter = None` / `UvicornWorker = object`, and `CustomUvicornWorker` is never used on that path.

No automated tests were added; the change is platform launch plumbing and the Linux/Docker path is untouched.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable) — N/A, platform launch plumbing
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories — N/A (this is the Python machine-learning service, not the server)
- [ ] All code in `src/repositories/` is basic/simple — N/A

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. An LLM (Claude) wrote the code changes and the documentation; I directed the work, made the decisions, and validated the result on real hardware (running the ML service natively on Windows with an NVIDIA GPU against a live Immich server). I'm aware CONTRIBUTING.md asks contributors not to open LLM-generated PRs — I'm disclosing this openly so you can decide whether it's worth keeping. No hard feelings if you'd rather close it.
