### PR TITLE
fix(mobile): app doesn't exit full-screen mode

### DIFF
--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_bottom_info.widget.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_card.widget.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/utils/system_ui.utils.dart';
 import 'package:immich_mobile/widgets/memories/memory_epilogue.dart';
 import 'package:immich_mobile/widgets/memories/memory_progress_indicator.dart';
 
@@ -49,7 +50,7 @@ class DriftMemoryPage extends HookConsumerWidget {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
       return () {
         // Clean up to normal edge to edge when we are done
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+        restoreSystemUI();
       };
     });
 
@@ -328,7 +329,7 @@ class DriftMemoryPage extends HookConsumerWidget {
                               // turn off full screen mode here
                               // https://github.com/Milad-Akarie/auto_route_library/issues/1799
                               context.maybePop();
-                              SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+                              restoreSystemUI();
                             },
                             shape: const CircleBorder(),
                             color: Colors.white.withValues(alpha: 0.2),

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -50,7 +50,7 @@ class DriftMemoryPage extends HookConsumerWidget {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
       return () {
         // Clean up to normal edge to edge when we are done
-        restoreSystemUI();
+        restoreEdgeToEdge();
       };
     });
 
@@ -329,7 +329,7 @@ class DriftMemoryPage extends HookConsumerWidget {
                               // turn off full screen mode here
                               // https://github.com/Milad-Akarie/auto_route_library/issues/1799
                               context.maybePop();
-                              restoreSystemUI();
+                              restoreEdgeToEdge();
                             },
                             shape: const CircleBorder(),
                             color: Colors.white.withValues(alpha: 0.2),

--- a/mobile/lib/presentation/pages/drift_slideshow.page.dart
+++ b/mobile/lib/presentation/pages/drift_slideshow.page.dart
@@ -77,7 +77,7 @@ class _DriftSlideshowPageState extends ConsumerState<DriftSlideshowPage> with Si
     _pageController.dispose();
     _crossfadeController.dispose();
     unawaited(WakelockPlus.disable());
-    unawaited(restoreSystemUI());
+    unawaited(restoreEdgeToEdge());
     super.dispose();
   }
 
@@ -256,7 +256,7 @@ class _DriftSlideshowPageState extends ConsumerState<DriftSlideshowPage> with Si
   }
 
   void _onTapUp() async {
-    await (_showAppBar ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive) : restoreSystemUI());
+    await (_showAppBar ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive) : restoreEdgeToEdge());
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {

--- a/mobile/lib/presentation/pages/drift_slideshow.page.dart
+++ b/mobile/lib/presentation/pages/drift_slideshow.page.dart
@@ -19,6 +19,7 @@ import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart'
 import 'package:immich_mobile/providers/asset_viewer/video_player_provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/system_ui.utils.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -76,7 +77,7 @@ class _DriftSlideshowPageState extends ConsumerState<DriftSlideshowPage> with Si
     _pageController.dispose();
     _crossfadeController.dispose();
     unawaited(WakelockPlus.disable());
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    unawaited(restoreSystemUI());
     super.dispose();
   }
 
@@ -255,7 +256,7 @@ class _DriftSlideshowPageState extends ConsumerState<DriftSlideshowPage> with Si
   }
 
   void _onTapUp() async {
-    await SystemChrome.setEnabledSystemUIMode(_showAppBar ? SystemUiMode.immersive : SystemUiMode.edgeToEdge);
+    await (_showAppBar ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive) : restoreSystemUI());
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -129,7 +129,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     _reloadSubscription?.cancel();
     _stackChildrenKeepAlive?.close();
 
-    unawaited(restoreSystemUI());
+    unawaited(restoreEdgeToEdge());
 
     super.dispose();
   }
@@ -253,7 +253,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
   void _setSystemUIMode(bool controls, bool details) {
     final immersive = !controls || (CurrentPlatform.isIOS && details);
-    unawaited(immersive ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky) : restoreSystemUI());
+    unawaited(immersive ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky) : restoreEdgeToEdge());
   }
 
   @override

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -23,6 +23,7 @@ import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart'
 import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/utils/system_ui.utils.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
 
 @RoutePage()
@@ -128,7 +129,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     _reloadSubscription?.cancel();
     _stackChildrenKeepAlive?.close();
 
-    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    unawaited(restoreSystemUI());
 
     super.dispose();
   }
@@ -251,10 +252,8 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
   }
 
   void _setSystemUIMode(bool controls, bool details) {
-    final mode = !controls || (CurrentPlatform.isIOS && details)
-        ? SystemUiMode.immersiveSticky
-        : SystemUiMode.edgeToEdge;
-    unawaited(SystemChrome.setEnabledSystemUIMode(mode));
+    final immersive = !controls || (CurrentPlatform.isIOS && details);
+    unawaited(immersive ? SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky) : restoreSystemUI());
   }
 
   @override

--- a/mobile/lib/utils/system_ui.utils.dart
+++ b/mobile/lib/utils/system_ui.utils.dart
@@ -8,7 +8,7 @@ import 'package:flutter/services.dart';
 /// setEnabledSystemUIMode(edgeToEdge) does NOT re-show bars that an immersive
 /// mode (immersive / immersiveSticky) previously hid. Explicitly request all
 /// overlays first, then return to edge-to-edge layout.
-Future<void> restoreSystemUI() async {
+Future<void> restoreEdgeToEdge() async {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: SystemUiOverlay.values);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 }

--- a/mobile/lib/utils/system_ui.utils.dart
+++ b/mobile/lib/utils/system_ui.utils.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+/// Restore the system bars and return to edge-to-edge layout.
+///
+/// On Android 15+/API 36 edge-to-edge is enforced, so calling
+/// setEnabledSystemUIMode(edgeToEdge) does NOT re-show bars that an immersive
+/// mode (immersive / immersiveSticky) previously hid. Explicitly request all
+/// overlays first, then return to edge-to-edge layout.
+Future<void> restoreSystemUI() async {
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: SystemUiOverlay.values);
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+}


### PR DESCRIPTION
## Description

Fixes #29198 - An issue on Android where the phone would get stuck in full-screen mode after exiting video player/memories.

The bug came in through the Flutter 3.44.1 upgrade.

The chain:
- Flutter 3.44.1 sets `targetSdk` to 36 (Android 16)
- On API 36, edge-to-edge is enforced.
- `immersiveSticky` still hides the bars when a video goes fullscreen, but the restore path `SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge)` is a no-op for bar visibility because the app is already in edge-to-edge. So the bars that immersive mode hid are never shown again, and they stay hidden app-wide.

## How Has This Been Tested?

- [x] Play a video - phone goes into full-screen mode
- [x] Exit video player - phone goes back to edge-to-edge mode

**Needs testing on iOS. I've only tested on Android!**

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude was used to identify the issue
