### PR TITLE
feat: remove current photo from album with and without additional confirmation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1743,6 +1743,7 @@
   "remove_filter": "Remove filter",
   "remove_from_album": "Remove from album",
   "remove_from_album_action_prompt": "{count} removed from the album",
+  "remove_from_album_without_confirmation": "Remove from album without confirmation",
   "remove_from_favorites": "Remove from favorites",
   "remove_from_lock_folder_action_prompt": "{count} removed from the locked folder",
   "remove_from_locked_folder": "Remove from locked folder",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1720,6 +1720,7 @@
   "remove_filter": "Usuń filtr",
   "remove_from_album": "Usuń z albumu",
   "remove_from_album_action_prompt": "{count} usunięto z albumu",
+  "remove_from_album_without_confirmation": "Usuń z albumu bez potwierdzania",
   "remove_from_favorites": "Usuń z ulubionych",
   "remove_from_lock_folder_action_prompt": "{count} usunięte z folderu zablokowanego",
   "remove_from_locked_folder": "Usuń z folderu zablokowanego",

--- a/web/src/lib/components/asset-viewer/AssetViewer.spec.ts
+++ b/web/src/lib/components/asset-viewer/AssetViewer.spec.ts
@@ -1,13 +1,16 @@
-import { updateAsset } from '@immich/sdk';
+import { AlbumUserRole, AssetTypeEnum, updateAsset } from '@immich/sdk';
+import { modalManager } from '@immich/ui';
 import { fireEvent, waitFor } from '@testing-library/svelte';
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import { getResizeObserverMock } from '$lib/__mocks__/resize-observer.mock';
 import { authManager } from '$lib/managers/auth-manager.svelte';
+import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
 import { SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
 import { renderWithTooltips } from '$tests/helpers';
+import { albumFactory } from '@test-data/factories/album-factory';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
-import { userAdminFactory } from '@test-data/factories/user-factory';
+import { userAdminFactory, userFactory } from '@test-data/factories/user-factory';
 import AssetViewer from './AssetViewer.svelte';
 
 vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
@@ -75,5 +78,41 @@ describe('AssetViewer', () => {
       expect(updateAsset).toHaveBeenCalledWith({ id: asset.id, updateAssetDto: { isFavorite: true } }),
     );
     await waitFor(() => expect(getByLabelText('unfavorite')).toBeInTheDocument());
+  });
+
+  it('opens album-specific keyboard shortcuts when pressing ?', async () => {
+    const ownerId = 'owner-id';
+    const user = userAdminFactory.build({ id: ownerId });
+    const albumOwner = userFactory.build({ id: ownerId });
+    const asset = assetFactory.build({ ownerId, isTrashed: false, type: AssetTypeEnum.Image });
+    const album = albumFactory.build({
+      albumUsers: [{ user: albumOwner, role: AlbumUserRole.Owner }],
+    });
+    const showModal = vi.spyOn(modalManager, 'show').mockResolvedValue(undefined);
+
+    authManager.setUser(user);
+    authManager.setPreferences(preferencesFactory.build({ cast: { gCastEnabled: false } }));
+
+    renderWithTooltips(AssetViewer, {
+      cursor: { current: asset },
+      album,
+      showNavigation: false,
+    });
+
+    await fireEvent.keyDown(document, { key: '?', shiftKey: true });
+
+    await waitFor(() =>
+      expect(showModal).toHaveBeenCalledWith(
+        ShortcutsModal,
+        expect.objectContaining({
+          shortcuts: expect.objectContaining({
+            actions: expect.arrayContaining([
+              expect.objectContaining({ key: ['x'], action: 'remove_from_album' }),
+              expect.objectContaining({ key: ['⇧', 'x'], action: 'remove_from_album_without_confirmation' }),
+            ]),
+          }),
+        }),
+      ),
+    );
   });
 });

--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { focusTrap } from '$lib/actions/focus-trap';
-  import { shortcuts } from '$lib/actions/shortcut';
+  import { shortcuts, type ShortcutOptions } from '$lib/actions/shortcut';
   import type { Action, OnAction, PreAction } from '$lib/components/asset-viewer/actions/action';
   import NextAssetAction from '$lib/components/asset-viewer/actions/NextAssetAction.svelte';
   import PreviousAssetAction from '$lib/components/asset-viewer/actions/PreviousAssetAction.svelte';
@@ -15,6 +15,7 @@
   import { editManager, EditToolType } from '$lib/managers/edit/edit-manager.svelte';
   import { eventManager } from '$lib/managers/event-manager.svelte';
   import { getAssetActions } from '$lib/services/asset.service';
+  import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { faceManager } from '$lib/stores/face.svelte';
   import { ocrManager } from '$lib/stores/ocr.svelte';
   import { alwaysLoadOriginalVideo } from '$lib/stores/preferences.store';
@@ -35,7 +36,7 @@
     type PersonResponseDto,
     type StackResponseDto,
   } from '@immich/sdk';
