### PR TITLE
fix(server): dissolve stack when its non-primary assets are deleted

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -568,6 +568,34 @@ describe(AssetService.name, () => {
       expect(mocks.stack.delete).toHaveBeenCalledWith(asset.stackId);
     });
 
+    it('should delete the stack when a non-primary asset is deleted and only the primary would remain', async () => {
+      const asset = AssetFactory.from().build();
+      const deletionAsset = {
+        ...getForAssetDeletion(asset),
+        stack: { id: newUuid(), primaryAssetId: newUuid(), assets: [{ id: asset.id }] },
+      };
+      mocks.stack.delete.mockResolvedValue();
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(deletionAsset);
+
+      await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
+
+      expect(mocks.stack.delete).toHaveBeenCalledWith(deletionAsset.stack.id);
+    });
+
+    it('should keep the stack when a non-primary asset is deleted and the primary plus another asset remain', async () => {
+      const asset = AssetFactory.from().build();
+      const deletionAsset = {
+        ...getForAssetDeletion(asset),
+        stack: { id: newUuid(), primaryAssetId: newUuid(), assets: [{ id: asset.id }, { id: newUuid() }] },
+      };
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(deletionAsset);
+
+      await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
+
+      expect(mocks.stack.delete).not.toHaveBeenCalled();
+      expect(mocks.stack.update).not.toHaveBeenCalled();
+    });
+
     it('should delete a live photo', async () => {
       const motionAsset = AssetFactory.from({ type: AssetType.Video, visibility: AssetVisibility.Hidden }).build();
       const asset = AssetFactory.create({ livePhotoVideoId: motionAsset.id });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -316,17 +316,22 @@ export class AssetService extends BaseService {
       return JobStatus.Failed;
     }
 
-    // replace the parent of the stack children with a new asset
-    if (asset.stack?.primaryAssetId === id) {
-      // this only includes timeline visible assets and excludes the primary asset
-      const stackAssetIds = asset.stack.assets.map((a) => a.id);
-      if (stackAssetIds.length >= 2) {
-        const newPrimaryAssetId = stackAssetIds.find((a) => a !== id)!;
-        await this.stackRepository.update(asset.stack.id, {
-          id: asset.stack.id,
-          primaryAssetId: newPrimaryAssetId,
-        });
-      } else {
+    if (asset.stack) {
+      // asset.stack.assets only includes timeline visible assets and excludes the primary asset
+      const remainingStackAssetIds = asset.stack.assets.map((a) => a.id).filter((assetId) => assetId !== id);
+
+      if (asset.stack.primaryAssetId === id) {
+        // the primary asset is being deleted: promote another asset to primary, or dissolve the
+        // stack when it would be left with a single asset
+        await (remainingStackAssetIds.length >= 2
+          ? this.stackRepository.update(asset.stack.id, {
+              id: asset.stack.id,
+              primaryAssetId: remainingStackAssetIds[0],
+            })
+          : this.stackRepository.delete(asset.stack.id));
+      } else if (remainingStackAssetIds.length === 0) {
+        // a non-primary asset is being deleted, leaving only the primary: dissolve the stack so it
+        // does not linger as a single-asset stack (e.g. when its library is deleted)
         await this.stackRepository.delete(asset.stack.id);
       }
     }

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -320,19 +320,21 @@ export class AssetService extends BaseService {
       // asset.stack.assets only includes timeline visible assets and excludes the primary asset
       const remainingStackAssetIds = asset.stack.assets.map((a) => a.id).filter((assetId) => assetId !== id);
 
-      if (asset.stack.primaryAssetId === id) {
-        // the primary asset is being deleted: promote another asset to primary, or dissolve the
-        // stack when it would be left with a single asset
-        await (remainingStackAssetIds.length >= 2
-          ? this.stackRepository.update(asset.stack.id, {
-              id: asset.stack.id,
-              primaryAssetId: remainingStackAssetIds[0],
-            })
-          : this.stackRepository.delete(asset.stack.id));
-      } else if (remainingStackAssetIds.length === 0) {
-        // a non-primary asset is being deleted, leaving only the primary: dissolve the stack so it
-        // does not linger as a single-asset stack (e.g. when its library is deleted)
+      // the primary survives unless it is the asset being deleted
+      let remainingCount = remainingStackAssetIds.length;
+      if (asset.stack.primaryAssetId !== id) {
+        remainingCount++;
+      }
+
+      if (remainingCount < 2) {
+        // 0 or 1 asset would remain: dissolve the stack so it does not linger as a single-asset stack
         await this.stackRepository.delete(asset.stack.id);
+      } else if (asset.stack.primaryAssetId === id) {
+        // the primary is being deleted but others remain: promote a new primary
+        await this.stackRepository.update(asset.stack.id, {
+          id: asset.stack.id,
+          primaryAssetId: remainingStackAssetIds[0],
+        });
       }
     }
 


### PR DESCRIPTION
## Description

Stack cleanup in `handleAssetDeletion` only ran when the **primary** asset of a stack was deleted (`asset.stack?.primaryAssetId === id`). Deleting a **non-primary** asset never re-validated the stack, so a stack could be left holding only its primary asset, lingering in the timeline as an invalid single-asset stack.

This is most visible when deleting an external library: each asset is removed via its own `AssetDelete` job, and the stack's cover photo stays behind and has to be unstacked manually.

The cleanup now handles non-primary deletions too: if removing a non-primary asset would leave only the primary asset, the stack is dissolved. The primary-deletion behaviour (promote another asset, or delete a would-be single-asset stack) is unchanged.

Fixes #16151

## How Has This Been Tested?

- [x] Added unit test: dissolves the stack when a non-primary asset is deleted and only the primary would remain (confirmed failing against the previous logic, passing with this change).
- [x] Added unit test: keeps the stack when a non-primary asset is deleted but the primary plus another asset remain.
- [x] `pnpm --filter immich test src/services/asset.service.spec.ts` — 54/54 passing.
- [x] `tsc --noEmit` and `eslint --max-warnings 0` clean on the changed files.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — server-side logic change, covered by unit tests.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI coding assistant was used to help scaffold the unit tests and draft the implementation. The root-cause investigation, the final code, and the design of the fix were directed, reviewed, and verified by me. All tests (`asset.service.spec.ts`, 54/54), type checks, and lint pass.
