### PR TITLE
fix(web): missing i18n strings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2150,6 +2150,7 @@
   "unknown": "Unknown",
   "unknown_country": "Unknown Country",
   "unknown_date": "Unknown date",
+  "unknown_schema": "Unknown schema",
   "unknown_year": "Unknown Year",
   "unlimited": "Unlimited",
   "unlink_motion_video": "Unlink motion video",

--- a/web/src/lib/components/SchemaConfiguration.svelte
+++ b/web/src/lib/components/SchemaConfiguration.svelte
@@ -107,6 +107,6 @@
     <Input bind:value={() => getValue<string>(), setValue} />
   </Field>
 {:else}
-  <Text>Unknown schema</Text>
+  <Text>{$t('unknown_schema')}</Text>
   <CodeBlock code={JSON.stringify(schema, null, 2)} />
 {/if}

--- a/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/LargeAssetData.svelte
+++ b/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/LargeAssetData.svelte
@@ -3,6 +3,7 @@
   import { getFileSize } from '$lib/utils/asset-utils';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
   import { type AssetResponseDto } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
 
   interface Props {
     asset: AssetResponseDto;
@@ -25,7 +26,9 @@
     <Thumbnail asset={toTimelineAsset(asset)} readonly onClick={() => onViewAsset(asset)} thumbnailSize={boxWidth} />
 
     {#if !!asset.libraryId}
-      <div class="absolute inset-e-3 bottom-1 rounded-xl bg-red-500 px-4 py-1 text-xs transition-colors">External</div>
+      <div class="absolute inset-e-3 bottom-1 rounded-xl bg-red-500 px-4 py-1 text-xs transition-colors">
+        {$t('external')}
+      </div>
     {/if}
   </div>
   <div class="mt-4 truncate px-4 text-center text-sm font-normal" title={asset.originalFileName}>


### PR DESCRIPTION
## Description

`SchemaConfiguration.svelte` and `LargeAssetData.svelte` had hardcoded English strings ("Unknown schema" and "External") instead of going through the existing svelte-i18n setup, so those strings could never be translated. This wraps both in `$t()` and adds the missing `unknown_schema` key to `i18n/en.json` (the `external` key already existed).

Fixes # (none — found while looking for i18n gaps, no existing issue)

## How Has This Been Tested?

- [x] `prettier --check i18n/en.json` passes
- [x] `prettier --check` on both edited `.svelte` files passes
- [x] Manually confirmed both translation keys resolve in `en.json`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — text-only i18n key swap, no visual change.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude Code) was used to find the two hardcoded strings via grep-based search across the codebase and to write the actual code changes (wrapping strings in `$t()`, adding the i18n key). All changes were reviewed by me before pushing.