### PR TITLE
fix(server,web): reject "/" in shared link custom URL slug

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -23019,6 +23019,7 @@
           "slug": {
             "description": "Custom URL slug",
             "nullable": true,
+            "pattern": "^[^/]*$",
             "type": "string"
           },
           "type": {
@@ -23065,6 +23066,7 @@
           "slug": {
             "description": "Custom URL slug",
             "nullable": true,
+            "pattern": "^[^/]*$",
             "type": "string"
           }
         },

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -4,7 +4,7 @@ import { HistoryBuilder } from 'src/decorators';
 import { AlbumResponseSchema, mapAlbum } from 'src/dtos/album.dto';
 import { AssetResponseSchema, mapAsset } from 'src/dtos/asset-response.dto';
 import { SharedLinkTypeSchema } from 'src/enum';
-import { isoDatetimeToDate } from 'src/validation';
+import { isoDatetimeToDate, slugRegex } from 'src/validation';
 import z from 'zod';
 
 const SharedLinkSearchSchema = z
@@ -25,7 +25,12 @@ const SharedLinkCreateSchema = z
     albumId: z.uuidv4().optional().describe('Album ID (for album sharing)'),
     description: z.string().nullable().optional().describe('Link description'),
     password: z.string().nullable().optional().describe('Link password'),
-    slug: z.string().nullable().optional().describe('Custom URL slug'),
+    slug: z
+      .string()
+      .regex(slugRegex, 'Custom URL must not contain "/"')
+      .nullable()
+      .optional()
+      .describe('Custom URL slug'),
     expiresAt: isoDatetimeToDate.nullable().describe('Expiration date').default(null).optional(),
     allowUpload: z.boolean().optional().describe('Allow uploads'),
     allowDownload: z.boolean().default(true).optional().describe('Allow downloads'),
@@ -37,7 +42,12 @@ const SharedLinkEditSchema = z
   .object({
     description: z.string().nullable().optional().describe('Link description'),
     password: z.string().nullable().optional().describe('Link password'),
-    slug: z.string().nullable().optional().describe('Custom URL slug'),
+    slug: z
+      .string()
+      .regex(slugRegex, 'Custom URL must not contain "/"')
+      .nullable()
+      .optional()
+      .describe('Custom URL slug'),
     expiresAt: isoDatetimeToDate.nullish().describe('Expiration date'),
     allowUpload: z.boolean().optional().describe('Allow uploads'),
     allowDownload: z.boolean().optional().describe('Allow downloads'),

--- a/server/src/validation.spec.ts
+++ b/server/src/validation.spec.ts
@@ -1,8 +1,25 @@
-import { IsNotSiblingOf } from 'src/validation';
+import { IsNotSiblingOf, slugRegex } from 'src/validation';
 import { describe, expect, it } from 'vitest';
 import z from 'zod';
 
 describe('Validation', () => {
+  describe('slugRegex', () => {
+    const SlugSchema = z.object({ slug: z.string().regex(slugRegex) });
+
+    it('passes for a plain slug', () => {
+      expect(SlugSchema.safeParse({ slug: 'my-custom-link' }).success).toBe(true);
+    });
+
+    it('passes for an empty string', () => {
+      expect(SlugSchema.safeParse({ slug: '' }).success).toBe(true);
+    });
+
+    it('fails for a slug containing a forward slash', () => {
+      expect(SlugSchema.safeParse({ slug: '/my-custom-link' }).success).toBe(false);
+      expect(SlugSchema.safeParse({ slug: 'my/custom/link' }).success).toBe(false);
+    });
+  });
+
   describe('IsNotSiblingOf', () => {
     const MySchemaBase = z.object({
       attribute1: z.string().optional(),

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -255,3 +255,9 @@ export const hexColor = z
   .transform((val) => (val.startsWith('#') ? val : `#${val}`));
 
 export const sanitizeFilename = z.string().transform((val) => sanitize(val.replaceAll('.', '')));
+
+/**
+ * URL slug validation - must not contain "/" since a slug is used as a single path segment
+ * (e.g. a shared link's custom URL). Allowing "/" would break routing.
+ */
+export const slugRegex = /^[^/]*$/;

--- a/web/src/lib/components/SharedLinkFormFields.spec.ts
+++ b/web/src/lib/components/SharedLinkFormFields.spec.ts
@@ -29,4 +29,22 @@ describe('SharedLinkFormFields component', () => {
     expect(isChecked(showMetadataSwitch)).toBe(false);
     expect(isChecked(allowDownloadSwitch)).toBe(false);
   });
+
+  it('strips forward slashes from the custom URL field', async () => {
+    const { container } = renderWithTooltips(SharedLinkFormFields, {
+      slug: '',
+      password: '',
+      description: '',
+      allowDownload: true,
+      allowUpload: false,
+      showMetadata: true,
+      expiresAt: null,
+    });
+    const user = userEvent.setup();
+
+    const input = container.querySelector('input[type="text"], input:not([type])') as HTMLInputElement;
+    await user.type(input, 'foo/bar');
+
+    expect(input.value).toBe('foobar');
+  });
 });

--- a/web/src/lib/components/SharedLinkFormFields.svelte
+++ b/web/src/lib/components/SharedLinkFormFields.svelte
@@ -33,7 +33,7 @@
 <div class="mt-4 flex flex-col gap-4">
   <div>
     <Field label={$t('custom_url')} description={$t('shared_link_custom_url_description')}>
-      <Input bind:value={slug} autocomplete="off" />
+      <Input bind:value={() => slug, (value) => (slug = value.replaceAll('/', ''))} autocomplete="off" />
     </Field>
     {#if slug}
       <Text size="tiny" color="muted" class="pt-2 break-all">/s/{encodeURIComponent(slug)}</Text>


### PR DESCRIPTION
## Description

A custom shared link URL (slug) that contains a forward slash breaks web routing, since the slug is used as a single path segment (`/s/<slug>`). A `/` in the value either 404s or gets misrouted into the route's other optional path segments.

This PR:
- Adds a reusable `slugRegex` (`/^[^/]*$/`) in `server/src/validation.ts`, following the same convention as other regex helpers in that file (e.g. `hexColor`, `FilenameParamSchema`).
- Applies `slugRegex` to the `slug` field in both `SharedLinkCreateSchema` and `SharedLinkEditSchema` in `server/src/dtos/shared-link.dto.ts`, so the API rejects any `/` in the custom URL with a clear error message.
- Updates `web/src/lib/components/SharedLinkFormFields.svelte` so the custom URL input strips `/` as the user types, preventing the invalid value from being entered in the first place.
- Regenerates `open-api/immich-openapi-specs.json` to reflect the new `pattern` constraint on the `slug` field.

Fixes #29569

## How Has This Been Tested?

- [x] Added `server/src/validation.spec.ts` cases for `slugRegex` (plain slug, empty string, slug containing `/`)
- [x] Added `web/src/lib/components/SharedLinkFormFields.spec.ts` case verifying `/` is stripped from the input as typed
- [x] Ran `vitest` for `shared-link.service.spec.ts` and `shared-link.controller.spec.ts` (31 existing tests, all pass)
- [x] `tsc --noEmit` clean for touched server files
- [x] `eslint` and `prettier --check` clean for touched files
- [x] `svelte-check` clean for touched web files

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI coding assistant (Claude Code) was used to help investigate the issue, implement parts of the fix, and write tests. All changes were reviewed, tested, and verified by me before submission.
