### PR TITLE
fix(web): use Container component for responsive admin maintenance la…

### DIFF
--- a/web/src/routes/admin/maintenance/+page.svelte
+++ b/web/src/routes/admin/maintenance/+page.svelte
@@ -16,7 +16,7 @@
     type JobCreateDto,
     type QueuesResponseLegacyDto,
   } from '@immich/sdk';
-  import { Button, HStack, Text } from '@immich/ui';
+  import { Button, Container, HStack, Text } from '@immich/ui';
   import { mdiRefresh } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t, type Translations } from 'svelte-i18n';
@@ -108,8 +108,8 @@
 <OnEvents {onJobCreate} />
 
 <AdminPageLayout breadcrumbs={[{ title: data.meta.title }]} actions={[StartMaintenance]}>
-  <section id="setting-content" class="flex place-content-center sm:mx-4">
-    <section class="w-full pb-4 sm:w-5/6 md:w-[850px]">
+  <Container size="large" center class="my-4 flex flex-col gap-6">
+    <section class="w-full pb-4">
       <HStack>
         <Text size="small">{$t('admin.maintenance_integrity_report')}</Text>
         <Button
@@ -177,10 +177,8 @@
         {/each}
       </div>
     </section>
-  </section>
 
-  <section id="setting-content" class="flex place-content-center sm:mx-4">
-    <section class="w-full pb-28 sm:w-5/6 md:w-212.5">
+    <section class="w-full pb-28">
       <Text size="small">{$t('admin.maintenance_backup_management')}</Text>
 
       <SettingAccordion
@@ -192,5 +190,5 @@
         <MaintenanceBackupsList backups={data.backups} expectedVersion={data.expectedVersion} />
       </SettingAccordion>
     </section>
-  </section>
+  </Container>
 </AdminPageLayout>


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

this updates the admin maintenance page to use the shared container component instead of  custom responsive layout wrapper.

Fixes #29454

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Tested the /admin/maintenance page at different window sizes.
- Confirmed the page no longer gets cut off and the layout stays aligned.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

i have used ai to discuss the issue and the possible potential solution for the problem.
...
