### PR TITLE
feat(server): allow shared link access on bulk-upload-check

### DIFF
--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -25,7 +25,11 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUploadCheckDto] assetBulkUploadCheckDto (required):
-  Future<Response> checkBulkUploadWithHttpInfo(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { Future<void>? abortTrigger, }) async {
+  ///
+  /// * [String] key:
+  ///
+  /// * [String] slug:
+  Future<Response> checkBulkUploadWithHttpInfo(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/bulk-upload-check';
 
@@ -35,6 +39,13 @@ class AssetsApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
+    if (slug != null) {
+      queryParams.addAll(_queryParams('', 'slug', slug));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -58,8 +69,12 @@ class AssetsApi {
   /// Parameters:
   ///
   /// * [AssetBulkUploadCheckDto] assetBulkUploadCheckDto (required):
-  Future<AssetBulkUploadCheckResponseDto?> checkBulkUpload(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { Future<void>? abortTrigger, }) async {
-    final response = await checkBulkUploadWithHttpInfo(assetBulkUploadCheckDto, abortTrigger: abortTrigger,);
+  ///
+  /// * [String] key:
+  ///
+  /// * [String] slug:
+  Future<AssetBulkUploadCheckResponseDto?> checkBulkUpload(AssetBulkUploadCheckDto assetBulkUploadCheckDto, { String? key, String? slug, Future<void>? abortTrigger, }) async {
+    final response = await checkBulkUploadWithHttpInfo(assetBulkUploadCheckDto, key: key, slug: slug, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3455,7 +3455,24 @@
       "post": {
         "description": "Determine which assets have already been uploaded to the server based on their SHA1 checksums.",
         "operationId": "checkBulkUpload",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slug",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -4144,13 +4144,18 @@ export function updateAssets({ assetBulkUpdateDto }: {
 /**
  * Check bulk upload
  */
-export function checkBulkUpload({ assetBulkUploadCheckDto }: {
+export function checkBulkUpload({ key, slug, assetBulkUploadCheckDto }: {
+    key?: string;
+    slug?: string;
     assetBulkUploadCheckDto: AssetBulkUploadCheckDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: AssetBulkUploadCheckResponseDto;
-    }>("/assets/bulk-upload-check", oazapfts.json({
+    }>(`/assets/bulk-upload-check${QS.query(QS.explode({
+        key,
+        slug
+    }))}`, oazapfts.json({
         ...opts,
         method: "POST",
         body: assetBulkUploadCheckDto

--- a/server/src/controllers/asset-media.controller.spec.ts
+++ b/server/src/controllers/asset-media.controller.spec.ts
@@ -1,6 +1,6 @@
 import { AssetMediaController } from 'src/controllers/asset-media.controller';
 import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
-import { AssetMetadataKey } from 'src/enum';
+import { AssetMetadataKey, Permission } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { AssetMediaService } from 'src/services/asset-media.service';
 import request from 'supertest';
@@ -189,6 +189,22 @@ describe(AssetMediaController.name, () => {
         const { status } = await request(ctx.getHttpServer()).get(`/assets/${factory.uuid()}/thumbnail?size=original`);
         expect(status).toBe(302);
       });
+    });
+  });
+
+  describe('POST /assets/bulk-upload-check', () => {
+    it('should be an authenticated route that allows shared link access', async () => {
+      service.bulkUploadCheck.mockResolvedValue({ results: [] });
+
+      await request(ctx.getHttpServer())
+        .post('/assets/bulk-upload-check')
+        .send({ assets: [{ id: '1', checksum: 'd2947b871a706081be194569951b7db246907957' }] });
+
+      expect(ctx.authenticate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ permission: Permission.AssetUpload, sharedLinkRoute: true }),
+        }),
+      );
     });
   });
 });

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -178,7 +178,7 @@ export class AssetMediaController {
   }
 
   @Post('bulk-upload-check')
-  @Authenticated({ permission: Permission.AssetUpload })
+  @Authenticated({ permission: Permission.AssetUpload, sharedLink: true })
   @Endpoint({
     summary: 'Check bulk upload',
     description: 'Determine which assets have already been uploaded to the server based on their SHA1 checksums.',

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -830,6 +830,30 @@ describe(AssetMediaService.name, () => {
 
       expect(mocks.asset.getByChecksums).toHaveBeenCalledWith(authStub.admin.user.id, [file1, file2]);
     });
+
+    it('should allow a shared link with upload access', async () => {
+      const auth = AuthFactory.from().sharedLink({ allowUpload: true }).build();
+
+      mocks.asset.getByChecksums.mockResolvedValue([]);
+
+      await expect(
+        sut.bulkUploadCheck(auth, { assets: [{ id: '1', checksum: file1.toString('hex') }] }),
+      ).resolves.toEqual({
+        results: [{ id: '1', action: AssetUploadAction.ACCEPT }],
+      });
+
+      expect(mocks.asset.getByChecksums).toHaveBeenCalledWith(auth.user.id, [file1]);
+    });
+
+    it('should reject a shared link without upload access', async () => {
+      const auth = AuthFactory.from().sharedLink({ allowUpload: false }).build();
+
+      await expect(
+        sut.bulkUploadCheck(auth, { assets: [{ id: '1', checksum: file1.toString('hex') }] }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(mocks.asset.getByChecksums).not.toHaveBeenCalled();
+    });
   });
 
   describe('onUploadError', () => {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -312,6 +312,13 @@ export class AssetMediaService extends BaseService {
   }
 
   async bulkUploadCheck(auth: AuthDto, dto: AssetBulkUploadCheckDto): Promise<AssetBulkUploadCheckResponseDto> {
+    await this.requireAccess({
+      auth,
+      permission: Permission.AssetUpload,
+      // do not need an id here, but the interface requires it
+      ids: [auth.user.id],
+    });
+
     const checksums: Buffer[] = dto.assets.map((asset) => fromChecksum(asset.checksum));
     const results = await this.assetRepository.getByChecksums(auth.user.id, checksums);
     const checksumMap: Record<string, { id: string; isTrashed: boolean }> = {};

--- a/server/test/medium/specs/services/asset-media.service.spec.ts
+++ b/server/test/medium/specs/services/asset-media.service.spec.ts
@@ -1,6 +1,6 @@
 import { Kysely } from 'kysely';
 import { randomBytes } from 'node:crypto';
-import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
+import { AssetMediaStatus, AssetRejectReason, AssetUploadAction } from 'src/dtos/asset-media-response.dto';
 import { AssetMediaSize } from 'src/dtos/asset-media.dto';
 import { AssetFileType, SharedLinkType } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
@@ -258,6 +258,66 @@ describe(AssetService.name, () => {
       const assets = [...result];
       expect(assets).toHaveLength(1);
       expect(assets[0]).toEqual(response.id);
+    });
+  });
+
+  describe('bulkUploadCheck', () => {
+    it('should detect duplicates for a shared link with upload access', async () => {
+      const { sut, ctx } = setup();
+
+      const sharedLinkRepo = ctx.get(SharedLinkRepository);
+
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      const sharedLink = await sharedLinkRepo.create({
+        key: randomBytes(50),
+        type: SharedLinkType.Individual,
+        description: 'Shared link description',
+        userId: user.id,
+        allowDownload: true,
+        allowUpload: true,
+      });
+
+      const auth = factory.auth({ user: { id: user.id }, sharedLink });
+
+      await expect(
+        sut.bulkUploadCheck(auth, { assets: [{ id: '1', checksum: asset.checksum.toString('hex') }] }),
+      ).resolves.toEqual({
+        results: [
+          {
+            id: '1',
+            action: AssetUploadAction.REJECT,
+            reason: AssetRejectReason.DUPLICATE,
+            assetId: asset.id,
+            isTrashed: false,
+          },
+        ],
+      });
+    });
+
+    it('should reject a shared link without upload access', async () => {
+      const { sut, ctx } = setup();
+
+      const sharedLinkRepo = ctx.get(SharedLinkRepository);
+
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      const sharedLink = await sharedLinkRepo.create({
+        key: randomBytes(50),
+        type: SharedLinkType.Individual,
+        description: 'Shared link description',
+        userId: user.id,
+        allowDownload: true,
+        allowUpload: false,
+      });
+
+      const auth = factory.auth({ user: { id: user.id }, sharedLink });
+
+      await expect(
+        sut.bulkUploadCheck(auth, { assets: [{ id: '1', checksum: asset.checksum.toString('hex') }] }),
+      ).rejects.toThrow('Not found or no asset.upload access');
     });
   });
 


### PR DESCRIPTION
## Description

`POST /api/assets` accepts shared-link authentication (`@Authenticated({ permission: Permission.AssetUpload, sharedLink: true })`), so guests of a link with `allowUpload` enabled can upload assets. The pre-upload checksum endpoint `POST /api/assets/bulk-upload-check` did not (`sharedLink: true` missing), so those same guests could not check which files already exist before transferring bytes.

Because of that, the web client explicitly skips its hash + dedupe path on share pages (`if (!authManager.isSharedLink)` in `web/src/lib/utils/file-uploader.ts`), and share-page guests re-upload the full bytes of files that already exist, only for the server to flag them as duplicates after the transfer. Third-party consumers of shared links (e.g. immich-public-proxy) currently need the same workaround.

This PR:

- adds `sharedLink: true` to the `bulk-upload-check` route,
- gates the service method with the same access check `uploadAsset` uses (`requireAccess` with `Permission.AssetUpload`), so links with `allowUpload: false` are rejected exactly like the upload path (`checkSharedLinkAccess` → `sharedLink.allowUpload ? ids : new Set()`),
- leaves the checksum lookup scope unchanged: it remains `auth.user.id`, which for shared-link auth is the link owner — the same scope the upload route's own dedupe check (`x-immich-checksum` handling in `AssetUploadInterceptor`) already uses.

No new information exposure: the `x-immich-checksum` header on the upload route already lets a share-key holder test checksum existence (one checksum at a time) against the link owner's library. This change only enables the bulk form of that existing capability, and only for links whose owner enabled `allowUpload`.

Possible follow-up (not part of this PR): the web client could enable its existing hash + bulk-check path for shared links, so share-page guests skip re-uploading duplicates.

Note: I'm aware of the feature freeze on Sharing — this is intentionally a minimal consistency change (one decorator flag + matching access gate) to an existing endpoint pair, not new sharing functionality. Happy to take it to the `#contributing` channel instead if you'd prefer.

## API Changes

`POST /api/assets/bulk-upload-check` now accepts shared-link credentials (`key`/`slug` query params, same as `POST /api/assets`). OpenAPI spec and generated SDKs regenerated (`open-api/immich-openapi-specs.json`, `packages/sdk/src/fetch-client.ts`, `mobile/openapi/lib/api/assets_api.dart`).

## How Has This Been Tested?

- [x] Unit (small): `server/src/controllers/asset-media.controller.spec.ts` — route metadata asserts `sharedLinkRoute: true` + `Permission.AssetUpload`; `server/src/services/asset-media.service.spec.ts` — shared link with `allowUpload` gets results scoped to the link owner, shared link without `allowUpload` is rejected (`BadRequestException`), `getByChecksums` never called. Ran: `vitest run src/services/asset-media.service.spec.ts src/controllers/asset-media.controller.spec.ts` → 144 passed / 2 skipped.
- [x] Medium (real Postgres via testcontainers): `server/test/medium/specs/services/asset-media.service.spec.ts` — upload-allowed link detects a duplicate of the owner's existing asset; `allowUpload: false` link rejected with `Not found or no asset.upload access`. Ran: `vitest run --config test/vitest.config.medium.mjs test/medium/specs/services/asset-media.service.spec.ts` → 14 passed.
- [x] `tsc --noEmit`, scoped `eslint` and `prettier --check` on touched files all clean.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Full transparency: the code, tests, and this PR text were written by an LLM agent (Claude) working under my direction; I reviewed the diff and the access-layer analysis before opening this. I read the note in CONTRIBUTING.md about LLM-generated PRs and understand if you close this on that basis — I kept it as small and fully tested as I could to minimize review cost, and the underlying inconsistency report (upload allows shared links, bulk-upload-check doesn't, web client works around it) stands regardless of the patch.
