### PR TITLE
fix: downmix audio to stereo to fix broken channel layout

### DIFF
--- a/server/src/services/transcoding.service.spec.ts
+++ b/server/src/services/transcoding.service.spec.ts
@@ -381,6 +381,8 @@ describe(TranscodingService.name, () => {
       '50',
       '-keyint_min',
       '50',
+      '-ac',
+      '2',
       '-copyts',
       '-r',
       '50130000/2012441',

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -200,6 +200,10 @@ export class BaseConfig implements VideoCodecSWConfig {
     const options = ['-c:v', videoCodec, '-c:a', audioCodec, '-map', `0:${videoStream.index}`, '-map_metadata', '-1'];
     if (audioStream) {
       options.push('-map', `0:${audioStream.index}`);
+      // If there are more than 2 channels sometimes the channel config is broken when re-encoded
+      if ([TranscodeTarget.All, TranscodeTarget.Audio].includes(target)) {
+        options.push('-ac', '2');
+      }
     }
     if (this.getBFrames() > -1) {
       options.push('-bf', `${this.getBFrames()}`);

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -201,6 +201,7 @@ export class BaseConfig implements VideoCodecSWConfig {
     if (audioStream) {
       options.push('-map', `0:${audioStream.index}`);
       // If there are more than 2 channels sometimes the channel config is broken when re-encoded
+      // TODO: Store the number of channels in the db and then set it during the transcoding: -channel_layout 5.1
       if ([TranscodeTarget.All, TranscodeTarget.Audio].includes(target)) {
         options.push('-ac', '2');
       }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Videos with 5.1 audio that were transcoded failed to play in firefox and failed to play in all major browsers (firefox and chrome) when live transcoding was enabled. It looked like the channel config was broken. It can also be fixed by passing the correct flag for channel layout `-channel_layout 5.1` for this file.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Play video with 5.1 audio and it fails. Sample file: [00465.MTS.zip](https://github.com/user-attachments/files/16144681/00465.MTS.zip)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Helped generate ffmpeg commands for analyzing video.