### PR TITLE
feat(web): add wake lock when uploading assets

### DIFF
--- a/web/src/lib/utils/wakelock.svelte.ts
+++ b/web/src/lib/utils/wakelock.svelte.ts
@@ -3,7 +3,7 @@ import { browser } from '$app/environment';
 
 const isSupported = browser && 'wakeLock' in navigator;
 
-let sentinel: WakeLockSentinel | null = null;
+let sentinel: WakeLockSentinel | undefined;
 let acquiring = false;
 
 export async function acquireWakeLock() {
@@ -11,12 +11,10 @@ export async function acquireWakeLock() {
     return;
   }
   // eslint-disable-next-line tscompat/tscompat
-  if (sentinel !== null && !sentinel.released) {
-    // There is already a wake lock
+  if (sentinel && !sentinel.released) {
     return;
   }
   if (acquiring) {
-    // There is already a wake lock request in progress
     return;
   }
   acquiring = true;
@@ -31,10 +29,10 @@ export async function acquireWakeLock() {
 }
 
 export async function releaseWakeLock() {
-  if (sentinel !== null) {
+  if (sentinel) {
     const toReleaseSentinel = sentinel;
-    // Set to null first to avoid race condition after await
-    sentinel = null;
+    // Unset first to avoid race condition after await
+    sentinel = undefined;
 
     // eslint-disable-next-line tscompat/tscompat
     await toReleaseSentinel.release();
@@ -45,7 +43,7 @@ if (isSupported) {
   // Wake lock is cleared when user changes to a different tab,
   // so we need to reacquire the wake lock when they come back.
   on(globalThis, 'visibilitychange', () => {
-    if (sentinel !== null && document.visibilityState === 'visible') {
+    if (sentinel && document.visibilityState === 'visible') {
       void acquireWakeLock();
     }
   });

--- a/web/src/lib/utils/wakelock.svelte.ts
+++ b/web/src/lib/utils/wakelock.svelte.ts
@@ -1,0 +1,52 @@
+import { on } from 'svelte/events';
+import { browser } from '$app/environment';
+
+const isSupported = browser && 'wakeLock' in navigator;
+
+let sentinel: WakeLockSentinel | null = null;
+let acquiring = false;
+
+export async function acquireWakeLock() {
+  if (!isSupported) {
+    return;
+  }
+  // eslint-disable-next-line tscompat/tscompat
+  if (sentinel !== null && !sentinel.released) {
+    // There is already a wake lock
+    return;
+  }
+  if (acquiring) {
+    // There is already a wake lock request in progress
+    return;
+  }
+  acquiring = true;
+  try {
+    // eslint-disable-next-line tscompat/tscompat
+    sentinel = await navigator.wakeLock.request('screen');
+  } catch (error) {
+    console.warn('Failed to acquire wake lock:', error);
+  } finally {
+    acquiring = false;
+  }
+}
+
+export async function releaseWakeLock() {
+  if (sentinel !== null) {
+    const toReleaseSentinel = sentinel;
+    // Set to null first to avoid race condition after await
+    sentinel = null;
+
+    // eslint-disable-next-line tscompat/tscompat
+    await toReleaseSentinel.release();
+  }
+}
+
+if (isSupported) {
+  // Wake lock is cleared when user changes to a different tab,
+  // so we need to reacquire the wake lock when they come back.
+  on(globalThis, 'visibilitychange', () => {
+    if (sentinel !== null && document.visibilityState === 'visible') {
+      void acquireWakeLock();
+    }
+  });
+}

--- a/web/src/routes/UploadPanel.svelte
+++ b/web/src/routes/UploadPanel.svelte
@@ -2,6 +2,7 @@
   import { locale } from '$lib/stores/preferences.store';
   import { uploadAssetsStore } from '$lib/stores/upload';
   import { uploadExecutionQueue } from '$lib/utils/file-uploader';
+  import { acquireWakeLock, releaseWakeLock } from '$lib/utils/wakelock.svelte';
   import { Icon, IconButton, toastManager } from '@immich/ui';
   import { mdiCancel, mdiCloudUploadOutline, mdiCog, mdiWindowMinimize } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -15,9 +16,19 @@
 
   let { stats, isDismissible, isUploading, remainingUploads } = uploadAssetsStore;
 
+  let hasRemaining = $derived($remainingUploads > 0);
+
   $effect(() => {
     if ($isUploading) {
       showDetail = true;
+    }
+  });
+
+  $effect(() => {
+    if (hasRemaining) {
+      void acquireWakeLock();
+    } else {
+      void releaseWakeLock();
     }
   });
 </script>


### PR DESCRIPTION
## Description

This prevents a situation where the user, especially on mobile devices, has to keep tapping their screen to avoid the upload being interrupted.

## How Has This Been Tested?

I changed the screen timeout on my phone to the smallest allowed (15 seconds) and then started a big upload and checked that 15s had passed without the screen turning off.
Also attempted to switch tabs and leave the browser during the upload to test the `visibilitychange` event listener.

Additionally, used `console.log` to check that the wakelock was being acquired/released at the correct times.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] ~~I have made corresponding changes to the documentation if applicable~~ (not applicable)
- [x] I have no unrelated changes in the PR.
- [x] ~~I have confirmed that any new dependencies are strictly necessary.~~ (no new dependencies)
- [x] ~~I have written tests for new code (if applicable)~~ (don't think there's an easy way to write tests for this given the use of browser APIs)
- [x] I have followed naming conventions/patterns in the surrounding code (I believe so, but I'm not sure if `wakelock.svelte.js` should be somewhere else)
- [x] ~~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~ (not applicable)
- [x] ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~ (not applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM
