### PR TITLE
fix(server): return bday in UTC instead of server-local time

### DIFF
--- a/server/src/utils/date.spec.ts
+++ b/server/src/utils/date.spec.ts
@@ -1,5 +1,6 @@
+import { Settings } from 'luxon';
 import { asDateString, asDateTimeString } from 'src/utils/date';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 describe('asDateString', () => {
   it('should return null for null input', () => {
@@ -10,9 +11,18 @@ describe('asDateString', () => {
     expect(asDateString('2000-01-15')).toBe('2000-01-15');
   });
 
-  it('should return the local calendar date, not the UTC date', () => {
-    const date = new Date(2000, 0, 15); // 15 Jan 2000, local midnight
+  afterEach(() => {
+    Settings.defaultZone = 'system';
+  });
+
+  it('should return the UTC calendar date', () => {
+    const date = new Date('2000-01-15'); // parsed as UTC midnight, like a database `date` column
     expect(asDateString(date)).toBe('2000-01-15');
+  });
+
+  it('should not shift the date when the server runs in a timezone behind UTC', () => {
+    Settings.defaultZone = 'America/Chicago';
+    expect(asDateString(new Date('1994-09-01'))).toBe('1994-09-01');
   });
 
   it('should correctly pad years with a leading 0', () => {

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -164,7 +164,7 @@ export const isoDateToDate = z
     z.date(),
     {
       decode: (isoString) => new Date(isoString),
-      encode: (date) => DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'),
+      encode: (date) => DateTime.fromJSDate(date, { zone: 'utc' }).toFormat('yyyy-MM-dd'),
     },
   )
   .meta({ example: '2024-01-01' });


### PR DESCRIPTION
## Description

Fixes #29578

Somewhere in recent weeks or months a regression was introduced that caused birthdays to display as off by one day. This appears to be caused by UTC vs local timezone calculations.

If I understand the problem correctly, birthdays get stored as a plain date in Postgres (e.g., 1994-09-01), which is why my database query for my birthday returned the expected date. When Node or the API reads the date from the database and sends it through JavaScript's `Date` as a bare YYYY-MM-DD string in UTC midnight[[1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)], not the user's local midnight.

From there, the old code converts that UTC-midnight `Date` back to the server's local timezone. Anyone behind UTC time (like me in America/Chicago UTC-5) would get my dates rolled back. So my 1994-09-01 that I enter in the UI becomes 1994-09-01 in the database, which becomes an ISO string parsed as UTC 1994-09-01 00:00 UTC to the Date function, which renders as 1994-08-31 19:00 America/Chicago CDT in the UI and the API, as seen in the API Endpoint result part of my issue.

The old code tested the timezone case with the comma separated multi-arg Date function which makes a new local-midnight Date and not a UTC one. Since the dates come in from Postgres as ISO strings parsed as UTC, I had to change the test to use the same '2000-01-15' format used in the expect statement. CI should now catch this timezone/UTC issue correctly.

I added another test to check that timezones behind UTC (like mine) don't shift the dates like they had been. I added an `afterEach` to reset the default zone back to `system` so the test for timezones behind UTC (e.g., America/Chicago) gets restored to `system` after testing to not pollute downstream tests with the modified default zone.

## How Has This Been Tested?

I ran 

- [x] The mise checklists in https://docs.immich.app/developer/pr-checklist
  -  `mise //server:checklist` gives the same `Unhandled Error Could not find a working container runtime strategy` and `[//server:test-medium] ERROR task failed` on my branch and the main branch. Mine has an additional passed test reflecting the test I added,
```
✓  server:unit  src/services/api.service.spec.ts (3 tests) 2ms

 Test Files  91 passed (91)
      Tests  2238 passed | 2 skipped
```
- [x] The `mise dev` command still doesn't work or I'd spin up my own test server to try this out and get some screenshots. I haven't yet figured out how to set this up on my own.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

None due to `mise dev` not getting me anywhere.

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`

No API endpoint changes. Only change in behavior is now the outputs of the existing endpoints is more correct.
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used for orienting me to the codebase and locating the files related to the date discrepancy I found in the testing shown in the issue I opened. An LLM was used for sanity checking my work. I have written this PR myself. I apologize if my description section is redundantly worded. I tried my best to explain my thinking as clearly as possible.