### PR TITLE
fix(mobile): show the right day in the ios memories widget

### DIFF
--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -203,7 +203,13 @@ class ImmichAPI {
 
   func fetchMemory(for date: Date) async throws -> [MemoryResult] {
     // get URL
-    let memoryParams = [URLQueryItem(name: "for", value: date.ISO8601Format())]
+    // server buckets memories by UTC day, so send noon UTC of the device's local day
+    var utcCalendar = Calendar(identifier: .gregorian)
+    utcCalendar.timeZone = TimeZone(identifier: "UTC")!
+    var components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+    components.hour = 12
+    let localDay = utcCalendar.date(from: components) ?? date
+    let memoryParams = [URLQueryItem(name: "for", value: localDay.ISO8601Format())]
     guard
       let searchURL = buildRequestURL(
         serverConfig: serverConfig,


### PR DESCRIPTION
## Description

the ios memories widget asked the server for memories using a utc timestamp, so depending on your timezone it could show the wrong day (in the evening it'd jump to tomorrow's memories). now it sends your local calendar day instead.

tested on device set to kiritimati (utc+14): before, the widget showed the utc day (wrong); after, it shows the local day (right).

closes #19985
