### PR TITLE
fix(server): allow clearing/removing birthdate

### DIFF
--- a/server/src/controllers/person.controller.spec.ts
+++ b/server/src/controllers/person.controller.spec.ts
@@ -174,6 +174,24 @@ describe(PersonController.name, () => {
         errorDto.validationError([{ path: ['birthDate'], message: 'Birth date cannot be in the future' }]),
       );
     });
+
+    it('should accept an empty string birth date as null', async () => {
+      const { status } = await request(ctx.getHttpServer())
+        .put(`/people/${factory.uuid()}`)
+        .send({ birthDate: '' })
+        .set('Authorization', `Bearer token`);
+      expect(status).toBe(200);
+      expect(service.update).toHaveBeenCalledWith(undefined, expect.any(String), { birthDate: null });
+    });
+
+    it('should accept a null birth date', async () => {
+      const { status } = await request(ctx.getHttpServer())
+        .put(`/people/${factory.uuid()}`)
+        .send({ birthDate: null })
+        .set('Authorization', `Bearer token`);
+      expect(status).toBe(200);
+      expect(service.update).toHaveBeenCalledWith(undefined, expect.any(String), { birthDate: null });
+    });
   });
 
   describe('DELETE /people/:id', () => {

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -16,10 +16,10 @@ const PersonCreateSchema = z
   .object({
     name: z.string().optional().describe('Person name'),
     birthDate: z
-      .string()
-      .meta({ format: 'date' })
-      .nullable()
-      .optional()
+      .preprocess(
+        (val) => (typeof val === 'string' && val.trim() === '' ? null : val),
+        z.string().meta({ format: 'date' }).nullable().optional(),
+      )
       .refine((val) => (val ? new Date(val) <= new Date() : true), { error: 'Birth date cannot be in the future' })
       .describe('Person date of birth'),
     isHidden: z.boolean().optional().describe('Person visibility (hidden)'),


### PR DESCRIPTION
## Description

when a user cleared a person's birthdate, an empty string (`""`) was sent instead of `null`, causing the database update to fail.this change converts empty or whitespace-only `birthDate` values to `null` before validation, allowing the birthdate to be removed correctly. It also adds tests for this behavior.

Fixes #29951

## How Has This Been Tested?

- Tested clearing a person's birthdate and confirmed it is removed successfully.
- Run the related vitest controller tests and confirmed they passed.

## Screenshots (if appropriate)

N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in src/repositories/ is pretty basic/simple and does not have any Immich specific logic (that belongs in src/services/)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used aI to discuss the issue and possible solutions. I implemented the changes, tested them, and reviewed the final code myself.

......