### PR TITLE
fix(web): restore visible focus indicators on keyboard navigation

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -153,9 +153,26 @@
     background-color: black;
   }
 
+  /*
+   * Restore a visible keyboard-focus indicator.
+   *
+   * Tailwind ring utilities (e.g. `focus-visible:ring-*`) only cover elements
+   * that opt in. A blanket `input:focus-visible { outline: none !important }`
+   * rule stripped the keyboard-focus indicator on every native `<input>`
+   * without an explicit ring utility, breaking keyboard-only navigation
+   * (see #19498).
+   *
+   * This fallback ensures any focusable element without an explicit
+   * `focus-visible:` rule still receives a visible outline. `outline-offset`
+   * is reset on native inputs to neutralize the user-agent default offset.
+   */
+  :focus-visible {
+    outline: 2px solid var(--color-immich-primary);
+    outline-offset: 2px;
+  }
+
   input:focus-visible {
-    outline-offset: 0px !important;
-    outline: none !important;
+    outline-offset: 0;
   }
 
   .text-white-shadow {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Tailwind ring utilities (`focus-visible:ring-*`) only cover elements that opt in via utility classes. A blanket `input:focus-visible { outline: none !important }` rule in `web/src/app.css` was killing the keyboard-focus indicator on every native `<input>` that did not have an explicit `focus-visible:ring-*` class, breaking keyboard-only navigation (see #19498).

- Drop the global `outline: none !important` on `input:focus-visible`.
- Add a defensive `:focus-visible` fallback that paints a 2px outline in the brand primary color, so any focusable element without an explicit ring utility still receives a visible focus indicator.
- Keep `outline-offset: 0` on native inputs to neutralize the user-agent default offset, but allow the outline itself to render.

Fixes #19498

## How Has This Been Tested?

<!--- Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- `pnpm --filter immich-web run format` → all matched files use Prettier code style
- `pnpm --filter immich-web run lint` → 0 warnings (`--max-warnings 0`)
- `pnpm --filter immich-web run check:svelte` → 0 errors / 0 warnings on 411 files
- Local verification in `vite dev`: focused native `<input>` resolves to computed `outline: solid 2px rgb(66, 80, 175)` (matches `--immich-primary`). Before the fix, the same focused `<input>` resolved to `outline-style: none`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before: focused native `<input>` shows no outline (bug).

After: focused native `<input>` shows a 2px solid `--immich-primary` outline.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used Claude as a research/review assistant to navigate the codebase, draft the PR description, and verify the change end-to-end in a sandboxed dev environment (format/lint/svelte-check all passing, before/after computed-style comparison captured). All CSS edits and the final commit are my own.