### PR TITLE
feat(web): add maintenance link to command palette

### DIFF
--- a/web/src/lib/commands.ts
+++ b/web/src/lib/commands.ts
@@ -25,6 +25,7 @@ import {
   mdiThemeLightDark,
   mdiToolboxOutline,
   mdiTrashCanOutline,
+  mdiWrench,
 } from '@mdi/js';
 import type { MessageFormatter } from 'svelte-i18n';
 import { goto } from '$app/navigation';
@@ -65,6 +66,12 @@ export const getPagesProvider = ($t: MessageFormatter) => {
       description: $t('admin.server_stats_page_description'),
       icon: mdiServer,
       onAction: () => goto(Route.systemStatistics()),
+    },
+    {
+      title: $t('admin.maintenance_settings'),
+      description: $t('admin.maintenance_settings_description'),
+      icon: mdiWrench,
+      onAction: () => goto(Route.systemMaintenance()),
     },
   ].map((route) => ({ ...route, $if: () => authManager.authenticated && authManager.user.isAdmin }));
 


### PR DESCRIPTION
## Description

Added a maintenance page link to the command palette options.
No maintenance page link in the command palette.
No existing issue ID.

Fixes <NoIssueID>

## How Has This Been Tested?

- [x] Ran the UI locally and the maintenance page link shows and works as expected

<!-- API endpoint changes (if relevant)
## API Changes
No API Changes
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM usage