### PR TITLE
fix(mobile): live debounced map bounds tracking

### DIFF
--- a/mobile/lib/extensions/maplibrecontroller_extensions.dart
+++ b/mobile/lib/extensions/maplibrecontroller_extensions.dart
@@ -1,71 +1,9 @@
 import 'dart:async';
-import 'dart:io';
-import 'dart:math';
 
 import 'package:flutter/services.dart';
-import 'package:immich_mobile/models/map/map_marker.model.dart';
-import 'package:immich_mobile/utils/map_utils.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 extension MapMarkers on MapLibreMapController {
-  static var _completer = Completer()..complete();
-
-  Future<void> addGeoJSONSourceForMarkers(List<MapMarker> markers) async {
-    return addSource(
-      MapUtils.defaultSourceId,
-      GeojsonSourceProperties(data: MapUtils.generateGeoJsonForMarkers(markers.toList())),
-    );
-  }
-
-  Future<void> reloadAllLayersForMarkers(List<MapMarker> markers) async {
-    // Wait for previous reload to complete
-    if (!_completer.isCompleted) {
-      return _completer.future;
-    }
-    _completer = Completer();
-
-    // !! Make sure to remove layers before sources else the native
-    // maplibre library would crash when removing the source saying that
-    // the source is still in use
-    final existingLayers = await getLayerIds();
-    if (existingLayers.contains(MapUtils.defaultHeatMapLayerId)) {
-      await removeLayer(MapUtils.defaultHeatMapLayerId);
-    }
-
-    final existingSources = await getSourceIds();
-    if (existingSources.contains(MapUtils.defaultSourceId)) {
-      await removeSource(MapUtils.defaultSourceId);
-    }
-
-    await addGeoJSONSourceForMarkers(markers);
-
-    if (Platform.isAndroid) {
-      await addCircleLayer(
-        MapUtils.defaultSourceId,
-        MapUtils.defaultHeatMapLayerId,
-        const CircleLayerProperties(
-          circleRadius: 10,
-          circleColor: "rgba(150,86,34,0.7)",
-          circleBlur: 1.0,
-          circleOpacity: 0.7,
-          circleStrokeWidth: 0.1,
-          circleStrokeColor: "rgba(203,46,19,0.5)",
-          circleStrokeOpacity: 0.7,
-        ),
-      );
-    }
-
-    if (Platform.isIOS) {
-      await addHeatmapLayer(
-        MapUtils.defaultSourceId,
-        MapUtils.defaultHeatMapLayerId,
-        MapUtils.defaultHeatMapLayerProperties,
-      );
-    }
-
-    _completer.complete();
-  }
-
   Future<Symbol?> addMarkerAtLatLng(LatLng centre) async {
     // no marker is displayed if asset-path is incorrect
     try {
@@ -75,15 +13,5 @@ extension MapMarkers on MapLibreMapController {
     } finally {
       // no-op
     }
-  }
-
-  Future<LatLngBounds> getBoundsFromPoint(Point<double> point, double distance) async {
-    final southWestPx = Point(point.x - distance, point.y + distance);
-    final northEastPx = Point(point.x + distance, point.y - distance);
-
-    final southWest = await toLatLng(southWestPx);
-    final northEast = await toLatLng(northEastPx);
-
-    return LatLngBounds(southwest: southWest, northeast: northEast);
   }
 }

--- a/mobile/lib/presentation/widgets/map/map.widget.dart
+++ b/mobile/lib/presentation/widgets/map/map.widget.dart
@@ -51,7 +51,12 @@ class DriftMap extends ConsumerStatefulWidget {
 class _DriftMapState extends ConsumerState<DriftMap> {
   MapLibreMapController? mapController;
   final _reloadMutex = AsyncMutex();
-  final _debouncer = Debouncer(interval: const Duration(milliseconds: 500), maxWaitTime: const Duration(seconds: 2));
+
+  final _debouncer = Debouncer(
+    interval: const Duration(milliseconds: 150),
+    maxWaitTime: const Duration(milliseconds: 500),
+  );
+
   final ValueNotifier<double> bottomSheetOffset = ValueNotifier(0.25);
   final GlobalKey _bottomSheetKey = GlobalKey();
   StreamSubscription? _eventSubscription;
@@ -116,7 +121,7 @@ class _DriftMapState extends ConsumerState<DriftMap> {
   }
 
   void onMapMoved() {
-    if (mapController!.isCameraMoving || !mounted) {
+    if (!mounted) {
       return;
     }
 
@@ -216,6 +221,8 @@ class _Map extends StatelessWidget {
               : CameraPosition(target: initialLocation, zoom: MapUtils.mapZoomToAssetLevel),
           compassEnabled: false,
           rotateGesturesEnabled: false,
+          // Get continuous movement events for bounds tracking
+          trackCameraPosition: true,
           styleString: style,
           onMapCreated: onMapCreated,
           onStyleLoadedCallback: onMapReady,

--- a/mobile/lib/presentation/widgets/map/map.widget.dart
+++ b/mobile/lib/presentation/widgets/map/map.widget.dart
@@ -224,6 +224,9 @@ class _Map extends StatelessWidget {
           // Get continuous movement events for bounds tracking
           trackCameraPosition: true,
           styleString: style,
+          // We don't currently use annotations and MapLibre_gl has insufficient guards around instantiation
+          // of annotation controllers (resulting in map crashs about missing styles), so we disable them
+          annotationOrder: const [],
           onMapCreated: onMapCreated,
           onStyleLoadedCallback: onMapReady,
           attributionButtonPosition: AttributionButtonPosition.topRight,


### PR DESCRIPTION
Continuation from #29735 and #29772.

Live track (with debouncing) map bounds changes to repopulate the asset heatmap and current filter results. No significant change to CPU usage observed.

### Before (after #29735)

<img width="603" height="1311" alt="ScreenRecording_07-08-2026 06-31-11_1" src="https://github.com/user-attachments/assets/fef29b4c-77e1-427f-ad86-488112f2d54b" />

### After

<img width="603" height="1311" alt="ScreenRecording_07-09-2026 12-12-46_1" src="https://github.com/user-attachments/assets/5ff1f88a-abae-4de0-a477-27a6d58c82fb" />
