### PR TITLE
fix(web): show Save button on narrow screens in workflow editor

### DIFF
--- a/web/src/routes/(user)/workflows/[workflowId]/+page.svelte
+++ b/web/src/routes/(user)/workflows/[workflowId]/+page.svelte
@@ -277,10 +277,11 @@
       translations={{ close: $t('back') }}
       closeIcon={mdiArrowLeft}
       actions={[Duplicate, CopyJson, Download, Delete].map((item) => ({ ...item, color: undefined }))}
+      class="workflow-action-bar"
     >
-      <ControlBarHeader>
-        <ControlBarTitle>{data.workflow.name}</ControlBarTitle>
-        <ControlBarDescription>{data.workflow.description}</ControlBarDescription>
+      <ControlBarHeader class="min-w-0 flex-1">
+        <ControlBarTitle class="truncate">{data.workflow.name}</ControlBarTitle>
+        <ControlBarDescription class="truncate">{data.workflow.description}</ControlBarDescription>
       </ControlBarHeader>
       <ControlBarContent class="flex items-center justify-end gap-6">
         {#if hasChanges}
@@ -299,6 +300,17 @@
       </ControlBarContent>
     </ActionBar>
   </AppShellBar>
+
+  <style>
+    /*
+     * Allow the toolbar header to shrink on narrow screens so long workflow
+     * titles truncate instead of pushing the action buttons off-screen.
+     */
+    .workflow-action-bar :global(> div:first-child) {
+      flex-shrink: 1;
+      min-width: 0;
+    }
+  </style>
 
   <Container size="medium" class="pt-8 pb-24" center>
     <VStack gap={4}>


### PR DESCRIPTION
## Description

This fixes the workflow editor toolbar on narrow screens where the **Save** button can disappear.

On smaller viewports, long workflow titles take up all the available space in the left side of the toolbar. Since the left section can't shrink, the center section containing the **Save** button gets pushed off-screen.

### Fix

- Added `class="workflow-action-bar"` to `ActionBar` so the page can apply a scoped layout override.
- Added `flex-1 min-w-0` to `ControlBarHeader` so the header can shrink when space is limited.
- Added `truncate` to the workflow title and description so long text is clipped with an ellipsis instead of expanding indefinitely.
- Added a scoped CSS rule that allows the left toolbar section to shrink on narrow screens, keeping the **Save** button visible.

This only affects the layout when space is constrained. The desktop layout remains unchanged.

Fixes #29534

## How Has This Been Tested?

- [x] Verified the **Save** button remains visible on narrow viewports (~360–430px wide).
- [x] Verified long workflow titles are truncated instead of pushing the **Save** button off-screen.
- [x] Verified the desktop layout behaves as before.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help me understand the issue while I was investigating it. The implementation, testing, and final changes were completed and verified by me before submitting this pull request.
