### PR TITLE
fix(web): improve slideshow controls visibility on bright backgrounds

### DIFF
--- a/web/src/lib/components/asset-viewer/SlideshowBar.svelte
+++ b/web/src/lib/components/asset-viewer/SlideshowBar.svelte
@@ -172,7 +172,7 @@
 
 {#if showControls}
   <div
-    class="dark m-4 flex gap-2"
+    class="dark m-4 flex gap-2 rounded-3xl bg-black/40 px-2 backdrop-blur-sm"
     onmouseenter={() => (isOverControls = true)}
     onmouseleave={() => (isOverControls = false)}
     transition:fly={{ duration: 150 }}


### PR DESCRIPTION

## Description

The slideshow controls used white icons on a transparent background, making them hard to see on bright images, 
this change adds a subtle dark, blurred background behind the slideshow controls to improve visibility while keeping the existing design.

Fixes #29945

## How Has This Been Tested?

- [x] tested the slideshow with bright images and confirmed the controls are easier to see.
- [x] tested the slideshow with dark images and confirmed the existing appearance is preserved.

## Screenshots (if appropriate)

N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in src/repositories/ is pretty basic/simple and does not have any Immich specific logic (that belongs in src/services/)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used aI to discuss the issue and review possible approaches. I investigated the code, implemented the change, and verified the behavior myself.