-  import { CommandPaletteDefaultProvider } from '@immich/ui';
+  import { CommandPaletteDefaultProvider, modalManager } from '@immich/ui';
   import { onDestroy, onMount, untrack } from 'svelte';
   import type { SwipeCustomEvent } from 'svelte-gestures';
   import { t } from 'svelte-i18n';
@@ -447,6 +448,51 @@
       ocrManager.hasOcrData,
   );
 
+  let isShortcutModalOpen = false;
+
+  const handleOpenShortcutModal = async () => {
+    if (isShortcutModalOpen) {
+      return;
+    }
+
+    isShortcutModalOpen = true;
+    await modalManager.show(ShortcutsModal, { shortcuts: albumAssetViewerShortcuts });
+    isShortcutModalOpen = false;
+  };
+
+  const albumAssetViewerShortcuts = $derived({
+    general: [
+      { key: ['←', 'a'], action: $t('view_previous_asset') },
+      { key: ['→', 'd'], action: $t('view_next_asset') },
+      { key: ['Esc'], action: $t('back_close_deselect') },
+    ],
+    actions: [
+      { key: ['f'], action: $t('favorite_or_unfavorite_photo') },
+      { key: ['i'], action: $t('show_or_hide_info') },
+      { key: ['l'], action: $t('add_to_album') },
+      { key: ['t'], action: $t('tag_assets') },
+      { key: ['p'], action: $t('tag_people') },
+      { key: ['x'], action: $t('remove_from_album') },
+      { key: ['⇧', 'x'], action: $t('remove_from_album_without_confirmation') },
+      { key: ['⇧', 'a'], action: $t('archive_or_unarchive_photo') },
+      { key: ['⇧', 'd'], action: $t('download') },
+      { key: ['Del'], action: $t('trash_delete_asset'), info: $t('shift_to_permanent_delete') },
+      ...(authManager.authenticated && authManager.preferences.ratings.enabled
+        ? [{ key: ['1-5'], action: $t('rate_asset'), info: $t('zero_to_clear_rating') }]
+        : []),
+    ],
+  });
+  const shortcutModalShortcuts = $derived<ShortcutOptions[]>(
+    album && $slideshowState === SlideshowState.None && !assetViewerManager.isShowEditor
+      ? [{ shortcut: { key: '?', shift: true }, onShortcut: handleOpenShortcutModal }]
+      : [],
+  );
+  const documentShortcuts = $derived<ShortcutOptions[]>([
+    { shortcut: { key: 'ArrowUp' }, onShortcut: () => navigateStack('previous') },
+    { shortcut: { key: 'ArrowDown' }, onShortcut: () => navigateStack('next') },
+    ...shortcutModalShortcuts,
+  ]);
+
   const { Tag, TagPeople } = $derived(getAssetActions($t, asset));
   const showDetailPanel = $derived(
     asset.hasMetadata &&
@@ -477,13 +523,7 @@
 <CommandPaletteDefaultProvider name={$t('assets')} actions={[Tag, TagPeople]} />
 <OnEvents {onAssetUpdate} />
 
-<svelte:document
-  bind:fullscreenElement
-  use:shortcuts={[
-    { shortcut: { key: 'ArrowUp' }, onShortcut: () => navigateStack('previous') },
-    { shortcut: { key: 'ArrowDown' }, onShortcut: () => navigateStack('next') },
-  ]}
-/>
+<svelte:document bind:fullscreenElement use:shortcuts={documentShortcuts} />
 
 <section
   id="immich-asset-viewer"

--- a/web/src/lib/components/timeline/actions/RemoveFromAlbumAction.spec.ts
+++ b/web/src/lib/components/timeline/actions/RemoveFromAlbumAction.spec.ts
@@ -1,0 +1,56 @@
+import { getAlbumInfo, removeAssetFromAlbum } from '@immich/sdk';
+import { modalManager } from '@immich/ui';
+import '@testing-library/jest-dom';
+import { fireEvent, waitFor } from '@testing-library/svelte';
+import { renderWithTooltips } from '$tests/helpers';
+import { albumFactory } from '@test-data/factories/album-factory';
+import RemoveFromAlbumAction from './RemoveFromAlbumAction.svelte';
+
+vi.mock('@immich/sdk', async () => {
+  const sdk = await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk');
+  return {
+    ...sdk,
+    getAlbumInfo: vi.fn(),
+    removeAssetFromAlbum: vi.fn(),
+  };
+});
+
+describe('RemoveFromAlbumAction component', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('asks for confirmation before removing a single asset with x', async () => {
+    const album = albumFactory.build({ id: 'album-id' });
+    vi.spyOn(modalManager, 'showDialog').mockResolvedValue(true);
+    vi.mocked(removeAssetFromAlbum).mockResolvedValue([{ id: 'asset-id', success: true }]);
+    vi.mocked(getAlbumInfo).mockResolvedValue(album);
+    const onRemove = vi.fn();
+
+    renderWithTooltips(RemoveFromAlbumAction, { album, onRemove, assetIds: ['asset-id'], menuItem: true });
+
+    await fireEvent.keyDown(document, { key: 'x' });
+
+    await waitFor(() => expect(modalManager.showDialog).toHaveBeenCalledOnce());
+    expect(removeAssetFromAlbum).toHaveBeenCalledWith({ id: 'album-id', bulkIdsDto: { ids: ['asset-id'] } });
+    expect(onRemove).toHaveBeenCalledWith(['asset-id']);
+  });
+
+  it('removes a single asset without confirmation with Shift+X', async () => {
+    const album = albumFactory.build({ id: 'album-id' });
+    vi.spyOn(modalManager, 'showDialog').mockResolvedValue(true);
+    vi.mocked(removeAssetFromAlbum).mockResolvedValue([{ id: 'asset-id', success: true }]);
+    vi.mocked(getAlbumInfo).mockResolvedValue(album);
+    const onRemove = vi.fn();
+
+    renderWithTooltips(RemoveFromAlbumAction, { album, onRemove, assetIds: ['asset-id'], menuItem: true });
+
+    await fireEvent.keyDown(document, { key: 'X', shiftKey: true });
+
+    await waitFor(() =>
+      expect(removeAssetFromAlbum).toHaveBeenCalledWith({ id: 'album-id', bulkIdsDto: { ids: ['asset-id'] } }),
+    );
+    expect(modalManager.showDialog).not.toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalledWith(['asset-id']);
+  });
+});

