### PR TITLE
docs: note VectorChord release link org redirect

### DIFF
--- a/docs/docs/administration/postgres-standalone.md
+++ b/docs/docs/administration/postgres-standalone.md
@@ -16,6 +16,10 @@ running `apt install postgresql-NN-pgvector`, where `NN` is your Postgres versio
 
 You must install VectorChord into your instance of Postgres using their [instructions][vchord-install]. After installation, add `shared_preload_libraries = 'vchord.so'` to your `postgresql.conf`. If you already have some `shared_preload_libraries` set, you can separate each extension with a comma. For example, `shared_preload_libraries = 'pg_stat_statements, vchord.so'`.
 
+:::note
+When following VectorChord's installation instructions, the GitHub release links may redirect to a different organization name than expected. This is a known, benign artifact of a recent repository transfer, not a sign of a compromised package.
+:::
+
 :::note Supported versions
 Immich is known to work with Postgres versions `>= 14, < 20`.
 


### PR DESCRIPTION
Adds a note to the VectorChord prerequisites section warning standalone-Postgres users that GitHub release links may redirect to a different organization name (github.com/tensorchord/VectorChord now redirects to supervc-stack/VectorChord).

Ran into this directly while migrating a standalone Postgres instance off pgvecto.rs. Followed the linked installation instructions, and the wget'd release URL silently redirected to an unfamiliar org with zero explanation, which took real effort to verify wasn't a compromised package before installing something that runs as root against a production Postgres instance.

This note doesn't fix the underlying redirect, just gives the next person a heads up that it's expected and benign rather than something they need to independently investigate.

## Description

Single-line doc addition. No code changes, no functional changes.

## How Has This Been Tested?

Docs-only change. Verified the added `:::note` block uses the same Docusaurus admonition syntax as the surrounding content in this file.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own change
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (N/A, docs only)

The src/services/ and src/repositories/ checklist items don't apply, this PR doesn't touch application code.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Claude to help locate the exact source file and diagnose that the redirect originates from a recent GitHub org transfer for VectorChord's repo, rather than a compromised release. The wording of the note itself was drafted with AI assistance and reviewed/edited by me before submitting.