### PR TITLE
fix(web): hide stack thumbnail tray in slideshow mode

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -625,7 +625,7 @@
     </div>
   {/if}
 
-  {#if stack && withStacked && !assetViewerManager.isShowEditor}
+  {#if stack && withStacked && !assetViewerManager.isShowEditor && $slideshowState === SlideshowState.None}
     {@const stackedAssets = stack.assets}
     <div id="stack-slideshow" class="absolute bottom-0 col-span-4 col-start-1 w-fit max-w-full">
       <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">


### PR DESCRIPTION
## Description

This hides the stack overlay while a slideshow is running so it doesn't cover the media information.

Fixes #29458

## How Has This Been Tested?

* Started a slideshow with stacked assets.
* Checked that the media information is no longer covered.
* Checked that the stack overlay still appears when not in slideshow mode.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

* [x] I have carefully read CONTRIBUTING.md
* [x] I have performed a self-review of my own code
* [ ] I have made corresponding changes to the documentation if applicable
* [x] I have no unrelated changes in the PR.
* [x] I have confirmed that any new dependencies are strictly necessary.
* [ ] I have written tests for new code (if applicable)
* [x] I have followed naming conventions/patterns in the surrounding code
* [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
* [ ] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used AI to discuss the issue and possible solutions. I made the final changes and tested them myself.

......