### PR TITLE
fix(web): clear asset selection when search context changes

### DIFF
--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -242,6 +242,7 @@
 
   function removeFilter(key: keyof SearchTerms) {
     delete terms[key];
+    assetMultiSelectManager.clear();
     void goto(Route.search(terms));
   }
 </script>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Clear selection when the search context changes in the search page

In the search page, when assets are selected, search context changes (e.g, remove search chips), the selection state still persists, which is not intended behavior.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Select some assets on the search page
<img width="1601" height="720" alt="image" src="https://github.com/user-attachments/assets/ebcc2309-0d40-4f2c-a646-39ece845d2ae" />

After the search chip is removed, the selection still persists
<img width="1595" height="570" alt="image" src="https://github.com/user-attachments/assets/c8d00f0f-16ec-4f33-93ae-2506ee4c8c33" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
NONE
...
