### PR TITLE
fix(mobile): treat wired ethernet as unmetered on ios

### DIFF
--- a/mobile/ios/Runner/Connectivity/ConnectivityApiImpl.swift
+++ b/mobile/ios/Runner/Connectivity/ConnectivityApiImpl.swift
@@ -43,15 +43,16 @@ class ConnectivityApiImpl: ConnectivityApi {
       capabilities.append(.vpn)
     }
     
-    // Determine if connection is unmetered:
-    // - Must be on WiFi (not cellular)
-    // - Must not be expensive (rules out personal hotspot)
-    // - Must not be constrained (Low Data Mode)
-    // Note: VPN over cellular should still be considered metered
+    // Determine if connection is unmetered from the OS metered flags rather than
+    // the interface type, so wired ethernet (iPhone USB adapters, Apple Silicon
+    // Macs) is treated as unmetered like Wi-Fi:
+    // - Not on cellular
+    // - Not expensive (also rules out cellular and personal hotspot)
+    // - Not constrained (Low Data Mode)
+    // Note: VPN over cellular stays metered because the path is still expensive.
     let isOnCellular = path.usesInterfaceType(.cellular)
-    let isOnWifi = path.usesInterfaceType(.wifi)
-    
-    if isOnWifi && !isOnCellular && !path.isExpensive && !path.isConstrained {
+
+    if !isOnCellular && !path.isExpensive && !path.isConstrained {
       capabilities.append(.unmetered)
     }
     


### PR DESCRIPTION
## Description

on ios, backup only counted wifi as unmetered. so with "upload over cellular" off and only a wired ethernet connection (usb-c adapter, or the ios app on a mac), backups got prepared but never uploaded — turning "upload over cellular" on made it work, which is the tell. now the apple side checks the path's metered flags (not cellular, not expensive, not constrained) instead of the interface type, same as android already does, so wired ethernet counts like wifi.

tested on an iphone 15 pro max with a usb-c ethernet adapter in airplane mode (wifi + cellular off, ethernet only) and "upload over cellular" off. before: backup skips everything (network capabilities come back empty, isUnmetered false). after: same setup reports unmetered and the photo uploads over ethernet and shows up on the server. wifi-only backup still behaves the same.

fixes #26493