### PR TITLE
feat(cli): Add --visibility flag to immich CLI upload subcommand

### DIFF
--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -99,6 +99,7 @@ Options:
   -H, --include-hidden        Include hidden folders (default: false, env: IMMICH_INCLUDE_HIDDEN)
   -a, --album                 Automatically create albums based on folder name (default: false, env: IMMICH_AUTO_CREATE_ALBUM)
   -A, --album-name <name>     Add all assets to specified album (env: IMMICH_ALBUM_NAME)
+  --visibility <visibility>   Set the visibility of uploaded assets (choices: "archive", "timeline", "hidden", "locked", env: IMMICH_VISIBILITY)
   -n, --dry-run               Don't perform any actions, just show what will be done (default: false, env: IMMICH_DRY_RUN)
   -c, --concurrency <number>  Number of assets to upload at the same time (default: 4, env: IMMICH_UPLOAD_CONCURRENCY)
   -j, --json-output           Output detailed information in json format (default: false, env: IMMICH_JSON_OUTPUT)
@@ -174,6 +175,12 @@ By default, hidden files are skipped. If you want to include hidden files, use t
 
 ```bash
 immich upload --include-hidden --recursive directory/
+```
+
+You can set the visibility of uploaded assets to `archive`, `timeline`, `hidden`, or `locked` with the `--visibility` option:
+
+```bash
+immich upload --visibility archive --recursive directory/
 ```
 
 You can use the `--json-output` option to get a json printed which includes

--- a/packages/cli/src/commands/asset.spec.ts
+++ b/packages/cli/src/commands/asset.spec.ts
@@ -80,20 +80,6 @@ describe('uploadFiles', () => {
     ]);
   });
 
-  it('uploads assets with the specified visibility', async () => {
-    fetchMocker.doMockIf(new RegExp(`${baseUrl}/assets$`), function () {
-      return {
-        status: 200,
-        body: JSON.stringify({ id: 'fc5621b1-86f6-44a1-9905-403e607df9f5', status: 'created' }),
-      };
-    });
-
-    await uploadFiles([testFilePath], { concurrency: 1, visibility: AssetVisibility.Hidden });
-
-    const formData = fetchMocker.mock.calls[0]?.[1]?.body as FormData;
-    expect(formData.get('visibility')).toBe('hidden');
-  });
-
   it('returns new assets when upload file retry is successful', async () => {
     let counter = 0;
     fetchMocker.doMockIf(new RegExp(`${baseUrl}/assets$`), function () {
@@ -122,6 +108,20 @@ describe('uploadFiles', () => {
     });
 
     await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual([]);
+  });
+
+  it('uploads assets with the specified visibility', async () => {
+    fetchMocker.doMockIf(new RegExp(`${baseUrl}/assets$`), function () {
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 'fc5621b1-86f6-44a1-9905-403e607df9f5', status: 'created' }),
+      };
+    });
+
+    await uploadFiles([testFilePath], { concurrency: 1, visibility: AssetVisibility.Hidden });
+
+    const formData = fetchMocker.mock.calls[0]?.[1]?.body as FormData;
+    expect(formData.get('visibility')).toBe('hidden');
   });
 });
 

--- a/packages/cli/src/commands/asset.spec.ts
+++ b/packages/cli/src/commands/asset.spec.ts
@@ -4,7 +4,14 @@ import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { describe, expect, it, MockedFunction, vi } from 'vitest';
 
-import { AssetRejectReason, AssetUploadAction, checkBulkUpload, defaults, getSupportedMediaTypes } from '@immich/sdk';
+import {
+  AssetRejectReason,
+  AssetUploadAction,
+  AssetVisibility,
+  checkBulkUpload,
+  defaults,
+  getSupportedMediaTypes,
+} from '@immich/sdk';
 import createFetchMock from 'vitest-fetch-mock';
 
 import {
@@ -71,6 +78,20 @@ describe('uploadFiles', () => {
         id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
       },
     ]);
