### PR TITLE
fix(mobile): stop double close animation when dismissing an asset

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -168,6 +168,12 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       return;
     }
 
+    // The viewer is closing; don't flip the current asset now. Flipping it swaps
+    // the grid tile hero keys mid pop and animates the close on two tiles (#23779).
+    if (!mounted || !(ModalRoute.of(context)?.isActive ?? true)) {
+      return;
+    }
+
     AssetViewer._setAsset(ref, asset);
     _preloader.preload(index, context.sizeData);
     _handleCasting();


### PR DESCRIPTION
## Description

Fixes #23779.

Swiping down to close an asset sometimes lets a tiny sideways scroll sneak in first, so the pager is parked between two assets when it pops. The current asset then changes while it's closing, which resets the grid thumbnail keys and breaks the running close animation, so it ends up playing on two tiles instead of one.

Fix: don't change the current asset once the viewer is on its way out. The guard sits in the one spot every asset change flows through, so the scroll settle, tap navigation and background reloads are all covered.

I can reproduce it locally but it's very hard to trigger, so if you've run into this, please grab the signed APK from this PR (the Build Mobile artifact) and give it a test.
