### PR TITLE
chore: keep selection state after sharing action

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
@@ -159,8 +159,6 @@ class ShareActionButton extends ConsumerWidget {
                 return;
               }
 
-              ref.read(multiSelectProvider.notifier).reset();
-
               if (!result.success) {
                 ImmichToast.show(
                   context: context,
@@ -173,7 +171,6 @@ class ShareActionButton extends ConsumerWidget {
               buildContext.pop();
             });
 
-        // Show download progress with a "Preparing" message
         return preparingDialog;
       },
       barrierDismissible: false,


### PR DESCRIPTION
Keep the current selection state after finish sharing, so that the users can choose to continue to share those assets unless explicitly exit from the selection state.
