### PR TITLE
chore: webhook headers ordering

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -151,13 +151,13 @@ const methods = wrapper<Manifest>({
   }),
 
   webhook: ({ config, data, functions, type, trigger }) => {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
+    const headers: Record<string, string> = {};
 
     if (config.headerName && config.headerValue) {
       headers[config.headerName] = config.headerValue;
     }
+
+    headers['Content-Type'] = 'application/json';
 
     functions.httpRequest(config.url, {
       method: config.method ?? 'POST',


### PR DESCRIPTION
Just a small tweak to stop people from overriding the Content-Type header