### PR TITLE
fix(server): use frsize instead of bsize for disk usage

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -211,10 +211,16 @@ export class StorageRepository {
 
   async checkDiskUsage(folder: string): Promise<DiskUsage> {
     const stats = await fs.statfs(folder);
+    // `blocks`/`bfree`/`bavail` are counts of `frsize` (fundamental block size),
+    // not `bsize` (preferred I/O size). Equal on native filesystems, but they
+    // diverge on FUSE mounts (Docker Desktop VirtioFS, OrbStack), where using
+    // `bsize` overstates capacity (often ~32x). `frsize` is exposed since Node 24
+    // (nodejs/node#62277); fall back to `bsize` on older runtimes.
+    const blockSize = stats.frsize || stats.bsize;
     return {
-      available: stats.bavail * stats.bsize,
-      free: stats.bfree * stats.bsize,
-      total: stats.blocks * stats.bsize,
+      available: stats.bavail * blockSize,
+      free: stats.bfree * blockSize,
+      total: stats.blocks * blockSize,
     };
   }
 


### PR DESCRIPTION
## Description

`StorageRepository.checkDiskUsage` computes totals as `stats.blocks * stats.bsize`. Per POSIX, the block counts returned by `statfs` (`blocks`/`bfree`/`bavail`) are in units of the **fundamental** block size (`frsize`), not the preferred I/O block size (`bsize`). On native Linux filesystems `bsize === frsize` so this is invisible — but on FUSE-backed mounts (Docker Desktop VirtioFS, OrbStack, colima virtiofs) they diverge, and multiplying by `bsize` overstates capacity, commonly by ~32× (e.g. a 16 TiB drive reported as ~524 TiB, ~31 TiB "used").

This uses `frsize` with a `bsize` fallback. `frsize` is exposed by `fs.statfs` since **Node 24** (nodejs/node#62277), which Immich already targets (`@types/node ^24`); the `|| stats.bsize` fallback keeps behavior identical on native filesystems and on older runtimes.

This is a fresh take on #27374 / #27375 (thanks @juicecultus), which were closed in favor of fixing it upstream in Node first — that has since merged (nodejs/node#62277), so the server-side change is now clean.

## How Has This Been Tested?

- [x] Reproduced on a colima virtiofs-over-HFS+ mount where `stat -f` reports `f_bsize`=1048576 (1 MiB) and `f_frsize`=32768 (32 KiB): the current `blocks * bsize` yields ~32× the real size (matching the wrong figure Immich showed); multiplying by `frsize` yields the correct total, equal to `df`.
- Not run against a patched build — this is a minimal arithmetic correction with a no-op fallback on native filesystems (`bsize === frsize`).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. An LLM (Claude) located the code, wrote the one-line fix, and drafted this description. The change is a small, well-understood arithmetic correction and was reviewed before submission.
