### PR TITLE
fix(web): always initialize language manager to set lang and dir

### DIFF
--- a/web/src/lib/managers/language-manager.svelte.ts
+++ b/web/src/lib/managers/language-manager.svelte.ts
@@ -5,11 +5,19 @@ import { langs } from '$lib/utils/i18n';
 class LanguageManager {
   constructor() {
     eventManager.on({
-      AppInit: () => lang.subscribe((lang) => this.setLanguage(lang)),
+      AppInit: () => this.init(),
     });
   }
 
+  initialized = $state(false);
   rtl = $state(false);
+
+  init() {
+    if (!this.initialized) {
+      this.initialized = true;
+      lang.subscribe((lang) => this.setLanguage(lang));
+    }
+  }
 
   setLanguage(code: string) {
     const item = langs.find((item) => item.code === code);

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -1,5 +1,6 @@
 import { commandPaletteManager } from '@immich/ui';
 import { goto } from '$app/navigation';
+import { languageManager } from '$lib/managers/language-manager.svelte';
 import { serverConfigManager } from '$lib/managers/server-config-manager.svelte';
 import { maintenanceCreateUrl, maintenanceReturnUrl, maintenanceShouldRedirect } from '$lib/utils/maintenance';
 import { init } from '$lib/utils/server';
@@ -23,6 +24,7 @@ export const load = (async ({ fetch, url }) => {
   }
 
   commandPaletteManager.enable();
+  languageManager.init();
 
   return {
     error,


### PR DESCRIPTION
## Description
The language manager is only constructed on its first import, meaning the `AppInit` event may have already happened if the language manager is not imported on the first loaded page. This can result in weird behavior, either when using an RTL language or when changing the language.

Related issue, at least partially: https://github.com/immich-app/immich/issues/27678#issuecomment-4900642531

### alternative implementation
We could also do away with the `on('AppInit')`  entirely, but maybe there's a reason for it.

---

I can't 100% reliably reproduce the issue, but it looks like this:

On main preview instance, after logging in and navigating straight to user settings, and setting language to an RTL language like arabic: notice the broken switches and the fact that the page direction is not actually RTL.

<img width="789" height="359" alt="image" src="https://github.com/user-attachments/assets/a8cb8c3f-d8ce-45c8-b263-cece4abef76e" />

