### PR TITLE
fix(web): keep Save button visible in workflow editor on narrow screens

### DIFF
--- a/web/src/routes/(user)/workflows/[workflowId]/+page.svelte
+++ b/web/src/routes/(user)/workflows/[workflowId]/+page.svelte
@@ -277,10 +277,11 @@
       translations={{ close: $t('back') }}
       closeIcon={mdiArrowLeft}
       actions={[Duplicate, CopyJson, Download, Delete].map((item) => ({ ...item, color: undefined }))}
+      class="workflow-action-bar"
     >
-      <ControlBarHeader>
-        <ControlBarTitle>{data.workflow.name}</ControlBarTitle>
-        <ControlBarDescription>{data.workflow.description}</ControlBarDescription>
+      <ControlBarHeader class="flex-1 min-w-0">
+        <ControlBarTitle class="truncate">{data.workflow.name}</ControlBarTitle>
+        <ControlBarDescription class="truncate">{data.workflow.description}</ControlBarDescription>
       </ControlBarHeader>
       <ControlBarContent class="flex items-center justify-end gap-6">
         {#if hasChanges}
@@ -299,6 +300,17 @@
       </ControlBarContent>
     </ActionBar>
   </AppShellBar>
+
+  <style>
+    /*
+     * Allow the toolbar header to shrink on narrow screens so long workflow
+     * titles truncate instead of pushing the action buttons off-screen.
+     */
+    .workflow-action-bar :global(> div:first-child) {
+      flex-shrink: 1;
+      min-width: 0;
+    }
+  </style>
 
   <Container size="medium" class="pt-8 pb-24" center>
     <VStack gap={4}>


### PR DESCRIPTION
## Description

This PR fixes the workflow editor toolbar on narrow screens where the **Save** button becomes inaccessible.

On small viewports, the workflow title and description expand to their intrinsic width, preventing the left section of the toolbar from shrinking. As a result, the center section containing the **Save** button is compressed to zero width and pushed off-screen.

### Root Cause

The shared `ControlBar` component renders its left section with `flex-shrink: 0`. When workflow titles are long, the left section consumes the available width on narrow screens, leaving no space for the Save button.

### Fix

This change applies a minimal, page-scoped layout fix in `web/src/routes/(user)/workflows/[workflowId]/+page.svelte`:

- Added `class="workflow-action-bar"` to `ActionBar` to provide a scoped styling hook.
- Added `flex-1 min-w-0` to `ControlBarHeader` so the header can participate in flex shrinking.
- Added `truncate` to the workflow title and description so long text is clipped instead of expanding indefinitely.
- Added a page-scoped CSS override that allows the left toolbar section to shrink, ensuring the Save button remains visible on narrow screens without modifying the shared `ControlBar` component.

This is a layout-only change and does not modify workflow functionality, shared UI components, or translations.

Fixes #29534

## How Has This Been Tested?

- [x] Verified the Save button remains visible using browser responsive mode at narrow viewport widths (approximately 360–430px).
- [x] Verified long workflow titles are truncated with an ellipsis instead of pushing the Save button off-screen.
- [x] Verified the desktop layout remains unchanged.
- [x] Verified no workflow functionality or save behavior was affected.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help analyze the layout issue, explain the underlying flexbox behavior, and assist in drafting the proposed fix and PR description. All suggested changes were manually reviewed, implemented, and verified before submission.
