### PR TITLE
fix(server): queue thumbnail generation for hidden motion-photo companion videos

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -390,14 +390,15 @@ describe(MediaService.name, () => {
       expect(mocks.asset.update).not.toHaveBeenCalledWith();
     });
 
-    it('should skip invisible assets', async () => {
-      const asset = AssetFactory.from({ visibility: AssetVisibility.Hidden }).exif().build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+    it('should generate thumbnails for hidden motion-photo companion videos', async () => {
+      const asset = AssetFactory.from({ type: AssetType.Video, visibility: AssetVisibility.Hidden }).exif().build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue({
+        ...getForGenerateThumbnail(asset),
+        ...probeStub.videoStream2160p,
+      });
 
-      expect(await sut.handleGenerateThumbnails({ id: asset.id })).toEqual(JobStatus.Skipped);
-
-      expect(mocks.media.generateThumbnail).not.toHaveBeenCalled();
-      expect(mocks.asset.update).not.toHaveBeenCalledWith();
+      await expect(sut.handleGenerateThumbnails({ id: asset.id })).resolves.toBe(JobStatus.Success);
+      expect(mocks.media.transcode).toHaveBeenCalled();
     });
 
     it('should delete previous preview if different path', async () => {
@@ -2041,6 +2042,16 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should queue thumbnail generation after successful transcoding', async () => {
+      mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.videoStream2160p });
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.All } });
+      await sut.handleVideoConversion({ id: asset.id });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetGenerateThumbnails,
+        data: { id: asset.id },
+      });
+    });
+
     it('should transcode when optimal and too big', async () => {
       mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.videoStream2160p });
       mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.Optimal } });
@@ -2274,6 +2285,20 @@ describe(MediaService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.Disabled } });
       await sut.handleVideoConversion({ id: 'video-id' });
       expect(mocks.media.transcode).not.toHaveBeenCalled();
+    });
+
+    it('should queue thumbnail generation but not create an encoded-video file entry when no transcode is required', async () => {
+      const localAsset = AssetFactory.from({ type: AssetType.Video, originalPath: '/original/path.ext' }).build();
+      mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...localAsset, ...probeStub.videoStreamH264 });
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.Disabled } });
+
+      await sut.handleVideoConversion({ id: localAsset.id });
+
+      expect(mocks.asset.upsertFile).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetGenerateThumbnails,
+        data: { id: localAsset.id },
+      });
     });
 
     it('should not remux when input is not an accepted container and transcoding is disabled', async () => {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -9,7 +9,6 @@ import { SystemConfigFFmpegDto } from 'src/dtos/system-config.dto';
 import {
   AssetFileType,
   AssetType,
-  AssetVisibility,
   AudioCodec,
   Colorspace,
   ImageFormat,
@@ -216,10 +215,6 @@ export class MediaService extends BaseService {
       return JobStatus.Failed;
     }
 
-    if (asset.visibility === AssetVisibility.Hidden) {
-      this.logger.verbose(`Thumbnail generation skipped for asset ${id}: not visible`);
-      return JobStatus.Skipped;
-    }
 
     let generated: Awaited<ReturnType<MediaService['generateImageThumbnails']>>;
     if (asset.type === AssetType.Video || asset.originalFileName.toLowerCase().endsWith('.gif')) {
@@ -592,14 +587,14 @@ export class MediaService extends BaseService {
     const target = this.getTranscodeTarget(ffmpeg, videoStream, audioStream);
     if (target === TranscodeTarget.None && !this.isRemuxRequired(ffmpeg, format)) {
       const encodedVideo = getAssetFile(asset.files, AssetFileType.EncodedVideo, { isEdited: false });
-      if (encodedVideo) {
+      if (encodedVideo && encodedVideo.path !== input) {
         this.logger.log(`Transcoded video exists for asset ${asset.id}, but is no longer required. Deleting...`);
         await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [encodedVideo.path] } });
         await this.assetRepository.deleteFiles([encodedVideo]);
-      } else {
-        this.logger.verbose(`Asset ${asset.id} does not require transcoding based on current policy, skipping`);
       }
 
+      this.logger.verbose(`Asset ${asset.id} does not require transcoding based on current policy; using original file`);
+      await this.jobRepository.queue({ name: JobName.AssetGenerateThumbnails, data: { id: asset.id } });
       return JobStatus.Skipped;
     }
 
@@ -649,6 +644,8 @@ export class MediaService extends BaseService {
       path: output,
       isEdited: false,
     });
+
+    await this.jobRepository.queue({ name: JobName.AssetGenerateThumbnails, data: { id: asset.id } });
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
## Description

When video conversion completed without requiring transcoding, hidden motion-photo companion videos never had thumbnail generation triggered. Since hidden assets are excluded from the batch thumbnail generation queue, the required preview and thumbnail files were never created, causing companion video thumbnail requests to return `Asset media not found`.

This change fixes the thumbnail generation flow by:

- Queueing `AssetGenerateThumbnails` after video conversion completes, including when transcoding is skipped.
- Allowing hidden motion-photo companion videos to generate the preview and thumbnail files required for playback.
- Removing the previous approach of creating an `EncodedVideo` asset file for the original media, since thumbnail generation already operates directly on the original video.

Fixes #29846

## How Has This Been Tested?

- [x] Added regression tests covering the no-transcode video conversion path.
- [x] Verified that thumbnail generation is queued when video conversion completes without transcoding.
- [x] Verified that no `EncodedVideo` asset file is created when transcoding is skipped.
- [x] Ran the updated server unit tests covering the modified behavior.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help analyze the existing codebase and discuss possible approaches. The implementation, debugging, testing, and final validation were completed manually.