+  });
+
+  it('uploads assets with the specified visibility', async () => {
+    fetchMocker.doMockIf(new RegExp(`${baseUrl}/assets$`), function () {
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 'fc5621b1-86f6-44a1-9905-403e607df9f5', status: 'created' }),
+      };
+    });
+
+    await uploadFiles([testFilePath], { concurrency: 1, visibility: AssetVisibility.Hidden });
+
+    const formData = fetchMocker.mock.calls[0]?.[1]?.body as FormData;
+    expect(formData.get('visibility')).toBe('hidden');
   });
 
   it('returns new assets when upload file retry is successful', async () => {

--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -48,10 +48,6 @@ export interface UploadOptionsDto {
   jsonOutput?: boolean;
 }
 
-interface UploadFileDto {
-  visibility?: AssetVisibility;
-}
-
 class UploadFile extends File {
   constructor(
     private filepath: string,
@@ -407,7 +403,7 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
 const uploadFile = async (
   input: string,
   stats: Stats,
-  { visibility }: UploadFileDto,
+  { visibility }: UploadOptionsDto,
 ): Promise<AssetMediaResponseDto> => {
   const { baseUrl, headers } = defaults;
 

--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -404,7 +404,11 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
   return newAssets;
 };
 
-const uploadFile = async (input: string, stats: Stats, { visibility }: UploadFileDto): Promise<AssetMediaResponseDto> => {
+const uploadFile = async (
+  input: string,
+  stats: Stats,
+  { visibility }: UploadFileDto,
+): Promise<AssetMediaResponseDto> => {
   const { baseUrl, headers } = defaults;
 
   const formData = new FormData();

--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -4,6 +4,7 @@ import {
   AssetMediaResponseDto,
   AssetMediaStatus,
   AssetUploadAction,
+  AssetVisibility,
   Permission,
   addAssetsToAlbum,
   checkBulkUpload,
@@ -39,11 +40,16 @@ export interface UploadOptionsDto {
   deleteDuplicates?: boolean;
   album?: boolean;
   albumName?: string;
+  visibility?: AssetVisibility;
   includeHidden?: boolean;
   concurrency: number;
   progress?: boolean;
   watch?: boolean;
   jsonOutput?: boolean;
+}
+
+interface UploadFileDto {
+  visibility?: AssetVisibility;
 }
 
 class UploadFile extends File {
@@ -306,10 +312,8 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
   return { newFiles, duplicates };
 };
 
-export const uploadFiles = async (
-  files: string[],
-  { dryRun, concurrency, progress }: UploadOptionsDto,
-): Promise<Asset[]> => {
+export const uploadFiles = async (files: string[], options: UploadOptionsDto): Promise<Asset[]> => {
+  const { dryRun, concurrency, progress } = options;
   if (files.length === 0) {
     console.log('All assets were already uploaded, nothing to do.');
     return [];
@@ -358,7 +362,7 @@ export const uploadFiles = async (
         throw new Error(`Stats not found for ${filepath}`);
       }
 
-      const response = await uploadFile(filepath, stats);
+      const response = await uploadFile(filepath, stats, options);
       newAssets.push({ id: response.id, filepath });
       if (response.status === AssetMediaStatus.Duplicate) {
         duplicateCount++;
@@ -400,7 +404,7 @@ export const uploadFiles = async (
   return newAssets;
 };
 
-const uploadFile = async (input: string, stats: Stats): Promise<AssetMediaResponseDto> => {
+const uploadFile = async (input: string, stats: Stats, { visibility }: UploadFileDto): Promise<AssetMediaResponseDto> => {
   const { baseUrl, headers } = defaults;
 
   const formData = new FormData();
@@ -409,6 +413,9 @@ const uploadFile = async (input: string, stats: Stats): Promise<AssetMediaRespon
   formData.append('fileSize', String(stats.size));
   formData.append('isFavorite', 'false');
   formData.append('assetData', new UploadFile(input, stats.size));
+  if (visibility) {
+    formData.append('visibility', visibility);
+  }
 
   const sidecarPath = findSidecar(input);
   if (sidecarPath) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+import { AssetVisibility } from '@immich/sdk';
 import { Command, Option } from 'commander';
 import os from 'node:os';
 import path from 'node:path';
@@ -57,6 +58,11 @@ program
     new Option('-A, --album-name <name>', 'Add all assets to specified album')
       .env('IMMICH_ALBUM_NAME')
       .conflicts('album'),
+  )
+  .addOption(
+    new Option('--visibility <visibility>', 'Set the visibility of uploaded assets')
+      .choices(Object.values(AssetVisibility))
+      .env('IMMICH_VISIBILITY'),
   )
   .addOption(
     new Option('-n, --dry-run', "Don't perform any actions, just show what will be done")


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds `--visibility` flag to Immich CLI's `upload` subcommand, such that assets being uploaded can be associated with the given visibility automatically.

This would be useful in cases where users would like to watch for a directory of photos and automatically upload them as archived assets, for example.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] `pnpm --filter @immich/cli test --run src/commands/asset.spec.ts`

e2e test with my selfhosted instance:

```
$ pnpm --pm-on-fail=ignore --filter @immich/cli build
$ IMMICH_INSTANCE_URL=<my-host-url> IMMICH_API_KEY=<my-key> node packages/cli/dist/index.js upload \
    --visibility archive \
    --recursive ~/Desktop/test
```

Then the image is properly uploaded and marked as archived.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used codex to generate the initial draft, then human reviewed and applied tweaks.
