### PR TITLE
fix(web): collapse stacks in album timeline view

### DIFF
--- a/web/src/lib/components/album-page/AlbumViewer.svelte
+++ b/web/src/lib/components/album-page/AlbumViewer.svelte
@@ -34,7 +34,7 @@
 
   let { slideshowState, slideshowNavigation } = slideshowStore;
 
-  const options = $derived({ albumId: album.id, order: album.order });
+  const options = $derived({ albumId: album.id, order: album.order, withStacked: true });
   let timelineManager = $state<TimelineManager>() as TimelineManager;
 
   dragAndDropFilesStore.subscribe((value) => {
@@ -71,7 +71,7 @@
 />
 
 <main class="relative h-dvh overflow-hidden px-2 pt-(--navbar-height) max-md:pt-(--navbar-height-md) md:px-6">
-  <Timeline enableRouting={true} {album} bind:timelineManager {options} assetInteraction={assetMultiSelectManager}>
+  <Timeline enableRouting={true} {album} bind:timelineManager {options} withStacked assetInteraction={assetMultiSelectManager}>
     <section class="px-2 pt-8 md:px-0 md:pt-24">
       <!-- ALBUM TITLE -->
       <h1 class="text-2xl text-primary transition-all outline-none md:text-4xl lg:text-6xl">


### PR DESCRIPTION
## Description

Immich's main Photos timeline collapses asset stacks (RAW+JPEG pairs, bursts) to their primary via the `withStacked` flag, but **album views do not**. The album grid uses the same shared `Timeline` / time-bucket code path yet never passes `withStacked`, so albums list every stacked member — a RAW+JPEG pair shows both tiles, and an un-thumbnailable RAW shows up as a separate blank tile.

The server already collapses album time-buckets when the flag is set: the collapse predicate in `getTimeBuckets` / `getTimeBucket` (`server/src/repositories/asset.repository.ts`) is independent of `albumId`. The album view simply never set it.

This makes `web/src/lib/components/album-page/AlbumViewer.svelte`:
- pass `withStacked: true` in the timeline `options` → drives the server-side bucket collapse (`TimelineManager.updateOptions` → `getTimeBuckets` / `getTimeBucket`), and
- pass the `withStacked` prop on `<Timeline>` → drives the stack badge (`showStackedIcon`),

mirroring how the Photos page already does it. Web-only; no API or server changes.

Partially addresses #16549 (the "stacks on all views" meta-issue) — it does **not** close it: mobile (`remoteAlbum` Drift query) and the optional "only collapse when the stack's primary is in the album" server refinement remain follow-ups discussed there.

## How Has This Been Tested?

- [x] Verified against a live v2.7.x instance that the time-bucket endpoint already collapses album buckets when asked: `GET /timeline/bucket?...&albumId=<id>&withStacked=true` returns the primary-only set, while `withStacked=false` returns every member — confirming this is purely a "the album view never asked" gap, not a server change.
- [ ] I have not run a full local web dev build; the change mirrors the existing Photos-page usage (`options.withStacked` + the `withStacked` prop, both already part of `TimelineManagerOptions` / `Timeline`'s props), so it relies on CI type-check. Happy to add a component test if preferred.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- before/after of an album containing RAW+JPEG stacks -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (n/a — web-only change)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (n/a — web-only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used substantially, under my direction and review: to research the current behavior, locate the relevant code paths, confirm the server already supports collapsing album time-buckets, and draft both the change and this description. I reviewed the two-line diff and verified the server-side behavior against a live instance before submitting.
