### PR TITLE
fix!: disallow forward slash in shared link slug

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -23019,6 +23019,7 @@
           "slug": {
             "description": "Custom URL slug",
             "nullable": true,
+            "pattern": "^[^\\/]*$",
             "type": "string"
           },
           "type": {
@@ -23065,6 +23066,7 @@
           "slug": {
             "description": "Custom URL slug",
             "nullable": true,
+            "pattern": "^[^\\/]*$",
             "type": "string"
           }
         },
@@ -23145,6 +23147,7 @@
           "slug": {
             "description": "Custom URL slug",
             "nullable": true,
+            "pattern": "^[^\\/]*$",
             "type": "string"
           },
           "type": {

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -18,6 +18,12 @@ const SharedLinkSearchSchema = z
   })
   .meta({ id: 'SharedLinkSearchDto' });
 
+const SharedLinkSlugSchema = z
+  .string()
+  .regex(/^[^\/]*$/, 'forward slash "/" is not allowed')
+  .nullable()
+  .describe('Custom URL slug');
+
 const SharedLinkCreateSchema = z
   .object({
     type: SharedLinkTypeSchema,
@@ -25,7 +31,7 @@ const SharedLinkCreateSchema = z
     albumId: z.uuidv4().optional().describe('Album ID (for album sharing)'),
     description: z.string().nullable().optional().describe('Link description'),
     password: z.string().nullable().optional().describe('Link password'),
-    slug: z.string().nullable().optional().describe('Custom URL slug'),
+    slug: SharedLinkSlugSchema.optional(),
     expiresAt: isoDatetimeToDate.nullable().describe('Expiration date').default(null).optional(),
     allowUpload: z.boolean().optional().describe('Allow uploads'),
     allowDownload: z.boolean().default(true).optional().describe('Allow downloads'),
@@ -37,7 +43,7 @@ const SharedLinkEditSchema = z
   .object({
     description: z.string().nullable().optional().describe('Link description'),
     password: z.string().nullable().optional().describe('Link password'),
-    slug: z.string().nullable().optional().describe('Custom URL slug'),
+    slug: SharedLinkSlugSchema.optional(),
     expiresAt: isoDatetimeToDate.nullish().describe('Expiration date'),
     allowUpload: z.boolean().optional().describe('Allow uploads'),
     allowDownload: z.boolean().optional().describe('Allow downloads'),
@@ -66,7 +72,7 @@ const SharedLinkResponseSchema = z
     allowUpload: z.boolean().describe('Allow uploads'),
     allowDownload: z.boolean().describe('Allow downloads'),
     showMetadata: z.boolean().describe('Show metadata'),
-    slug: z.string().nullable().describe('Custom URL slug'),
+    slug: SharedLinkSlugSchema,
   })
   .describe('Shared link response')
   .meta({ id: 'SharedLinkResponseDto' });

--- a/web/src/lib/components/SharedLinkFormFields.svelte
+++ b/web/src/lib/components/SharedLinkFormFields.svelte
@@ -32,8 +32,8 @@
 
 <div class="mt-4 flex flex-col gap-4">
   <div>
-    <Field label={$t('custom_url')} description={$t('shared_link_custom_url_description')}>
-      <Input bind:value={slug} autocomplete="off" />
+    <Field label={$t('custom_url')} description={$t('shared_link_custom_url_description')} invalid={slug.includes('/')}>
+      <Input bind:value={slug} pattern="[^\/]*" autocomplete="off" />
     </Field>
     {#if slug}
       <Text size="tiny" color="muted" class="pt-2 break-all">/s/{encodeURIComponent(slug)}</Text>


### PR DESCRIPTION
## Description
Disallow forward slashes in shared link slugs, because they are confusing.

Fixes #29569

## How Has This Been Tested?
- Server DTO and error message
- Web validation

## API Changes
The `SharedLink*Dto` DTOs now don't allow slugs like `/asdf`, `asdf/`, and `asdf/asdf`  anymore.

