### PR TITLE
fix: do not log out on automatic url switch

### DIFF
--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -183,6 +183,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> saveLocalEndpoint(String url) async {
     await _ref.read(settingsProvider).write(.networkLocalEndpoint, url);
+    await _apiService.updateHeaders();
   }
 
   String? getSavedWifiName() {

--- a/mobile/lib/widgets/settings/networking_settings/external_network_preference.dart
+++ b/mobile/lib/widgets/settings/networking_settings/external_network_preference.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/models/auth/auxilary_endpoint.model.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/widgets/settings/networking_settings/endpoint_input.dart';
 
@@ -26,13 +27,16 @@ class ExternalNetworkPreference extends HookConsumerWidget {
           .map((e) => e.url)
           .toList();
 
-      ref.read(settingsProvider).write(SettingsKey.networkExternalEndpointList, urls);
+      return ref.read(settingsProvider).write(SettingsKey.networkExternalEndpointList, urls);
     }
 
-    updateValidationStatus(String url, int index, AuxCheckStatus status) {
+    updateValidationStatus(String url, int index, AuxCheckStatus status) async {
       entries.value[index] = entries.value[index].copyWith(url: url, status: status);
 
-      saveEndpointList();
+      await saveEndpointList();
+      if (status == AuxCheckStatus.valid) {
+        await ref.read(apiServiceProvider).updateHeaders();
+      }
     }
 
     handleReorder(int oldIndex, int newIndex) {


### PR DESCRIPTION
Fixes #29700

The auth flow logged out the user to the login page because the resolve external endpoint overwrote the serverEndpoint field and the cookie jar on the native side did not have a token for the new external endpoint. The user inputted server url is now included in the list of valid urls and headers are updated after the endpoints are resolved to populate the token for all valid domains 