### PR TITLE
fix(mobile): send a full datetime from the android memories widget

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
@@ -14,6 +14,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 class ImmichAPI(cfg: ServerConfig) {
@@ -88,7 +89,8 @@ class ImmichAPI(cfg: ServerConfig) {
   }
 
   suspend fun fetchMemory(date: LocalDate): List<MemoryResult> = withContext(Dispatchers.IO) {
-    val iso8601 = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+    // server matches memories by the UTC day, so send noon UTC of the local day to land on the right day in every timezone
+    val iso8601 = date.atTime(12, 0).atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     val url = buildRequestURL("/memories", listOf("for" to iso8601))
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "GET"


### PR DESCRIPTION
## Description

the android memories widget asked the server with a date-only value (`for=2026-07-03`), but the 3.0 server now requires a full datetime, so it 400s and the widget just spins on "Loading Widget" forever.

now it sends noon utc of the local day (same as the ios widget in #29368), which is a valid datetime and also lands on the right day in every timezone.

fixes #29495

tested on a pixel 9a against a 3.0 server: before, the widget stuck on the spinner and the log showed a `FileNotFoundException` on the date-only url. after, it loads the memory. also checked the server directly, `for=2026-07-03` returns 400 and `for=2026-07-03T12:00:00.000Z` returns 200.
