### PR TITLE
fix(mobile): show partial add toast when some assets already exist in album

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,6 +29,7 @@
   "add_to_album": "Add to album",
   "add_to_album_bottom_sheet_added": "Added to {album}",
   "add_to_album_bottom_sheet_already_exists": "Already in {album}",
+  "add_to_album_bottom_sheet_partial_added": "{added} added to {album}, {existing} already existed",
   "add_to_album_bottom_sheet_some_local_assets": "Some local assets could not be added to album",
   "add_to_albums": "Add to albums",
   "add_to_albums_count": "Add to albums ({count})",

--- a/i18n/en_GB.json
+++ b/i18n/en_GB.json
@@ -29,6 +29,7 @@
   "add_to_album": "Add to album",
   "add_to_album_bottom_sheet_added": "Added to {album}",
   "add_to_album_bottom_sheet_already_exists": "Already in {album}",
+  "add_to_album_bottom_sheet_partial_added": "{added} added to {album}, {existing} already existed",
   "add_to_album_bottom_sheet_some_local_assets": "Some local assets could not be added to album",
   "add_to_albums": "Add to albums",
   "add_to_albums_count": "Add to albums ({count})",

--- a/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
@@ -64,12 +64,17 @@ class _ArchiveBottomSheetState extends ConsumerState<ArchiveBottomSheet> {
         return;
       }
 
-      ImmichToast.show(
-        context: context,
-        msg: result.count == 0
-            ? 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name})
-            : 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name}),
-      );
+      final String msg;
+      if (result.count == 0) {
+        msg = 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name});
+      } else if (result.existing > 0) {
+        msg = 'add_to_album_bottom_sheet_partial_added'.tr(
+          namedArgs: {'added': result.count.toString(), 'album': album.name, 'existing': result.existing.toString()},
+        );
+      } else {
+        msg = 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name});
+      }
+      ImmichToast.show(context: context, msg: msg);
     }
 
     Future<void> onKeyboardExpand() {

--- a/mobile/lib/presentation/widgets/bottom_sheet/favorite_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/favorite_bottom_sheet.widget.dart
@@ -52,10 +52,18 @@ class FavoriteBottomSheet extends ConsumerWidget {
         );
       }
 
-      if (addedCount != remoteAssets.length) {
+      final existingCount = remoteAssets.length - addedCount;
+      if (addedCount == 0) {
         ImmichToast.show(
           context: context,
           msg: 'add_to_album_bottom_sheet_already_exists'.t(args: {"album": album.name}),
+        );
+      } else if (existingCount > 0) {
+        ImmichToast.show(
+          context: context,
+          msg: 'add_to_album_bottom_sheet_partial_added'.t(
+            args: {"added": addedCount.toString(), "album": album.name, "existing": existingCount.toString()},
+          ),
         );
       } else {
         ImmichToast.show(

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -71,12 +71,17 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
         ImmichToast.show(context: context, msg: 'scaffold_body_error_occurred'.tr(), toastType: ToastType.error);
         return;
       }
-      ImmichToast.show(
-        context: context,
-        msg: result.count == 0
-            ? 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name})
-            : 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name}),
-      );
+      final String msg;
+      if (result.count == 0) {
+        msg = 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name});
+      } else if (result.existing > 0) {
+        msg = 'add_to_album_bottom_sheet_partial_added'.tr(
+          namedArgs: {'added': result.count.toString(), 'album': album.name, 'existing': result.existing.toString()},
+        );
+      } else {
+        msg = 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name});
+      }
+      ImmichToast.show(context: context, msg: msg);
     }
 
     Future<void> onKeyboardExpand() {

--- a/mobile/lib/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart
@@ -47,12 +47,17 @@ class _LocalAlbumBottomSheetState extends ConsumerState<LocalAlbumBottomSheet> {
         return;
       }
 
-      ImmichToast.show(
-        context: context,
-        msg: result.count == 0
-            ? 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name})
-            : 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name}),
-      );
+      final String msg;
+      if (result.count == 0) {
+        msg = 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name});
+      } else if (result.existing > 0) {
+        msg = 'add_to_album_bottom_sheet_partial_added'.tr(
+          namedArgs: {'added': result.count.toString(), 'album': album.name, 'existing': result.existing.toString()},
+        );
+      } else {
+        msg = 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name});
+      }
+      ImmichToast.show(context: context, msg: msg);
     }
 
     Future<void> onKeyboardExpand() {

--- a/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
@@ -73,12 +73,18 @@ class _RemoteAlbumBottomSheetState extends ConsumerState<RemoteAlbumBottomSheet>
         return;
       }
 
