### PR TITLE
fix(mobile): update album creation to use user-defined name from dialog

### DIFF
--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -745,10 +745,15 @@ class AddToAlbumHeader extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     Future<void> onCreateAlbum() async {
+      final albumName = await showDialog<String?>(context: context, builder: (context) => const NewAlbumNameModal());
+      if (albumName == null) {
+        return;
+      }
+
       final selectedAssets = ref.read(multiSelectProvider).selectedAssets;
       final newAlbum = await ref
           .read(remoteAlbumProvider.notifier)
-          .createAlbumWithAssets(title: "Untitled Album", assets: selectedAssets);
+          .createAlbumWithAssets(title: albumName, assets: selectedAssets);
 
       if (newAlbum == null) {
         ImmichToast.show(context: context, toastType: ToastType.error, msg: 'errors.failed_to_create_album'.tr());


### PR DESCRIPTION
## Description

When selecting assets in the timeline and pressing "create new album" a new album with the name "untitled album" was created.

In the codebase there already exists a NewAlbumNameModal, which asks the user for an album name. I think it's better UX to let the user decide a name before creating a new album, than having the user later press on the name/edit and change the name.

The same dialog is already used in other create album actions (eg. the one from the asset viewer)

## How Has This Been Tested?

- Manually creating an album in an emulator

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None