### PR TITLE
fix(web): recursively unnest class arrays

### DIFF
--- a/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/Thumbnail.svelte
@@ -247,7 +247,7 @@
     >
       <ImageThumbnail
         class={['absolute group-focus-visible:rounded-lg', { 'rounded-xl': selected }, imageClass]}
-        brokenAssetClass={['z-1 absolute group-focus-visible:rounded-lg', { 'rounded-xl': selected }, brokenAssetClass]}
+        brokenAssetClass={['z-1 absolute group-focus-visible:rounded-lg', selected && 'rounded-2xl', brokenAssetClass]}
         url={getAssetMediaUrl({ id: asset.id, size: AssetMediaSize.Thumbnail, cacheKey: asset.thumbhash })}
         altText={$getAltText(asset)}
         widthStyle="{width}px"

--- a/web/src/lib/index.spec.ts
+++ b/web/src/lib/index.spec.ts
@@ -12,6 +12,10 @@ describe('cleanClass', () => {
   it('should unnest arrays', () => {
     expect(cleanClass('class1', ['class2', 'class3'])).toBe('class1 class2 class3');
   });
+
+  it('should unnest doubly nested arrays', () => {
+    expect(cleanClass('class1', [['class2a', 'class2b'], 'class3'])).toBe('class1 class2a class2b class3');
+  });
 });
 
 describe('isDefined', () => {

--- a/web/src/lib/index.ts
+++ b/web/src/lib/index.ts
@@ -3,8 +3,7 @@ import { twMerge } from 'tailwind-merge';
 
 export const cleanClass = (...classNames: unknown[]) => {
   return twMerge(
-    classNames
-      .flatMap((className) => (Array.isArray(className) ? className : [className]))
+    flattenClass(classNames)
       .filter((className) => {
         if (!className || typeof className === 'boolean') {
           return false;
@@ -15,6 +14,9 @@ export const cleanClass = (...classNames: unknown[]) => {
       .join(' '),
   );
 };
+
+const flattenClass = (classNames: unknown[]): unknown[] =>
+  classNames.flatMap((className) => (Array.isArray(className) ? flattenClass(className) : [className]));
 
 export const isDefined = <T>(value: T): value is NonNullable<T> => value !== null && value !== undefined;
 


### PR DESCRIPTION
## Description
`cleanClass` unnests arrays but only one level deep. In the case of the broken asset classes, there was a lot more nesting going on. Extract the array flattening to a recursive helper function.

It doesn't handle objects either so I change that in the classlist, rather than adapting `cleanClass`. I think at some point weshould just use the same clsx functions that svelte uses internally as well.

Fixes #29611

## How Has This Been Tested?
- unit test
- visually
- inspect html
- console logging the final computed classes and check to see if all updates propagate properly
- quick look through the main Immich pages to see if anything is off
