### PR TITLE
fix: re-evaluate OIDC role claim on every login and support array values

### DIFF
--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -1095,6 +1095,124 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ isAdmin: true }));
     });
+
+    it('should create an admin user if the role claim is an array containing admin', async () => {
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthWithAutoRegister);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
+        profile: OAuthProfileFactory.create({ immich_role: ['user', 'admin'] }),
+      });
+      mocks.user.getByEmail.mockResolvedValue(void 0);
+      mocks.user.getByOAuthId.mockResolvedValue(void 0);
+      mocks.user.create.mockResolvedValue(UserFactory.create({ oauthId: 'oauth-id' }));
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foo' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ isAdmin: true }));
+    });
+
+    it('should create a standard user if the role claim is an array containing only user', async () => {
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthWithAutoRegister);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
+        profile: OAuthProfileFactory.create({ immich_role: ['user'] }),
+      });
+      mocks.user.getByEmail.mockResolvedValue(void 0);
+      mocks.user.getByOAuthId.mockResolvedValue(void 0);
+      mocks.user.create.mockResolvedValue(UserFactory.create({ oauthId: 'oauth-id' }));
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foo' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.create).toHaveBeenCalledWith(expect.objectContaining({ isAdmin: false }));
+    });
+
+    it('should promote an existing user to admin if the role claim contains admin on login', async () => {
+      const user = UserFactory.create({ isAdmin: false, oauthId: 'oauth-id' });
+
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
+        profile: OAuthProfileFactory.create({ sub: user.oauthId, immich_role: 'admin' }),
+      });
+      mocks.user.getByOAuthId.mockResolvedValue(user);
+      mocks.user.update.mockResolvedValue({ ...user, isAdmin: true });
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foo' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.update).toHaveBeenCalledWith(user.id, { isAdmin: true });
+    });
+
+    it('should demote an existing admin if the role claim only contains user on login', async () => {
+      const user = UserFactory.create({ isAdmin: true, oauthId: 'oauth-id' });
+
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
+        profile: OAuthProfileFactory.create({ sub: user.oauthId, immich_role: ['user'] }),
+      });
+      mocks.user.getByOAuthId.mockResolvedValue(user);
+      mocks.user.update.mockResolvedValue({ ...user, isAdmin: false });
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foo' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.update).toHaveBeenCalledWith(user.id, { isAdmin: false });
+    });
+
+    it('should not change isAdmin for an existing user if the role claim is blank', async () => {
+      const user = UserFactory.create({ isAdmin: true, oauthId: 'oauth-id' });
+
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
+        profile: OAuthProfileFactory.create({ sub: user.oauthId }),
+      });
+      mocks.user.getByOAuthId.mockResolvedValue(user);
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foo' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.update).not.toHaveBeenCalled();
+    });
+
+    it('should re-evaluate the role claim for a user linked by email', async () => {
+      const user = UserFactory.create({ isAdmin: false });
+      const profile = OAuthProfileFactory.create({ immich_role: 'admin' });
+
+      mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
+      mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({ profile });
+      mocks.user.getByEmail.mockResolvedValue(user);
+      mocks.user.update.mockResolvedValueOnce({ ...user, oauthId: profile.sub });
+      mocks.user.update.mockResolvedValueOnce({ ...user, oauthId: profile.sub, isAdmin: true });
+      mocks.session.create.mockResolvedValue(SessionFactory.create());
+
+      await sut.callback(
+        { url: 'http://immich/auth/login?code=abc123', state: 'xyz789', codeVerifier: 'foobar' },
+        {},
+        loginDetails,
+      );
+
+      expect(mocks.user.update).toHaveBeenCalledWith(user.id, { oauthId: profile.sub });
+      expect(mocks.user.update).toHaveBeenCalledWith(user.id, { isAdmin: true });
+    });
   });
 
   describe('link', () => {

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -1122,6 +1122,7 @@ describe(AuthService.name, () => {
       });
       mocks.user.getByEmail.mockResolvedValue(void 0);
       mocks.user.getByOAuthId.mockResolvedValue(void 0);
+      mocks.user.getAdmin.mockResolvedValue(UserFactory.create({ isAdmin: true }));
       mocks.user.create.mockResolvedValue(UserFactory.create({ oauthId: 'oauth-id' }));
       mocks.session.create.mockResolvedValue(SessionFactory.create());
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -329,6 +329,14 @@ export class AuthService extends BaseService {
       }
     }
 
+    // sync role from the IdP on every login for existing users
+    if (user) {
+      const role = this.getRoleClaim(profile, roleClaim);
+      if (role !== undefined && (role === 'admin') !== user.isAdmin) {
+        user = await this.userRepository.update(user.id, { isAdmin: role === 'admin' });
+      }
+    }
+
     // register new user
     if (!user) {
       if (!autoRegister) {
@@ -354,11 +362,7 @@ export class AuthService extends BaseService {
         default: defaultStorageQuota,
         isValid: (value: unknown) => Number(value) >= 0,
       });
-      const role = this.getClaim<'admin' | 'user'>(profile, {
-        key: roleClaim,
-        default: 'user',
-        isValid: (value: unknown) => typeof value === 'string' && ['admin', 'user'].includes(value),
-      });
+      const role = this.getRoleClaim(profile, roleClaim) ?? 'user';
 
       user = await this.createUser({
         name:
@@ -618,6 +622,20 @@ export class AuthService extends BaseService {
   private getClaim<T>(profile: OAuthProfile, options: ClaimOptions<T>): T {
     const value = profile[options.key as keyof OAuthProfile];
     return options.isValid(value) ? (value as T) : options.default;
+  }
+
+  private getRoleClaim(profile: OAuthProfile, roleClaim: string): 'admin' | 'user' | undefined {
+    const value = profile[roleClaim as keyof OAuthProfile];
+    const roles = Array.isArray(value) ? value : [value];
+    const isRole = (role: string) => roles.some((item) => item === role);
+
+    if (isRole('admin')) {
+      return 'admin';
+    }
+    if (isRole('user')) {
+      return 'user';
+    }
+    return undefined;
   }
 
   private resolveRedirectUri(

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -329,14 +329,11 @@ export class AuthService extends BaseService {
       }
     }
 
-	// grab the role from the OIDC submission, for use in the next couple of blocks
-	const role = this.getRoleClaim(profile, roleClaim) ?? 'user';
-	  
-    // sync role from the IdP on every login for existing users
-    if (user) {
-      if (role !== undefined && (role === 'admin') !== user.isAdmin) {
-        user = await this.userRepository.update(user.id, { isAdmin: role === 'admin' });
-      }
+    const role = this.getRoleClaim(profile, roleClaim);
+    const isAdmin = role === 'admin';
+
+    if (user && role && isAdmin !== user.isAdmin) {
+      user = await this.userRepository.update(user.id, { isAdmin });
     }
 
     // register new user
@@ -375,7 +372,7 @@ export class AuthService extends BaseService {
         oauthId: profile.sub,
         quotaSizeInBytes: storageQuota === null ? null : storageQuota * HumanReadableSize.GiB,
         storageLabel: storageLabel || null,
-        isAdmin: role === 'admin',
+        isAdmin,
       });
     }
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -329,9 +329,11 @@ export class AuthService extends BaseService {
       }
     }
 
+	// grab the role from the OIDC submission, for use in the next couple of blocks
+	const role = this.getRoleClaim(profile, roleClaim) ?? 'user';
+	  
     // sync role from the IdP on every login for existing users
     if (user) {
-      const role = this.getRoleClaim(profile, roleClaim);
       if (role !== undefined && (role === 'admin') !== user.isAdmin) {
         user = await this.userRepository.update(user.id, { isAdmin: role === 'admin' });
       }
@@ -362,7 +364,6 @@ export class AuthService extends BaseService {
         default: defaultStorageQuota,
         isValid: (value: unknown) => Number(value) >= 0,
       });
-      const role = this.getRoleClaim(profile, roleClaim) ?? 'user';
 
       user = await this.createUser({
         name:
@@ -635,7 +636,6 @@ export class AuthService extends BaseService {
     if (isRole('user')) {
       return 'user';
     }
-    return undefined;
   }
 
   private resolveRedirectUri(

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -627,7 +627,7 @@ export class AuthService extends BaseService {
   private getRoleClaim(profile: OAuthProfile, roleClaim: string): 'admin' | 'user' | undefined {
     const value = profile[roleClaim as keyof OAuthProfile];
     const roles = Array.isArray(value) ? value : [value];
-    const isRole = (role: string) => roles.some((item) => item === role);
+    const isRole = (role: string) => roles.includes(role);
 
     if (isRole('admin')) {
       return 'admin';


### PR DESCRIPTION
## Description

Previously the OIDC role claim (recommended: `immich_role`) was only read at user auto-registration time and only accepted as a scalar string, so admin status never updated after the first login and array-valued role/group claims (common with Azure AD/Entra ID, along with may other IdPs) were silently ignored.

Now the role claim is normalized from either a string or an array of strings, and existing users have their isAdmin flag synced from the claim on every login, keeping the IdP as the source of truth for privileges while leaving isAdmin untouched when the claim is blank.



## How Has This Been Tested?

- [x] User/Pass auth works as before
- [x]  OIDC works with a scalar string value for the RoleClaim (as before)
- [x]  OIDC works with an array of strings in the RoleClaim (`"roles": ["admin","user"]`) detects admin (This used a standard Entra ID application role assignment w/o claims mappings for the testing)
- [x]  OIDC is evaluated at each login (an existing user has the value of `isAdmin` updated based on the presence of the `admin` RoleClaim
- [x] OIDC defaults to `user` in the event RoleClaim doesn't contain `admin`, regardless of the presence of the `user` value (it defaults safe to user, even on malformed or null claim results)



## Screenshots (if appropriate)

No visible/UI changes, all server processing of OIDC auth



## API Changes

No API changes in the PR



## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
    - No changes to `src/repositories/`



## Please describe to which degree, if any, an LLM was used in creating this pull request.

Coding performed by a human.  An internal Code Review was performed with Claude Sonnet 5.