### PR TITLE
fix(web): keep face editor box border width uniform while scaling

### DIFF
--- a/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
@@ -72,8 +72,6 @@
       width: 112,
       height: 112,
       objectCaching: true,
-      // keep the stroke width uniform while scaling; without this the cached
-      // bitmap is stretched during the transform and only re-rendered at the end
       noScaleCache: false,
       rx: 8,
       ry: 8,

--- a/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/FaceEditor.svelte
@@ -72,6 +72,9 @@
       width: 112,
       height: 112,
       objectCaching: true,
+      // keep the stroke width uniform while scaling; without this the cached
+      // bitmap is stretched during the transform and only re-rendered at the end
+      noScaleCache: false,
       rx: 8,
       ry: 8,
     });


### PR DESCRIPTION
## Description

When manually tagging a face, the bounding box border visibly stretches while the box is being resized, then snaps back to its uniform 2px width when the drag ends.

The rect already uses `strokeUniform: true`, but fabric's `InteractiveFabricObject` defaults to `noScaleCache: true`: during an active scale transform the object's cache is not re-rendered (`_updateCacheCanvas()` returns early in `src/shapes/Object/InteractiveObject.ts`, fabric 7.4.0) and the cached bitmap is simply stretched, so `strokeUniform` only takes effect once the transform ends. Setting `noScaleCache: false` re-renders the cache during scaling, keeping the border at a constant 2px throughout the drag. Fabric's own `Textbox` sets `noScaleCache: false` for the same reason.

## How Has This Been Tested?

- [x] `check:typescript`, `check:svelte` (0 errors), `lint`, and `format` pass
- [x] Manually: web dev server → asset viewer → tag face → resized the box via the corner handles; the border now stays 2px during the drag (previously it stretched and snapped back on release)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Optional: before/after screen recording of dragging a corner handle. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was made with substantial LLM assistance (Claude Code): the model located the root cause and authored the one-line fix; I directed the process, reviewed the change, and manually tested it in the running app. I'm aware of the CONTRIBUTING guidance on LLM-generated PRs — since this is a verified one-line fix I hope it's acceptable, but I'm happy to close it in favor of a maintainer-authored change if you prefer.
