### PR TITLE
fix(server): return workflow steps in ascending order

### DIFF
--- a/server/src/queries/workflow.repository.sql
+++ b/server/src/queries/workflow.repository.sql
@@ -25,6 +25,8 @@ select
           inner join "plugin" on "plugin"."id" = "plugin_method"."pluginId"
         where
           "workflow"."id" = "workflow_step"."workflowId"
+        order by
+          "workflow_step"."order" asc
       ) as agg
   ) as "steps"
 from
@@ -57,6 +59,8 @@ select
           inner join "plugin" on "plugin"."id" = "plugin_method"."pluginId"
         where
           "workflow"."id" = "workflow_step"."workflowId"
+        order by
+          "workflow_step"."order" asc
       ) as agg
   ) as "steps"
 from

--- a/server/src/repositories/workflow.repository.ts
+++ b/server/src/repositories/workflow.repository.ts
@@ -39,7 +39,8 @@ export class WorkflowRepository {
               'plugin_method.name as methodName',
               'workflow_step.config',
               'workflow_step.enabled',
-            ]),
+            ])
+            .orderBy('workflow_step.order', 'asc'),
         ).as('steps'),
       ]);
   }


### PR DESCRIPTION
Returns workflow steps in the order in which they were configured. Currently causes issues where the web client always displays the wrong order, or always reports workflows as unsaved due to differing orders.