### PR TITLE
fix(mobile): birthday picker date order follows locale

### DIFF
--- a/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
@@ -65,6 +65,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
         child: ClipRRect(
           borderRadius: const BorderRadius.all(Radius.circular(16.0)),
           child: ScrollDatePicker(
+            viewType: datePickerColumnOrder(DateFormat.yMd(context.locale.toLanguageTag()).pattern),
             options: DatePickerOptions(
               backgroundColor: context.colorScheme.surfaceContainerHigh,
               itemExtent: 50,
@@ -117,4 +118,19 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
       ],
     );
   }
+}
+
+List<DatePickerViewType>? datePickerColumnOrder(String? pattern) {
+  if (pattern == null) {
+    return null;
+  }
+  final positions = {
+    DatePickerViewType.year: pattern.indexOf('y'),
+    DatePickerViewType.month: pattern.indexOf('M'),
+    DatePickerViewType.day: pattern.indexOf('d'),
+  };
+  if (positions.values.any((position) => position < 0)) {
+    return null;
+  }
+  return positions.keys.toList()..sort((a, b) => positions[a]!.compareTo(positions[b]!));
 }

--- a/mobile/test/presentation/widgets/people/person_edit_birthday_modal_test.dart
+++ b/mobile/test/presentation/widgets/people/person_edit_birthday_modal_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/people/person_edit_birthday_modal.widget.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:scroll_date_picker/scroll_date_picker.dart';
+
+void main() {
+  group('datePickerColumnOrder', () {
+    test('month first (en_US)', () {
+      expect(
+        datePickerColumnOrder('M/d/y'),
+        orderedEquals([DatePickerViewType.month, DatePickerViewType.day, DatePickerViewType.year]),
+      );
+    });
+
+    test('day first (pl)', () {
+      expect(
+        datePickerColumnOrder('dd.MM.y'),
+        orderedEquals([DatePickerViewType.day, DatePickerViewType.month, DatePickerViewType.year]),
+      );
+    });
+
+    test('year first (ko)', () {
+      expect(
+        datePickerColumnOrder('y. M. d.'),
+        orderedEquals([DatePickerViewType.year, DatePickerViewType.month, DatePickerViewType.day]),
+      );
+    });
+
+    test('null pattern falls back to package default', () {
+      expect(datePickerColumnOrder(null), isNull);
+    });
+
+    test('missing field falls back to package default', () {
+      expect(datePickerColumnOrder('M/y'), isNull);
+    });
+  });
+
+  group('datePickerColumnOrder with real locale patterns', () {
+    setUpAll(() async {
+      await initializeDateFormatting();
+    });
+
+    test('en uses month/day/year', () {
+      expect(
+        datePickerColumnOrder(DateFormat.yMd('en').pattern),
+        orderedEquals([DatePickerViewType.month, DatePickerViewType.day, DatePickerViewType.year]),
+      );
+    });
+
+    test('pl uses day/month/year', () {
+      expect(
+        datePickerColumnOrder(DateFormat.yMd('pl').pattern),
+        orderedEquals([DatePickerViewType.day, DatePickerViewType.month, DatePickerViewType.year]),
+      );
+    });
+
+    test('ko uses year/month/day', () {
+      expect(
+        datePickerColumnOrder(DateFormat.yMd('ko').pattern),
+        orderedEquals([DatePickerViewType.year, DatePickerViewType.month, DatePickerViewType.day]),
+      );
+    });
+  });
+}

--- a/mobile/test/presentation/widgets/people/person_edit_birthday_modal_test.dart
+++ b/mobile/test/presentation/widgets/people/person_edit_birthday_modal_test.dart
@@ -41,25 +41,29 @@ void main() {
       await initializeDateFormatting();
     });
 
-    test('en uses month/day/year', () {
-      expect(
-        datePickerColumnOrder(DateFormat.yMd('en').pattern),
-        orderedEquals([DatePickerViewType.month, DatePickerViewType.day, DatePickerViewType.year]),
-      );
-    });
-
-    test('pl uses day/month/year', () {
-      expect(
-        datePickerColumnOrder(DateFormat.yMd('pl').pattern),
-        orderedEquals([DatePickerViewType.day, DatePickerViewType.month, DatePickerViewType.year]),
-      );
-    });
-
-    test('ko uses year/month/day', () {
-      expect(
-        datePickerColumnOrder(DateFormat.yMd('ko').pattern),
-        orderedEquals([DatePickerViewType.year, DatePickerViewType.month, DatePickerViewType.day]),
-      );
-    });
+    for (final (locales, order, name) in const [
+      (
+        ['en', 'en-US', 'en-PH'],
+        [DatePickerViewType.month, DatePickerViewType.day, DatePickerViewType.year],
+        'month/day/year',
+      ),
+      (
+        ['en-GB', 'fr', 'fr-FR', 'de', 'de-DE', 'pl'],
+        [DatePickerViewType.day, DatePickerViewType.month, DatePickerViewType.year],
+        'day/month/year',
+      ),
+      (
+        ['ja', 'ja-JP', 'zh', 'zh-CN', 'ko', 'ko-KR'],
+        [DatePickerViewType.year, DatePickerViewType.month, DatePickerViewType.day],
+        'year/month/day',
+      ),
+      (['ky'], [DatePickerViewType.year, DatePickerViewType.day, DatePickerViewType.month], 'year/day/month'),
+    ]) {
+      for (final locale in locales) {
+        test('$locale uses $name', () {
+          expect(datePickerColumnOrder(DateFormat.yMd(locale).pattern), orderedEquals(order));
+        });
+      }
+    }
   });
 }


### PR DESCRIPTION
## Description

The person birthday picker always showed month/day/year no matter the locale. The scroll_date_picker package only reorders its columns for a few hardcoded languages and falls back to month/day/year for the rest, and we never passed it an order. So Polish, English in Europe, etc. got the wrong order even though dates are correct everywhere else in the app.

Now we build the order from the locale's own short date format and pass it to the picker, so it lines up with the rest of the app.

Tested on device in Polish (day/month/year now), plus a small unit test covering en/pl/ko.

Fixes #26977
