### PR TITLE
fix(web): correctly display asset dates in historical timezones

### DIFF
--- a/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
@@ -8,12 +8,23 @@
   import { Icon, modalManager } from '@immich/ui';
   import { mdiCalendar, mdiPencil } from '@mdi/js';
   import { t } from 'svelte-i18n';
+  import { onMount } from 'svelte';
+  import { websocketEvents } from '$lib/stores/websocket';
 
   type Props = {
     asset: AssetResponseDto;
   };
 
-  const { asset }: Props = $props();
+  onMount(() => {
+    return websocketEvents.on('on_asset_update', (assetUpdate) => {
+      if (assetUpdate.id === asset.id) {
+        asset = assetUpdate;
+      }
+    });
+  });
+
+  let { asset: initialState }: Props = $props();
+  let asset: AssetResponseDto = $state(initialState);
 
   const timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
   const modernOffset = $derived(

--- a/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
@@ -3,6 +3,7 @@
   import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
   import { locale } from '$lib/stores/preferences.store';
   import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
+  import { getModernOffsetForZoneAndDate } from '$lib/modals/timezone-utils';
   import { type AssetResponseDto } from '@immich/sdk';
   import { Icon, modalManager } from '@immich/ui';
   import { mdiCalendar, mdiPencil } from '@mdi/js';
@@ -15,6 +16,11 @@
   const { asset }: Props = $props();
 
   const timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
+  const modernOffset = $derived(
+    timeZone && asset.exifInfo?.dateTimeOriginal
+      ? getModernOffsetForZoneAndDate(timeZone, asset.exifInfo.dateTimeOriginal).offsetFormat
+      : undefined,
+  );
   const dateTime = $derived(
     timeZone && asset.exifInfo?.dateTimeOriginal
       ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
@@ -59,11 +65,13 @@
                 hour: 'numeric',
                 minute: '2-digit',
                 second: '2-digit',
-                timeZoneName: timeZone ? 'longOffset' : undefined,
               },
               { locale: $locale },
             )}
           </p>
+          {#if modernOffset}
+            GMT{modernOffset}
+          {/if}
         </div>
       </div>
     </div>

--- a/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelDate.svelte
@@ -23,8 +23,8 @@
     });
   });
 
-  let { asset: initialState }: Props = $props();
-  let asset: AssetResponseDto = $state(initialState);
+  let { asset: initialAsset }: Props = $props();
+  let asset: AssetResponseDto = $state(initialAsset);
 
   const timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
   const modernOffset = $derived(

--- a/web/src/lib/modals/timezone-utils.ts
+++ b/web/src/lib/modals/timezone-utils.ts
@@ -1,4 +1,4 @@
-import { DateTime, Duration } from 'luxon';
+import { DateTime } from 'luxon';
 
 export type ZoneOption = {
   /**
@@ -136,7 +136,6 @@ export function getPreferredTimeZone(
 }
 
 export function toDatetime(selectedDate: string, selectedZone: ZoneOption) {
-  // Create a DateTime object in this fixed-offset zone, preserving the local time.
   return DateTime.fromISO(selectedDate, { zone: selectedZone.value });
 }
 

--- a/web/src/lib/modals/timezone-utils.ts
+++ b/web/src/lib/modals/timezone-utils.ts
@@ -136,16 +136,8 @@ export function getPreferredTimeZone(
 }
 
 export function toDatetime(selectedDate: string, selectedZone: ZoneOption) {
-  const dtComponents = DateTime.fromISO(selectedDate, { zone: 'utc' });
-
-  // Determine the modern, DST-aware offset for the selected IANA zone
-  const { offsetMinutes } = getModernOffsetForZoneAndDate(selectedZone.value, selectedDate);
-
-  // Construct the final ISO string with a fixed-offset zone.
-  const fixedOffsetZone = `UTC${offsetMinutes >= 0 ? '+' : ''}${Duration.fromObject({ minutes: offsetMinutes }).toFormat('hh:mm')}`;
-
   // Create a DateTime object in this fixed-offset zone, preserving the local time.
-  return DateTime.fromObject(dtComponents.toObject(), { zone: fixedOffsetZone });
+  return DateTime.fromISO(selectedDate, { zone: selectedZone.value });
 }
 
 export function toIsoDate(selectedDate: string, selectedZone: ZoneOption) {


### PR DESCRIPTION
## Description

Fixes an issue where editing and displaying asset dates in timezones with historical offset changes could result in an incorrect local time being shown in the web UI.

Additionally, I've addressed a subtle UI desync issue when editing datetime values for assets. When you edit an asset's timestamp via the modal, it will now reflect the same changed value inside of the detail panel as well.

Fixes #29364

## How Has This Been Tested?

- [x] Manually tested editing the date and time of an asset using `America/Indiana/Vincennes`
- [x] Verified that setting an asset to March 15, 1990 at 3:58PM preserves the entered local time
- [x] Verified that the resulting timestamp is correctly shown using the historical timezone offset
- [x] Verified that changing only the time or date + both the date and time shows the correct date/time

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Used an LLM to assist with understanding the existing date handling code and investigating the interaction between timezone conversions and Svelte code. I performed the implementation and code changes myself.