### PR TITLE
Extract manufacturer and device for samsung videos

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -74,6 +74,10 @@ export interface ImmichTags extends Omit<Tags, TagsWithWrongTypes> {
   AndroidModel?: string;
   DeviceManufacturer?: string;
   DeviceModelName?: string;
+
+  // Samsung specific tags
+  Author?: string;
+  SamsungModel?: string;
 }
 
 @Injectable()

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -292,9 +292,18 @@ export class MetadataService extends BaseService {
 
       // camera
       make:
-        exifTags.Make ?? exifTags.Device?.Manufacturer ?? exifTags.AndroidMake ?? (exifTags.DeviceManufacturer || null),
+        exifTags.Make ??
+        exifTags.Device?.Manufacturer ??
+        exifTags.AndroidMake ??
+        exifTags.DeviceManufacturer ??
+        (exifTags.SamsungModel ? 'Samsung' : null),
       model:
-        exifTags.Model ?? exifTags.Device?.ModelName ?? exifTags.AndroidModel ?? (exifTags.DeviceModelName || null),
+        exifTags.Model ??
+        exifTags.Device?.ModelName ??
+        exifTags.AndroidModel ??
+        exifTags.DeviceModelName ??
+        exifTags.Author ??
+        null,
       fps: video?.frameRate ?? validate(Number.parseFloat(exifTags.VideoFrameRate!)),
       iso: validate(exifTags.ISO) as number,
       exposureTime: exifTags.ExposureTime ?? null,


### PR DESCRIPTION
## Description

So far immich was not able to extract any device details from videos taken with a Samsung device, as mentioned in  issue #20329.
I extended the metadata extractor to fall back to reading the Author tag set by Samsung and sets the manufacturer to Samsung if the tag 'Samsung Model' exists.

Does not yet fix the issue as there are still problems with other camera types.

## How Has This Been Tested?

- [x] Videos from Samsung devices are working now
- [x] Photos and Videos working before are still working

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="352" height="275" alt="image" src="https://github.com/user-attachments/assets/d121a29c-8d72-4082-9cce-d5156bef6be0" />

</details>

## API Changes
no changes

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
