### PR TITLE
fix(server): transcode Live Photo videos in the bulk conversion job

### DIFF
--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -589,7 +589,17 @@ where
       "asset_file"."assetId" = "asset"."id"
       and "asset_file"."type" = 'encoded_video'
   )
-  and "asset"."visibility" != 'hidden'
+  and (
+    "asset"."visibility" != 'hidden'
+    or exists (
+      select
+        "motionParent"."id"
+      from
+        "asset" as "motionParent"
+      where
+        "motionParent"."livePhotoVideoId" = "asset"."id"
+    )
+  )
   and "asset"."deletedAt" is null
 
 -- AssetJobRepository.getForVideoConversion

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -329,7 +329,19 @@ export class AssetJobRepository {
               ),
             ),
           )
-          .where('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+          // Exclude hidden assets, except Live Photo motion videos (hidden by design but
+          // still in need of transcoding) — see #22985.
+          .where((eb) =>
+            eb.or([
+              eb('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+              eb.exists(
+                eb
+                  .selectFrom('asset as motionParent')
+                  .select('motionParent.id')
+                  .whereRef('motionParent.livePhotoVideoId', '=', 'asset.id'),
+              ),
+            ]),
+          ),
       )
       .where('asset.deletedAt', 'is', null)
       .stream();

--- a/server/test/medium/specs/repositories/asset-job.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset-job.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetFileType } from 'src/enum';
+import { AssetFileType, AssetType, AssetVisibility } from 'src/enum';
 import { AssetJobRepository } from 'src/repositories/asset-job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
@@ -112,6 +112,50 @@ describe(AssetJobRepository.name, () => {
       const stream = sut.streamForThumbnailJob({ force: false, fullsizeEnabled: true });
       await expect(consume(stream)).resolves.not.toEqual(
         expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+  });
+
+  describe('streamForVideoConversion', () => {
+    it('should queue a video asset', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id, type: AssetType.Video });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+
+    it('should skip a hidden video that is not a Live Photo motion video', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Hidden,
+      });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+
+    it('should queue a hidden Live Photo motion video', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: motionAsset } = await ctx.newAsset({
+        ownerId: user.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Hidden,
+      });
+      await ctx.newAsset({ ownerId: user.id, livePhotoVideoId: motionAsset.id });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: motionAsset.id })]),
       );
     });
   });


### PR DESCRIPTION
## Description

The **Transcode Videos** job (when not set to "All videos") skips assets with `visibility = hidden`. The motion-video component of a Live Photo is stored as a separate video asset with `visibility = hidden`, so these motion videos were never picked up by the bulk transcode job — they only received an encoded version at upload time. Users who upload Live Photos with transcoding disabled (e.g. on a low-powered server) and later run the job found their Live Photos still had no web-playable video.

`AssetJobRepository.streamForVideoConversion` now keeps excluding regular hidden assets, but **includes hidden videos that are the motion component of a Live Photo** (i.e. referenced by another asset's `livePhotoVideoId`). The per-asset transcode handler already processes hidden assets, so only the selection query needed changing.

Fixes #22985

## How Has This Been Tested?

Added medium repository tests for `streamForVideoConversion`:

- queues a normal video asset
- skips a hidden video that is **not** a Live Photo motion video (guards against over-selecting)
- queues a hidden Live Photo motion video (the regression case)

Also updated the `asset.job.repository.sql` snapshot for the changed query.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
