### PR TITLE
fix(web): stream archive downloads to disk to avoid Safari memory exhaustion

### DIFF
--- a/web/src/lib/utils.spec.ts
+++ b/web/src/lib/utils.spec.ts
@@ -1,5 +1,5 @@
 import { AssetTypeEnum } from '@immich/sdk';
-import { getAssetUrl, semverToName } from '$lib/utils';
+import { downloadRequestToFile, downloadUrl, getAssetUrl, semverToName } from '$lib/utils';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 
@@ -168,6 +168,121 @@ describe('utils', () => {
 
     it('should append release candidate if set', () => {
       expect(semverToName({ major: 3, minor: 0, patch: 0, prerelease: 0 })).toEqual('v3.0.0-rc.0');
+    });
+  });
+
+  describe(downloadUrl.name, () => {
+    const revokeObjectURLMock = vi.fn();
+
+    beforeAll(() => {
+      Object.defineProperty(URL, 'revokeObjectURL', { writable: true, value: revokeObjectURLMock });
+    });
+
+    beforeEach(() => {
+      revokeObjectURLMock.mockClear();
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should defer revoking blob urls until after the download has started', () => {
+      downloadUrl('blob:https://immich.test/some-id', 'archive.zip');
+
+      expect(revokeObjectURLMock).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:https://immich.test/some-id');
+    });
+
+    it('should not revoke non-blob urls', () => {
+      downloadUrl('https://immich.test/api/assets/id/original', 'photo.jpg');
+
+      vi.runAllTimers();
+
+      expect(revokeObjectURLMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(downloadRequestToFile.name, () => {
+    const expectedFile = new File([new Uint8Array([1, 2, 3, 4, 5])], 'archive.zip');
+    const writable = {
+      write: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+      abort: vi.fn(() => Promise.resolve()),
+    };
+    const fileHandle = { createWritable: vi.fn(() => Promise.resolve(writable)), getFile: () => expectedFile };
+    const directory = {
+      async *keys() {},
+      getFileHandle: vi.fn(() => Promise.resolve(fileHandle)),
+      removeEntry: vi.fn(() => Promise.resolve()),
+    };
+    const root = { getDirectoryHandle: vi.fn(() => Promise.resolve(directory)) };
+
+    class FileSystemFileHandleMock {
+      createWritable() {}
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.stubGlobal('FileSystemFileHandle', FileSystemFileHandleMock);
+      Object.defineProperty(navigator, 'storage', {
+        configurable: true,
+        value: { getDirectory: () => Promise.resolve(root) },
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      Object.defineProperty(navigator, 'storage', { configurable: true, value: undefined });
+    });
+
+    it('should return null when the file system APIs are not available', async () => {
+      Object.defineProperty(navigator, 'storage', { configurable: true, value: undefined });
+
+      await expect(downloadRequestToFile({ url: 'https://immich.test/api/download/archive' })).resolves.toBeNull();
+    });
+
+    it('should stream the response to a disk-backed file', async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve(new Response(body, { status: 200 }))),
+      );
+      const onDownloadProgress = vi.fn();
+
+      const file = await downloadRequestToFile({
+        method: 'POST',
+        url: 'https://immich.test/api/download/archive',
+        data: { assetIds: ['asset-id'] },
+        onDownloadProgress,
+      });
+
+      expect(file).toBe(expectedFile);
+      expect(writable.write).toHaveBeenCalledTimes(2);
+      expect(writable.close).toHaveBeenCalled();
+      expect(onDownloadProgress).toHaveBeenLastCalledWith(expect.objectContaining({ loaded: 5 }));
+      expect(directory.removeEntry).not.toHaveBeenCalled();
+    });
+
+    it('should remove the temporary file when the request fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve(new Response('error', { status: 500 }))),
+      );
+
+      await expect(downloadRequestToFile({ url: 'https://immich.test/api/download/archive' })).rejects.toThrow();
+
+      expect(writable.abort).toHaveBeenCalled();
+      expect(directory.removeEntry).toHaveBeenCalled();
     });
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -35,7 +35,7 @@ interface DownloadRequestOptions<T = unknown> {
   url: string;
   data?: T;
   signal?: AbortSignal;
-  onDownloadProgress?: (event: ProgressEvent<XMLHttpRequestEventTarget>) => void;
+  onDownloadProgress?: (event: ProgressEvent) => void;
 }
 
 interface DateFormatter {
@@ -168,6 +168,115 @@ export const downloadRequest = <TBody = unknown>(options: DownloadRequestOptions
   });
 };
 
+const OPFS_DOWNLOADS_DIRECTORY = 'downloads';
+const OPFS_DOWNLOAD_MAX_AGE_MS = 60 * 60 * 1000;
+
+const getOpfsDownloadsDirectory = async (): Promise<FileSystemDirectoryHandle | null> => {
+  if (
+    !globalThis.navigator?.storage?.getDirectory ||
+    typeof FileSystemFileHandle === 'undefined' ||
+    !('createWritable' in FileSystemFileHandle.prototype)
+  ) {
+    return null;
+  }
+
+  try {
+    const root = await navigator.storage.getDirectory();
+    return await root.getDirectoryHandle(OPFS_DOWNLOADS_DIRECTORY, { create: true });
+  } catch {
+    // OPFS can be unavailable in some browsing contexts (e.g. private browsing)
+    return null;
+  }
+};
+
+const removeStaleOpfsDownloads = async (directory: FileSystemDirectoryHandle) => {
+  const now = Date.now();
+  try {
+    for await (const name of directory.keys()) {
+      const timestamp = Number(name.split('-')[0]);
+      if (!Number.isFinite(timestamp) || now - timestamp > OPFS_DOWNLOAD_MAX_AGE_MS) {
+        await directory.removeEntry(name).catch(() => {});
+      }
+    }
+  } catch {
+    // a failed cleanup should never block the download itself
+  }
+};
+
+/**
+ * Downloads a request to a temporary file backed by the origin private file system instead of
+ * buffering the whole response in memory. Safari cannot spill large blobs to disk, so in-memory
+ * downloads of large archives make the page run out of memory (see #28316).
+ *
+ * Returns `null` when the browser does not support the required file system APIs, in which case
+ * the caller should fall back to an in-memory download.
+ */
+export const downloadRequestToFile = async <TBody = unknown>(
+  options: DownloadRequestOptions<TBody>,
+): Promise<File | null> => {
+  const directory = await getOpfsDownloadsDirectory();
+  if (!directory) {
+    return null;
+  }
+
+  await removeStaleOpfsDownloads(directory);
+
+  const temporaryFileName = `${Date.now()}-${crypto.randomUUID()}`;
+  let writable: FileSystemWritableFileStream;
+  let fileHandle: FileSystemFileHandle;
+  try {
+    fileHandle = await directory.getFileHandle(temporaryFileName, { create: true });
+    // Unsupported in Safari <26; guarded by the feature detection in getOpfsDownloadsDirectory
+    // eslint-disable-next-line tscompat/tscompat
+    writable = await fileHandle.createWritable();
+  } catch {
+    return null;
+  }
+
+  const { signal, method, url, data: body, onDownloadProgress: onProgress } = options;
+
+  try {
+    const response = await fetch(url, {
+      method: method || 'GET',
+      signal,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      throw new ApiError(response.statusText, response.status, await response.text());
+    }
+
+    if (!response.body) {
+      throw new Error(`Response for ${url} has no body`);
+    }
+
+    const total = Number(response.headers.get('Content-Length')) || 0;
+    const reader = response.body.getReader();
+    let loaded = 0;
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      // eslint-disable-next-line tscompat/tscompat
+      await writable.write(value);
+      loaded += value.byteLength;
+      onProgress?.(new ProgressEvent('progress', { lengthComputable: total > 0, loaded, total }));
+    }
+
+    // eslint-disable-next-line tscompat/tscompat
+    await writable.close();
+    return await fileHandle.getFile();
+  } catch (error) {
+    // eslint-disable-next-line tscompat/tscompat
+    await writable.abort().catch(() => {});
+    await directory.removeEntry(temporaryFileName).catch(() => {});
+    throw error;
+  }
+};
+
 let _sharedLink: SharedLinkResponseDto | undefined;
 
 export const setSharedLink = (sharedLink: typeof _sharedLink) => (_sharedLink = sharedLink);
@@ -282,6 +391,8 @@ const jsonReplacer = (_key: string, value: unknown) =>
         }, {})
     : value;
 
