### PR TITLE
fix(server): store null instead of empty string for album and exif descriptions

### DIFF
--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -110,7 +110,7 @@ export const AlbumResponseSchema = z
   .object({
     id: z.uuidv4().describe('Album ID'),
     albumName: z.string().describe('Album name'),
-    description: z.string().describe('Album description'),
+    description: z.string().nullable().describe('Album description'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     createdAt: z.string().meta({ format: 'date-time' }).describe('Creation date'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
@@ -171,7 +171,7 @@ export type MapAlbumDto = {
   assets?: ShallowDehydrateObject<MapAsset>[];
   sharedLinks?: ShallowDehydrateObject<AuthSharedLink>[];
   albumName: string;
-  description: string;
+  description: string | null;
   albumThumbnailAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/schema/migrations/1752748800000-NullifyEmptyDescriptions.ts
+++ b/server/src/schema/migrations/1752748800000-NullifyEmptyDescriptions.ts
@@ -1,0 +1,17 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE "albums" ALTER COLUMN "description" DROP DEFAULT, ALTER COLUMN "description" DROP NOT NULL`.execute(
+    db,
+  );
+  await sql`UPDATE "albums" SET "description" = NULL WHERE "description" = ''`.execute(db);
+
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" DROP DEFAULT, ALTER COLUMN "description" DROP NOT NULL`.execute(
+    db,
+  );
+  await sql`UPDATE "asset_exif" SET "description" = NULL WHERE "description" = ''`.execute(db);
+}
+
+export async function down(): Promise<void> {
+  // not supported
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -36,8 +36,8 @@ export class AlbumTable {
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>;
+  @Column({ type: 'text', nullable: true })
+  description!: Generated<string | null>;
 
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;

--- a/server/src/schema/tables/asset-exif.table.ts
+++ b/server/src/schema/tables/asset-exif.table.ts
@@ -74,8 +74,8 @@ export class AssetExifTable {
   @Column({ type: 'character varying', nullable: true })
   country!: string | null;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>; // or caption
+  @Column({ type: 'text', nullable: true })
+  description!: Generated<string | null>; // or caption
 
   @Column({ type: 'double precision', nullable: true })
   fps!: number | null;

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1296,7 +1296,7 @@ describe(MetadataService.name, () => {
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
         expect.objectContaining({
           exif: expect.objectContaining({
-            description: '',
+            description: null,
           }),
           lockedPropertiesBehavior: 'skip',
         }),

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -303,7 +303,7 @@ export class MetadataService extends BaseService {
       focalLength: validate(exifTags.FocalLength),
 
       // comments
-      description: String(exifTags.ImageDescription || exifTags.Description || '').trim(),
+      description: (exifTags.ImageDescription || exifTags.Description || '').toString().trim() || null,
       profileDescription: exifTags.ProfileDescription || null,
       rating: exifTags.Rating === 0 ? null : validateRange(exifTags.Rating, 1, 5),
 


### PR DESCRIPTION
## Description

Currently, `albums.description` and `asset_exif.description` have `DEFAULT ''` and `NOT NULL` constraints, making it impossible to distinguish between "a description was never set" and "the description was explicitly cleared". Both cases store an empty string.

This change:
- Drops the `DEFAULT ''` and `NOT NULL` constraints on both columns
- Nullifies existing empty-string rows via a migration
- Updates the schema table decorators to reflect `nullable: true`
- Updates `metadata.service.ts` to write `null` instead of `''` when no description is present
- Updates the DTO and test spec to handle `string | null`

Fixes #28832

## How Has This Been Tested?

- [x] Ran existing unit test suite (`metadata.service.spec.ts`) — the one relevant assertion (`description: ''`) was updated to `description: null` and passes

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Code was used to locate the relevant files and generate the migration. The logic and approach were reviewed manually.