### PR TITLE
fix(web): add ARIA label to ServerStatisticsCard

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -41,7 +41,7 @@
       <span class="shimmer-text text-gray-300 dark:text-gray-600">{zeros()}</span>
     </div>
   {:then data}
-    <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="{data.value} {data.unit ? data.unit : ''}">
+    <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="{data.value} {data.unit ?? ''}">
       <span class="text-gray-300 dark:text-gray-600">{zeros(data)}</span><span>{data.value}</span>
       {#if data.unit}
         <code class="font-mono text-base font-normal">{data.unit}</code>

--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -37,18 +37,18 @@
   </div>
 
   {#await valuePromise}
-    <div class="relative mx-auto font-mono text-2xl font-medium">
+    <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="0">
       <span class="shimmer-text text-gray-300 dark:text-gray-600">{zeros()}</span>
     </div>
   {:then data}
-    <div class="relative mx-auto font-mono text-2xl font-medium">
+    <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="{data.value} {data.unit ? data.unit : ''}">
       <span class="text-gray-300 dark:text-gray-600">{zeros(data)}</span><span>{data.value}</span>
       {#if data.unit}
         <code class="font-mono text-base font-normal">{data.unit}</code>
       {/if}
     </div>
   {:catch _}
-    <div class="relative mx-auto font-mono text-2xl font-medium">
+    <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="0">
       <span class="text-gray-300 dark:text-gray-600">{zeros()}</span>
     </div>
   {/await}


### PR DESCRIPTION
## Description

This PR fixes an accessibility issue with the ServerStatisticsCard component. This component has leading zeroes to pad the number out so that it's a fixed width:

<img width="338" height="202" alt="image" src="https://github.com/user-attachments/assets/1bce1478-8e50-4a51-8fa9-c5dbb9074334" />

Some screen readers (I tested with Apple's VoiceOver) will read these leading zeroes then each of the individual digits, which is not a great experience.

<img width="646" height="156" alt="image" src="https://github.com/user-attachments/assets/03efb0b9-abdd-4426-9823-c1533c41c3bf" />

This reads out as "zero-zero-zero-zero [...] nine-one-zero-six-seven"

Adding `aria-label` attributes expressing the actual value eliminates this problem.

## How Has This Been Tested?

I did not build this on my local machine, but I did modify the DOM of my live Immich instance by adding the `aria-label` attributes where they are in this PR and VoiceOver reads out normally.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.