### PR TITLE
fix(web): create emptyStringToNull helper func and apply it to country/state filter

### DIFF
--- a/web/src/lib/modals/SearchFilterModal.svelte
+++ b/web/src/lib/modals/SearchFilterModal.svelte
@@ -35,6 +35,8 @@
     return value === null ? undefined : value;
   }
 
+  const emptyStringToNull = (value: string | undefined): string | null | undefined => (value === '' ? null : value);
+
   function storeQueryType(type: SearchFilter['queryType']) {
     localStorage.setItem('searchQueryType', type);
   }
@@ -137,8 +139,8 @@
       originalFileName: filter.queryType === 'metadata' ? query : undefined,
       description: filter.queryType === 'description' ? query : undefined,
       originalPath: filter.queryType === 'fullPath' ? filter.query.trim() || undefined : undefined,
-      country: filter.location.country,
-      state: filter.location.state,
+      country: emptyStringToNull(filter.location.country),
+      state: emptyStringToNull(filter.location.state),
       city: filter.location.city,
       make: filter.camera.make,
       model: filter.camera.model,


### PR DESCRIPTION
## Description

Converted empty-string location filters back to `null` when constructing the search request.

The location search comboboxes use an empty string to represent an unknown country or state because the shared combobox components do not currently support nullable values well. However, the search request was passing that empty string directly to the API, so filtering for unknown countries or states did not work.

Fixes #29435

## How Has This Been Tested?

- [x] Open Immich web
- [x] Search using the "Unknown" country or state filter
- [x] Observe that media without an identified country/state will be present compared to before
<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Before
<img width="1870" height="443" alt="image" src="https://github.com/user-attachments/assets/36a1465e-4879-4a7b-8f05-d43769cbbf71" />

After
<img width="1870" height="434" alt="image" src="https://github.com/user-attachments/assets/1bf3e265-1235-462a-8aba-d381f7c3121e" />

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
