### PR TITLE
feat(web): stream large uploads to bypass proxy body-size limits (Cloudflare 413)

### DIFF
--- a/web/src/lib/utils.spec.ts
+++ b/web/src/lib/utils.spec.ts
@@ -1,5 +1,5 @@
 import { AssetTypeEnum } from '@immich/sdk';
-import { getAssetUrl, semverToName } from '$lib/utils';
+import { buildMultipartParts, getAssetUrl, semverToName } from '$lib/utils';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 
@@ -168,6 +168,37 @@ describe('utils', () => {
 
     it('should append release candidate if set', () => {
       expect(semverToName({ major: 3, minor: 0, patch: 0, prerelease: 0 })).toEqual('v3.0.0-rc.0');
+    });
+  });
+
+  describe('buildMultipartParts', () => {
+    it('should serialize fields and files like multipart/form-data', async () => {
+      const formData = new FormData();
+      formData.append('isFavorite', 'false');
+      formData.append('assetData', new File(['hello world'], 'photo.jpg', { type: 'image/jpeg' }));
+
+      const parts = buildMultipartParts(formData, 'BOUNDARY');
+      const body = new Blob(parts as BlobPart[]);
+      const total = parts.reduce((size, part) => size + (part instanceof Uint8Array ? part.byteLength : part.size), 0);
+
+      expect(total).toBe(body.size);
+      expect(await body.text()).toBe(
+        '--BOUNDARY\r\nContent-Disposition: form-data; name="isFavorite"\r\n\r\nfalse\r\n' +
+          '--BOUNDARY\r\nContent-Disposition: form-data; name="assetData"; filename="photo.jpg"\r\n' +
+          'Content-Type: image/jpeg\r\n\r\nhello world\r\n' +
+          '--BOUNDARY--\r\n',
+      );
+    });
+
+    it('should escape quotes and newlines in filenames and default the content type', async () => {
+      const formData = new FormData();
+      formData.append('assetData', new File(['x'], 'we"ird\r\n.bin'));
+
+      const parts = buildMultipartParts(formData, 'BOUNDARY');
+      const body = await new Blob(parts as BlobPart[]).text();
+
+      expect(body).toContain('filename="we%22ird%0D%0A.bin"');
+      expect(body).toContain('Content-Type: application/octet-stream');
     });
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -64,7 +64,7 @@ export class AbortError extends Error {
   override name = 'AbortError';
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   override name = 'ApiError';
 
   constructor(
@@ -126,6 +126,137 @@ export const uploadRequest = async <T>(options: UploadRequestOptions): Promise<{
     xhr.responseType = 'json';
     xhr.send(data);
   });
+};
+
+interface StreamingUploadRequestOptions {
+  url: string;
+  method?: 'POST' | 'PUT';
+  data: FormData;
+  onUploadProgress?: (progress: { loaded: number; total: number }) => void;
+}
+
+let streamingUploadSupport: boolean | undefined;
+
+export const supportsStreamingUpload = (): boolean => {
+  if (streamingUploadSupport === undefined) {
+    try {
+      let duplexAccessed = false;
+      const hasContentType = new Request('https://localhost/', {
+        body: new ReadableStream(),
+        method: 'POST',
+        get duplex() {
+          duplexAccessed = true;
+          return 'half';
+        },
+      } as RequestInit).headers.has('content-type');
+      streamingUploadSupport = duplexAccessed && !hasContentType;
+    } catch {
+      streamingUploadSupport = false;
+    }
+  }
+
+  return streamingUploadSupport;
+};
+
+const encoder = new TextEncoder();
+
+// per RFC 2388, quotes and newlines in names/filenames are percent-encoded
+const escapeMultipartValue = (value: string) =>
+  value.replaceAll('\r', '%0D').replaceAll('\n', '%0A').replaceAll('"', '%22');
+
+export const buildMultipartParts = (data: FormData, boundary: string): Array<Uint8Array | File> => {
+  const parts: Array<Uint8Array | File> = [];
+  for (const [name, value] of data) {
+    const disposition = `--${boundary}\r\nContent-Disposition: form-data; name="${escapeMultipartValue(name)}"`;
+    if (typeof value === 'string') {
+      parts.push(encoder.encode(`${disposition}\r\n\r\n${value}\r\n`));
+    } else {
+      parts.push(
+        encoder.encode(
+          `${disposition}; filename="${escapeMultipartValue(value.name)}"\r\nContent-Type: ${value.type || 'application/octet-stream'}\r\n\r\n`,
+        ),
+        value,
+        encoder.encode('\r\n'),
+      );
+    }
+  }
+
+  parts.push(encoder.encode(`--${boundary}--\r\n`));
+  return parts;
+};
+
+async function* generateMultipartChunks(parts: Array<Uint8Array | File>) {
+  for (const part of parts) {
+    if (part instanceof Uint8Array) {
+      yield part;
+      continue;
+    }
+
+    const reader = part.stream().getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      yield value;
+    }
+  }
+}
+
+// Streams the multipart body via fetch() instead of XHR, so the request goes out without a
+// Content-Length header. Proxies that enforce a maximum request body size based on that header
+// (e.g. Cloudflare's 100 MB limit) let streamed requests through — the same mechanism the mobile
+// app relies on for large uploads. Chromium only allows request streaming over HTTP/2 or later;
+// on an HTTP/1.1 connection the fetch rejects with a TypeError before anything is sent.
+export const uploadRequestStreaming = async <T>(
+  options: StreamingUploadRequestOptions,
+): Promise<{ data: T; status: number }> => {
+  const { url, data, onUploadProgress: onProgress } = options;
+
+  // crypto.randomUUID() is unavailable in non-secure contexts (plain-http deployments)
+  const boundary = `----immich-multipart-${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+  const parts = buildMultipartParts(data, boundary);
+  const total = parts.reduce((size, part) => size + (part instanceof Uint8Array ? part.byteLength : part.size), 0);
+  const chunks = generateMultipartChunks(parts);
+  let loaded = 0;
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await chunks.next();
+      if (done) {
+        controller.close();
+        return;
+      }
+
+      loaded += value.byteLength;
+      onProgress?.({ loaded, total });
+      controller.enqueue(value);
+    },
+    cancel() {
+      void chunks.return(undefined);
+    },
+  });
+
+  const abortController = new AbortController();
+  const unsubscribe = trackUpload(() => abortController.abort());
+
+  try {
+    const response = await fetch(url, {
+      method: options.method || 'POST',
+      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+      body,
+      signal: abortController.signal,
+      duplex: 'half',
+    } as RequestInit);
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new ApiError(response.statusText, response.status, await response.text());
+    }
+
+    return { data: (await response.json()) as T, status: response.status };
+  } finally {
+    unsubscribe();
+  }
 };
 
 export const downloadRequest = <TBody = unknown>(options: DownloadRequestOptions<TBody> | string) => {

--- a/web/src/lib/utils/file-uploader.spec.ts
+++ b/web/src/lib/utils/file-uploader.spec.ts
@@ -69,4 +69,35 @@ describe('fileUploader error handling', () => {
     expect(items.length).toBe(1);
     expect(items[0].state).toBe(UploadState.STARTED);
   });
+
+  describe('proxy body size limits', () => {
+    it('should retry as a streaming upload when a proxy rejects the body with 413', async () => {
+      vi.spyOn(utils, 'supportsStreamingUpload').mockReturnValue(true);
+      const uploadSpy = vi
+        .spyOn(utils, 'uploadRequest')
+        .mockRejectedValue(new utils.ApiError('Payload Too Large', 413, ''));
+      const streamingSpy = vi
+        .spyOn(utils, 'uploadRequestStreaming')
+        .mockResolvedValue({ status: 201, data: mockUploadResponse });
+
+      await fileUploadHandler({ files: [mockFile] });
+
+      expect(uploadSpy).toHaveBeenCalled();
+      expect(streamingSpy).toHaveBeenCalled();
+      const items = get(uploadAssetsStore);
+      expect(items[0].state).toBe(UploadState.DONE);
+    });
+
+    it('should not retry as a streaming upload for other errors', async () => {
+      vi.spyOn(utils, 'supportsStreamingUpload').mockReturnValue(true);
+      vi.spyOn(utils, 'uploadRequest').mockRejectedValue(new utils.ApiError('Internal Server Error', 500, ''));
+      const streamingSpy = vi.spyOn(utils, 'uploadRequestStreaming');
+
+      await fileUploadHandler({ files: [mockFile] });
+
+      expect(streamingSpy).not.toHaveBeenCalled();
+      const items = get(uploadAssetsStore);
+      expect(items[0].state).toBe(UploadState.ERROR);
+    });
+  });
 });

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -15,7 +15,7 @@ import { uploadManager } from '$lib/managers/upload-manager.svelte';
 import { addAssetsToAlbums } from '$lib/services/album.service';
 import { uploadAssetsStore } from '$lib/stores/upload';
 import { UploadState } from '$lib/types';
-import { uploadRequest } from '$lib/utils';
+import { ApiError, supportsStreamingUpload, uploadRequest, uploadRequestStreaming } from '$lib/utils';
 import { ExecutorQueue } from '$lib/utils/executor-queue';
 import { asQueryString } from '$lib/utils/shared-links';
 import { handleError } from './handle-error';
@@ -160,6 +160,42 @@ type FileUploaderParams = {
   deviceAssetId: string;
 };
 
+// Proxies may reject uploads whose body exceeds a fixed size — most notably Cloudflare, which
+// caps request bodies at 100 MB and responds with a 413. Requests streamed without a
+// Content-Length header are exempt from that check, so large uploads use a streaming upload
+// where supported (see supportsStreamingUpload).
+const PROXY_BODY_SIZE_LIMIT = 100 * 1024 * 1024;
+
+async function uploadAssetMedia(
+  url: string,
+  formData: FormData,
+  assetFile: File,
+  onUploadProgress: (progress: { loaded: number; total: number }) => void,
+): Promise<{ data: AssetMediaResponseDto; status: number }> {
+  if (supportsStreamingUpload() && assetFile.size >= PROXY_BODY_SIZE_LIMIT) {
+    try {
+      return await uploadRequestStreaming<AssetMediaResponseDto>({ url, data: formData, onUploadProgress });
+    } catch (error) {
+      // fetch() rejects with a TypeError when the connection cannot stream at all (e.g. Chromium
+      // refuses to stream over HTTP/1.1); a regular upload may still work there
+      if (!(error instanceof TypeError)) {
+        throw error;
+      }
+    }
+  }
+
+  try {
+    return await uploadRequest<AssetMediaResponseDto>({ url, data: formData, onUploadProgress });
+  } catch (error) {
+    // a 413 means a proxy rejected the body for its size before it reached the server;
+    // retry as a streaming upload, which is exempt from that check
+    if (!supportsStreamingUpload() || !(error instanceof ApiError) || error.statusCode !== 413) {
+      throw error;
+    }
+    return await uploadRequestStreaming<AssetMediaResponseDto>({ url, data: formData, onUploadProgress });
+  }
+}
+
 // TODO: should probably use the @api SDK
 async function fileUploader({
   assetFile,
@@ -214,11 +250,12 @@ async function fileUploader({
       const queryParams = asQueryString(authManager.params);
 
       uploadAssetsStore.updateItem(deviceAssetId, { message: $t('asset_uploading') });
-      const response = await uploadRequest<AssetMediaResponseDto>({
-        url: getBaseUrl() + '/assets' + (queryParams ? `?${queryParams}` : ''),
-        data: formData,
-        onUploadProgress: (event) => uploadAssetsStore.updateProgress(deviceAssetId, event.loaded, event.total),
-      });
+      const response = await uploadAssetMedia(
+        getBaseUrl() + '/assets' + (queryParams ? `?${queryParams}` : ''),
+        formData,
+        assetFile,
+        ({ loaded, total }) => uploadAssetsStore.updateProgress(deviceAssetId, loaded, total),
+      );
 
       if (![200, 201].includes(response.status)) {
         throw new Error($t('errors.unable_to_upload_file'));


### PR DESCRIPTION
## Problem

When Immich is served through a proxy that caps request body sizes — most commonly a Cloudflare tunnel with its fixed 100 MB limit — web uploads of larger files fail with `413 Request Entity Too Large`. The mobile app is not affected because its uploads are streamed without a `Content-Length` header, which such proxies exempt from the body-size check (see also the note in `docs/docs/FAQ.mdx` about Cloudflare tunnels).

## Solution

Teach the web uploader to do the same thing, using the existing `POST /assets` endpoint:

- Files **≥ 100 MB** are uploaded via `fetch()` with a `ReadableStream` body (`duplex: 'half'`), so the request goes out with no `Content-Length`. The multipart body is serialized manually because `FormData` cannot be streamed directly (and a hand-built stream lets us report exact upload progress).
- If a regular upload is rejected with a **413**, it is retried once as a streaming upload (covers proxies with limits below 100 MB).
- Support is feature-detected. Chromium additionally requires HTTP/2+ for request streaming; on an HTTP/1.1 connection the `fetch` rejects with a `TypeError` before any bytes are sent and the uploader falls back to the regular XHR path.

**No server or API changes** — the server already accepts chunked bodies; this only changes how the browser sends them.

## Browser support

- Chromium and Safari: streaming path available (feature-detected).
- Firefox: does not implement request streaming ([Bugzilla 1387483](https://bugzilla.mozilla.org/show_bug.cgi?id=1387483)), so behavior there is unchanged (uploads over the proxy limit still fail, as today).

## Relation to #22385 / #26026

#26026 was closed as a duplicate of #22385 (RUFH resumable uploads), but that PR is server-side only, with client support explicitly deferred to follow-up PRs. This change is a small, web-only interim fix for the same pain point that requires no new protocol or server code, and can simply be deleted once a web RUFH client lands.

## Testing

- Unit tests for the multipart serialization (exact byte-for-byte expected output, filename escaping, computed length) and for the 413-fallback routing.
- Protocol-level smoke test against a real HTTP server: request goes out chunked with no `Content-Length`, multipart body reassembles byte-identical, progress events are monotonic and reach the total.
- Deployed to a production instance behind a Cloudflare tunnel (v3.0.1); an end-to-end >100 MB browser upload through the tunnel is the remaining verification, hence draft status.
- `check:svelte`, `check:typescript`, lint, and format all pass.
