### PR TITLE
fix(web): stop intercepting original assets in service worker

### DIFF
--- a/web/src/service-worker/index.ts
+++ b/web/src/service-worker/index.ts
@@ -5,7 +5,7 @@
 import { installMessageListener } from './messaging';
 import { handleFetch as handleAssetFetch } from './request';
 
-const ASSET_REQUEST_REGEX = /^\/api\/assets\/[a-f0-9-]+\/(original|thumbnail)/;
+const ASSET_REQUEST_REGEX = /^\/api\/assets\/[a-f0-9-]+\/thumbnail$/;
 
 const sw = globalThis as unknown as ServiceWorkerGlobalScope;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Default video playback uses the `/video/playback` endpoint, which already bypasses the service worker and allows the browser to use native byte-range requests.

Enabling "Play original video" switches playback to the `/original` endpoint. This endpoint is currently intercepted and deduplicated by the service worker, causing affected original videos to be downloaded in full before playback. This is inconsistent with the existing default `/video/playback` playback behavior and should not be an expected approach of playing the original file.

Limit service worker handling to thumbnail requests, matching its documented scope.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Confirmed original video requests bypass the service worker and receive `206 Partial Content` responses.
- [x] Confirmed thumbnails, hovering video previews and original images continue to load normally.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help set up a local dev environment. This change was manually written and tested.
