### PR TITLE
fix(mobile): prevent snapping to center on pinch-to-zoom release (#29207)

### DIFF
--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -201,7 +201,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     } else if (scaleState == PhotoViewScaleState.zoomedIn) {
       animateRotation(controller.rotation, 0);
       if (_shouldAllowPanRotate()) {
-        animatePosition(controller.position, Offset.zero);
+        animatePosition(controller.position, clampPosition());
       }
     }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
changed photo_view_core.dart animatePosition to clampPosition():

```
...
    } else if (scaleState == PhotoViewScaleState.zoomedIn) {
      animateRotation(controller.rotation, 0);
      if (_shouldAllowPanRotate()) {
 FROM    animatePosition(controller.position, Offset.zero);
 TO      animatePosition(controller.position, clampPosition());
      }
    }
...
```

<!--- Why is this change required? What problem does it solve? -->
In `onScaleEnd` (in `photo_view_core.dart`), when the state is `PhotoViewScaleState.zoomedIn` and `_shouldAllowPanRotate()` evaluates to `true` (due to `hasZoomedOutManually` being set), the animation target was hardcoded to center the image:
animatePosition(controller.position, Offset.zero);

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #29207

## How Has This Been Tested?
- ran flutter analyze, no issues
- ran flutter test, translation failed for files not related to this

- built it and repeated steps mentioned above, and there were no issues. flipped through albums and randomly zoomed out/in/pan right/pan left with and without zooming and found no anomalies.
## API Changes
- none 

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [NA] I have confirmed that any new dependencies are strictly necessary.
- [NA] I have written tests for new code (if applicable)
- [NA] I have followed naming conventions/patterns in the surrounding code
- [NA] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [NA] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- used it to answer Q&A questions regarding the repo

...
