### PR TITLE
fix: oauth account linking

### DIFF
--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -426,7 +426,7 @@ export class AuthService extends BaseService {
       throw new BadRequestException('This OAuth account has already been linked to another user.');
     }
 
-    if (auth.session) {
+    if (auth.session && sid) {
       await this.sessionRepository.update(auth.session.id, { oauthSid: sid });
     }
 


### PR DESCRIPTION
`sid` can be `undefined` if the IDP does not support it (or the claim has not been requested), which results in passing `{ sid: undefined }` to the query, which in turn is an update with `{ }` which does not work.

Fixes #29498