### PR TITLE
chore(server): prefer null over empty strings (#28832)

### DIFF
--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -177,8 +177,11 @@ export class StorageCore {
     });
   }
 
-  async movePersonFile(person: { id: string; ownerId: string; thumbnailPath: string }, pathType: PersonPathType) {
+  async movePersonFile(person: { id: string; ownerId: string; thumbnailPath: string | null }, pathType: PersonPathType) {
     const { id: entityId, thumbnailPath } = person;
+    if (!thumbnailPath) {
+      return;
+    }
     switch (pathType) {
       case PersonPathType.Face: {
         await this.moveFile({

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -125,10 +125,10 @@ export type Asset = {
 
 export type User = {
   id: string;
-  name: string;
+  name: string | null;
   email: string;
   avatarColor: UserAvatarColor | null;
-  profileImagePath: string;
+  profileImagePath: string | null;
   profileChangedAt: Date;
 };
 
@@ -139,7 +139,7 @@ export type UserAdmin = User & {
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
-  oauthId: string;
+  oauthId: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;
   status: UserStatus;
@@ -230,8 +230,8 @@ export type Session = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date | null;
-  deviceOS: string;
-  deviceType: string;
+  deviceOS: string | null;
+  deviceType: string | null;
   appVersion: string | null;
   pinExpiresAt: Date | null;
   isPendingSyncReset: boolean;
@@ -246,12 +246,12 @@ export type Person = {
   updatedAt: Date;
   updateId: string;
   isFavorite: boolean;
-  name: string;
+  name: string | null;
   birthDate: Date | null;
   color: string | null;
   faceAssetId: string | null;
   isHidden: boolean;
-  thumbnailPath: string;
+  thumbnailPath: string | null;
 };
 
 export type AssetFace = {

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -157,7 +157,7 @@ export type MapAlbumDto = {
   assets?: ShallowDehydrateObject<MapAsset>[];
   sharedLinks?: ShallowDehydrateObject<AuthSharedLink>[];
   albumName: string;
-  description: string;
+  description: string | null;
   albumThumbnailAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -193,7 +193,7 @@ export const mapAlbum = (entity: MaybeDehydrated<MapAlbumDto>): AlbumResponseDto
 
   return {
     albumName: entity.albumName,
-    description: entity.description,
+    description: entity.description ?? '',
     albumThumbnailAssetId: entity.albumThumbnailAssetId,
     createdAt: asDateTimeString(entity.createdAt),
     updatedAt: asDateTimeString(entity.updatedAt),

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -48,9 +48,9 @@ export function mapLoginResponse(entity: UserAdmin, accessToken: string): LoginR
     accessToken,
     userId: entity.id,
     userEmail: entity.email,
-    name: entity.name,
+    name: entity.name ?? entity.email,
     isAdmin: entity.isAdmin,
-    profileImagePath: entity.profileImagePath,
+    profileImagePath: entity.profileImagePath ?? '',
     shouldChangePassword: entity.shouldChangePassword,
     isOnboarded: onboardingMetadata?.isOnboarded ?? false,
   };

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -174,9 +174,9 @@ export class PeopleResponseDto extends createZodDto(PeopleResponseSchema) {}
 export function mapPerson(person: MaybeDehydrated<Person>): PersonResponseDto {
   return {
     id: person.id,
-    name: person.name,
+    name: person.name ?? '',
     birthDate: asDateString(person.birthDate),
-    thumbnailPath: person.thumbnailPath,
+    thumbnailPath: person.thumbnailPath ?? '',
     isHidden: person.isHidden,
     isFavorite: person.isFavorite,
     color: person.color ?? undefined,

--- a/server/src/dtos/session.dto.ts
+++ b/server/src/dtos/session.dto.ts
@@ -46,7 +46,7 @@ export const mapSession = (entity: Session, currentId?: string): SessionResponse
   expiresAt: entity.expiresAt?.toISOString(),
   current: currentId === entity.id,
   appVersion: entity.appVersion,
-  deviceOS: entity.deviceOS,
-  deviceType: entity.deviceType,
+  deviceOS: entity.deviceOS ?? '',
+  deviceType: entity.deviceType ?? '',
   isPendingSyncReset: entity.isPendingSyncReset,
 });

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -58,8 +58,8 @@ export const mapUser = (entity: MaybeDehydrated<User | UserAdmin>): UserResponse
   return {
     id: entity.id,
     email: entity.email,
-    name: entity.name,
-    profileImagePath: entity.profileImagePath,
+    name: entity.name ?? entity.email,
+    profileImagePath: entity.profileImagePath ?? '',
     avatarColor: entity.avatarColor ?? emailToAvatarColor(entity.email),
     profileChangedAt: asDateTimeString(entity.profileChangedAt),
   };
@@ -145,7 +145,7 @@ export function mapUserAdmin(entity: UserAdmin): UserAdminResponseDto {
     createdAt: entity.createdAt,
     deletedAt: entity.deletedAt,
     updatedAt: entity.updatedAt,
-    oauthId: entity.oauthId,
+    oauthId: entity.oauthId ?? '',
     quotaSizeInBytes: entity.quotaSizeInBytes,
     quotaUsageInBytes: entity.quotaUsageInBytes,
     status: entity.status,

--- a/server/src/queries/user.repository.sql
+++ b/server/src/queries/user.repository.sql
@@ -310,7 +310,7 @@ order by
 -- UserRepository.getUserStats
 select
   "user"."id" as "userId",
-  "user"."name" as "userName",
+  coalesce("user"."name", "user"."email") as "userName",
   "user"."quotaSizeInBytes",
   count(*) filter (
     where

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -116,18 +116,18 @@ type QueueStartEvent = {
 };
 
 type UserEvent = {
-  name: string;
+  name: string | null;
   id: string;
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
   status: UserStatus;
   email: string;
-  profileImagePath: string;
+  profileImagePath: string | null;
   isAdmin: boolean;
   shouldChangePassword: boolean;
   avatarColor: UserAvatarColor | null;
-  oauthId: string;
+  oauthId: string | null;
   storageLabel: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -47,7 +47,7 @@ export interface DeleteFacesOptions {
 
 export interface GetAllPeopleOptions {
   ownerId?: string;
-  thumbnailPath?: string;
+  thumbnailPath?: string | null;
   faceAssetId?: string | null;
   isHidden?: boolean;
 }
@@ -130,7 +130,10 @@ export class PersonRepository {
       .selectFrom('person')
       .selectAll('person')
       .$if(!!options.ownerId, (qb) => qb.where('person.ownerId', '=', options.ownerId!))
-      .$if(options.thumbnailPath !== undefined, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
+      .$if(options.thumbnailPath === null, (qb) => qb.where('person.thumbnailPath', 'is', null))
+      .$if(typeof options.thumbnailPath === 'string', (qb) =>
+        qb.where('person.thumbnailPath', '=', options.thumbnailPath!),
+      )
       .$if(options.faceAssetId === null, (qb) => qb.where('person.faceAssetId', 'is', null))
       .$if(!!options.faceAssetId, (qb) => qb.where('person.faceAssetId', '=', options.faceAssetId!))
       .$if(options.isHidden !== undefined, (qb) => qb.where('person.isHidden', '=', options.isHidden!))
@@ -142,7 +145,7 @@ export class PersonRepository {
     return this.db
       .selectFrom('person')
       .select(['id', 'thumbnailPath'])
-      .where('thumbnailPath', '!=', sql.lit(''))
+      .where('thumbnailPath', 'is not', null)
       .limit(sql.lit(3))
       .execute();
   }
@@ -166,7 +169,7 @@ export class PersonRepository {
       .orderBy('person.isFavorite', 'desc')
       .having((eb) =>
         eb.or([
-          eb('person.name', '!=', ''),
+          eb('person.name', 'is not', null),
           eb(
             (innerEb) => innerEb.fn.count('asset_face.assetId'),
             '>=',
@@ -200,9 +203,9 @@ export class PersonRepository {
       )
       .$if(!options?.closestFaceAssetId, (qb) =>
         qb
-          .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
+          .orderBy(sql`person.name is null`, 'asc')
           .orderBy((eb) => eb.fn.count('asset_face.assetId'), 'desc')
-          .orderBy(sql`NULLIF(person.name, '')`, (om) => om.asc().nullsLast())
+          .orderBy('person.name', (om) => om.asc().nullsLast())
           .orderBy('person.createdAt'),
       )
       .$if(!options?.withHidden, (qb) => qb.where('person.isHidden', '=', false))
@@ -338,9 +341,10 @@ export class PersonRepository {
       .selectFrom('person')
       .select(['person.id', 'person.name'])
       .distinctOn((eb) => eb.fn('lower', ['person.name']))
-      .where((eb) => eb.and([eb('person.ownerId', '=', userId), eb('person.name', '!=', '')]))
+      .where((eb) => eb.and([eb('person.ownerId', '=', userId), eb('person.name', 'is not', null)]))
       .$if(!withHidden, (qb) => qb.where('person.isHidden', '=', false))
-      .execute();
+      .execute()
+      .then((rows) => rows.filter((row): row is PersonNameResponse => row.name !== null));
   }
 
   @GenerateSql({ params: [DummyValue.UUID] })

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -234,7 +234,7 @@ export class UserRepository {
       .selectFrom('user')
       .leftJoin('asset', (join) => join.onRef('asset.ownerId', '=', 'user.id').on('asset.deletedAt', 'is', null))
       .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
-      .select(['user.id as userId', 'user.name as userName', 'user.quotaSizeInBytes'])
+      .select(['user.id as userId', sql<string>`coalesce(${sql.ref('user.name')}, ${sql.ref('user.email')})`.as('userName'), 'user.quotaSizeInBytes'])
       .select((eb) => [
         eb.fn
           .countAll<number>()

--- a/server/src/schema/migrations/1783220786880-PreferNullOverEmptyStrings.ts
+++ b/server/src/schema/migrations/1783220786880-PreferNullOverEmptyStrings.ts
@@ -1,0 +1,60 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "password" = NULL WHERE "password" = ''`.execute(db);
+  await sql`UPDATE "user" SET "profileImagePath" = NULL WHERE "profileImagePath" = ''`.execute(db);
+  await sql`UPDATE "user" SET "oauthId" = NULL WHERE "oauthId" = ''`.execute(db);
+  await sql`UPDATE "user" SET "name" = NULL WHERE "name" = ''`.execute(db);
+  await sql`UPDATE "album" SET "description" = NULL WHERE "description" = ''`.execute(db);
+  await sql`UPDATE "asset_exif" SET "description" = NULL WHERE "description" = ''`.execute(db);
+  await sql`UPDATE "person" SET "name" = NULL WHERE "name" = ''`.execute(db);
+  await sql`UPDATE "person" SET "thumbnailPath" = NULL WHERE "thumbnailPath" = ''`.execute(db);
+  await sql`UPDATE "session" SET "deviceType" = NULL WHERE "deviceType" = ''`.execute(db);
+  await sql`UPDATE "session" SET "deviceOS" = NULL WHERE "deviceOS" = ''`.execute(db);
+
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" DROP NOT NULL;`.execute(db);
+
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET DEFAULT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET DEFAULT NULL;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET NOT NULL;`.execute(db);
+
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT ''::text;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET DEFAULT ''::text;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET DEFAULT ''::character varying;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET DEFAULT ''::character varying;`.execute(db);
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -36,8 +36,8 @@ export class AlbumTable {
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>;
+  @Column({ type: 'text', nullable: true, default: null })
+  description!: string | null;
 
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;

--- a/server/src/schema/tables/asset-exif.table.ts
+++ b/server/src/schema/tables/asset-exif.table.ts
@@ -74,8 +74,8 @@ export class AssetExifTable {
   @Column({ type: 'character varying', nullable: true })
   country!: string | null;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>; // or caption
+  @Column({ type: 'text', nullable: true, default: null })
+  description!: string | null; // or caption
 
   @Column({ type: 'double precision', nullable: true })
   fps!: number | null;

--- a/server/src/schema/tables/person.table.ts
+++ b/server/src/schema/tables/person.table.ts
@@ -43,11 +43,11 @@ export class PersonTable {
   @ForeignKeyColumn(() => UserTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false })
   ownerId!: string;
 
-  @Column({ default: '' })
-  name!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  name!: string | null;
 
-  @Column({ default: '' })
-  thumbnailPath!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  thumbnailPath!: string | null;
 
   @Column({ type: 'boolean', default: false })
   isHidden!: Generated<boolean>;

--- a/server/src/schema/tables/session.table.ts
+++ b/server/src/schema/tables/session.table.ts
@@ -35,11 +35,11 @@ export class SessionTable {
   @ForeignKeyColumn(() => SessionTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE', nullable: true })
   parentId!: string | null;
 
-  @Column({ default: '' })
-  deviceType!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  deviceType!: string | null;
 
-  @Column({ default: '' })
-  deviceOS!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  deviceOS!: string | null;
 
   @Column({ nullable: true })
   appVersion!: string | null;

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -31,8 +31,8 @@ export class UserTable {
   @Column({ unique: true })
   email!: string;
 
-  @Column({ default: '' })
-  password!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  password!: string | null;
 
   @Column({ nullable: true })
   pinCode!: string | null;
@@ -40,8 +40,8 @@ export class UserTable {
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
 
-  @Column({ default: '' })
-  profileImagePath!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  profileImagePath!: string | null;
 
   @Column({ type: 'boolean', default: false })
   isAdmin!: Generated<boolean>;
@@ -55,8 +55,8 @@ export class UserTable {
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;
 
-  @Column({ default: '' })
-  oauthId!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  oauthId!: string | null;
 
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
@@ -64,9 +64,8 @@ export class UserTable {
   @Column({ unique: true, nullable: true, default: null })
   storageLabel!: string | null;
 
-  // TODO remove default, make nullable, and convert empty spaces to null
-  @Column({ default: '' })
-  name!: string;
+  @Column({ nullable: true, default: null })
+  name!: string | null;
 
   @Column({ type: 'bigint', nullable: true })
   quotaSizeInBytes!: ColumnType<number> | null;

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -278,14 +278,14 @@ describe(AlbumService.name, () => {
       await sut.create(AuthFactory.create(owner), {
         albumName: album.albumName,
         albumUsers: [albumUser],
-        description: album.description,
+        description: album.description ?? undefined,
         assetIds: [assetId],
       });
 
       expect(mocks.album.create).toHaveBeenCalledWith(
         {
           albumName: album.albumName,
-          description: album.description,
+          description: album.description ?? undefined,
           order: 'asc',
           albumThumbnailAssetId: assetId,
         },
@@ -330,14 +330,14 @@ describe(AlbumService.name, () => {
 
       await sut.create(AuthFactory.create(owner), {
         albumName: album.albumName,
-        description: album.description,
+        description: album.description ?? undefined,
         assetIds: [assetId, 'asset-2'],
       });
 
       expect(mocks.album.create).toHaveBeenCalledWith(
         {
           albumName: album.albumName,
-          description: album.description,
+          description: album.description ?? undefined,
           order: 'desc',
           albumThumbnailAssetId: assetId,
         },

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -20,6 +20,7 @@ import { BaseService } from 'src/services/base.service';
 import { addAssets, removeAssets } from 'src/utils/asset.util';
 import { asDateTimeString } from 'src/utils/date';
 import { getPreferences } from 'src/utils/preferences';
+import { nullIfEmpty } from 'src/utils/string';
 
 @Injectable()
 export class AlbumService extends BaseService {
@@ -120,7 +121,7 @@ export class AlbumService extends BaseService {
     const album = await this.albumRepository.create(
       {
         albumName: dto.albumName,
-        description: dto.description,
+        description: nullIfEmpty(dto.description),
         albumThumbnailAssetId: assetIds[0] || null,
         order: getPreferences(userMetadata).albums.defaultAssetOrder,
       },
@@ -152,7 +153,7 @@ export class AlbumService extends BaseService {
       {
         id: album.id,
         albumName: dto.albumName,
-        description: dto.description,
+        description: nullIfEmpty(dto.description),
         albumThumbnailAssetId: dto.albumThumbnailAssetId,
         isActivityEnabled: dto.isActivityEnabled,
         order: dto.order,

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -46,6 +46,7 @@ import {
 } from 'src/utils/asset.util';
 import { updateLockedColumns } from 'src/utils/database';
 import { extractTimeZone } from 'src/utils/date';
+import { nullIfEmpty } from 'src/utils/string';
 import { transformOcrBoundingBox } from 'src/utils/transform';
 
 @Injectable()
@@ -506,7 +507,7 @@ export class AssetService extends BaseService {
     const { id, description, dateTimeOriginal, latitude, longitude, rating } = dto;
     const writes = _.omitBy(
       {
-        description,
+        description: nullIfEmpty(description),
         dateTimeOriginal,
         timeZone: extractTimeZone(dateTimeOriginal)?.name,
         latitude,

--- a/server/src/services/auth-admin.service.ts
+++ b/server/src/services/auth-admin.service.ts
@@ -5,7 +5,6 @@ import { BaseService } from 'src/services/base.service';
 @Injectable()
 export class AuthAdminService extends BaseService {
   async unlinkAll(_auth: AuthDto) {
-    // TODO replace '' with null
-    await this.userRepository.updateAll({ oauthId: '' });
+    await this.userRepository.updateAll({ oauthId: null });
   }
 }

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -21,8 +21,8 @@ const email = 'test@immich.com';
 const loginDetails = {
   isSecure: true,
   clientIp: '127.0.0.1',
-  deviceOS: '',
-  deviceType: '',
+  deviceOS: null,
+  deviceType: null,
   appVersion: null,
 };
 
@@ -858,7 +858,7 @@ describe(AuthService.name, () => {
       expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Given Family' }));
     });
 
-    it('should fallback to email when no username is provided', async () => {
+    it('should store a null name when no username is provided', async () => {
       const profile = OAuthProfileFactory.create({ name: undefined, given_name: undefined, family_name: undefined });
 
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.enabled);
@@ -874,7 +874,7 @@ describe(AuthService.name, () => {
         loginDetails,
       );
 
-      expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ name: profile.email }));
+      expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ name: null }));
     });
 
     it('should ignore an invalid storage quota', async () => {
@@ -1017,7 +1017,7 @@ describe(AuthService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
         profile: OAuthProfileFactory.create({
-          sub: user.oauthId,
+          sub: user.oauthId!,
           email: user.email,
           picture: 'https://auth.immich.cloud/profiles/1.jpg',
         }),
@@ -1141,8 +1141,7 @@ describe(AuthService.name, () => {
 
     it('should not link an already linked oauth.sub', async () => {
       const authUser = UserFactory.create();
-      const authApiKey = ApiKeyFactory.create({ permissions: [] });
-      const auth = { user: authUser, apiKey: authApiKey };
+      const auth = AuthFactory.from(authUser).apiKey({ permissions: [] }).build();
 
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.enabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({ profile: OAuthProfileFactory.create() });
@@ -1166,7 +1165,7 @@ describe(AuthService.name, () => {
 
       await sut.unlink(auth);
 
-      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: '' });
+      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: null });
     });
 
     it('should unlink an account and remove the oauthSid from the session', async () => {
@@ -1181,7 +1180,7 @@ describe(AuthService.name, () => {
       await sut.unlink(auth);
 
       expect(mocks.session.update).toHaveBeenCalledWith(session.id, { oauthSid: null });
-      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: '' });
+      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: null });
     });
   });
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -28,11 +28,12 @@ import { isGranted } from 'src/utils/access';
 import { HumanReadableSize } from 'src/utils/bytes';
 import { generateProfileImage } from 'src/utils/profile-image';
 import { getUserAgentDetails } from 'src/utils/request';
+import { nullIfEmpty } from 'src/utils/string';
 export interface LoginDetails {
   isSecure: boolean;
   clientIp: string;
-  deviceType: string;
-  deviceOS: string;
+  deviceType: string | null;
+  deviceOS: string | null;
   appVersion: string | null;
 }
 
@@ -207,7 +208,7 @@ export class AuthService extends BaseService {
     const admin = await this.createUser({
       isAdmin: true,
       email: dto.email,
-      name: dto.name,
+      name: nullIfEmpty(dto.name),
       password: dto.password,
       storageLabel: 'admin',
     });
@@ -361,11 +362,12 @@ export class AuthService extends BaseService {
       });
 
       user = await this.createUser({
-        name:
+        name: nullIfEmpty(
           profile.name ||
-          `${profile.given_name || ''} ${profile.family_name || ''}`.trim() ||
-          profile.preferred_username ||
-          normalizedEmail,
+            `${profile.given_name || ''} ${profile.family_name || ''}`.trim() ||
+            profile.preferred_username ||
+            '',
+        ),
         email: normalizedEmail,
         oauthId: profile.sub,
         quotaSizeInBytes: storageQuota === null ? null : storageQuota * HumanReadableSize.GiB,
@@ -439,7 +441,7 @@ export class AuthService extends BaseService {
       await this.sessionRepository.update(auth.session.id, { oauthSid: null });
     }
 
-    const user = await this.userRepository.update(auth.user.id, { oauthId: '' });
+    const user = await this.userRepository.update(auth.user.id, { oauthId: null });
     return mapUserAdmin(user);
   }
 
@@ -493,7 +495,10 @@ export class AuthService extends BaseService {
       throw new UnauthorizedException('Invalid share key');
     }
 
-    return { user: sharedLink.user, sharedLink };
+    return {
+      user: { ...sharedLink.user, name: sharedLink.user.name ?? sharedLink.user.email },
+      sharedLink,
+    };
   }
 
   async validateSharedLinkSlug(slug: string | string[]): Promise<AuthDto> {
@@ -504,12 +509,15 @@ export class AuthService extends BaseService {
       throw new UnauthorizedException('Invalid share slug');
     }
 
-    return { user: sharedLink.user, sharedLink };
+    return {
+      user: { ...sharedLink.user, name: sharedLink.user.name ?? sharedLink.user.email },
+      sharedLink,
+    };
   }
 
   private isValidSharedLink(
-    sharedLink?: AuthSharedLink & { user: AuthUser | null },
-  ): sharedLink is AuthSharedLink & { user: AuthUser } {
+    sharedLink?: AuthSharedLink & { user: (Omit<AuthUser, 'name'> & { name: string | null }) | null },
+  ): sharedLink is AuthSharedLink & { user: Omit<AuthUser, 'name'> & { name: string | null } } {
     return !!sharedLink?.user && (!sharedLink.expiresAt || new Date(sharedLink.expiresAt) > new Date());
   }
 
@@ -518,7 +526,7 @@ export class AuthService extends BaseService {
     const apiKey = await this.apiKeyRepository.getKey(hashed);
     if (apiKey?.user) {
       return {
-        user: apiKey.user,
+        user: { ...apiKey.user, name: apiKey.user.name ?? apiKey.user.email },
         apiKey,
       };
     }
@@ -567,7 +575,7 @@ export class AuthService extends BaseService {
       }
 
       return {
-        user: session.user,
+        user: { ...session.user, name: session.user.name ?? session.user.email },
         session: {
           id: session.id,
           hasElevatedPermission,

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -295,6 +295,12 @@ export class BaseService {
     }
 
     const payload: Insertable<UserTable> = { ...dto };
+    if (payload.name === '') {
+      payload.name = null;
+    }
+    if (payload.oauthId === '') {
+      payload.oauthId = null;
+    }
     if (payload.password) {
       payload.password = await this.cryptoRepository.hashBcrypt(payload.password, SALT_ROUNDS);
     }

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -291,7 +291,9 @@ export class IntegrityService extends BaseService {
 
     const personThumbnailPaths = await this.integrityRepository.getPersonThumbnailPathsByPaths(paths);
     for (const { thumbnailPath } of personThumbnailPaths) {
-      untrackedFiles.delete(thumbnailPath);
+      if (thumbnailPath) {
+        untrackedFiles.delete(thumbnailPath);
+      }
     }
 
     if (untrackedFiles.size > 0) {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -122,7 +122,7 @@ describe(MediaService.name, () => {
       await sut.handleQueueGenerateThumbnails({ force: false });
 
       expect(mocks.assetJob.streamForThumbnailJob).toHaveBeenCalledWith({ force: false, fullsizeEnabled: false });
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
       expect(mocks.person.getRandomFace).toHaveBeenCalled();
       expect(mocks.person.update).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
@@ -149,7 +149,7 @@ describe(MediaService.name, () => {
         },
       ]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should queue all assets with missing preview', async () => {
@@ -162,7 +162,7 @@ describe(MediaService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.AssetGenerateThumbnails, data: { id: asset.id } },
       ]);
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should queue all assets with missing thumbhash', async () => {
@@ -178,7 +178,7 @@ describe(MediaService.name, () => {
         { name: JobName.AssetGenerateThumbnails, data: { id: asset.id } },
       ]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should queue all assets with missing fullsize when feature is enabled', async () => {
@@ -196,7 +196,7 @@ describe(MediaService.name, () => {
         },
       ]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should not queue assets with missing fullsize when feature is disabled', async () => {
@@ -209,7 +209,7 @@ describe(MediaService.name, () => {
       expect(mocks.assetJob.streamForThumbnailJob).toHaveBeenCalledWith({ force: false, fullsizeEnabled: false });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should queue assets with edits but missing edited thumbnails', async () => {
@@ -226,7 +226,7 @@ describe(MediaService.name, () => {
         },
       ]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should not queue assets with missing edited fullsize when feature is disabled', async () => {
@@ -239,7 +239,7 @@ describe(MediaService.name, () => {
       expect(mocks.assetJob.streamForThumbnailJob).toHaveBeenCalledWith({ force: false, fullsizeEnabled: false });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
 
-      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: '' });
+      expect(mocks.person.getAll).toHaveBeenCalledWith({ thumbnailPath: null });
     });
 
     it('should queue assets with missing fullsize when force is true, regardless of setting', async () => {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -93,7 +93,7 @@ export class MediaService extends BaseService {
 
     await queueAll();
 
-    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: '' });
+    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: null });
 
     for await (const person of people) {
       if (!person.faceAssetId) {

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1296,7 +1296,7 @@ describe(MetadataService.name, () => {
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
         expect.objectContaining({
           exif: expect.objectContaining({
-            description: '',
+            description: null,
           }),
           lockedPropertiesBehavior: 'skip',
         }),
@@ -1380,7 +1380,7 @@ describe(MetadataService.name, () => {
 
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
       mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
-      const faceTags = makeFaceTags({ Name: person.name });
+      const faceTags = makeFaceTags({ Name: person.name ?? undefined });
 
       // Simulating EXIF returning a string with >16 decimal places
       faceTags.RegionInfo!.RegionList[0].Area.X = '0.48564814814814824';
@@ -1409,7 +1409,7 @@ describe(MetadataService.name, () => {
 
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
       mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
-      mockReadTags(makeFaceTags({ Name: person.name }));
+      mockReadTags(makeFaceTags({ Name: person.name ?? undefined }));
       mocks.person.getDistinctNames.mockResolvedValue([]);
       mocks.person.createAll.mockResolvedValue([person.id]);
       mocks.person.update.mockResolvedValue(person);
@@ -1451,8 +1451,8 @@ describe(MetadataService.name, () => {
 
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
       mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
-      mockReadTags(makeFaceTags({ Name: person.name }));
-      mocks.person.getDistinctNames.mockResolvedValue([{ id: person.id, name: person.name }]);
+      mockReadTags(makeFaceTags({ Name: person.name ?? undefined }));
+      mocks.person.getDistinctNames.mockResolvedValue([{ id: person.id, name: person.name! }]);
       mocks.person.createAll.mockResolvedValue([]);
       mocks.person.update.mockResolvedValue(person);
       await sut.handleMetadataExtraction({ id: asset.id });
@@ -1538,7 +1538,7 @@ describe(MetadataService.name, () => {
 
           mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
           mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
-          mockReadTags(makeFaceTags({ Name: person.name }, orientation));
+          mockReadTags(makeFaceTags({ Name: person.name ?? undefined }, orientation));
           mocks.person.getDistinctNames.mockResolvedValue([]);
           mocks.person.createAll.mockResolvedValue([person.id]);
           mocks.person.update.mockResolvedValue(person);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -36,6 +36,7 @@ import { isAssetChecksumConstraint } from 'src/utils/database';
 import { mergeTimeZone } from 'src/utils/date';
 import { mimeTypes } from 'src/utils/mime-types';
 import { isFaceImportEnabled } from 'src/utils/misc';
+import { nullIfEmpty } from 'src/utils/string';
 import { upsertTags } from 'src/utils/tag';
 import { Tasks } from 'src/utils/tasks';
 
@@ -303,7 +304,7 @@ export class MetadataService extends BaseService {
       focalLength: validate(exifTags.FocalLength),
 
       // comments
-      description: String(exifTags.ImageDescription || exifTags.Description || '').trim(),
+      description: nullIfEmpty(String(exifTags.ImageDescription || exifTags.Description || '').trim()),
       profileDescription: exifTags.ProfileDescription || null,
       rating: exifTags.Rating === 0 ? null : validateRange(exifTags.Rating, 1, 5),
 

--- a/server/src/services/notification-admin.service.ts
+++ b/server/src/services/notification-admin.service.ts
@@ -39,7 +39,7 @@ export class NotificationAdminService extends BaseService {
       template: EmailTemplate.TEST_EMAIL,
       data: {
         baseUrl: getExternalDomain(server),
-        displayName: user.name,
+        displayName: user.name ?? user.email,
       },
       customTemplate: tempTemplate!,
     });

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -253,7 +253,7 @@ export class NotificationService extends BaseService {
       template: EmailTemplate.TEST_EMAIL,
       data: {
         baseUrl: getExternalDomain(server),
-        displayName: user.name,
+        displayName: user.name ?? user.email,
       },
       customTemplate: tempTemplate!,
     });
@@ -282,7 +282,7 @@ export class NotificationService extends BaseService {
       template: EmailTemplate.WELCOME,
       data: {
         baseUrl: getExternalDomain(server),
-        displayName: user.name,
+        displayName: user.name ?? user.email,
         username: user.email,
         password,
       },
@@ -332,7 +332,7 @@ export class NotificationService extends BaseService {
         albumId: album.id,
         albumName: album.albumName,
         senderName,
-        recipientName: recipient.name,
+        recipientName: recipient.name ?? recipient.email,
         cid: attachment ? attachment.cid : undefined,
       },
       customTemplate: templates.email.albumInviteTemplate,
@@ -388,7 +388,7 @@ export class NotificationService extends BaseService {
         baseUrl: getExternalDomain(server),
         albumId: album.id,
         albumName: album.albumName,
-        recipientName: user.name,
+        recipientName: user.name ?? user.email,
         cid: attachment ? attachment.cid : undefined,
       },
       customTemplate: templates.email.albumUpdateTemplate,
@@ -456,7 +456,7 @@ export class NotificationService extends BaseService {
   }
 
   private async sendAlbumLocalNotification(
-    album: MapAlbumDto,
+    album: Pick<MapAlbumDto, 'id' | 'albumName'>,
     userId: string,
     type: NotificationType.AlbumInvite | NotificationType.AlbumUpdate,
     senderName?: string,

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -155,7 +155,7 @@ describe(PersonService.name, () => {
       mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
       await expect(sut.getThumbnail(auth, person.id)).resolves.toEqual(
         new ImmichFileResponse({
-          path: person.thumbnailPath,
+          path: person.thumbnailPath!,
           contentType: 'image/jpeg',
           cacheControl: CacheControl.PrivateWithoutCache,
         }),

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -44,6 +44,7 @@ import { getDimensions } from 'src/utils/asset.util';
 import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 import { isFacialRecognitionEnabled } from 'src/utils/misc';
+import { nullIfEmpty } from 'src/utils/string';
 import { Point, transformPoints } from 'src/utils/transform';
 
 @Injectable()
@@ -177,7 +178,7 @@ export class PersonService extends BaseService {
   async create(auth: AuthDto, dto: PersonCreateDto): Promise<PersonResponseDto> {
     const person = await this.personRepository.create({
       ownerId: auth.user.id,
-      name: dto.name,
+      name: nullIfEmpty(dto.name),
       birthDate: dto.birthDate,
       isHidden: dto.isHidden,
       isFavorite: dto.isFavorite,
@@ -206,7 +207,7 @@ export class PersonService extends BaseService {
     const person = await this.personRepository.update({
       id,
       faceAssetId: faceId,
-      name,
+      name: nullIfEmpty(name),
       birthDate,
       isHidden,
       isFavorite,
@@ -251,8 +252,10 @@ export class PersonService extends BaseService {
   }
 
   @Chunked()
-  private async removeAllPeople(people: { id: string; thumbnailPath: string }[]) {
-    await Promise.all(people.map((person) => this.storageRepository.unlink(person.thumbnailPath)));
+  private async removeAllPeople(people: { id: string; thumbnailPath: string | null }[]) {
+    await Promise.all(
+      people.map((person) => (person.thumbnailPath ? this.storageRepository.unlink(person.thumbnailPath) : Promise.resolve())),
+    );
     await this.personRepository.delete(people.map((person) => person.id));
     this.logger.debug(`Deleted ${people.length} people`);
   }

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -238,7 +238,11 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.AuthUserV1;
     const upserts = this.syncRepository.authUser.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, profileImagePath, ...data } of upserts) {
-      send(response, { type: upsertType, ids: [updateId], data: { ...data, hasProfileImage: !!profileImagePath } });
+      send(response, {
+        type: upsertType,
+        ids: [updateId],
+        data: { ...data, name: data.name ?? data.email, oauthId: data.oauthId ?? '', hasProfileImage: !!profileImagePath },
+      });
     }
   }
 
@@ -252,7 +256,11 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.UserV1;
     const upserts = this.syncRepository.user.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, profileImagePath, ...data } of upserts) {
-      send(response, { type: upsertType, ids: [updateId], data: { ...data, hasProfileImage: !!profileImagePath } });
+      send(response, {
+        type: upsertType,
+        ids: [updateId],
+        data: { ...data, name: data.name ?? data.email, hasProfileImage: !!profileImagePath },
+      });
     }
   }
 
@@ -437,7 +445,11 @@ export class SyncService extends BaseService {
     const upserts = this.syncRepository.album.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
       const albumUsers = await this.syncRepository.album.getAlbumUsers(data.id);
-      send(response, { type: upsertType, ids: [updateId], data: syncAlbumV2ToV1(data, albumUsers) });
+      send(response, {
+        type: upsertType,
+        ids: [updateId],
+        data: syncAlbumV2ToV1({ ...data, description: data.description ?? '' }, albumUsers),
+      });
     }
   }
 
@@ -451,7 +463,7 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.AlbumV2;
     const upserts = this.syncRepository.album.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
-      send(response, { type: upsertType, ids: [updateId], data });
+      send(response, { type: upsertType, ids: [updateId], data: { ...data, description: data.description ?? '' } });
     }
   }
 
@@ -825,7 +837,7 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.PersonV1;
     const upserts = this.syncRepository.person.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
-      send(response, { type: upsertType, ids: [updateId], data });
+      send(response, { type: upsertType, ids: [updateId], data: { ...data, name: data.name ?? '' } });
     }
   }
 

--- a/server/src/services/user-admin.service.spec.ts
+++ b/server/src/services/user-admin.service.spec.ts
@@ -41,7 +41,7 @@ describe(UserAdminService.name, () => {
       await expect(
         sut.create({
           email: userStub.user1.email,
-          name: userStub.user1.name,
+          name: userStub.user1.name ?? userStub.user1.email,
           password: 'password',
           storageLabel: 'label',
         }),

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
+import { Updateable } from 'kysely';
 import { SALT_ROUNDS } from 'src/constants';
 import { AssetStatsDto, AssetStatsResponseDto, mapStats } from 'src/dtos/asset.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
@@ -15,9 +16,11 @@ import {
 } from 'src/dtos/user.dto';
 import { JobName, UserMetadataKey, UserStatus } from 'src/enum';
 import { UserFindOptions } from 'src/repositories/user.repository';
+import { UserTable } from 'src/schema/tables/user.table';
 import { BaseService } from 'src/services/base.service';
 import { getCalendarHeatmap } from 'src/services/shared/user-methods';
 import { getPreferences, getPreferencesPartial, mergePreferences } from 'src/utils/preferences';
+import { nullIfEmpty } from 'src/utils/string';
 
 @Injectable()
 export class UserAdminService extends BaseService {
@@ -90,7 +93,13 @@ export class UserAdminService extends BaseService {
       dto.storageLabel = null;
     }
 
-    const updatedUser = await this.userRepository.update(id, { ...dto, updatedAt: new Date() });
+    const update: Updateable<UserTable> = {
+      ...dto,
+      name: nullIfEmpty(dto.name),
+      updatedAt: new Date(),
+    };
+
+    const updatedUser = await this.userRepository.update(id, update);
 
     return mapUserAdmin(updatedUser);
   }

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -22,6 +22,7 @@ import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 import { getPreferences, getPreferencesPartial, mergePreferences } from 'src/utils/preferences';
 import { generateProfileImage } from 'src/utils/profile-image';
+import { nullIfEmpty } from 'src/utils/string';
 
 @Injectable()
 export class UserService extends BaseService {
@@ -63,7 +64,7 @@ export class UserService extends BaseService {
 
     const update: Updateable<UserTable> = {
       email: dto.email,
-      name: dto.name,
+      name: nullIfEmpty(dto.name),
       avatarColor: dto.avatarColor,
     };
 
@@ -127,17 +128,17 @@ export class UserService extends BaseService {
 
     return {
       userId: user.id,
-      profileImagePath: user.profileImagePath,
+      profileImagePath: user.profileImagePath ?? '',
       profileChangedAt: user.profileChangedAt,
     };
   }
 
   async deleteProfileImage(auth: AuthDto): Promise<void> {
     const user = await this.findOrFail(auth.user.id, { withDeleted: false });
-    if (user.profileImagePath === '') {
+    if (!user.profileImagePath) {
       throw new BadRequestException("Can't delete a missing profile Image");
     }
-    await this.userRepository.update(auth.user.id, { profileImagePath: '', profileChangedAt: new Date() });
+    await this.userRepository.update(auth.user.id, { profileImagePath: null, profileChangedAt: new Date() });
     await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [user.profileImagePath] } });
   }
 

--- a/server/src/utils/request.ts
+++ b/server/src/utils/request.ts
@@ -18,8 +18,8 @@ export const getUserAgentDetails = (headers: IncomingHttpHeaders) => {
   const appVersion = getAppVersionFromUA(headers['user-agent'] ?? '');
 
   return {
-    deviceType: userAgent.browser.name || userAgent.device.type || (headers['devicemodel'] as string) || '',
-    deviceOS: userAgent.os.name || (headers['devicetype'] as string) || '',
+    deviceType: userAgent.browser.name || userAgent.device.type || (headers['devicemodel'] as string) || null,
+    deviceOS: userAgent.os.name || (headers['devicetype'] as string) || null,
     appVersion,
   };
 };

--- a/server/src/utils/string.ts
+++ b/server/src/utils/string.ts
@@ -1,0 +1,13 @@
+export function nullIfEmpty(value: string): string | null;
+export function nullIfEmpty(value: string | undefined): string | null | undefined;
+export function nullIfEmpty(value: string | null | undefined): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null || value === '') {
+    return null;
+  }
+
+  return value;
+}

--- a/server/test/factories/auth.factory.ts
+++ b/server/test/factories/auth.factory.ts
@@ -46,7 +46,7 @@ export class AuthFactory {
       user: {
         id,
         isAdmin,
-        name,
+        name: name ?? email,
         email,
         quotaUsageInBytes,
         quotaSizeInBytes,

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -274,7 +274,7 @@ export class MediumTestContext<S extends BaseService = BaseService> {
       session,
       user: {
         id: user.id,
-        name: user.name,
+        name: user.name ?? user.email,
         email: user.email,
       },
     });
@@ -778,8 +778,8 @@ const loginResponse = (): LoginResponseDto => {
     accessToken: 'access-token',
     userId: user.id,
     userEmail: user.email,
-    name: user.name,
-    profileImagePath: user.profileImagePath,
+    name: user.name ?? user.email,
+    profileImagePath: user.profileImagePath ?? '',
     isAdmin: user.isAdmin,
     shouldChangePassword: user.shouldChangePassword,
     isOnboarded: false,

--- a/server/test/medium/specs/services/auth-admin.service.spec.ts
+++ b/server/test/medium/specs/services/auth-admin.service.spec.ts
@@ -31,7 +31,7 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
 
@@ -43,7 +43,7 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
 
@@ -56,10 +56,10 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user1.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
       await expect(userRepo.get(user2.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
   });

--- a/server/test/medium/specs/services/shared-link.service.spec.ts
+++ b/server/test/medium/specs/services/shared-link.service.spec.ts
@@ -90,7 +90,7 @@ describe(SharedLinkService.name, () => {
       assetIds: assets.map(({ asset }) => asset.id),
     });
 
-    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toMatchObject({
+    await expect(sut.getMine(factory.auth({ user, sharedLink }), [])).resolves.toMatchObject({
       assets: assets.map(({ asset }) => expect.objectContaining({ id: asset.id })),
     });
   });
@@ -614,7 +614,7 @@ describe(SharedLinkService.name, () => {
       assetIds: [asset.id],
     });
 
-    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toMatchObject({
+    await expect(sut.getMine(factory.auth({ user, sharedLink }), [])).resolves.toMatchObject({
       assets: [expect.objectContaining({ id: asset.id })],
     });
 
@@ -622,6 +622,6 @@ describe(SharedLinkService.name, () => {
       assetIds: [asset.id],
     });
 
-    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toHaveProperty('assets', []);
+    await expect(sut.getMine(factory.auth({ user, sharedLink }), [])).resolves.toHaveProperty('assets', []);
   });
 });

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -88,17 +88,17 @@ const authApiKeyFactory = (apiKey: Partial<AuthApiKey> = {}) => ({
   ...apiKey,
 });
 
-const authUserFactory = (authUser: Partial<AuthUser> = {}) => {
+const authUserFactory = (authUser: Partial<UserAdmin> = {}) => {
   const {
     id = newUuid(),
     isAdmin = false,
-    name = 'Test User',
+    name: rawName = 'Test User',
     email = 'test@immich.cloud',
     quotaUsageInBytes = 0,
     quotaSizeInBytes = null,
   } = authUser;
 
-  return { id, isAdmin, name, email, quotaUsageInBytes, quotaSizeInBytes };
+  return { id, isAdmin, name: rawName ?? email, email, quotaUsageInBytes, quotaSizeInBytes };
 };
 
 const queueStatisticsFactory = (dto?: Partial<QueueStatisticsDto>) => ({


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Immich previously stored empty strings ('') in several optional string columns. This change makes the database and API write paths store NULL instead.

Schema: 10 columns are now nullable with default: null:
  user: password, profileImagePath, oauthId, name
  person: name, thumbnailPath
  session: deviceType, deviceOS
  album: description
  asset_exif: description

Migration: 1783220786880-PreferNullOverEmptyStrings backfills existing '' → NULL, drops NOT NULL, and sets default to NULL.

Write paths: Normalized via nullIfEmpty() and targeted fixes (OAuth unlink, EXIF metadata extraction, session user-agent parsing, album/person/user/asset updates, etc.) so new writes no longer persist ''.

API responses / sync: Unchanged for backward compatibility — mappers still coerce null to sensible defaults (e.g. name ?? email, description ?? '') on read. This PR addresses storage, not response shape.

Fixes #28832  (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

 cd server && pnpm run check (TypeScript)
 pnpm test src/services/auth.service.spec.ts src/services/person.service.spec.ts src/services/user-admin.service.spec.ts src/services/metadata.service.spec.ts src/services/media.service.spec.ts
 pnpm run build && pnpm run migrations:run && pnpm run migrations:generate → migration applies; no schema drift (No changes detected)
 Manual DB check: no remaining '' in affected user columns after migration

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [✔] I have carefully read CONTRIBUTING.md
- [✔] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [✔] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
