### PR TITLE
chore(security.txt): bump expired Expires field (RFC 9116)

### DIFF
--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -4,4 +4,4 @@
 Policy: https://github.com/immich-app/immich/blob/main/SECURITY.md
 Contact: mailto:security@immich.app
 Preferred-Languages: en
-Expires: 2026-05-01T23:59:00.000Z
+Expires: 2027-05-01T23:59:00.000Z


### PR DESCRIPTION
## Description

The `security.txt` at `web/static/.well-known/security.txt` (served live at `https://immich.app/.well-known/security.txt`) has an `Expires` value in the past — `2026-05-01T23:59:00.000Z`. Today is 2026-07-15, so the file is expired.

RFC 9116 §2.5.5 requires `Expires` to be a single date in the future; some security scanners and researcher tooling treat an expired `security.txt` as stale/invalid, which can undercut the discoverability of your reporting channel.

This change bumps only the `Expires` date one year, to `2027-05-01T23:59:00.000Z` — keeping the existing May cadence and staying under the RFC's recommended one-year horizon. Nothing else is changed. Feel free to adjust the exact date if you'd prefer a different refresh point.

Fixes # (no issue — the repo's blank-issue setting steered this toward a direct PR)

## How Has This Been Tested?

- [x] Verified the currently-served file is expired: `curl -sSL https://immich.app/.well-known/security.txt` shows `Expires: 2026-05-01T23:59:00.000Z`.
- [x] Confirmed the change is a single-line edit to the served source file (`web/static/.well-known/security.txt`) and that the new value parses as a valid RFC 9116 future `Expires`.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted in identifying the expired `Expires` field and drafting this description. I verified the live file and the repository source myself, and the change is a single-line date bump.
