### PR TITLE
chore(mobile): Adds Belarusian language option in settings on mobile

### DIFF
--- a/mobile/lib/constants/locales.dart
+++ b/mobile/lib/constants/locales.dart
@@ -6,6 +6,7 @@ const Map<String, Locale> locales = {
   // Additional locales
   'Arabic (ar)': Locale('ar'),
   'Basque (eu)': Locale('eu'),
+  'Belarusian (be)': Locale('be'),
   'Bosnian (bl)': Locale('bn'),
   'Brazilian Portuguese (pt_BR)': Locale('pt', 'BR'),
   'Bulgarian (bg)': Locale('bg'),


### PR DESCRIPTION
## Description

Adds Belarusian to the mobile app language list. The translation (75%) already exists and works on web, but the locale was not registered in `mobile/lib/constants/locales.dart`, so it cannot be picked on mobile.

## How Has This Been Tested?

No tests

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM was not used.