### PR TITLE
feat: workflow filter assets by upload path

### DIFF
--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -103,6 +103,12 @@
             "default": false,
             "title": "Case sensitive",
             "description": "Whether matching should be case-sensitive"
+          },
+          "usePath": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use path",
+            "description": "Match the full server upload path instead of the upload filename"
           }
         },
         "required": ["pattern"]

--- a/packages/plugin-core/manifest.json
+++ b/packages/plugin-core/manifest.json
@@ -108,7 +108,7 @@
             "type": "boolean",
             "default": false,
             "title": "Use path",
-            "description": "Match the full server upload path instead of the upload filename"
+            "description": "Match the full path on the server instead of the original filename"
           }
         },
         "required": ["pattern"]

--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -54,11 +54,11 @@ const methods = wrapper<Manifest>({
   },
 
   assetFileFilter: ({ data, config }) => {
-    const { pattern, matchType = 'contains', caseSensitive = false } = config;
+    const { pattern, matchType = 'contains', caseSensitive = false, usePath = false } = config;
 
     const { asset } = data;
 
-    const fileName = asset.originalFileName || '';
+    const fileName = usePath ? asset.originalPath : asset.originalFileName;
     const searchName = caseSensitive ? fileName : fileName.toLowerCase();
     const searchPattern = caseSensitive ? pattern : pattern.toLowerCase();
 


### PR DESCRIPTION
Adds an option to the asset filename filter to use `originalPath` over  `originalFileName`, e.g. for filtering based on folders in external libraries.