### PR TITLE
chore: make webhooks workflow-agnostic

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -150,7 +150,7 @@ const methods = wrapper<Manifest>({
     changes: { asset: { visibility: config.visibility as AssetVisibility } },
   }),
 
-  webhook: ({ config, data, functions }) => {
+  webhook: ({ config, data, functions, type, trigger }) => {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -161,7 +161,11 @@ const methods = wrapper<Manifest>({
 
     functions.httpRequest(config.url, {
       method: config.method ?? 'POST',
-      body: JSON.stringify(data.asset),
+      body: JSON.stringify({
+        type,
+        trigger,
+        data,
+      }),
       headers,
     });
 


### PR DESCRIPTION
Webhooks send all event data regardless of type. Webhook JSON is formatted as `{"type": "AssetV1", "trigger": "AssetCreate", "data": { "asset": {...} } }`