### PR TITLE
fix(server): enforce AAC audio for real-time HLS transcoding

### DIFF
--- a/server/src/services/transcoding.service.spec.ts
+++ b/server/src/services/transcoding.service.spec.ts
@@ -5,6 +5,7 @@ import {
   HLS_INACTIVITY_TIMEOUT_MS,
   HLS_LEASE_DURATION_MS,
 } from 'src/constants';
+import { AudioCodec } from 'src/enum';
 import { TranscodingService } from 'src/services/transcoding.service';
 import { VIDEO_STREAM_SESSION_PK_CONSTRAINT } from 'src/utils/database';
 import { eiffelTower, train, waterfall } from 'test/fixtures/media.stub';
@@ -485,6 +486,19 @@ describe(TranscodingService.name, () => {
       await sut.onSegmentRequest({ sessionId, assetId, variantIndex, segmentIndex: 0 });
 
       expect(mocks.process.spawn.mock.calls[0][1].toSorted()).toEqual(expected);
+    });
+
+    it('always encodes audio as AAC, regardless of the configured target audio codec', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        ffmpeg: { realtime: { enabled: true }, targetAudioCodec: AudioCodec.Mp3 },
+      });
+      mocks.process.spawn.mockReturnValue(mockSpawn(0, '', ''));
+
+      await sut.onSessionRequest({ sessionId, assetId, ownerId });
+      await sut.onSegmentRequest({ sessionId, assetId, variantIndex: 0, segmentIndex: 0 });
+
+      const args = mocks.process.spawn.mock.calls[0][1] as string[];
+      expect(args).toEqual(expect.arrayContaining(['-c:a', 'aac']));
     });
   });
 

--- a/server/src/services/transcoding.service.ts
+++ b/server/src/services/transcoding.service.ts
@@ -14,7 +14,7 @@ import {
 } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { OnEvent, OnJob } from 'src/decorators';
-import { DatabaseLock, ImmichWorker, JobName, QueueName, TranscodeTarget } from 'src/enum';
+import { AudioCodec, DatabaseLock, ImmichWorker, JobName, QueueName, TranscodeTarget } from 'src/enum';
 import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { VideoInterfaces } from 'src/types';
@@ -219,6 +219,9 @@ export class TranscodingService extends BaseService {
         {
           ...ffmpeg,
           targetVideoCodec: variant.codec,
+          // The HLS manifest always advertises AAC (see hls.service.ts), so the actual
+          // output must match regardless of the configured audio codec.
+          targetAudioCodec: AudioCodec.Aac,
           targetResolution: String(variant.resolution),
           maxBitrate: `${Math.round(variant.bitrate / 1000)}k`,
           gopSize: gop,


### PR DESCRIPTION
## Description

Real-time (live) HLS playback fails when the configured audio codec is MP3, while AAC or offline/non-realtime transcoding work fine.

Root cause, confirmed by @mertalev in the issue thread: the HLS master manifest always advertises AAC (`mp4a.40.2`) as the audio codec (`hls.service.ts`), but real-time transcoding never enforced that codec. `TranscodingService.startTranscode` already overrides the video codec, resolution, bitrate, etc. per HLS variant, but it left the audio codec to whatever `ffmpeg.targetAudioCodec` was configured globally. When that setting is MP3, ffmpeg produces MP3 audio while the manifest still promises AAC, and HLS clients reject the mismatch.

This change forces `AudioCodec.Aac` in the real-time transcode config, the same way the video codec is already overridden per variant, so the manifest and the actual encoded output always agree.

Fixes #29963

## How Has This Been Tested?

- [x] Added a regression test in `transcoding.service.spec.ts` that configures `targetAudioCodec: AudioCodec.Mp3` and asserts the spawned ffmpeg command still contains `-c:a aac`.
- [x] `pnpm test` in `server/` : 91 files, 2238 tests passed (2 skipped), including the full existing `transcoding.service.spec.ts` and `hls.service.spec.ts` suites.
- [x] `pnpm lint` in `server/` : clean.
- [x] `pnpm check` (`tsc --noEmit`) in `server/` : clean.
- [x] `pnpm format` in `server/` : clean.

I was not able to exercise the live HLS playback path against a real browser/client in this environment, so the change is verified at the ffmpeg-command and manifest level via the test suite, not with an end-to-end playback check.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was authored end to end by an autonomous coding agent: it located the relevant code, implemented the fix, wrote the regression test, and ran the test/lint/typecheck suite. The root cause diagnosis itself came from the maintainer's comment on the issue, not from the agent.