### PR TITLE
fix(mobile): refresh timeline after foreground backup completes

### DIFF
--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/utils/upload_speed_calculator.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 
@@ -185,6 +186,7 @@ class DriftBackupState {
 
 final driftBackupProvider = StateNotifierProvider<DriftBackupNotifier, DriftBackupState>((ref) {
   return DriftBackupNotifier(
+    ref,
     ref.watch(foregroundUploadServiceProvider),
     ref.watch(backgroundUploadServiceProvider),
     UploadSpeedManager(),
@@ -192,7 +194,7 @@ final driftBackupProvider = StateNotifierProvider<DriftBackupNotifier, DriftBack
 });
 
 class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
-  DriftBackupNotifier(this._foregroundUploadService, this._backgroundUploadService, this._uploadSpeedManager)
+  DriftBackupNotifier(this._ref, this._foregroundUploadService, this._backgroundUploadService, this._uploadSpeedManager)
     : super(
         const DriftBackupState(
           totalCount: 0,
@@ -205,6 +207,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
         ),
       );
 
+  final Ref _ref;
   final ForegroundUploadService _foregroundUploadService;
   final BackgroundUploadService _backgroundUploadService;
   final UploadSpeedManager _uploadSpeedManager;
@@ -256,7 +259,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     state = state.copyWith(isSyncing: isSyncing);
   }
 
-  Future<void> startForegroundBackup(String userId) {
+  Future<void> startForegroundBackup(String userId) async {
     // Cancel any existing backup before starting a new one
     if (_cancelToken != null) {
       stopForegroundBackup();
@@ -266,7 +269,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
 
     _cancelToken = Completer<void>();
 
-    return _foregroundUploadService.uploadCandidates(
+    await _foregroundUploadService.uploadCandidates(
       userId,
       _cancelToken!,
       callbacks: UploadCallbacks(
@@ -276,6 +279,13 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
         onICloudProgress: _handleICloudProgress,
       ),
     );
+
+    // Once the candidate upload completes, sync remote assets so the UI (like Live Photos) updates
+    try {
+      await _ref.read(backgroundSyncProvider).syncRemote();
+    } catch (e, stack) {
+      _logger.warning("Failed to sync remote assets after backup", e, stack);
+    }
   }
 
   void stopForegroundBackup() {


### PR DESCRIPTION
## Description

Fixes #26020

After a foreground backup finishes, the app now runs a remote sync to fetch the latest asset changes.

This updates the Photos tab right away after uploading iOS Live Photos, so the merged Motion Photo is shown without needing to switch tabs or reopen the app.

If the sync fails, the error is logged and the upload is still treated as successful.

## How Has This Been Tested?

- [x] Reviewed the upload flow and the sync logic
- [x] Verified that the sync is triggered after a successful foreground backup
- [ ] Tested on an iOS device with Live Photos

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used AI to discuss the issue and review possible approaches. I investigated the code, implemented the change, and reviewed the final changes myself.