--- a/web/src/lib/components/timeline/actions/RemoveFromAlbumAction.svelte
+++ b/web/src/lib/components/timeline/actions/RemoveFromAlbumAction.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcuts, type ShortcutOptions } from '$lib/actions/shortcut';
   import MenuOption from '$lib/components/shared-components/context-menu/MenuOption.svelte';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { handleError } from '$lib/utils/handle-error';
@@ -15,16 +16,29 @@
   }
 
   let { album = $bindable(), onRemove, assetIds, menuItem = false }: Props = $props();
+  const removeSingleAssetShortcut = $derived(assetIds?.length === 1 ? { key: 'x' } : null);
+  const singleAssetShortcuts = $derived<ShortcutOptions[]>(
+    assetIds?.length === 1
+      ? [
+          {
+            shortcut: { key: 'X', shift: true },
+            onShortcut: () => removeFromAlbum({ skipConfirmation: true }),
+          },
+        ]
+      : [],
+  );
 
-  const removeFromAlbum = async () => {
+  const removeFromAlbum = async ({ skipConfirmation = false }: { skipConfirmation?: boolean } = {}) => {
     const ids = assetIds ?? assetMultiSelectManager.assets.map(({ id }) => id) ?? [];
 
-    const isConfirmed = await modalManager.showDialog({
-      prompt: $t('remove_assets_album_confirmation', { values: { count: ids.length } }),
-    });
+    if (!skipConfirmation) {
+      const isConfirmed = await modalManager.showDialog({
+        prompt: $t('remove_assets_album_confirmation', { values: { count: ids.length } }),
+      });
 
-    if (!isConfirmed) {
-      return;
+      if (!isConfirmed) {
+        return;
+      }
     }
 
     try {
@@ -47,8 +61,15 @@
   };
 </script>
 
+<svelte:document use:shortcuts={singleAssetShortcuts} />
+
 {#if menuItem}
-  <MenuOption text={$t('remove_from_album')} icon={mdiImageRemoveOutline} onClick={removeFromAlbum} />
+  <MenuOption
+    text={$t('remove_from_album')}
+    icon={mdiImageRemoveOutline}
+    onClick={removeFromAlbum}
+    shortcut={removeSingleAssetShortcut}
+  />
 {:else}
   <IconButton
     shape="round"
@@ -56,6 +77,6 @@
     variant="ghost"
     aria-label={$t('remove_from_album')}
     icon={mdiDeleteOutline}
-    onclick={removeFromAlbum}
+    onclick={() => removeFromAlbum()}
   />
 {/if}


### PR DESCRIPTION
## Description

Whenever I have to work on a big album, it is difficult and time consuming to quickly remove photo from album.
This feature adds "x" shortcut to trigger "remove photo from album" feature.
There is also "X" (uppercase x) which does the same, but without prompting user for approval.
This is very helpful when you add all your photos to an album and then progressively remove the ones which you want to trim down the final album.
This feature also adds the "Keyboard shortcuts" under "?" with correspond to available actions when user is viewing single photo within an album.

## How Has This Been Tested?
- [x] Run the app locally
- [x] Created album with a couple of photos and then
- - [x] pressed "x" - got dialog for approval, approved, photo got removed from the album
- - [x] pressed "X" - and got the photo removed from the album immediately

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code


## Please describe to which degree, if any, an LLM was used in creating this pull request.

I have used Codex to implement this feature.