### PR TITLE
fix: Ken Burns effect on sliver app bar jittery on Android

### DIFF
--- a/mobile/lib/widgets/common/mesmerizing_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/mesmerizing_sliver_app_bar.dart
@@ -393,10 +393,8 @@ class _RandomAssetBackgroundState extends State<_RandomAssetBackground> with Tic
       builder: (context, child) {
         return Transform.scale(
           scale: _zoomAnimation.value,
-          filterQuality: Platform.isAndroid ? FilterQuality.low : null,
           child: Transform.translate(
             offset: _panAnimation.value,
-            filterQuality: Platform.isAndroid ? FilterQuality.low : null,
             child: Stack(
               fit: StackFit.expand,
               children: [

--- a/mobile/lib/widgets/common/person_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/person_sliver_app_bar.dart
@@ -496,10 +496,8 @@ class _RandomAssetBackgroundState extends State<_RandomAssetBackground> with Tic
       builder: (context, child) {
         return Transform.scale(
           scale: _zoomAnimation.value,
-          filterQuality: Platform.isAndroid ? FilterQuality.low : null,
           child: Transform.translate(
             offset: _panAnimation.value,
-            filterQuality: Platform.isAndroid ? FilterQuality.low : null,
             child: Stack(
               fit: StackFit.expand,
               children: [

--- a/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
@@ -472,10 +472,8 @@ class _RandomAssetBackgroundState extends State<_RandomAssetBackground> with Tic
       builder: (context, child) {
         return Transform.scale(
           scale: _zoomAnimation.value,
-          filterQuality: Platform.isAndroid ? FilterQuality.low : null,
           child: Transform.translate(
             offset: _panAnimation.value,
-            filterQuality: Platform.isAndroid ? FilterQuality.low : null,
             child: Stack(
               fit: StackFit.expand,
               children: [


### PR DESCRIPTION
Fix the issue of Ken Burns effect on mesmerizing sliver app bar keep jittering and rendering the white border on Android while animating. Removing this quality filter fixes the issue. Tested on Android and iOS and they are animating smoothly now, without any quality loss or artifacts