### PR TITLE
fix(web): detect Chinese browser locales

### DIFF
--- a/web/src/lib/i18n.spec.ts
+++ b/web/src/lib/i18n.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from 'node:fs';
-import { getClosestAvailableLocale, langs } from '$lib/utils/i18n';
+import { getClosestAvailableLocale, getPreferredLocale, langs } from '$lib/utils/i18n';
 
 describe('i18n', () => {
   describe('loaders', () => {
@@ -57,6 +57,17 @@ describe('i18n', () => {
       expect(getClosestAvailableLocale(['pt_BR'], allLocales)).toBe('pt_BR');
       expect(getClosestAvailableLocale(['sr_Cyrl'], allLocales)).toBe('sr_Cyrl');
       expect(getClosestAvailableLocale(['zh_Hant'], allLocales)).toBe('zh_Hant');
+    });
+  });
+
+  describe('getPreferredLocale', () => {
+    it('maps Chinese browser locales to available script-based translations', () => {
+      expect(getPreferredLocale(['zh-CN'])).toBe('zh-Hans');
+      expect(getPreferredLocale(['zh-SG'])).toBe('zh-Hans');
+      expect(getPreferredLocale(['zh'])).toBe('zh-Hans');
+      expect(getPreferredLocale(['zh-TW'])).toBe('zh-Hant');
+      expect(getPreferredLocale(['zh-HK'])).toBe('zh-Hant');
+      expect(getPreferredLocale(['zh-MO'])).toBe('zh-Hant');
     });
   });
 });

--- a/web/src/lib/utils/i18n.ts
+++ b/web/src/lib/utils/i18n.ts
@@ -23,6 +23,20 @@ export const convertBCP47 = (code: string) => code.replaceAll('_', '-');
 
 export const langCodes = fileCodes.map((code) => convertBCP47(code));
 
+const localeAliases: Record<string, string[]> = {
+  zh: ['zh-Hans'],
+  'zh-CN': ['zh-Hans'],
+  'zh-HK': ['zh-Hant'],
+  'zh-MO': ['zh-Hant'],
+  'zh-SG': ['zh-Hans'],
+  'zh-TW': ['zh-Hant'],
+};
+
+const getLocaleCandidates = (locale: string) => {
+  const normalizedLocale = convertBCP47(locale);
+  return [normalizedLocale, ...(localeAliases[normalizedLocale] ?? [])];
+};
+
 // https://github.com/kaisermann/svelte-i18n/blob/780932a3e1270d521d348aac8ba03be9df309f04/src/runtime/stores/locale.ts#L11
 const getSubLocales = (locale: string) => {
   return convertBCP47(locale)
@@ -36,7 +50,11 @@ export const getClosestAvailableLocale = (locales: readonly string[], allLocales
   return locales.find((locale) => getSubLocales(locale).some((subLocale) => allLocalesSet.has(subLocale)));
 };
 
-export const getPreferredLocale = () => getClosestAvailableLocale(navigator.languages, langCodes);
+export const getPreferredLocale = (locales: readonly string[] = navigator.languages) =>
+  getClosestAvailableLocale(
+    locales.flatMap((locale) => getLocaleCandidates(locale)),
+    langCodes,
+  );
 
 const rtlCodes = new Set([
   'ae',


### PR DESCRIPTION
## Description

Fixes #29490

This updates web locale detection so browser locales such as `zh-CN`, `zh-SG`, `zh`, `zh-TW`, `zh-HK`, and `zh-MO` can resolve to Immich's existing `zh-Hans` and `zh-Hant` translation files instead of falling back to English.

Root cause: the available web translation files use script-based codes (`zh_Hans.json` / `zh_Hant.json`), while browsers commonly report region-based Chinese locales (`zh-CN`, `zh-TW`, etc.).

## How Has This Been Tested?

- [x] `corepack pnpm --dir web test src/lib/i18n.spec.ts`
- [x] `corepack pnpm --dir web format`
- [x] `corepack pnpm --dir web lint`
- [x] `corepack pnpm --dir web check:typescript`
- [x] `corepack pnpm --dir web check:svelte`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable; this is locale selection logic covered by unit tests.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
