### PR TITLE
fix(server): prioritize exact place name matches in location search

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -142,7 +142,7 @@ where
   or f_unaccent ("admin1Name") %>> f_unaccent ($3)
   or f_unaccent ("alternateNames") %>> f_unaccent ($4)
 order by
-  coalesce(f_unaccent (name) <->>> f_unaccent ($5), 0.1) + coalesce(
+  (coalesce(f_unaccent (name) <->>> f_unaccent ($5), 0.1) * 3) + coalesce(
     f_unaccent ("admin2Name") <->>> f_unaccent ($6),
     0.1
   ) + coalesce(

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -367,7 +367,7 @@ export class SearchRepository {
       )
       .orderBy(
         sql`
-          coalesce(f_unaccent(name) <->>> f_unaccent(${placeName}), 0.1) +
+          (coalesce(f_unaccent(name) <->>> f_unaccent(${placeName}), 0.1) * 3) +
           coalesce(f_unaccent("admin2Name") <->>> f_unaccent(${placeName}), 0.1) +
           coalesce(f_unaccent("admin1Name") <->>> f_unaccent(${placeName}), 0.1) +
           coalesce(f_unaccent("alternateNames") <->>> f_unaccent(${placeName}), 0.1)


### PR DESCRIPTION
## Description

When searching for a location to assign to a photo (for example, searching for `Kent`), exact city matches could be ranked below less relevant results. The search previously ordered results solely by the combined trigram similarity across multiple fields, allowing places that matched several fields (such as "Kent County") to rank higher than a city whose primary name exactly matched the query.

This change introduces a small ordering adjustment that prioritizes exact primary name matches before the existing trigram similarity ordering. All other results continue to use the existing trigram-based ranking, preserving the current fuzzy-search behavior while ensuring exact primary name matches are returned first.

Fixes #29842

## How Has This Been Tested?

- [x] Verified that searching for an exact city name (for example, `Kent`) returns the expected city before less relevant matches.
- [x] Verified that non-exact searches continue to use the existing trigram similarity ordering.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich-specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help analyze the existing search ranking logic and discuss possible approaches. The implementation, testing, and final review were completed manually.