### PR TITLE
fix(server): allow float values for percentageLimit in integrity check config

### DIFF
--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -73,7 +73,7 @@ const SystemConfigIntegrityJobSchema = z
 
 const SystemConfigIntegrityChecksumJobSchema = SystemConfigIntegrityJobSchema.extend({
   timeLimit: z.int().nonnegative().describe('How long the integrity checksum job may run for'),
-  percentageLimit: z.int().nonnegative().describe('Percentage limit of the integrity checksum job'),
+  percentageLimit: z.number().nonnegative().describe('Percentage limit of the integrity checksum job'),
 })
   .describe('Integrity checksum job config')
   .meta({ id: 'SystemConfigIntegrityChecksumJob' });


### PR DESCRIPTION
## What

Changes the Zod schema for `percentageLimit` in `SystemConfigIntegrityChecksumFilesDto` from `z.int()` to `z.number()`.

## Why

`percentageLimit` represents a ratio (e.g. `0.01` = 1%, `0.5` = 50%, `1.0` = 100%). The UI correctly allows values between 0.01 and 1.0, but `z.int()` rejects any non-integer, making it impossible to set any value except `1` through the API.

The TypeScript type in `config.ts` was already correctly typed as `number` — only the Zod validator was wrong.

```diff
- percentageLimit: z.int().nonnegative()
+ percentageLimit: z.number().nonnegative()
```

Fixes #29541