### PR TITLE
fix(server): workflow date filter, make end date inclusive

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -127,7 +127,7 @@ const methods = wrapper<Manifest>({
   assetDateFilter: ({ config, data }) => {
     const assetDate = new Date(data.asset.localDateTime);
     let startDate = new Date(config.startDate.year, config.startDate.month - 1, config.startDate.day);
-    let endDate = new Date(config.endDate.year, config.endDate.month - 1, config.endDate.day);
+    let endDate = new Date(config.endDate.year, config.endDate.month - 1, config.endDate.day + 1);
 
     if (config.recurring) {
       startDate.setFullYear(assetDate.getFullYear());
@@ -142,7 +142,7 @@ const methods = wrapper<Manifest>({
       }
     }
 
-    return { workflow: { continue: assetDate >= startDate && assetDate <= endDate } };
+    return { workflow: { continue: assetDate >= startDate && assetDate < endDate } };
   },
 
   assetLock: ({ config, data }) => {

--- a/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
+++ b/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
@@ -431,11 +431,9 @@ describe('core plugin', () => {
   describe('assetDateFilter', () => {
     it('should favorite assets created during the first 7 days of a specific year and month', async () => {
       const { user } = await ctx.newUser();
-      const [{ asset: asset1 }, { asset: asset2 }, { asset: asset3 }, { asset: asset4 }] = await Promise.all([
-        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 2, 31, 13, 0, 0, 0) }),
-        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 1, 2, 0, 0, 0) }),
-        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 7, 14, 0, 0, 0) }),
-        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 8, 0, 0, 0, 0) }),
+      const [{ asset: asset1 }, { asset: asset2 }] = await Promise.all([
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date('2000-04-01') }),
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date('2000-04-07T23:59:59Z') }),
       ]);
 
       const workflow = await createWorkflow({
@@ -459,20 +457,11 @@ describe('core plugin', () => {
       await expect(
         ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset1.id }),
       ).resolves.toBeUndefined();
-      await expect(ctx.get(AssetRepository).getById(asset1.id)).resolves.toMatchObject({ isFavorite: false });
+      await expect(ctx.get(AssetRepository).getById(asset1.id)).resolves.toMatchObject({ isFavorite: true });
       await expect(
         ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset2.id }),
       ).resolves.toBeUndefined();
       await expect(ctx.get(AssetRepository).getById(asset2.id)).resolves.toMatchObject({ isFavorite: true });
-      await expect(
-        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset3.id }),
-      ).resolves.toBeUndefined();
-      await expect(ctx.get(AssetRepository).getById(asset3.id)).resolves.toMatchObject({ isFavorite: true });
-      await expect(
-        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset4.id }),
-      ).resolves.toBeUndefined();
-      await expect(ctx.get(AssetRepository).getById(asset4.id)).resolves.toMatchObject({ isFavorite: false });
-    });
   });
 
   describe('webhook', () => {

--- a/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
+++ b/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
@@ -428,6 +428,53 @@ describe('core plugin', () => {
     });
   });
 
+  describe('assetDateFilter', () => {
+    it('should favorite assets created during the first 7 days of a specific year and month', async () => {
+      const { user } = await ctx.newUser();
+      const [{ asset: asset1 }, { asset: asset2 }, { asset: asset3 }, { asset: asset4 }] = await Promise.all([
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 2, 31, 13, 0, 0, 0) }),
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 1, 2, 0, 0, 0) }),
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 7, 14, 0, 0, 0) }),
+        ctx.newAsset({ ownerId: user.id, localDateTime: new Date(2000, 3, 8, 0, 0, 0, 0) }),
+      ]);
+
+      const workflow = await createWorkflow({
+        ownerId: user.id,
+        trigger: WorkflowTrigger.AssetCreate,
+        steps: [
+          {
+            method: 'immich-plugin-core#assetDateFilter',
+            config: {
+              startDate: { day: 1, month: 4, year: 2000 },
+              endDate: { day: 7, month: 4, year: 2000 },
+              recurring: false,
+            },
+          },
+          {
+            method: 'immich-plugin-core#assetFavorite',
+          },
+        ],
+      });
+
+      await expect(
+        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset1.id }),
+      ).resolves.toBeUndefined();
+      await expect(ctx.get(AssetRepository).getById(asset1.id)).resolves.toMatchObject({ isFavorite: false });
+      await expect(
+        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset2.id }),
+      ).resolves.toBeUndefined();
+      await expect(ctx.get(AssetRepository).getById(asset2.id)).resolves.toMatchObject({ isFavorite: true });
+      await expect(
+        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset3.id }),
+      ).resolves.toBeUndefined();
+      await expect(ctx.get(AssetRepository).getById(asset3.id)).resolves.toMatchObject({ isFavorite: true });
+      await expect(
+        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset4.id }),
+      ).resolves.toBeUndefined();
+      await expect(ctx.get(AssetRepository).getById(asset4.id)).resolves.toMatchObject({ isFavorite: false });
+    });
+  });
+
   describe('webhook', () => {
     it('should trigger a webhook on asset upload', async () => {
       const { user } = await ctx.newUser();

--- a/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
+++ b/server/test/medium/specs/workflow/workflow-core-plugin.spec.ts
@@ -454,14 +454,12 @@ describe('core plugin', () => {
         ],
       });
 
-      await expect(
-        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset1.id }),
-      ).resolves.toBeUndefined();
+      await ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset1.id });
       await expect(ctx.get(AssetRepository).getById(asset1.id)).resolves.toMatchObject({ isFavorite: true });
-      await expect(
-        ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset2.id }),
-      ).resolves.toBeUndefined();
+
+      await ctx.sut.handleAssetTrigger({ workflowId: workflow.id, assetId: asset2.id });
       await expect(ctx.get(AssetRepository).getById(asset2.id)).resolves.toMatchObject({ isFavorite: true });
+    });
   });
 
   describe('webhook', () => {


### PR DESCRIPTION
## Description

In the new Workflow Date filter element, the "End Date" parameters create a new date at hour/minute 0:00. This results in the "End Date" day being excluded from the results.

<img width="573" height="465" alt="image" src="https://github.com/user-attachments/assets/d098ac1c-9da0-4f23-a1ec-2e1559f3fa0d" />

To make the filter include assets from the provided end date, we should change the comparison to "<" and make it against the following day. The Date constructor already handles overflow, so for example creating a Date with day 32 would not result in an error.

## How Has This Been Tested?

- [x] Created a workflow testing this exact use case and it correctly included the asset in the end date.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None