### PR TITLE
fix(server): file uploads for files with extension only filenames

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -443,6 +443,7 @@ export class AssetRepository {
   }
 
   create(asset: Insertable<AssetTable>) {
+    console.log(asset);
     return this.db.insertInto('asset').values(asset).returningAll().executeTakeFirstOrThrow();
   }
 

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -443,7 +443,6 @@ export class AssetRepository {
   }
 
   create(asset: Insertable<AssetTable>) {
-    console.log(asset);
     return this.db.insertInto('asset').values(asset).returningAll().executeTakeFirstOrThrow();
   }
 

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -269,6 +269,10 @@ describe(AssetMediaService.name, () => {
         'random-uuid.jpg',
       );
     });
+
+    it('should accept filenames with just an extension', () => {
+      expect(sut.getUploadFilename(uploadFile.filename(UploadFieldName.ASSET_DATA, '.jpg'))).toEqual('random-uuid.jpg');
+    });
   });
 
   describe('getUploadFolder', () => {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -1,5 +1,4 @@
 import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
-import { extname } from 'node:path';
 import sanitize from 'sanitize-filename';
 import { StorageCore } from 'src/cores/storage.core';
 import { AuthSharedLink } from 'src/database';
@@ -92,8 +91,7 @@ export class AssetMediaService extends BaseService {
   getUploadFilename({ auth, fieldName, file, body }: UploadRequest): string {
     requireUploadAccess(auth);
 
-    const extension = extname(body.filename || file.originalName);
-
+    const extension = getFilenameExtension(body.filename || file.originalName);
     const lookup = {
       [UploadFieldName.ASSET_DATA]: extension,
       [UploadFieldName.SIDECAR_DATA]: '.xmp',

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -20,7 +20,7 @@ import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { JobOf, StorageAsset } from 'src/types';
 import { getAssetFile } from 'src/utils/asset.util';
-import { getLivePhotoMotionFilename } from 'src/utils/file';
+import { getFilenameExtension, getLivePhotoMotionFilename } from 'src/utils/file';
 
 const storageTokens = {
   secondOptions: ['s', 'ss', 'SSS'],
@@ -267,10 +267,10 @@ export class StorageTemplateService extends BaseService {
     const { storageLabel, filename } = metadata;
 
     try {
-      const filenameWithoutExtension = path.basename(filename, path.extname(filename));
+      const filenameWithoutExtension = path.basename(filename, getFilenameExtension(filename));
 
       const source = asset.originalPath;
-      let extension = path.extname(source).split('.').pop() as string;
+      let extension = getFilenameExtension(source).split('.').pop() as string;
       const sanitized = sanitize(path.basename(filenameWithoutExtension, `.${extension}`));
       extension = extension?.toLowerCase();
       const rootPath = StorageCore.getLibraryFolder({ id: asset.ownerId, storageLabel });

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -1,23 +1,24 @@
 import { HttpException, NotFoundException, StreamableFile } from '@nestjs/common';
 import { NextFunction, Response } from 'express';
 import { access, constants } from 'node:fs/promises';
-import { basename, extname } from 'node:path';
+import { basename } from 'node:path';
 import { promisify } from 'node:util';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { ImmichReadStream } from 'src/repositories/storage.repository';
+import { getExtension } from 'src/utils/mime-types';
 import { isConnectionAborted } from 'src/utils/misc';
 
 export function getFileNameWithoutExtension(path: string): string {
-  return basename(path, extname(path));
+  return basename(path, getExtension(path));
 }
 
-export function getFilenameExtension(path: string): string {
-  return extname(path);
+export function getFilenameExtension(filename: string): string {
+  return getExtension(filename);
 }
 
 export function getLivePhotoMotionFilename(stillName: string, motionName: string) {
-  return getFileNameWithoutExtension(stillName) + extname(motionName);
+  return getFileNameWithoutExtension(stillName) + getExtension(motionName);
 }
 
 export class ImmichFileResponse {

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -1,7 +1,7 @@
 import { HttpException, NotFoundException, StreamableFile } from '@nestjs/common';
 import { NextFunction, Response } from 'express';
 import { access, constants } from 'node:fs/promises';
-import { extname, basename } from 'node:path';
+import { basename, extname } from 'node:path';
 import { promisify } from 'node:util';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -18,7 +18,7 @@ export function getFilenameExtension(path: string) {
     return path;
   }
   return extension;
-};
+}
 
 export function getLivePhotoMotionFilename(stillName: string, motionName: string) {
   return getFileNameWithoutExtension(stillName) + getFilenameExtension(motionName);

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -12,10 +12,10 @@ export function getFileNameWithoutExtension(path: string): string {
   return basename(path, getFilenameExtension(path));
 }
 
-export function getFilenameExtension(filename: string) {
-  const extension = extname(filename);
-  if (!extension && filename.startsWith('.') && !filename.includes('.', 1)) {
-    return filename;
+export function getFilenameExtension(path: string) {
+  const extension = extname(path);
+  if (!extension && path.startsWith('.') && !path.includes('.', 1)) {
+    return path;
   }
   return extension;
 };

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -1,24 +1,27 @@
 import { HttpException, NotFoundException, StreamableFile } from '@nestjs/common';
 import { NextFunction, Response } from 'express';
 import { access, constants } from 'node:fs/promises';
-import { basename } from 'node:path';
+import { extname, basename } from 'node:path';
 import { promisify } from 'node:util';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { ImmichReadStream } from 'src/repositories/storage.repository';
-import { getExtension } from 'src/utils/mime-types';
 import { isConnectionAborted } from 'src/utils/misc';
 
 export function getFileNameWithoutExtension(path: string): string {
-  return basename(path, getExtension(path));
+  return basename(path, getFilenameExtension(path));
 }
 
-export function getFilenameExtension(filename: string): string {
-  return getExtension(filename);
-}
+export function getFilenameExtension(filename: string) {
+  const extension = extname(filename);
+  if (!extension && filename.startsWith('.') && !filename.includes('.', 1)) {
+    return filename;
+  }
+  return extension;
+};
 
 export function getLivePhotoMotionFilename(stillName: string, motionName: string) {
-  return getFileNameWithoutExtension(stillName) + getExtension(motionName);
+  return getFileNameWithoutExtension(stillName) + getFilenameExtension(motionName);
 }
 
 export class ImmichFileResponse {

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -132,7 +132,7 @@ const sidecar: Record<string, string[]> = {
 
 const types = { ...image, ...video, ...sidecar };
 
-const getExtension = (filename: string) => {
+export const getExtension = (filename: string) => {
   const extension = extname(filename);
   if (!extension && filename.startsWith('.') && filename.indexOf('.', 1) === -1) {
     return filename;
@@ -140,10 +140,8 @@ const getExtension = (filename: string) => {
   return extension;
 };
 
-const isType = (filename: string, r: Record<string, string[]>) => {
-  console.log(`ext: ${getExtension(filename)}`);
-  return getExtension(filename).toLowerCase() in r;
-};
+const isType = (filename: string, r: Record<string, string[]>) =>
+  Object.hasOwn(r, getExtension(filename).toLowerCase());
 
 const lookup = (filename: string) => types[getExtension(filename).toLowerCase()]?.[0] ?? 'application/octet-stream';
 const toExtension = (mimeType: string) => {

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -132,10 +132,20 @@ const sidecar: Record<string, string[]> = {
 
 const types = { ...image, ...video, ...sidecar };
 
-const isType = (filename: string, record: Record<string, string[]>) =>
-  Object.hasOwn(record, extname(filename).toLowerCase());
+const getExtension = (filename: string) => {
+  const extension = extname(filename);
+  if (!extension && filename.startsWith('.') && filename.indexOf('.', 1) === -1) {
+    return filename;
+  }
+  return extension;
+};
 
-const lookup = (filename: string) => types[extname(filename).toLowerCase()]?.[0] ?? 'application/octet-stream';
+const isType = (filename: string, r: Record<string, string[]>) => {
+  console.log(`ext: ${getExtension(filename)}`);
+  return getExtension(filename).toLowerCase() in r;
+};
+
+const lookup = (filename: string) => types[getExtension(filename).toLowerCase()]?.[0] ?? 'application/octet-stream';
 const toExtension = (mimeType: string) => {
   return (
     extensionOverrides[mimeType] || Object.entries(types).find(([, mimeTypes]) => mimeTypes.includes(mimeType))?.[0]
@@ -158,7 +168,7 @@ export const mimeTypes = {
   isProfile: (filename: string) => isType(filename, profile),
   isSidecar: (filename: string) => isType(filename, sidecar),
   isVideo: (filename: string) => isType(filename, video),
-  canBeTransparent: (filename: string) => transparentCapableExtensions.has(extname(filename).toLowerCase()),
+  canBeTransparent: (filename: string) => transparentCapableExtensions.has(getExtension(filename).toLowerCase()),
   isRaw: (filename: string) => isType(filename, raw),
   lookup,
   /** return an extension (including a leading `.`) for a mime-type */

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -1,5 +1,5 @@
-import { extname } from 'node:path';
 import { AssetType } from 'src/enum';
+import { getFilenameExtension } from 'src/utils/file';
 
 const raw = {
   '.3fr': ['image/3fr', 'image/x-hasselblad-3fr'],
@@ -132,18 +132,12 @@ const sidecar: Record<string, string[]> = {
 
 const types = { ...image, ...video, ...sidecar };
 
-export const getExtension = (filename: string) => {
-  const extension = extname(filename);
-  if (!extension && filename.startsWith('.') && !filename.includes('.', 1)) {
-    return filename;
-  }
-  return extension;
-};
-
 const isType = (filename: string, r: Record<string, string[]>) =>
-  Object.hasOwn(r, getExtension(filename).toLowerCase());
+  Object.hasOwn(r, getFilenameExtension(filename).toLowerCase());
 
-const lookup = (filename: string) => types[getExtension(filename).toLowerCase()]?.[0] ?? 'application/octet-stream';
+const lookup = (filename: string) =>
+  types[getFilenameExtension(filename).toLowerCase()]?.[0] ?? 'application/octet-stream';
+
 const toExtension = (mimeType: string) => {
   return (
     extensionOverrides[mimeType] || Object.entries(types).find(([, mimeTypes]) => mimeTypes.includes(mimeType))?.[0]
@@ -166,7 +160,8 @@ export const mimeTypes = {
   isProfile: (filename: string) => isType(filename, profile),
   isSidecar: (filename: string) => isType(filename, sidecar),
   isVideo: (filename: string) => isType(filename, video),
-  canBeTransparent: (filename: string) => transparentCapableExtensions.has(getExtension(filename).toLowerCase()),
+  canBeTransparent: (filename: string) =>
+    transparentCapableExtensions.has(getFilenameExtension(filename).toLowerCase()),
   isRaw: (filename: string) => isType(filename, raw),
   lookup,
   /** return an extension (including a leading `.`) for a mime-type */

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -134,7 +134,7 @@ const types = { ...image, ...video, ...sidecar };
 
 export const getExtension = (filename: string) => {
   const extension = extname(filename);
-  if (!extension && filename.startsWith('.') && filename.indexOf('.', 1) === -1) {
+  if (!extension && filename.startsWith('.') && !filename.includes('.', 1)) {
     return filename;
   }
   return extension;


### PR DESCRIPTION
## Description

Fix the handling of files whose names consist solely of a recognized file extension. Previously, Node's `path.extname()` was used but returns an empty string for filenames such as `.png`, causing the server to reject these files during upload. The changes in my commits replace the extension detection logic so that extension-only filenames are correctly recognized while preserving the existing behavior for regular filenames and dotfiles.

Fixes #29514

## How Has This Been Tested?
- Manually tested uploading a file named `.png` through the Immich WebUI.
- Verified that the file is accepted as an asset and classified as an `IMAGE` rather than `OTHER`. This works for videos as well.
- Verified that regular image and video filenames such as `image.png` or `video.mp4` continue to work as expected.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
