### PR TITLE
fix: setting input field description spacing for description snippet

### DIFF
--- a/web/src/lib/components/shared-components/settings/SettingInputField.svelte
+++ b/web/src/lib/components/shared-components/settings/SettingInputField.svelte
@@ -101,7 +101,9 @@
       {description}
     </p>
   {:else}
-    {@render descriptionSnippet?.()}
+    <div class="pb-2">
+      {@render descriptionSnippet?.()}
+    </div>
   {/if}
 
   {#if inputType !== SettingInputFieldType.PASSWORD}


### PR DESCRIPTION
<img width="799" height="117" alt="Screenshot 2026-07-02 at 12 12 03" src="https://github.com/user-attachments/assets/dc5fd320-ebdf-4d05-8e75-1f4afd84fd48" />
