### PR TITLE
fix: zero byte image uploads

### DIFF
--- a/server/src/middleware/file-upload.interceptor.ts
+++ b/server/src/middleware/file-upload.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor, BadRequestException } from '@nestjs/common';
+import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { Reflector } from '@nestjs/core';
 import { transformException } from '@nestjs/platform-express/multer/multer/multer.utils';

--- a/server/src/middleware/file-upload.interceptor.ts
+++ b/server/src/middleware/file-upload.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor, BadRequestException } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { Reflector } from '@nestjs/core';
 import { transformException } from '@nestjs/platform-express/multer/multer/multer.utils';
@@ -128,6 +128,9 @@ export class FileUploadInterceptor implements NestInterceptor {
         if (error) {
           hash?.destroy();
           return callback(error);
+        }
+        if (size === 0) {
+          return callback(new BadRequestException('File is empty'));
         }
         callback(null, {
           path,


### PR DESCRIPTION
## Description

This PR fixes Immich allowing the upload of zero byte `.jpg` files. Brought up in #29416.

This is a simple fix that returns a `BadRequestException` once the byte stream is finished and the file size can be verified. 

Question: should I surface this to the client? Right now, it just fails with the default "Unable to upload file" message, but I was unsure if it's preferred to surface the "File is empty" to the user.

Any feedback is appreciated!

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested the functionality on a local instance before and after implementing the change. Please view the video below for the new behavior

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
https://github.com/user-attachments/assets/ac2d7d0f-e007-4392-ad5e-8688b561bb1e
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

- Claude Code to help with Docker configuration issues