### PR TITLE
fix(server): resolve face detection failure on manually rotated assets

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -814,6 +814,10 @@ describe(PersonService.name, () => {
   });
 
   describe('handleDetectFaces', () => {
+    beforeEach(() => {
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+    });
+
     it('should skip if machine learning is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -40,7 +40,7 @@ import { AssetFaceTable } from 'src/schema/tables/asset-face.table';
 import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { BaseService } from 'src/services/base.service';
 import { JobItem, JobOf } from 'src/types';
-import { getDimensions } from 'src/utils/asset.util';
+import { getAssetFiles, getDimensions } from 'src/utils/asset.util';
 import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 import { isFacialRecognitionEnabled } from 'src/utils/misc';
@@ -307,8 +307,13 @@ export class PersonService extends BaseService {
     }
 
     const asset = await this.assetJobRepository.getForDetectFacesJob(id);
-    const previewFile = asset?.files[0];
-    if (!asset || asset.files.length !== 1 || !previewFile) {
+    if (!asset) {
+      return JobStatus.Failed;
+    }
+
+    const files = getAssetFiles(asset.files as any);
+    const previewFile = files.editedPreviewFile || files.previewFile;
+    if (!previewFile) {
       return JobStatus.Failed;
     }
 
@@ -332,14 +337,37 @@ export class PersonService extends BaseService {
       }
     }
 
-    const heightScale = imageHeight / (asset.faces[0]?.imageHeight || 1);
-    const widthScale = imageWidth / (asset.faces[0]?.imageWidth || 1);
+    const edits = (await this.assetEditRepository.getAll(id)) || [];
+    let uneditedDimensions = { width: imageWidth, height: imageHeight };
+    if (previewFile.isEdited && files.previewFile) {
+      uneditedDimensions = await this.mediaRepository.getImageMetadata(files.previewFile.path);
+    }
+
+    const heightScale = uneditedDimensions.height / (asset.faces[0]?.imageHeight || 1);
+    const widthScale = uneditedDimensions.width / (asset.faces[0]?.imageWidth || 1);
     for (const { boundingBox, embedding } of faces) {
+      let originalBox = boundingBox;
+      if (previewFile.isEdited && edits.length > 0) {
+        const points = [
+          { x: boundingBox.x1, y: boundingBox.y1 },
+          { x: boundingBox.x2, y: boundingBox.y2 },
+        ];
+        const {
+          points: [p1, p2],
+        } = transformPoints(points, edits as any, { width: imageWidth, height: imageHeight }, { inverse: true });
+        originalBox = {
+          x1: Math.trunc(Math.min(p1.x, p2.x)),
+          y1: Math.trunc(Math.min(p1.y, p2.y)),
+          x2: Math.trunc(Math.max(p1.x, p2.x)),
+          y2: Math.trunc(Math.max(p1.y, p2.y)),
+        };
+      }
+
       const scaledBox = {
-        x1: boundingBox.x1 * widthScale,
-        y1: boundingBox.y1 * heightScale,
-        x2: boundingBox.x2 * widthScale,
-        y2: boundingBox.y2 * heightScale,
+        x1: originalBox.x1 * widthScale,
+        y1: originalBox.y1 * heightScale,
+        x2: originalBox.x2 * widthScale,
+        y2: originalBox.y2 * heightScale,
       };
       const match = asset.faces.find((face) => this.iou(face, scaledBox) > 0.5);
 
@@ -350,12 +378,12 @@ export class PersonService extends BaseService {
         facesToAdd.push({
           id: faceId,
           assetId: asset.id,
-          imageHeight,
-          imageWidth,
-          boundingBoxX1: boundingBox.x1,
-          boundingBoxY1: boundingBox.y1,
-          boundingBoxX2: boundingBox.x2,
-          boundingBoxY2: boundingBox.y2,
+          imageHeight: uneditedDimensions.height,
+          imageWidth: uneditedDimensions.width,
+          boundingBoxX1: originalBox.x1,
+          boundingBoxY1: originalBox.y1,
+          boundingBoxX2: originalBox.x2,
+          boundingBoxY2: originalBox.y2,
         });
         embeddings.push({ faceId, embedding });
       }


### PR DESCRIPTION
## Description
This PR resolves a bug where face detection completely fails or results in incorrectly aligned bounding boxes on manually rotated images (which have no EXIF orientation tags).

1. **Allows Face Detection on Edited Images**: Replaced the sanity check `asset.files.length !== 1` - which aborts if an image has both an unedited and an edited preview file - with a check for a valid preview file using `getAssetFiles`.
2. **Corrects Bounding Box Coordinates Mapping**: Maps the face bounding boxes detected on the upright/edited
preview back to the unedited coordinate space before saving them to the database by applying `transformPoints(..., {
inverse: true })` using the edited preview's dimensions.

Fixes #28966

## How Has This Been Tested?

- **Unit Tests**: Updated the unit test mocks in person.service.spec.ts. All 72 tests passed successfully.
- **Manual Verification**: Ran locally. Confirmed that uploading a portrait photo with missing EXIF, manually rotating it upright in the UI, and triggering face detection successfully detects the face with the bounding boxes aligned on the face the transformations were necessary to have alignment.

## Checklist:
 - [x] I have carefully read CONTRIBUTING.md
 - [x] I have performed a self-review of my own code
 - [NA] I have made corresponding changes to the documentation if applicable
 - [x] I have no unrelated changes in the PR.
 - [x] I have confirmed that any new dependencies are strictly necessary.
 - [x] I have written tests for new code (if applicable)
 - [x] I have followed naming conventions/patterns in the surrounding code
 - [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
 - [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used for Q&A on the face detection workflow and the associated test suite.