### PR TITLE
fix(server): updated default CSP config to support videos from V3 player

### DIFF
--- a/server/helmet.json
+++ b/server/helmet.json
@@ -5,6 +5,7 @@
       "script-src": ["'self'", "'wasm-unsafe-eval'", "'unsafe-inline'", "https://www.gstatic.com"],
       "style-src": ["'self'", "'unsafe-inline'"],
       "img-src": ["'self'", "data:", "blob:"],
+      "media-src": ["'self'", "data:", "blob:"],
       "connect-src": [
         "'self'",
         "blob:",


### PR DESCRIPTION
## Description

Immich V3 added a new video player that had the side effect of breaking current CSP configuration on Chromium-based browsers, as also seen with issue #29441.

This PR addresses those issues by adding the missing CSP directive.
Fixes #29441

## How Has This Been Tested?


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] In order to test this, we have to enable the default CSP policy with the env variable <code>IMMICH_HELMET_FILE</code>.
- [x] Run Immich V3 and upload a video
- [x] With these changes applied, even Chromium-based browsers should have no problems in playing back the video you previously uploaded. Without those changes, Chromium didn't played the video and complained about missing CSP directives.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs were used.