### PR TITLE
fix(mobile): http request handling after isolate death

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -309,8 +309,8 @@ packages:
     dependency: "direct main"
     description:
       path: "pkgs/cupertino_http"
-      ref: a0a933358517c6d01cff37fc2a2752ee2d744a3c
-      resolved-ref: a0a933358517c6d01cff37fc2a2752ee2d744a3c
+      ref: b65e9a327915d1ff1051b64dd5b85734830a28ba
+      resolved-ref: b65e9a327915d1ff1051b64dd5b85734830a28ba
       url: "https://github.com/mertalev/http"
     source: git
     version: "3.0.0-wip"
@@ -1158,12 +1158,13 @@ packages:
     source: hosted
     version: "0.5.0"
   objective_c:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
-      url: "https://pub.dev"
-    source: hosted
+      path: "pkgs/objective_c"
+      ref: "677cb071eb04aec758477c8897dee56e4e3f6c07"
+      resolved-ref: "677cb071eb04aec758477c8897dee56e4e3f6c07"
+      url: "https://github.com/mertalev/native"
+    source: git
     version: "9.4.1"
   octo_image:
     dependency: "direct main"

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -309,8 +309,8 @@ packages:
     dependency: "direct main"
     description:
       path: "pkgs/cupertino_http"
-      ref: "21e146ad5bdabb3806abb92c9f51314c2348acbb"
-      resolved-ref: "21e146ad5bdabb3806abb92c9f51314c2348acbb"
+      ref: "58b03c756b81d16b3975a8ae4b91d25360123bb5"
+      resolved-ref: "58b03c756b81d16b3975a8ae4b91d25360123bb5"
       url: "https://github.com/mertalev/http"
     source: git
     version: "3.0.0-wip"
@@ -1161,8 +1161,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "pkgs/objective_c"
-      ref: "677cb071eb04aec758477c8897dee56e4e3f6c07"
-      resolved-ref: "677cb071eb04aec758477c8897dee56e4e3f6c07"
+      ref: "2915556701f4734a784222f290a82adb1b101682"
+      resolved-ref: "2915556701f4734a784222f290a82adb1b101682"
       url: "https://github.com/mertalev/native"
     source: git
     version: "9.4.1"

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -309,8 +309,8 @@ packages:
     dependency: "direct main"
     description:
       path: "pkgs/cupertino_http"
-      ref: b65e9a327915d1ff1051b64dd5b85734830a28ba
-      resolved-ref: b65e9a327915d1ff1051b64dd5b85734830a28ba
+      ref: "21e146ad5bdabb3806abb92c9f51314c2348acbb"
+      resolved-ref: "21e146ad5bdabb3806abb92c9f51314c2348acbb"
       url: "https://github.com/mertalev/http"
     source: git
     version: "3.0.0-wip"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   cupertino_http:
     git:
       url: https://github.com/mertalev/http
-      ref: '21e146ad5bdabb3806abb92c9f51314c2348acbb'
+      ref: '58b03c756b81d16b3975a8ae4b91d25360123bb5'
       path: pkgs/cupertino_http/
   ok_http:
     git:
@@ -117,7 +117,7 @@ dependency_overrides:
   objective_c:
     git:
       url: https://github.com/mertalev/native
-      ref: '677cb071eb04aec758477c8897dee56e4e3f6c07'
+      ref: '2915556701f4734a784222f290a82adb1b101682'
       path: pkgs/objective_c/
 
 flutter:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   cupertino_http:
     git:
       url: https://github.com/mertalev/http
-      ref: 'b65e9a327915d1ff1051b64dd5b85734830a28ba'
+      ref: '21e146ad5bdabb3806abb92c9f51314c2348acbb'
       path: pkgs/cupertino_http/
   ok_http:
     git:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -117,7 +117,7 @@ dependency_overrides:
   objective_c:
     git:
       url: https://github.com/mertalev/native
-      ref: '2915556701f4734a784222f290a82adb1b101682'
+      ref: '2915556701f4734a784222f290a82adb1b101682' # https://github.com/dart-lang/native/pull/3458
       path: pkgs/objective_c/
 
 flutter:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   cupertino_http:
     git:
       url: https://github.com/mertalev/http
-      ref: 'a0a933358517c6d01cff37fc2a2752ee2d744a3c' # https://github.com/dart-lang/http/pull/1876
+      ref: 'b65e9a327915d1ff1051b64dd5b85734830a28ba'
       path: pkgs/cupertino_http/
   ok_http:
     git:
@@ -114,6 +114,11 @@ dev_dependencies:
 # Pin bonsoir to 5.x until cast releases a version compatible with bonsoir 6.x.
 dependency_overrides:
   bonsoir: ^5.1.11
+  objective_c:
+    git:
+      url: https://github.com/mertalev/native
+      ref: '677cb071eb04aec758477c8897dee56e4e3f6c07'
+      path: pkgs/objective_c/
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Description

This PR uses a branch that implements [safer ObjC blocks](https://github.com/dart-lang/native/issues/3265) as described upstream. In doing so, it fixes crashes that may occur during hot restart or when isolates are killed at the end of a background task.