### PR TITLE
refactor: use single bucket for none grouping

### DIFF
--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -26,7 +26,6 @@ const String kDownloadGroupLivePhoto = 'group_livephoto';
 const String kShareDownloadGroup = 'group_share';
 
 // Timeline constants
-const int kTimelineNoneSegmentSize = 120;
 const int kTimelineAssetLoadBatchSize = 1024;
 const int kTimelineAssetLoadOppositeSize = 64;
 

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:drift/drift.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
@@ -685,16 +684,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
   }
 }
 
-List<Bucket> _generateBuckets(int count) {
-  final buckets = List.filled(
-    (count / kTimelineNoneSegmentSize).ceil(),
-    const Bucket(assetCount: kTimelineNoneSegmentSize),
-  );
-  if (count % kTimelineNoneSegmentSize != 0) {
-    buckets[buckets.length - 1] = Bucket(assetCount: count % kTimelineNoneSegmentSize);
-  }
-  return buckets;
-}
+List<Bucket> _generateBuckets(int count) => count == 0 ? const [] : [Bucket(assetCount: count)];
 
 extension on Expression<DateTime> {
   Expression<String> dateFmt(GroupAssetsBy groupBy, {bool toLocal = false}) {


### PR DESCRIPTION
None grouped buckets rendered as a series of 120 asset buckets and bucket boundaries rendered without any spacing. But none grouped assets can all be part of a single bucket and making them a single bucket fixes the spacing issue as a nice side-effect