### PR TITLE
fix(server): recover facial recognition job from concurrent person merge/delete

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -4,6 +4,7 @@ import { mapFaces, mapPerson } from 'src/dtos/person.dto';
 import { AssetFileType, CacheControl, JobName, JobStatus, SourceType, SystemMetadataKey } from 'src/enum';
 import { FaceSearchResult } from 'src/repositories/search.repository';
 import { PersonService } from 'src/services/person.service';
+import { ASSET_FACE_PERSON_FKEY_CONSTRAINT } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
 import { AssetFaceFactory } from 'test/factories/asset-face.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
@@ -1041,6 +1042,47 @@ describe(PersonService.name, () => {
       expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
         faceIds: expect.not.arrayContaining([face.id]),
         newPersonId: primaryFace.person!.id,
+      });
+    });
+
+    it('should create a new person if the matched person was concurrently merged/deleted', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson1, primaryFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+
+      const faces = [
+        { ...noPerson1, distance: 0 },
+        { ...primaryFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+
+      const newPerson = PersonFactory.create();
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+      mocks.person.reassignFaces.mockRejectedValueOnce(
+        Object.assign(new Error('violates foreign key constraint'), {
+          constraint_name: ASSET_FACE_PERSON_FKEY_CONSTRAINT,
+        }),
+      );
+      mocks.person.create.mockResolvedValue(newPerson);
+
+      await sut.handleRecognizeFaces({ id: noPerson1.id });
+
+      expect(mocks.person.create).toHaveBeenCalledWith({
+        ownerId: asset.ownerId,
+        faceAssetId: noPerson1.id,
+      });
+      expect(mocks.person.reassignFaces).toHaveBeenCalledTimes(2);
+      expect(mocks.person.reassignFaces).toHaveBeenNthCalledWith(1, {
+        faceIds: [noPerson1.id],
+        newPersonId: primaryFace.person!.id,
+      });
+      expect(mocks.person.reassignFaces).toHaveBeenNthCalledWith(2, {
+        faceIds: [noPerson1.id],
+        newPersonId: newPerson.id,
       });
     });
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -41,6 +41,7 @@ import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { BaseService } from 'src/services/base.service';
 import { JobItem, JobOf } from 'src/types';
 import { getDimensions } from 'src/utils/asset.util';
+import { isAssetFacePersonFkeyConstraint } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 import { isFacialRecognitionEnabled } from 'src/utils/misc';
@@ -534,7 +535,19 @@ export class PersonService extends BaseService {
 
     if (personId) {
       this.logger.debug(`Assigning face ${id} to person ${personId}`);
-      await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
+      try {
+        await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
+      } catch (error: unknown) {
+        if (!isAssetFacePersonFkeyConstraint(error)) {
+          throw error;
+        }
+
+        // the matched person was merged/deleted concurrently; fall back to a new person for this face
+        this.logger.warn(`Person ${personId} no longer exists, creating new person for face ${id}`);
+        const newPerson = await this.personRepository.create({ ownerId: face.asset.ownerId, faceAssetId: face.id });
+        await this.jobRepository.queue({ name: JobName.PersonGenerateThumbnail, data: { id: newPerson.id } });
+        await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: newPerson.id });
+      }
     }
 
     return JobStatus.Success;

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -72,12 +72,16 @@ export const removeUndefinedKeys = <T extends object>(update: T, template: unkno
 
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
 export const VIDEO_STREAM_SESSION_PK_CONSTRAINT = 'video_stream_session_pkey';
+export const ASSET_FACE_PERSON_FKEY_CONSTRAINT = 'asset_face_personId_fkey';
 
 export const isAssetChecksumConstraint = (error: unknown) =>
   (error as PostgresError)?.constraint_name === ASSET_CHECKSUM_CONSTRAINT;
 
 export const isVideoStreamSessionPkConstraint = (error: unknown) =>
   (error as PostgresError)?.constraint_name === VIDEO_STREAM_SESSION_PK_CONSTRAINT;
+
+export const isAssetFacePersonFkeyConstraint = (error: unknown) =>
+  (error as PostgresError)?.constraint_name === ASSET_FACE_PERSON_FKEY_CONSTRAINT;
 
 export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'asset', O>) {
   return qb.where('asset.visibility', 'in', [sql.lit(AssetVisibility.Archive), sql.lit(AssetVisibility.Timeline)]);


### PR DESCRIPTION
## Description

`handleRecognizeFaces` (`server/src/services/person.service.ts`) resolves a matching `personId` for a face via an embedding similarity search, then later writes that `personId` to `asset_face` in a separate, unguarded `UPDATE` statement (`personRepository.reassignFaces`). This read-then-write is not wrapped in a transaction and takes no lock, and neither does the person-merge flow (`mergePerson`, same file).

If a concurrent `mergePerson` call deletes the matched person in the window between the recognition job's read and write (e.g. an admin merging people via the UI while a large-library facial-recognition scan is still running), the later `UPDATE asset_face SET personId = ...` violates the `asset_face_personId_fkey` foreign key constraint and the job fails outright:

```
PostgresError: insert or update on table "asset_face" violates foreign key constraint "asset_face_personId_fkey"
detail: Key (personId)=(...) is not present in table "person".
```

No data corruption occurs, but the job for that face fails and the face is left unassigned until it's reprocessed on a later run.

This PR catches that specific foreign key violation in `handleRecognizeFaces` and falls back to creating a new person for the face, instead of letting the job crash.

Fixes #29587

## How Has This Been Tested?

Added a unit test to `person.service.spec.ts` that mocks `reassignFaces` to reject once with a Postgres error carrying the `asset_face_personId_fkey` constraint name (simulating the concurrent merge/delete), and asserts the job recovers by creating a new person and reassigning the face to it.

- [x] `pnpm --filter immich run typecheck` passes
- [x] `pnpm --filter immich run lint` passes on changed files
- [x] Full `person.service.spec.ts` suite passes (74/74, including the new test)

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was written by an LLM (Claude), based on a race condition diagnosed from production server logs and confirmed by directly reading the relevant source (`person.service.ts`, `person.repository.ts`, `search.repository.ts`, `asset-face.table.ts`). The fix, its test, typecheck, and lint were all run and verified locally before opening this PR. A human reviewed and directed the investigation and the fix approach.