### PR TITLE
fix(mobile): mark Live Photo motion part hidden on upload

### DIFF
--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -22,6 +22,7 @@ import 'package:immich_mobile/repositories/upload.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:logging/logging.dart';
+import 'package:openapi/api.dart' as api;
 import 'package:path/path.dart' as p;
 
 final backgroundUploadServiceProvider = Provider((ref) {
@@ -335,7 +336,7 @@ class BackgroundUploadService {
       return null;
     }
 
-    final fields = {'livePhotoVideoId': livePhotoVideoId};
+    final fields = {'livePhotoVideoId': livePhotoVideoId, 'visibility': api.AssetVisibility.hidden.value};
 
     final requiresWiFi = _shouldRequireWiFi(asset);
     final originalFileName = await _assetMediaRepository.getOriginalFilename(asset.id) ?? asset.name;

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -336,6 +336,7 @@ class BackgroundUploadService {
       return null;
     }
 
+    // Visibility hidden on upload to prevent the server from running regular jobs on the live photo asset
     final fields = {'livePhotoVideoId': livePhotoVideoId, 'visibility': api.AssetVisibility.hidden.value};
 
     final requiresWiFi = _shouldRequireWiFi(asset);

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/asset_metadata.model.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart' hide AssetVisibility;
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/network_capability_extensions.dart';
@@ -19,6 +19,7 @@ import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/repositories/upload.repository.dart';
 import 'package:logging/logging.dart';
+import 'package:openapi/api.dart';
 import 'package:path/path.dart' as p;
 import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
 
@@ -338,7 +339,7 @@ class ForegroundUploadService {
         final livePhotoResult = await _uploadRepository.uploadFile(
           file: livePhotoFile,
           originalFileName: livePhotoTitle,
-          fields: fields,
+          fields: {...fields, 'visibility': AssetVisibility.hidden.value},
           cancelToken: cancelToken,
           onProgress: onProgress != null
               ? (bytes, totalBytes) => onProgress(asset.localId!, livePhotoTitle, bytes, totalBytes)

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -339,6 +339,7 @@ class ForegroundUploadService {
         final livePhotoResult = await _uploadRepository.uploadFile(
           file: livePhotoFile,
           originalFileName: livePhotoTitle,
+          // Visibility hidden on upload to prevent the server from running regular jobs on the live photo asset
           fields: {...fields, 'visibility': AssetVisibility.hidden.value},
           cancelToken: cancelToken,
           onProgress: onProgress != null

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -140,6 +140,7 @@ void main() {
       expect(task, isNotNull);
       expect(task!.fields['filename'], equals('OriginalLivePhoto.HEIC'));
       expect(task.fields['livePhotoVideoId'], equals('video-id-123'));
+      expect(task.fields['visibility'], equals('hidden'));
       verify(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).called(1);
     });
 
@@ -333,6 +334,7 @@ void main() {
       expect(task, isNotNull);
       expect(task!.fields.containsKey('metadata'), isTrue);
       expect(task.fields['livePhotoVideoId'], equals('video-123'));
+      expect(task.fields['visibility'], equals('hidden'));
 
       final metadata = jsonDecode(task.fields['metadata']!) as List;
       expect(metadata, hasLength(1));


### PR DESCRIPTION
Between the motion upload and linking, the server sees an ordinary asset and queues all preview / thumbnail generation for it which goes stale post linking as the asset gets hidden. Fixes it by setting the visibility to motion part on upload from the mobile app which prevents any jobs from getting queued at all