-      ImmichToast.show(
-        context: context,
-        msg: result.count == 0
-            ? 'add_to_album_bottom_sheet_already_exists'.t(context: context, args: {"album": album.name})
-            : 'add_to_album_bottom_sheet_added'.t(context: context, args: {"album": album.name}),
-      );
+      final String msg;
+      if (result.count == 0) {
+        msg = 'add_to_album_bottom_sheet_already_exists'.t(context: context, args: {"album": album.name});
+      } else if (result.existing > 0) {
+        msg = 'add_to_album_bottom_sheet_partial_added'.t(
+          context: context,
+          args: {"added": result.count.toString(), "album": album.name, "existing": result.existing.toString()},
+        );
+      } else {
+        msg = 'add_to_album_bottom_sheet_added'.t(context: context, args: {"album": album.name});
+      }
+      ImmichToast.show(context: context, msg: msg);
     }
 
     Future<void> onKeyboardExpand() {

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -34,14 +34,15 @@ final actionProvider = NotifierProvider<ActionNotifier, void>(ActionNotifier.new
 
 class ActionResult {
   final int count;
+  final int existing;
   final bool success;
   final String? error;
   final List<String> remoteAssetIds;
 
-  const ActionResult({required this.count, required this.success, this.error, this.remoteAssetIds = const []});
+  const ActionResult({required this.count, required this.success, this.existing = 0, this.error, this.remoteAssetIds = const []});
 
   @override
-  String toString() => 'ActionResult(count: $count, success: $success, error: $error, remoteAssetIds: $remoteAssetIds)';
+  String toString() => 'ActionResult(count: $count, existing: $existing, success: $success, error: $error, remoteAssetIds: $remoteAssetIds)';
 }
 
 class ActionNotifier extends Notifier<void> {
@@ -409,7 +410,7 @@ class ActionNotifier extends Notifier<void> {
     }
 
     if (localAssets.isEmpty) {
-      return ActionResult(count: addedRemote, success: true);
+      return ActionResult(count: addedRemote, existing: remoteIds.length - addedRemote, success: true);
     }
 
     final uploadResult = await upload(


### PR DESCRIPTION
## Description

When adding a selection of assets to an album where some were already present and some were new, the toast always showed "Already in [album]" — making it appear as if nothing was added, even though some assets were successfully added.

The root cause was in `favorite_bottom_sheet.widget.dart` which checked `addedCount != total` (triggers when ANY asset already exists) instead of `addedCount == 0` (triggers only when ALL assets already exist).

This fix adds a third toast case across all bottom sheets:
- All new → "Added to [album]"
- All existing → "Already in [album]"
- Mixed → "3 added to [album], 2 already existed"

Fixes #28709

## How Has This Been Tested?

- [x] Selected multiple photos where some are already in an album — toast now shows e.g. "3 added to Vacation, 2 already existed"
- [x] Selected photos all already in an album — toast still shows "Already in [album]"
- [x] Selected photos none of which are in the album — toast still shows "Added to [album]"

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="576" height="1280" alt="photo_2026-06-30_16-03-17" src="https://github.com/user-attachments/assets/dae03116-be5f-4701-8bb1-08180da576d8" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM (Claude) to help identify which files were affected and understand the root cause. I reviewed, understood, and tested all changes myself.
