### PR TITLE
fix(sync): prevent foreign key violations by ensuring asset delivery in sync stream

### DIFF
--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -731,6 +731,24 @@ where
     where
       "ownerId" = $3
   )
+  and "assetId" in (
+    select
+      "id"
+    from
+      "asset"
+    where
+      (
+        "ownerId" = $4
+        or "ownerId" in (
+          select
+            "sharedById"
+          from
+            "partner"
+          where
+            "sharedWithId" = $5
+        )
+      )
+  )
 order by
   "memory_asset"."updateId" asc
 

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -576,11 +576,32 @@ class MemoryToAssetSync extends BaseSync {
 
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getUpserts(options: SyncQueryOptions) {
-    return this.upsertQuery('memory_asset', options)
-      .select(['memoriesId as memoryId', 'assetId as assetId'])
-      .select('updateId')
-      .where('memoriesId', 'in', (eb) => eb.selectFrom('memory').select('id').where('ownerId', '=', options.userId))
-      .stream();
+    return (
+      this.upsertQuery('memory_asset', options)
+        .select(['memoriesId as memoryId', 'assetId as assetId'])
+        .select('updateId')
+        .where('memoriesId', 'in', (eb) => eb.selectFrom('memory').select('id').where('ownerId', '=', options.userId))
+        // Only sync links whose asset is also delivered to this user (own or partner assets).
+        // Otherwise the client inserts a memory_asset row referencing an unknown asset,
+        // hits a foreign-key violation, and jams the sync loop permanently.
+        // See https://github.com/immich-app/immich/issues/22772
+        .where('assetId', 'in', (eb) =>
+          eb
+            .selectFrom('asset')
+            .select('id')
+            .where((eb) =>
+              eb.or([
+                eb('ownerId', '=', options.userId),
+                eb(
+                  'ownerId',
+                  'in',
+                  eb.selectFrom('partner').select('sharedById').where('sharedWithId', '=', options.userId),
+                ),
+              ]),
+            ),
+        )
+        .stream()
+    );
   }
 }
 

--- a/server/test/medium/specs/sync/sync-memory-asset-fk-repro.spec.ts
+++ b/server/test/medium/specs/sync/sync-memory-asset-fk-repro.spec.ts
@@ -1,0 +1,66 @@
+import { Kysely } from 'kysely';
+import { SyncEntityType, SyncRequestType } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = async (db?: Kysely<DB>) => {
+  const ctx = new SyncTestContext(db || defaultDatabase);
+  const { auth, user, session } = await ctx.newSyncAuthUser();
+  return { auth, user, session, ctx };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+// Reproduction for https://github.com/immich-app/immich/issues/22772
+//
+// The mobile client inserts every `MemoryToAssetV1` link into `memory_asset_entity`,
+// whose FK constraints require both the memory row and the asset row to already exist
+// locally. If the server streams a link whose asset was never delivered to that client,
+// the insert fails with SqliteException(787). `updateMemoryAssetsV1` rethrows, the
+// checkpoint is never advanced, and the entire remote-sync loop permanently jams
+// (memories stay empty; People/faces/OCR ordered after it never sync either).
+//
+// Invariant under test: the server must never stream a memory->asset link for an asset
+// it does not also deliver to the same client in the same sync.
+//
+describe('MemoryToAssetV1 FK ordering (issue #22772)', () => {
+  it('should not sync a memory-to-asset link for an asset the client never receives', async () => {
+    const { auth, user, ctx } = await setup();
+
+    // A different, non-partnered user owns an asset. `auth` will never receive this
+    // asset via AssetsV2 (filtered by ownerId) nor PartnerAssetsV2 (no partnership).
+    const { user: otherUser } = await ctx.newSyncAuthUser();
+    const { asset: undeliverableAsset } = await ctx.newAsset({ ownerId: otherUser.id });
+
+    // ...but a memory owned by `user` links to it.
+    const { memory } = await ctx.newMemory({ ownerId: user.id });
+    await ctx.newMemoryAsset({ memoryId: memory.id, assetId: undeliverableAsset.id });
+
+    // Full sync, in the same dependency order the mobile client requests.
+    const response = await ctx.syncStream(auth, [
+      SyncRequestType.AssetsV2,
+      SyncRequestType.MemoriesV1,
+      SyncRequestType.MemoryToAssetsV1,
+    ]);
+
+    const deliveredAssetIds = new Set(
+      response
+        .filter((event) => event.type === SyncEntityType.AssetV2)
+        .map((event) => (event.data as { id: string }).id),
+    );
+    const linkedAssetIds = response
+      .filter((event) => event.type === SyncEntityType.MemoryToAssetV1)
+      .map((event) => (event.data as { assetId: string }).assetId);
+
+    // Every linked asset must have been delivered in the same stream, otherwise the
+    // client hits a foreign-key violation inserting into memory_asset_entity.
+    for (const assetId of linkedAssetIds) {
+      expect(deliveredAssetIds).toContain(assetId);
+    }
+  });
+});


### PR DESCRIPTION
## Description

The MemoryToAssetV1 sync stream emitted a link for every asset on a user's memories, including assets the client never receives. Inserting such a link violates the memory_asset foreign key on the device, which aborts and permanently jams the entire remote-sync loop.

Guard the upsert query so it only streams links whose asset is also delivered to the user (own or partner assets).

This PR just addresses the server concerns (to minimize PR scope). There is a second, optional client-side fix I have as well.

Refs #22772

## How Has This Been Tested?

New test added in commit. All existing tests and linting pass.

- [X] sync-memory-asset-fk-repro.spec.ts added; was failing before fix and is now passing.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used for problem analysis and assistance in generating the unit test case.
