### PR TITLE
fix(web): align ContextMenu z-index with design-system token

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/ContextMenu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/ContextMenu.svelte
@@ -64,7 +64,7 @@
 <div
   bind:this={menuScrollView}
   class={[
-    'fixed z-1 w-max max-w-75 min-w-50 immich-scrollbar rounded-lg bg-slate-100 shadow-lg duration-250 ease-in-out',
+    'fixed z-[70] w-max max-w-75 min-w-50 immich-scrollbar rounded-lg bg-slate-100 shadow-lg duration-250 ease-in-out',
     position.needScrollBar ? 'overflow-auto' : 'overflow-hidden',
   ]}
   style:left="{position.left}px"

--- a/web/src/lib/components/shared-components/context-menu/ContextMenu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/ContextMenu.svelte
@@ -64,7 +64,7 @@
 <div
   bind:this={menuScrollView}
   class={[
-    'fixed z-[70] w-max max-w-75 min-w-50 immich-scrollbar rounded-lg bg-slate-100 shadow-lg duration-250 ease-in-out',
+    'fixed z-70 w-max max-w-75 min-w-50 immich-scrollbar rounded-lg bg-slate-100 shadow-lg duration-250 ease-in-out',
     position.needScrollBar ? 'overflow-auto' : 'overflow-hidden',
   ]}
   style:left="{position.left}px"


### PR DESCRIPTION
## Description

When a toast notification is visible, it can appear on top of the context menu and block the menu items.

This change updates the context menu z-index so it is displayed above toast notifications.

Fixes #13196

## How Has This Been Tested?

* Opened the context menu while a toast notification was visible.
* Verified that the context menu appears above the toast notification.
* Verified that all menu items remain clickable.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

* [x] I have carefully read CONTRIBUTING.md
* [x] I have performed a self-review of my own code
* [ ] I have made corresponding changes to the documentation if applicable
* [x] I have no unrelated changes in the PR.
* [x] I have confirmed that any new dependencies are strictly necessary.
* [ ] I have written tests for new code (if applicable)
* [x] I have followed naming conventions/patterns in the surrounding code
* [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
* [ ] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used AI to discuss the issue and possible solutions. I investigated the code, implemented the change, and reviewed the final changes myself.

....