### PR TITLE
fix(server/workflow): add trigger for external libraries AssetCreate

### DIFF
--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -42,7 +42,7 @@ type EventMap = {
   AlbumInvite: [{ id: string; userId: string; senderName: string }];
 
   // asset events
-  AssetCreate: [{ asset: Asset; file: UploadFile }];
+  AssetCreate: [{ asset: Pick<Asset, 'id' | 'ownerId'>; file?: UploadFile }];
   AssetTag: [{ assetId: string }];
   AssetUntag: [{ assetId: string }];
   AssetHide: [{ assetId: string; userId: string }];

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -576,6 +576,10 @@ describe(LibraryService.name, () => {
         }),
       ]);
 
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', {
+        asset: { id: asset.id, ownerId: library.ownerId },
+      });
+
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.SidecarCheck,

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -275,6 +275,10 @@ export class LibraryService extends BaseService {
 
     this.logger.log(`Imported ${assetIds.length} ${progressMessage} file(s) into library ${job.libraryId}`);
 
+    await Promise.all(
+      assetIds.map((assetId) => this.eventRepository.emit('AssetCreate', { asset: { id: assetId, ownerId: library.ownerId } })),
+    );
+
     await this.queuePostSyncJobs(assetIds);
 
     return JobStatus.Success;

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -276,7 +276,9 @@ export class LibraryService extends BaseService {
     this.logger.log(`Imported ${assetIds.length} ${progressMessage} file(s) into library ${job.libraryId}`);
 
     await Promise.all(
-      assetIds.map((assetId) => this.eventRepository.emit('AssetCreate', { asset: { id: assetId, ownerId: library.ownerId } })),
+      assetIds.map((assetId) =>
+        this.eventRepository.emit('AssetCreate', { asset: { id: assetId, ownerId: library.ownerId } }),
+      ),
     );
 
     await this.queuePostSyncJobs(assetIds);

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -239,7 +239,9 @@ export class UserService extends BaseService {
 
   @OnEvent({ name: 'AssetCreate' })
   async onAssetCreate({ asset, file }: ArgOf<'AssetCreate'>) {
-    await this.userRepository.updateUsage(asset.ownerId, file.size);
+    if (file) {
+      await this.userRepository.updateUsage(asset.ownerId, file.size);
+    }
   }
 
   @OnJob({ name: JobName.UserSyncUsage, queue: QueueName.BackgroundTask })


### PR DESCRIPTION
## Description
Currently the new workflow system only triggers for new file uploads but not for new files in external libraries. As per my understanding and discussion on discord. AssetCreate should trigger for both. This PR fixes it.

## How Has This Been Tested?
- [X] Add an asset to an external library, habe some action getting executed (add to album in my case)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
As the workflow system is new for me, have it explained to me. The dev environment did not work for me in the first place. Had an LLM help to fix mise stuff.
