### PR TITLE
fix(mobile): hide trash button when selection includes local-only assets

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -98,9 +98,10 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
           if (multiselect.onlyRemote) const DownloadActionButton(source: ActionSource.timeline),
-          isTrashEnable
-              ? const TrashActionButton(source: ActionSource.timeline)
-              : const DeletePermanentActionButton(source: ActionSource.timeline),
+          if (!multiselect.onlyLocal)
+            isTrashEnable
+                ? const TrashActionButton(source: ActionSource.timeline)
+                : const DeletePermanentActionButton(source: ActionSource.timeline),
           const FavoriteActionButton(source: ActionSource.timeline),
           const ArchiveActionButton(source: ActionSource.timeline),
           if (tagsEnabled) const BulkTagAssetsActionButton(source: ActionSource.timeline),


### PR DESCRIPTION
## Description

When a user selected both backed-up and local-only assets, the Move to Trash button was shown. It only deleted the backed-up assets and ignored the local-only ones, making it look like everything was deleted.
this change hides the 'Move to Trash' button for mixed selections, so users use the existing Delete action, which correctly handles both types of assets.

Fixes #29813

## How Has This Been Tested?

-Tested with only backed-up assets and confirmed Move to Trash works as before.
-Tested with only local-only assets and confirmed only Delete is shown.
-Tested with both backed-up and local-only assets and confirmed Move to Trash is hidden and Delete works correctly.
-Tested with merged assets and confirmed the existing behavior is unchanged.

## Screenshots (if appropriate)

N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in src/repositories/ is pretty basic/simple and does not have any Immich specific logic (that belongs in src/services/)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

i used the ai ti discuss and analyze the issue and its corresponding possible solution