+const OBJECT_URL_REVOKE_DELAY_MS = 60 * 1000;
+
 export const downloadUrl = (url: string, filename: string) => {
   const anchor = document.createElement('a');
   anchor.href = url;
@@ -291,7 +402,11 @@ export const downloadUrl = (url: string, filename: string) => {
   anchor.click();
   anchor.remove();
 
-  URL.revokeObjectURL(url);
+  if (url.startsWith('blob:')) {
+    // Safari resolves the anchor's blob url asynchronously after the click, so revoking it
+    // synchronously can prevent the download from ever starting
+    setTimeout(() => URL.revokeObjectURL(url), OBJECT_URL_REVOKE_DELAY_MS);
+  }
 };
 
 export const downloadBlob = (data: Blob, filename: string) => downloadUrl(URL.createObjectURL(data), filename);

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -26,7 +26,7 @@ import { authManager } from '$lib/managers/auth-manager.svelte';
 import { downloadManager } from '$lib/managers/download-manager.svelte';
 import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
-import { downloadBlob, downloadRequest, withError } from '$lib/utils';
+import { downloadBlob, downloadRequest, downloadRequestToFile, withError } from '$lib/utils';
 import { getByteUnitString } from '$lib/utils/byte-units';
 import { getFormatter } from '$lib/utils/i18n';
 import { navigate } from '$lib/utils/navigation';
@@ -103,15 +103,23 @@ export const downloadArchive = async (fileName: string, options: Omit<DownloadIn
 
     try {
       // TODO use sdk once it supports progress events
-      const { data } = await downloadRequest({
-        method: 'POST',
+      const requestOptions = {
+        method: 'POST' as const,
         url: getBaseUrl() + '/download/archive' + (queryParams ? `?${queryParams}` : ''),
         data: { assetIds: archive.assetIds, edited: true },
         signal: abort.signal,
-        onDownloadProgress: (event) => downloadManager.update(downloadKey, event.loaded),
-      });
+        onDownloadProgress: (event: ProgressEvent) => downloadManager.update(downloadKey, event.loaded),
+      };
 
-      downloadBlob(data, archiveName);
+      // Stream the archive to a disk-backed file when the browser supports it. Buffering it in
+      // memory makes Safari run out of memory for large archives (see #28316).
+      const file = await downloadRequestToFile(requestOptions);
+      if (file) {
+        downloadBlob(file, archiveName);
+      } else {
+        const { data } = await downloadRequest(requestOptions);
+        downloadBlob(data, archiveName);
+      }
     } catch (error) {
       const $t = get(t);
       handleError(error, $t('errors.unable_to_download_files'));


### PR DESCRIPTION
## Description

Archive (album / multi-asset) downloads currently buffer the entire zip in memory via an XHR with `responseType: 'blob'` before handing it to an anchor element. Chrome and Firefox spill large blobs to disk, but Safari keeps them fully in memory, so downloading an album larger than ~500 MB makes the tab hit its memory cap, thrash, and hang (diagnosis by @connorlurring in the issue). Additionally, `downloadUrl()` revoked the object URL synchronously after `anchor.click()`; Safari resolves the anchor's blob URL asynchronously after the click, so the URL could be revoked before the download ever started (previously identified in #28827, which was auto-closed for a template issue).

This PR:

- Adds `downloadRequestToFile()`, which streams the archive response into a temporary file in the origin private file system (OPFS) instead of buffering it in memory, and hands the disk-backed `File` to the existing `downloadBlob()` path. Progress reporting and abort behavior are preserved.
- Falls back to the previous in-memory XHR path when the browser does not support OPFS writes (`FileSystemFileHandle.createWritable`, supported in Chromium, Firefox, and Safari 26+), so older browsers behave exactly as before.
- Defers `URL.revokeObjectURL` for blob URLs so Safari has time to start the download.
- Cleans up stale OPFS temp files (older than 1 hour) on subsequent downloads, and removes the temp file immediately when a download fails or is aborted.

Fixes #28316

## How Has This Been Tested?

- [x] Unit tests added for `downloadUrl` (deferred revocation, non-blob URLs untouched) and `downloadRequestToFile` (unsupported-browser fallback, streaming + progress, temp-file cleanup on failure).
- [x] Manually against a local immich server (Docker) with a 20-asset / 268.6 MiB album, web dev server + Chrome:
  - Streaming path: archive was written to an OPFS temp file in chunks (correct final size, valid zip magic bytes), progress toast advanced to 100%, and the anchor received a disk-backed blob URL with the correct `Big Album-<timestamp>.zip` filename.
  - Deferred revoke: blob URL still resolvable shortly after the click, revoked after the delay.
  - Stale cleanup: a planted OPFS file with an old timestamp was removed by the next download; fresh files were retained.
  - Fallback: with `navigator.storage.getDirectory` failing, the download completed through the previous XHR/blob path.
- [ ] Not verified on a real Safari >500 MB album (no Safari automation available); the memory-exhaustion mechanism this avoids is Safari's in-memory blob handling, and the streaming path was verified in Chromium.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was developed with substantial LLM assistance (Claude): root-cause analysis, implementation, tests, and the manual verification against a local server were done with the AI agent, reviewed by me before submission.
