### PR TITLE
fix(mobile): reduce delay when opening Android view intents

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -235,7 +235,7 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
       }
     });
 
-    ref.read(viewIntentHandlerProvider).init();
+    unawaited(ref.read(viewIntentHandlerProvider).init());
     ref.read(shareIntentUploadProvider.notifier).init();
   }
 

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -278,10 +278,12 @@ class SplashScreenPage extends StatefulHookConsumerWidget {
 
 class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
   final log = Logger("SplashScreenPage");
+  late final Future<bool> _initialViewIntentCheck;
 
   @override
   void initState() {
     super.initState();
+    _initialViewIntentCheck = ref.read(viewIntentHandlerProvider).init();
     ref
         .read(authProvider.notifier)
         .setOpenApiServiceEndpoint()
@@ -297,71 +299,123 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
     log.info("Resuming session at $endpoint");
   }
 
-  void resumeSession() async {
+  void resumeSession() {
+    if (!mounted) {
+      return;
+    }
+
     final serverUrl = Store.tryGet(StoreKey.serverUrl);
     final endpoint = Store.tryGet(StoreKey.serverEndpoint);
     final accessToken = Store.tryGet(StoreKey.accessToken);
 
     if (accessToken != null && serverUrl != null && endpoint != null) {
-      final infoProvider = ref.read(serverInfoProvider.notifier);
-      final wsProvider = ref.read(websocketProvider.notifier);
-      final backgroundManager = ref.read(backgroundSyncProvider);
-      final backupProvider = ref.read(driftBackupProvider.notifier);
-      final viewIntentHandler = ref.read(viewIntentHandlerProvider);
-
-      unawaited(
-        ref.read(authProvider.notifier).saveAuthInfo(accessToken: accessToken).then(
-          (_) async {
-            try {
-              wsProvider.connect();
-              unawaited(infoProvider.getServerInfo());
-
-              bool syncSuccess = false;
-              await Future.wait([
-                backgroundManager.syncLocal(full: true),
-                backgroundManager.syncRemote().then((success) => syncSuccess = success),
-              ]);
-
-              await viewIntentHandler.flushDeferredViewIntent();
-
-              if (syncSuccess) {
-                await Future.wait([
-                  backgroundManager.hashAssets().then((_) {
-                    _resumeBackup(backupProvider);
-                  }),
-                  _resumeBackup(backupProvider),
-                  // TODO: Bring back when the soft freeze issue is addressed
-                  // backgroundManager.syncCloudIds(),
-                ]);
-              } else {
-                await backgroundManager.hashAssets();
-              }
-
-              if (SettingsRepository.instance.appConfig.backup.syncAlbums) {
-                await backgroundManager.syncLinkedAlbum();
-              }
-            } catch (e) {
-              log.severe('Failed establishing connection to the server: $e');
-            }
-          },
-          onError: (exception) => {
-            log.severe('Failed to update auth info with access token: $accessToken'),
-            ref.read(authProvider.notifier).logout(),
-            context.router.replaceAll([const LoginRoute()]),
-          },
-        ),
-      );
+      final authFuture = ref.read(authProvider.notifier).saveAuthInfo(accessToken: accessToken);
+      final initialRouteFuture = _showDefaultRouteWhenNoViewIntent();
+      unawaited(initialRouteFuture);
+      unawaited(_completeSessionResume(accessToken, authFuture, initialRouteFuture));
     } else {
       log.severe('Missing crucial offline login info - Logging out completely');
       unawaited(ref.read(authProvider.notifier).logout());
       unawaited(context.router.replaceAll([const LoginRoute()]));
+    }
+  }
+
+  Future<void> _showDefaultRouteWhenNoViewIntent() async {
+    final hasInitialViewIntent = await _initialViewIntentCheck;
+    if (!hasInitialViewIntent) {
+      await _replaceSplashWithTabs();
+    }
+  }
+
+  Future<void> _completeSessionResume(
+    String accessToken,
+    Future<bool> authFuture,
+    Future<void> initialRouteFuture,
+  ) async {
+    final bool authenticated;
+    try {
+      authenticated = await authFuture;
+    } catch (error, stackTrace) {
+      log.severe('Failed to update auth info with access token: $accessToken', error, stackTrace);
+      await _showLogin();
       return;
     }
 
-    // clean install - change the default of the flag
-    // current install not using beta timeline
-    if (context.router.current.name == SplashScreenRoute.name) {
-      unawaited(context.replaceRoute(const TabShellRoute()));
+    if (!authenticated) {
+      log.severe('Failed to authenticate using cached credentials');
+      await _showLogin();
+      return;
+    }
+
+    final hasInitialViewIntent = await _initialViewIntentCheck;
+    await initialRouteFuture;
+    if (!mounted) {
+      return;
+    }
+
+    bool openedViewIntent = false;
+    try {
+      openedViewIntent = await ref.read(viewIntentHandlerProvider).flushDeferredViewIntent();
+    } catch (error, stackTrace) {
+      log.warning('Failed to open pending view intent', error, stackTrace);
+    }
+
+    if (hasInitialViewIntent && !openedViewIntent) {
+      await _replaceSplashWithTabs();
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    final infoProvider = ref.read(serverInfoProvider.notifier);
+    final wsProvider = ref.read(websocketProvider.notifier);
+    final backgroundManager = ref.read(backgroundSyncProvider);
+    final backupProvider = ref.read(driftBackupProvider.notifier);
+
+    try {
+      wsProvider.connect();
+      unawaited(infoProvider.getServerInfo());
+
+      bool syncSuccess = false;
+      await Future.wait([
+        backgroundManager.syncLocal(full: true),
+        backgroundManager.syncRemote().then((success) => syncSuccess = success),
+      ]);
+
+      if (syncSuccess) {
+        await Future.wait([
+          backgroundManager.hashAssets().then((_) {
+            _resumeBackup(backupProvider);
+          }),
+          _resumeBackup(backupProvider),
+          // TODO: Bring back when the soft freeze issue is addressed
+          // backgroundManager.syncCloudIds(),
+        ]);
+      } else {
+        await backgroundManager.hashAssets();
+      }
+
+      if (SettingsRepository.instance.appConfig.backup.syncAlbums) {
+        await backgroundManager.syncLinkedAlbum();
+      }
+    } catch (error, stackTrace) {
+      log.severe('Failed establishing connection to the server', error, stackTrace);
+    }
+  }
+
+  Future<void> _showLogin() async {
+    if (!mounted) {
+      return;
+    }
+
+    unawaited(ref.read(authProvider.notifier).logout());
+    await context.router.replaceAll([const LoginRoute()]);
+  }
+
+  Future<void> _replaceSplashWithTabs() async {
+    if (mounted && context.router.current.name == SplashScreenRoute.name) {
+      await context.replaceRoute(const TabShellRoute());
     }
   }
 

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -32,6 +32,7 @@ class AssetViewerPage extends StatelessWidget {
   final TimelineService timelineService;
   final int? heroOffset;
   final RemoteAlbum? currentAlbum;
+  final bool instantTransition;
 
   const AssetViewerPage({
     super.key,
@@ -39,6 +40,7 @@ class AssetViewerPage extends StatelessWidget {
     required this.timelineService,
     this.heroOffset,
     this.currentAlbum,
+    this.instantTransition = false,
   });
 
   @override

--- a/mobile/lib/providers/view_intent/view_intent_handler.provider.dart
+++ b/mobile/lib/providers/view_intent/view_intent_handler.provider.dart
@@ -5,11 +5,11 @@ import 'package:immich_mobile/providers/view_intent/view_intent_handler_android.
 import 'package:immich_mobile/providers/view_intent/view_intent_handler_stub.dart';
 
 abstract class ViewIntentHandler {
-  void init();
+  Future<bool> init();
 
   Future<void> onAppResumed();
 
-  Future<void> flushDeferredViewIntent();
+  Future<bool> flushDeferredViewIntent();
 
   Future<void> handle(ViewIntentPayload attachment);
 }

--- a/mobile/lib/providers/view_intent/view_intent_handler_android.dart
+++ b/mobile/lib/providers/view_intent/view_intent_handler_android.dart
@@ -20,6 +20,9 @@ class AndroidViewIntentHandler implements ViewIntentHandler {
   final ViewIntentService _viewIntentService;
   final ViewIntentAssetResolver _viewIntentAssetResolver;
   final AppRouter _router;
+  Future<bool>? _initialCheck;
+  Future<void> _checkTail = Future<void>.value();
+  bool _initialCheckFinished = false;
   static final Logger _logger = Logger('ViewIntentHandler');
 
   AndroidViewIntentHandler(Ref ref)
@@ -29,35 +32,73 @@ class AndroidViewIntentHandler implements ViewIntentHandler {
       _router = ref.watch(appRouterProvider);
 
   @override
-  void init() {
+  Future<bool> init() {
     // Covers cold start from a view intent before the first lifecycle "resumed".
-    unawaited(onAppResumed());
+    final cachedCheck = _initialCheck;
+    if (cachedCheck != null) {
+      return cachedCheck;
+    }
+
+    final initialCheck = _enqueueViewIntentCheck();
+    return _initialCheck = initialCheck.whenComplete(() => _initialCheckFinished = true);
   }
 
   @override
-  Future<void> onAppResumed() => _checkForViewIntent();
-
-  @override
-  Future<void> flushDeferredViewIntent() => _flushPending();
-
-  Future<void> _checkForViewIntent() async {
-    final attachment = await _viewIntentService.consumeViewIntent();
-    if (attachment != null) {
-      await handle(attachment);
+  Future<void> onAppResumed() async {
+    final initialCheck = _initialCheck;
+    if (initialCheck == null) {
+      await init();
       return;
     }
 
-    if (_ref.read(viewIntentPendingProvider) == null) {
-      await _viewIntentService.cleanupStaleTempFiles();
+    if (!_initialCheckFinished) {
+      await initialCheck;
+      return;
     }
+
+    await _enqueueViewIntentCheck();
   }
 
-  Future<void> _flushPending() async {
+  @override
+  Future<bool> flushDeferredViewIntent() => _flushPending();
+
+  Future<bool> _enqueueViewIntentCheck() {
+    final check = _checkTail.then((_) => _checkForViewIntent());
+    _checkTail = check.then<void>((_) {});
+    return check;
+  }
+
+  Future<bool> _checkForViewIntent() async {
+    try {
+      final attachment = await _viewIntentService.consumeViewIntent();
+      if (attachment != null) {
+        await handle(attachment);
+        return true;
+      }
+
+      if (_ref.read(viewIntentPendingProvider) == null) {
+        await _viewIntentService.cleanupStaleTempFiles();
+      }
+    } catch (error, stackTrace) {
+      _logger.warning('Failed to process Android view intent', error, stackTrace);
+    }
+
+    return false;
+  }
+
+  Future<bool> _flushPending() async {
+    if (!_ref.read(authProvider).isAuthenticated) {
+      return false;
+    }
+
     final pendingAttachment = _ref.read(viewIntentPendingProvider.notifier).takeIfFresh();
     _logger.info('flushPending, pendingAttachment:$pendingAttachment');
-    if (pendingAttachment != null) {
-      await handle(pendingAttachment);
+    if (pendingAttachment == null) {
+      return false;
     }
+
+    await handle(pendingAttachment);
+    return true;
   }
 
   @override
@@ -98,7 +139,12 @@ class AndroidViewIntentHandler implements ViewIntentHandler {
 
     await _router.replaceAll([
       const TabShellRoute(),
-      AssetViewerRoute(key: UniqueKey(), initialIndex: 0, timelineService: timelineService),
+      AssetViewerRoute(
+        key: UniqueKey(),
+        initialIndex: 0,
+        timelineService: timelineService,
+        instantTransition: true,
+      ),
     ]);
   }
 }

--- a/mobile/lib/providers/view_intent/view_intent_handler_stub.dart
+++ b/mobile/lib/providers/view_intent/view_intent_handler_stub.dart
@@ -5,13 +5,13 @@ class StubViewIntentHandler implements ViewIntentHandler {
   const StubViewIntentHandler();
 
   @override
-  void init() {}
+  Future<bool> init() async => false;
 
   @override
   Future<void> onAppResumed() async {}
 
   @override
-  Future<void> flushDeferredViewIntent() async {}
+  Future<bool> flushDeferredViewIntent() async => false;
 
   @override
   Future<void> handle(ViewIntentPayload attachment) async {}

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -153,13 +153,27 @@ class AppRouter extends RootStackRouter {
       page: AssetViewerRoute.page,
       guards: [_authGuard, _duplicateGuard],
       type: RouteType.custom(
-        customRouteBuilder: <T>(context, child, page) => PageRouteBuilder<T>(
-          fullscreenDialog: page.fullscreenDialog,
-          settings: page,
-          pageBuilder: (_, __, ___) => child,
-          opaque: false,
-          transitionsBuilder: TransitionsBuilders.fadeIn,
-        ),
+        customRouteBuilder: <T>(context, child, page) {
+          final args = page.routeData.argsAs<AssetViewerRouteArgs>();
+          if (args.instantTransition) {
+            return PageRouteBuilder<T>(
+              fullscreenDialog: page.fullscreenDialog,
+              settings: page,
+              pageBuilder: (_, __, ___) => child,
+              opaque: true,
+              transitionDuration: Duration.zero,
+              transitionsBuilder: TransitionsBuilders.fadeIn,
+            );
+          }
+
+          return PageRouteBuilder<T>(
+            fullscreenDialog: page.fullscreenDialog,
+            settings: page,
+            pageBuilder: (_, __, ___) => child,
+            opaque: false,
+            transitionsBuilder: TransitionsBuilders.fadeIn,
+          );
+        },
       ),
     ),
     AutoRoute(page: DriftMemoryRoute.page, guards: [_authGuard, _duplicateGuard]),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -129,6 +129,7 @@ class AssetViewerRoute extends PageRouteInfo<AssetViewerRouteArgs> {
     required TimelineService timelineService,
     int? heroOffset,
     RemoteAlbum? currentAlbum,
+    bool instantTransition = false,
     List<PageRouteInfo>? children,
   }) : super(
          AssetViewerRoute.name,
@@ -138,6 +139,7 @@ class AssetViewerRoute extends PageRouteInfo<AssetViewerRouteArgs> {
            timelineService: timelineService,
            heroOffset: heroOffset,
            currentAlbum: currentAlbum,
+           instantTransition: instantTransition,
          ),
          initialChildren: children,
        );
@@ -154,6 +156,7 @@ class AssetViewerRoute extends PageRouteInfo<AssetViewerRouteArgs> {
         timelineService: args.timelineService,
         heroOffset: args.heroOffset,
         currentAlbum: args.currentAlbum,
+        instantTransition: args.instantTransition,
       );
     },
   );
@@ -166,6 +169,7 @@ class AssetViewerRouteArgs {
     required this.timelineService,
     this.heroOffset,
     this.currentAlbum,
+    this.instantTransition = false,
   });
 
   final Key? key;
@@ -178,9 +182,11 @@ class AssetViewerRouteArgs {
 
   final RemoteAlbum? currentAlbum;
 
+  final bool instantTransition;
+
   @override
   String toString() {
-    return 'AssetViewerRouteArgs{key: $key, initialIndex: $initialIndex, timelineService: $timelineService, heroOffset: $heroOffset, currentAlbum: $currentAlbum}';
+    return 'AssetViewerRouteArgs{key: $key, initialIndex: $initialIndex, timelineService: $timelineService, heroOffset: $heroOffset, currentAlbum: $currentAlbum, instantTransition: $instantTransition}';
   }
 
   @override
@@ -191,7 +197,8 @@ class AssetViewerRouteArgs {
         initialIndex == other.initialIndex &&
         timelineService == other.timelineService &&
         heroOffset == other.heroOffset &&
-        currentAlbum == other.currentAlbum;
+        currentAlbum == other.currentAlbum &&
+        instantTransition == other.instantTransition;
   }
 
   @override
@@ -200,7 +207,8 @@ class AssetViewerRouteArgs {
       initialIndex.hashCode ^
       timelineService.hashCode ^
       heroOffset.hashCode ^
-      currentAlbum.hashCode;
+      currentAlbum.hashCode ^
+      instantTransition.hashCode;
 }
 
 /// generated route for

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -176,15 +176,29 @@ class LoginForm extends HookConsumerWidget {
 
     Future<void> handleSyncFlow() async {
       final backgroundManager = ref.read(backgroundSyncProvider);
-      final viewIntentHandler = ref.read(viewIntentHandlerProvider);
 
       await backgroundManager.syncLocal(full: true);
       await backgroundManager.syncRemote();
-      await viewIntentHandler.flushDeferredViewIntent();
       await backgroundManager.hashAssets();
 
       if (SettingsRepository.instance.appConfig.backup.syncAlbums) {
         await backgroundManager.syncLinkedAlbum();
+      }
+    }
+
+    Future<void> navigateAfterLogin() async {
+      final viewIntentHandler = ref.read(viewIntentHandlerProvider);
+      await viewIntentHandler.init();
+
+      bool openedViewIntent = false;
+      try {
+        openedViewIntent = await viewIntentHandler.flushDeferredViewIntent();
+      } catch (error, stackTrace) {
+        log.warning('Failed to open pending view intent', error, stackTrace);
+      }
+
+      if (!openedViewIntent && context.mounted && context.router.current.name != AssetViewerRoute.name) {
+        await context.router.replaceAll([const TabShellRoute()]);
       }
     }
 
@@ -253,10 +267,13 @@ class LoginForm extends HookConsumerWidget {
           if (isSyncRemoteDeletionsMode()) {
             await getManageMediaPermission();
           }
-          unawaited(handleSyncFlow());
+          await navigateAfterLogin();
+          if (!context.mounted) {
+            return;
+          }
           ref.read(websocketProvider.notifier).connect();
           unawaited(ref.read(featureMessageServiceProvider).markSeen());
-          unawaited(context.router.replaceAll([const TabShellRoute()]));
+          unawaited(handleSyncFlow());
           return;
         }
       } catch (error) {
@@ -342,9 +359,12 @@ class LoginForm extends HookConsumerWidget {
             if (isSyncRemoteDeletionsMode()) {
               await getManageMediaPermission();
             }
-            unawaited(handleSyncFlow());
+            await navigateAfterLogin();
+            if (!context.mounted) {
+              return;
+            }
             unawaited(ref.read(featureMessageServiceProvider).markSeen());
-            unawaited(context.router.replaceAll([const TabShellRoute()]));
+            unawaited(handleSyncFlow());
             return;
           }
         } catch (error, stack) {

--- a/mobile/test/providers/view_intent/view_intent_handler_android_test.dart
+++ b/mobile/test/providers/view_intent/view_intent_handler_android_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -50,6 +51,9 @@ class FakeAssetService extends Fake implements AssetService {
 
 class TestViewIntentService extends ViewIntentService {
   ViewIntentPayload? consumedAttachment;
+  Completer<ViewIntentPayload?>? consumeCompleter;
+  Object? consumeError;
+  int consumeViewIntentCalls = 0;
   int cleanupStaleTempFilesCalls = 0;
   int cleanupManagedTempFileCalls = 0;
   final List<String> managedTempPaths = [];
@@ -57,7 +61,18 @@ class TestViewIntentService extends ViewIntentService {
   TestViewIntentService() : super(MockViewIntentHostApi());
 
   @override
-  Future<ViewIntentPayload?> consumeViewIntent() async => consumedAttachment;
+  Future<ViewIntentPayload?> consumeViewIntent() async {
+    consumeViewIntentCalls++;
+    final error = consumeError;
+    if (error != null) {
+      throw error;
+    }
+    final completer = consumeCompleter;
+    if (completer != null) {
+      return completer.future;
+    }
+    return consumedAttachment;
+  }
 
   @override
   Future<void> cleanupStaleTempFiles() async {
@@ -158,7 +173,7 @@ void main() {
     verifyNever(() => resolver.resolve(any()));
   });
 
-  testWidgets('flushDeferredViewIntent consumes the pending attachment and routes the viewer', (tester) async {
+  test('flushDeferredViewIntent consumes the pending attachment and routes the viewer', () async {
     authNotifier.setAuthenticated(false);
     container.read(viewIntentPendingProvider.notifier).defer(payload);
     authNotifier.setAuthenticated(true);
@@ -167,19 +182,93 @@ void main() {
       return ViewIntentResolvedAsset(asset: deepLinkAsset, timelineService: deepLinkTimelineService);
     });
 
-    unawaited(handler.flushDeferredViewIntent());
-    await tester.pump();
-    await tester.pump();
-    await tester.idle();
+    final opened = await handler.flushDeferredViewIntent();
 
+    expect(opened, isTrue);
     expect(container.read(viewIntentPendingProvider), isNull);
     verify(() => resolver.resolve(payload)).called(1);
   });
 
   test('flushDeferredViewIntent does nothing when there is no pending attachment', () async {
-    await handler.flushDeferredViewIntent();
+    final opened = await handler.flushDeferredViewIntent();
 
+    expect(opened, isFalse);
     verifyNever(() => resolver.resolve(any()));
+  });
+
+  test('flushDeferredViewIntent keeps the pending attachment while unauthenticated', () async {
+    authNotifier.setAuthenticated(false);
+    container.read(viewIntentPendingProvider.notifier).defer(payload);
+
+    final opened = await handler.flushDeferredViewIntent();
+
+    expect(opened, isFalse);
+    expect(container.read(viewIntentPendingProvider), payload);
+    verifyNever(() => resolver.resolve(any()));
+  });
+
+  test('flushDeferredViewIntent propagates resolution failures', () async {
+    container.read(viewIntentPendingProvider.notifier).defer(payload);
+    when(() => resolver.resolve(payload)).thenThrow(StateError('resolution failed'));
+
+    await expectLater(handler.flushDeferredViewIntent(), throwsStateError);
+
+    expect(container.read(viewIntentPendingProvider), isNull);
+  });
+
+  test('init returns false when there is no initial view intent', () async {
+    final consumed = await handler.init();
+
+    expect(consumed, isFalse);
+    expect(viewIntentService.consumeViewIntentCalls, 1);
+    expect(viewIntentService.cleanupStaleTempFilesCalls, 1);
+  });
+
+  test('init treats native lookup errors as no usable intent', () async {
+    viewIntentService.consumeError = StateError('native lookup failed');
+
+    final consumed = await handler.init();
+
+    expect(consumed, isFalse);
+    expect(viewIntentService.consumeViewIntentCalls, 1);
+  });
+
+  test('init and initial resume share one native consumption operation', () async {
+    authNotifier.setAuthenticated(false);
+    final completer = Completer<ViewIntentPayload?>();
+    viewIntentService.consumeCompleter = completer;
+
+    final firstInit = handler.init();
+    final secondInit = handler.init();
+    final resume = handler.onAppResumed();
+
+    await Future<void>.delayed(Duration.zero);
+    expect(viewIntentService.consumeViewIntentCalls, 1);
+    completer.complete(payload);
+
+    expect(await firstInit, isTrue);
+    expect(await secondInit, isTrue);
+    await resume;
+    expect(viewIntentService.consumeViewIntentCalls, 1);
+    expect(container.read(viewIntentPendingProvider), payload);
+  });
+
+  test('resume checks after initialization remain independent and serialized', () async {
+    await handler.init();
+    final firstResumeCompleter = Completer<ViewIntentPayload?>();
+    viewIntentService.consumeCompleter = firstResumeCompleter;
+
+    final firstResume = handler.onAppResumed();
+    final secondResume = handler.onAppResumed();
+
+    await Future<void>.delayed(Duration.zero);
+    expect(viewIntentService.consumeViewIntentCalls, 2);
+    viewIntentService.consumeCompleter = null;
+    firstResumeCompleter.complete(null);
+
+    await firstResume;
+    await secondResume;
+    expect(viewIntentService.consumeViewIntentCalls, 3);
   });
 
   test('onAppResumed cleans stale temp files when no attachment is present', () async {
@@ -201,17 +290,13 @@ void main() {
     verifyNever(() => resolver.resolve(any()));
   });
 
-  testWidgets('onAppResumed handles attachment immediately when authenticated', (tester) async {
+  test('onAppResumed handles attachment immediately when authenticated', () async {
     viewIntentService.consumedAttachment = payload;
     when(
       () => resolver.resolve(payload),
     ).thenAnswer((_) async => ViewIntentResolvedAsset(asset: deepLinkAsset, timelineService: deepLinkTimelineService));
 
-    unawaited(handler.onAppResumed());
-    await tester.pump();
-    await tester.pump();
-    await tester.pump();
-    await tester.idle();
+    await handler.onAppResumed();
 
     verify(() => resolver.resolve(payload)).called(1);
     // Routes the user to [TabShell, AssetViewer] so back-press lands on the
@@ -222,6 +307,47 @@ void main() {
     expect(routes, hasLength(2));
     expect(routes[0].routeName, TabShellRoute.name);
     expect(routes[1].routeName, AssetViewerRoute.name);
+    final viewerRoute = routes[1] as AssetViewerRoute;
+    final viewerArgs = viewerRoute.args as AssetViewerRouteArgs;
+    expect(viewerArgs.instantTransition, isTrue);
+    expect(viewerArgs.key, isA<UniqueKey>());
+  });
+
+  test('repeated warm intents use fresh asset viewer keys', () async {
+    final secondPayload = ViewIntentPayload(
+      path: '/tmp/second.jpg',
+      mimeType: 'image/jpeg',
+      localAssetId: 'local-2',
+    );
+    final secondAsset = _localAsset(id: 'local-2');
+    final secondTimelineService = await _createReadyTimelineService([secondAsset], TimelineOrigin.deepLink);
+    addTearDown(secondTimelineService.dispose);
+
+    when(
+      () => resolver.resolve(payload),
+    ).thenAnswer((_) async => ViewIntentResolvedAsset(asset: deepLinkAsset, timelineService: deepLinkTimelineService));
+    when(
+      () => resolver.resolve(secondPayload),
+    ).thenAnswer((_) async => ViewIntentResolvedAsset(asset: secondAsset, timelineService: secondTimelineService));
+
+    viewIntentService.consumedAttachment = payload;
+    await handler.onAppResumed();
+    viewIntentService.consumedAttachment = secondPayload;
+    await handler.onAppResumed();
+
+    final captured = verify(() => router.replaceAll(captureAny())).captured;
+    expect(captured, hasLength(2));
+    final firstRoutes = captured[0] as List<PageRouteInfo<dynamic>>;
+    final secondRoutes = captured[1] as List<PageRouteInfo<dynamic>>;
+    final firstArgs = firstRoutes[1].args as AssetViewerRouteArgs;
+    final secondArgs = secondRoutes[1].args as AssetViewerRouteArgs;
+    expect(firstArgs.key, isNot(secondArgs.key));
+  });
+
+  test('ordinary asset viewer routes retain the default transition', () {
+    final route = AssetViewerRoute(initialIndex: 0, timelineService: deepLinkTimelineService);
+
+    expect((route.args as AssetViewerRouteArgs).instantTransition, isFalse);
   });
 }
 


### PR DESCRIPTION
## Description

Opening media from an Android camera or gallery app could briefly display the Immich timeline and then wait for startup synchronization before opening the requested asset. This caused a visible flash/jitter and unnecessary latency, especially during cold starts or with a slow server connection.

The initial view intent was consumed while authentication was still being restored, so it was deferred. The splash and login flows then navigated to the main timeline and performed local/remote synchronization before flushing the pending intent.

This change:

- Caches the initial view-intent check so startup and the initial lifecycle resume share one native consumption operation.
- Serializes native intent checks while keeping subsequent warm intents independent.
- Returns whether `init()` and `flushDeferredViewIntent()` consumed or opened an intent.
- Keeps the splash screen visible when an initial view intent exists.
- Flushes the pending intent immediately after cached authentication is restored, before websocket setup, synchronization, hashing, backup, or linked-album work.
- Makes post-login navigation choose either the pending asset viewer or the main timeline, without subsequently overwriting the viewer.
- Uses an opaque, zero-duration forward transition for Android view-intent navigation.
- Preserves the existing `AssetViewerPage`, `[TabShellRoute, AssetViewerRoute]` stack, authentication behavior, ten-minute pending-intent lifetime, resolver behavior, and native/Pigeon interfaces.

Ordinary asset-viewer navigation retains its existing fade transition.

Related to #26109 and designed not to overlap with the asset-resolution changes in #28833.

## How Has This Been Tested?

Added tests covering:

- Initial intent checks returning whether an intent was consumed.
- Startup and initial lifecycle-resume calls sharing one native consumption.
- Later resume checks remaining independent and serialized.
- Native lookup errors falling back to normal startup.
- Pending intents remaining available while unauthenticated.
- Pending-intent resolution failures propagating to the caller.
- Successful pending intents navigating to the viewer.
- Repeated warm intents using fresh viewer keys.
- View-intent routes enabling the instant transition.
- Ordinary viewer routes retaining the default transition.

Static verification completed:

- [x] `git diff --check`
- [x] Confirmed no Android native, Pigeon, server, database, manifest, permission, or iOS files changed
- [ ] Run the focused Flutter tests
- [ ] Run Flutter analysis
- [ ] Verify cold-start camera photo opening on a physical Android device
- [ ] Verify warm-start and repeated photo opening
- [ ] Verify signed-out intent handling through login
- [ ] Verify offline and slow-server behavior
- [ ] Record before/after median and p95 intent-to-viewer timings


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich-specific logic

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with investigating the startup sequence, drafting the implementation and tests.