### PR TITLE
feat(docs): add bulgarian readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   <a href="readme_i18n/README_zh_TW.md">正體中文</a>
   <a href="readme_i18n/README_uk_UA.md">Українська</a>
   <a href="readme_i18n/README_ru_RU.md">Русский</a>
+  <a href="readme_i18n/README_bg_BG.md">Български</a>
   <a href="readme_i18n/README_pt_BR.md">Português Brasileiro</a>
   <a href="readme_i18n/README_sv_SE.md">Svenska</a>
   <a href="readme_i18n/README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_ar_JO.md
+++ b/readme_i18n/README_ar_JO.md
@@ -32,6 +32,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_th_TH.md">ภาษาไทย</a>

--- a/readme_i18n/README_bg_BG.md
+++ b/readme_i18n/README_bg_BG.md
@@ -1,0 +1,131 @@
+<p align="center"> 
+  <br/>  
+  <a href="https://opensource.org/license/agpl-v3"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg?color=3F51B5&style=for-the-badge&label=License&logoColor=000000&labelColor=ececec" alt="Лиценз: MIT"></a>
+  <a href="https://discord.immich.app">
+    <img src="https://img.shields.io/discord/979116623879368755.svg?label=Discord&logo=Discord&style=for-the-badge&logoColor=000000&labelColor=ececec" alt="Discord"/>
+  </a>
+  <br/>  
+  <br/>   
+</p>
+
+<p align="center">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Вход с персонализиран URL">
+</p>
+<h3 align="center">Високопроизводително самостоятелно хоствано решение за управление на снимки и видеа</h3>
+<br/>
+<a href="https://immich.app">
+<img src="../design/immich-screenshots.png" title="Основна снимка на екрана">
+</a>
+<br/>
+<p align="center">
+  <a href="../README.md">English</a>
+  <a href="README_ca_ES.md">Català</a>
+  <a href="README_es_ES.md">Español</a>
+  <a href="README_fr_FR.md">Français</a>
+  <a href="README_it_IT.md">Italiano</a>
+  <a href="README_ja_JP.md">日本語</a>
+  <a href="README_ko_KR.md">한국어</a>
+  <a href="README_de_DE.md">Deutsch</a>
+  <a href="README_nl_NL.md">Nederlands</a>
+  <a href="README_tr_TR.md">Türkçe</a>
+  <a href="README_zh_CN.md">简体中文</a>
+  <a href="README_zh_TW.md">正體中文</a>
+  <a href="README_uk_UA.md">Українська</a>
+  <a href="README_ru_RU.md">Русский</a>
+  <a href="README_pt_BR.md">Português Brasileiro</a>
+  <a href="README_sv_SE.md">Svenska</a>
+  <a href="README_ar_JO.md">العربية</a>
+  <a href="README_vi_VN.md">Tiếng Việt</a>
+  <a href="README_th_TH.md">ภาษาไทย</a>
+</p>
+
+> [!WARNING]
+> ⚠️ Винаги следвайте [плана за резервно копие 3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) за вашите ценни снимки и видеа!
+>
+
+> [!NOTE]
+> Основната документация, включително ръководства за инсталиране, е на [https://immich.app/](https://immich.app/).
+
+## Връзки
+
+- [Документация](https://docs.immich.app)
+- [За проекта](https://docs.immich.app/overview/introduction)
+- [Инсталиране](https://docs.immich.app/install/requirements)
+- [Пътна карта](https://immich.app/roadmap)
+- [Демо](#демо)
+- [Функции](#функции)
+- [Преводи](https://docs.immich.app/developer/translations)
+- [Принос към проекта](https://docs.immich.app/overview/support-the-project)
+
+## Демо
+
+Достъп до демото [тук](https://demo.immich.app). За мобилното приложение използвайте `https://demo.immich.app` като `Server Endpoint URL`.
+
+### Данни за вход
+
+| Имейл           | Парола |
+| --------------- | ------ |
+| demo@immich.app | demo   |
+
+## Функции
+
+| Функции                                                   | Мобилно | Уеб |
+| :-------------------------------------------------------- | ------- | --- |
+| Качване и преглед на видеа и снимки                       | Да      | Да  |
+| Автоматично резервно копие при отваряне на приложението   | Да      | N/A |
+| Предотвратяване на дублиране на файлове                   | Да      | Да  |
+| Избор на албум(и) за резервно копие                       | Да      | N/A |
+| Изтегляне на снимки и видеа на локалното устройство       | Да      | Да  |
+| Поддръжка на множество потребители                        | Да      | Да  |
+| Албуми и споделени албуми                                 | Да      | Да  |
+| Интерактивен плъзгач за превъртане                        | Да      | Да  |
+| Поддръжка на RAW формати                                  | Да      | Да  |
+| Преглед на метаданни (EXIF, карта)                        | Да      | Да  |
+| Търсене по метаданни, обекти, лица и CLIP                 | Да      | Да  |
+| Административни функции (управление на потребители)       | Не      | Да  |
+| Фоново резервно копие                                     | Да      | N/A |
+| Виртуално превъртане                                      | Да      | Да  |
+| Поддръжка на OAuth                                        | Да      | Да  |
+| API ключове                                               | N/A     | Да  |
+| Резервно копие и възпроизвеждане на LivePhoto/MotionPhoto | Да      | Да  |
+| Поддръжка на 360-градусови изображения                    | Не      | Да  |
+| Потребителска структура на съхранение                     | Да      | Да  |
+| Публично споделяне                                        | Да      | Да  |
+| Архив и любими                                            | Да      | Да  |
+| Глобална карта                                            | Да      | Да  |
+| Споделяне с партньор                                      | Да      | Да  |
+| Разпознаване и групиране на лица                          | Да      | Да  |
+| Спомени (преди x години)                                  | Да      | Да  |
+| Офлайн поддръжка                                          | Да      | Не  |
+| Галерия само за четене                                    | Да      | Да  |
+| Подредени снимки                                          | Да      | Да  |
+| Тагове                                                    | Не      | Да  |
+| Преглед по папки                                          | Да      | Да  |
+
+## Преводи
+
+Повече за преводите [тук](https://docs.immich.app/developer/translations).
+
+<a href="https://hosted.weblate.org/engage/immich/">
+<img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />
+</a>
+
+## Активност в хранилището
+
+![Activities](https://repobeats.axiom.co/api/embed/9e86d9dc3ddd137161f2f6d2e758d7863b1789cb.svg "Repobeats analytics image")
+
+## История на звездите
+
+<a href="https://star-history.com/#immich-app/immich&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+ </picture>
+</a>
+
+## Сътрудници
+
+<a href="https://github.com/alextran1502/immich/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=immich-app/immich" width="100%"/>
+</a>

--- a/readme_i18n/README_bg_BG.md
+++ b/readme_i18n/README_bg_BG.md
@@ -126,6 +126,6 @@
 
 ## Сътрудници
 
-<a href="https://github.com/alextran1502/immich/graphs/contributors">
+<a href="https://github.com/immich-app/immich/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=immich-app/immich" width="100%"/>
 </a>

--- a/readme_i18n/README_ca_ES.md
+++ b/readme_i18n/README_ca_ES.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_de_DE.md
+++ b/readme_i18n/README_de_DE.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_es_ES.md
+++ b/readme_i18n/README_es_ES.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_fr_FR.md
+++ b/readme_i18n/README_fr_FR.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_it_IT.md
+++ b/readme_i18n/README_it_IT.md
@@ -32,6 +32,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_ja_JP.md
+++ b/readme_i18n/README_ja_JP.md
@@ -30,6 +30,7 @@
   <a href="README_zh_CN.md">简体中文</a>
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_ko_KR.md
+++ b/readme_i18n/README_ko_KR.md
@@ -32,6 +32,7 @@
 <a href="README_zh_TW.md">正體中文</a>
 <a href="README_uk_UA.md">Українська</a>
 <a href="README_ru_RU.md">Русский</a>
+<a href="README_bg_BG.md">Български</a>
 <a href="README_pt_BR.md">Português Brasileiro</a>
 <a href="README_sv_SE.md">Svenska</a>
 <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_nl_NL.md
+++ b/readme_i18n/README_nl_NL.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_pt_BR.md
+++ b/readme_i18n/README_pt_BR.md
@@ -33,6 +33,7 @@
 <a href="README_zh_TW.md">正體中文</a>
 <a href="README_uk_UA.md">Українська</a>
 <a href="README_ru_RU.md">Русский</a>
+<a href="README_bg_BG.md">Български</a>
 <a href="README_sv_SE.md">Svenska</a>
 <a href="README_ar_JO.md">العربية</a>
 <a href="README_vi_VN.md">Tiếng Việt</a>

--- a/readme_i18n/README_ru_RU.md
+++ b/readme_i18n/README_ru_RU.md
@@ -31,6 +31,7 @@
   <a href="README_zh_CN.md">简体中文</a>
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <br>

--- a/readme_i18n/README_sv_SE.md
+++ b/readme_i18n/README_sv_SE.md
@@ -33,6 +33,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_ar_JO.md">العربية</a>
   <a href="README_th_TH.md">ภาษาไทย</a>

--- a/readme_i18n/README_th_TH.md
+++ b/readme_i18n/README_th_TH.md
@@ -35,6 +35,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_tr_TR.md
+++ b/readme_i18n/README_tr_TR.md
@@ -31,6 +31,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_uk_UA.md
+++ b/readme_i18n/README_uk_UA.md
@@ -32,6 +32,7 @@
   <a href="README_zh_CN.md">简体中文</a>
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_vi_VN.md
+++ b/readme_i18n/README_vi_VN.md
@@ -33,6 +33,7 @@
 <a href="README_zh_TW.md">正體中文</a>
 <a href="README_uk_UA.md">Українська</a>
 <a href="README_ru_RU.md">Русский</a>
+<a href="README_bg_BG.md">Български</a>
 <a href="README_pt_BR.md">Português Brasileiro</a>
 <a href="README_sv_SE.md">Svenska</a>
 <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_zh_CN.md
+++ b/readme_i18n/README_zh_CN.md
@@ -35,6 +35,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>

--- a/readme_i18n/README_zh_TW.md
+++ b/readme_i18n/README_zh_TW.md
@@ -33,6 +33,7 @@
   <a href="README_zh_TW.md">正體中文</a>
   <a href="README_uk_UA.md">Українська</a>
   <a href="README_ru_RU.md">Русский</a>
+  <a href="README_bg_BG.md">Български</a>
   <a href="README_pt_BR.md">Português Brasileiro</a>
   <a href="README_sv_SE.md">Svenska</a>
   <a href="README_ar_JO.md">العربية</a>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed that Bulgarian is translated at almost 100%, yet there's no readme.md in Bulgarian.

This adds it as well as updates the navigation for other readme's to include it.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Proof-read it a couple of times

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None, translated manually.
