### PR TITLE
fix(mobile): disable broken Xcode queue debugging

### DIFF
--- a/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -70,7 +70,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       enableGPUValidationMode = "1"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      queueDebuggingEnabled = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference


### PR DESCRIPTION
Building for devices running iOS 27 betas sometimes crashes immediately on startup with an error of the form:

```
  objc[14354]: -[OS_dispatch_mach_msg _setContext:]: unrecognized selector sent to instance 0x107a44f80 (no message forward handler is installed)
  -[OS_dispatch_mach_msg _setContext:]: unrecognized selector sent to instance 0x107a44f80 (no message forward handler is installed)
```

This is caused by the `queueDebuggingEnableBacktraceRecording` setting in the build scheme. Disable this for now, as it can be rather annoying to encounter, and we are unlikely to be using it.