### PR TITLE
fix(server): store null instead of empty string for person name

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -246,7 +246,7 @@ export type Person = {
   updatedAt: Date;
   updateId: string;
   isFavorite: boolean;
-  name: string;
+  name: string | null;
   birthDate: Date | null;
   color: string | null;
   faceAssetId: string | null;

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -14,7 +14,7 @@ import z from 'zod';
 
 const PersonCreateSchema = z
   .object({
-    name: z.string().optional().describe('Person name'),
+    name: z.string().nullish().transform((val) => (val === '' ? null : val)).describe('Person name'),
     birthDate: z
       .string()
       .meta({ format: 'date' })
@@ -61,7 +61,7 @@ const PersonSearchSchema = z
 export const PersonResponseSchema = z
   .object({
     id: z.uuidv4().describe('Person ID'),
-    name: z.string().describe('Person name'),
+    name: z.string().nullable().describe('Person name'),
     // TODO: use `isoDateToDate` when using `ZodSerializerDto` on the controllers.
     birthDate: z.string().meta({ format: 'date' }).describe('Person date of birth').nullable(),
     thumbnailPath: z.string().describe('Thumbnail path'),

--- a/server/src/schema/migrations/1783430865849-ConvertPersonNameEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1783430865849-ConvertPersonNameEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "person" SET "name" = NULL WHERE "name" = '';`.execute(db);
+}
+
+export async function down(): Promise<void> {
+  await sql`UPDATE "person" SET "name" = '' WHERE "name" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "name" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/person.table.ts
+++ b/server/src/schema/tables/person.table.ts
@@ -43,8 +43,8 @@ export class PersonTable {
   @ForeignKeyColumn(() => UserTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false })
   ownerId!: string;
 
-  @Column({ default: '' })
-  name!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  name!: string | null;
 
   @Column({ default: '' })
   thumbnailPath!: Generated<string>;


### PR DESCRIPTION
Fixes #28832 (person.name column only)

When a person's name is cleared via the API, the database now stores
`NULL` instead of an empty string `""`. This is consistent with other
nullable person fields (color, birthDate).

Changes:
- Zod schema: convert empty string input to null via .nullish() + .transform()
- DB column: nullable with default NULL; migration updates existing rows
- Response schema: allows null to reflect actual stored value
- TypeScript type: updated Person type to match
