### PR TITLE
feat(web): Keep show more open on duplicates

### DIFF
--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -262,8 +262,7 @@
         <DuplicatesCompareControl
           assets={duplicates[duplicatesIndex].assets}
           suggestedKeepAssetIds={duplicates[duplicatesIndex].suggestedKeepAssetIds}
-          {showMore}
-          onToggleShowMore={() => (showMore = !showMore)}
+          bind:showMore
           onResolve={(duplicateAssetIds, trashIds) =>
             handleResolve(duplicates[duplicatesIndex].duplicateId, duplicateAssetIds, trashIds)}
           onStack={(assets) => handleStack(duplicates[duplicatesIndex].duplicateId, assets)}

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -54,6 +54,7 @@
   };
 
   let duplicates = $state(data.duplicates);
+  let showMore = $state(false);
 
   const correctDuplicatesIndex = (index: number) => {
     return Math.max(0, Math.min(index, duplicates.length - 1));
@@ -261,6 +262,8 @@
         <DuplicatesCompareControl
           assets={duplicates[duplicatesIndex].assets}
           suggestedKeepAssetIds={duplicates[duplicatesIndex].suggestedKeepAssetIds}
+          {showMore}
+          onToggleShowMore={() => (showMore = !showMore)}
           onResolve={(duplicateAssetIds, trashIds) =>
             handleResolve(duplicates[duplicatesIndex].duplicateId, duplicateAssetIds, trashIds)}
           onStack={(assets) => handleStack(duplicates[duplicatesIndex].duplicateId, assets)}

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
@@ -23,12 +23,11 @@
     assets: AssetResponseDto[];
     suggestedKeepAssetIds: string[];
     showMore: boolean;
-    onToggleShowMore: () => void;
     onResolve: (duplicateAssetIds: string[], trashIds: string[]) => void;
     onStack: (assets: AssetResponseDto[]) => void;
   }
 
-  let { assets, suggestedKeepAssetIds, onResolve, onStack, showMore, onToggleShowMore }: Props = $props();
+  let { assets, suggestedKeepAssetIds, onResolve, onStack, showMore = $bindable() }: Props = $props();
   // eslint-disable-next-line svelte/no-unnecessary-state-wrap
   let selectedAssetIds = $state(new SvelteSet<string>());
   let trashCount = $derived(assets.length - selectedAssetIds.size);
@@ -188,7 +187,7 @@
 
   {#if hasMore}
     <div class="flex justify-center pb-2">
-      <Button size="small" variant="ghost" color="secondary" onclick={onToggleShowMore}>
+      <Button size="small" variant="ghost" color="secondary" onclick={() => (showMore = !showMore)}>
         <Icon icon={showMore ? mdiChevronUp : mdiChevronDown} size="18" class="me-1" />
         {showMore
           ? $t('show_less')

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
@@ -22,11 +22,13 @@
   interface Props {
     assets: AssetResponseDto[];
     suggestedKeepAssetIds: string[];
+    showMore: boolean;
+    onToggleShowMore: () => void;
     onResolve: (duplicateAssetIds: string[], trashIds: string[]) => void;
     onStack: (assets: AssetResponseDto[]) => void;
   }
 
-  let { assets, suggestedKeepAssetIds, onResolve, onStack }: Props = $props();
+  let { assets, suggestedKeepAssetIds, onResolve, onStack, showMore, onToggleShowMore }: Props = $props();
   // eslint-disable-next-line svelte/no-unnecessary-state-wrap
   let selectedAssetIds = $state(new SvelteSet<string>());
   let trashCount = $derived(assets.length - selectedAssetIds.size);
@@ -36,7 +38,6 @@
   const differingMetadataFields: DifferingMetadataFields = $derived(computeDifferingMetadataFields(assets));
   const differingCount = $derived(countDifferingMetadataItems(differingMetadataFields));
   const hasMore = $derived(differingCount > InitialVisibleCount);
-  let showMore = $state(false);
 
   onMount(() => {
     if (suggestedKeepAssetIds.length > 0) {
@@ -187,7 +188,7 @@
 
   {#if hasMore}
     <div class="flex justify-center pb-2">
-      <Button size="small" variant="ghost" color="secondary" onclick={() => (showMore = !showMore)}>
+      <Button size="small" variant="ghost" color="secondary" onclick={onToggleShowMore}>
         <Icon icon={showMore ? mdiChevronUp : mdiChevronDown} size="18" class="me-1" />
         {showMore
           ? $t('show_less')


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you show all fields in the duplicates util, it keeps open until you close it, without closing when navigating through duplicated assets.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Open the show more section and navigate forward and backward.
- [x] Close the show more section and navigate forward and backward.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- [ ] ~I have confirmed that any new dependencies are strictly necessary.~
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used
