### PR TITLE
fix(docs): use correct heading name for DB dump

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -31,7 +31,7 @@ You can trigger a database backup manually:
 
 1. Go to **Administration > Job Queues**
 2. Click **Create job** in the top right
-3. Select **Create Database Backup** and click **Confirm**
+3. Select **Create Database Dump** and click **Confirm**
 
 The backup will appear in `UPLOAD_LOCATION/backups` and counts toward your retention limit.
 


### PR DESCRIPTION
## Description

The documentation steps for [creating a manual backup](https://docs.immich.app/administration/backup-and-restore#creating-a-backup) do not match the actual copy that is displayed in the UI.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

View the updated docs.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/a
