### PR TITLE
chore: add GHSA as contact in security.txt

### DIFF
--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -1,7 +1,7 @@
 # This site is running an Immich instance.
 # Immich-related security problems should be reported to the Immich security team.
 # Security problems related to this instance should be reported to its administration.
-Policy: https://github.com/immich-app/immich/blob/main/SECURITY.md
+Policy: https://github.com/immich-app/immich?tab=security-ov-file
 Contact: https://github.com/immich-app/immich/security/advisories/new
 Contact: mailto:security@immich.app
 Preferred-Languages: en

--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -2,6 +2,7 @@
 # Immich-related security problems should be reported to the Immich security team.
 # Security problems related to this instance should be reported to its administration.
 Policy: https://github.com/immich-app/immich/blob/main/SECURITY.md
+Contact: https://github.com/immich-app/immich/security/advisories/new
 Contact: mailto:security@immich.app
 Preferred-Languages: en
 Expires: 2027-05-01T23:59:00.000Z


### PR DESCRIPTION
This marks github security advisories as our preferred security contact method, with emails secondary.

Counterpart: https://github.com/immich-app/.github/pull/36