### PR TITLE
fix(server): store null instead of empty string for person thumbnailPath

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -230,8 +230,8 @@ export type Session = {
   createdAt: Date;
   updatedAt: Date;
   expiresAt: Date | null;
-  deviceOS: string;
-  deviceType: string;
+  deviceOS: string | null;
+  deviceType: string | null;
   appVersion: string | null;
   pinExpiresAt: Date | null;
   isPendingSyncReset: boolean;

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -251,7 +251,7 @@ export type Person = {
   color: string | null;
   faceAssetId: string | null;
   isHidden: boolean;
-  thumbnailPath: string;
+  thumbnailPath: string | null;
 };
 
 export type AssetFace = {

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -64,7 +64,7 @@ export const PersonResponseSchema = z
     name: z.string().describe('Person name'),
     // TODO: use `isoDateToDate` when using `ZodSerializerDto` on the controllers.
     birthDate: z.string().meta({ format: 'date' }).describe('Person date of birth').nullable(),
-    thumbnailPath: z.string().describe('Thumbnail path'),
+    thumbnailPath: z.string().nullable().describe('Thumbnail path'),
     isHidden: z.boolean().describe('Is hidden'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     updatedAt: z

--- a/server/src/dtos/session.dto.ts
+++ b/server/src/dtos/session.dto.ts
@@ -5,8 +5,8 @@ import z from 'zod';
 const SessionCreateSchema = z
   .object({
     duration: z.int().min(1).optional().describe('Session duration in seconds'),
-    deviceType: z.string().optional().describe('Device type'),
-    deviceOS: z.string().optional().describe('Device OS'),
+    deviceType: z.string().nullish().transform((val) => (val === '' ? null : val)).describe('Device type'),
+    deviceOS: z.string().nullish().transform((val) => (val === '' ? null : val)).describe('Device OS'),
   })
   .meta({ id: 'SessionCreateDto' });
 
@@ -23,8 +23,8 @@ const SessionResponseSchema = z
     updatedAt: z.string().describe('Last update date'),
     expiresAt: z.string().optional().describe('Expiration date'),
     current: z.boolean().describe('Is current session'),
-    deviceType: z.string().describe('Device type'),
-    deviceOS: z.string().describe('Device OS'),
+    deviceType: z.string().nullable().describe('Device type'),
+    deviceOS: z.string().nullable().describe('Device OS'),
     appVersion: z.string().nullable().describe('App version'),
     isPendingSyncReset: z.boolean().describe('Is pending sync reset'),
   })

--- a/server/src/schema/migrations/1784471379379-ConvertSessionDeviceTypeAndOSEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784471379379-ConvertSessionDeviceTypeAndOSEmptyStringToNull.ts
@@ -1,0 +1,19 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "session" SET "deviceType" = NULL WHERE "deviceType" = '';`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "session" SET "deviceOS" = NULL WHERE "deviceOS" = '';`.execute(db);
+}
+
+export async function down(): Promise<void> {
+  await sql`UPDATE "session" SET "deviceOS" = '' WHERE "deviceOS" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceOS" SET NOT NULL;`.execute(db);
+  await sql`UPDATE "session" SET "deviceType" = '' WHERE "deviceType" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "session" ALTER COLUMN "deviceType" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/migrations/1784554467506-ConvertPersonThumbnailPathEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784554467506-ConvertPersonThumbnailPathEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "person" SET "thumbnailPath" = NULL WHERE "thumbnailPath" = '';`.execute(db);
+}
+
+export async function down(): Promise<void> {
+  await sql`UPDATE "person" SET "thumbnailPath" = '' WHERE "thumbnailPath" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "person" ALTER COLUMN "thumbnailPath" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/person.table.ts
+++ b/server/src/schema/tables/person.table.ts
@@ -46,8 +46,8 @@ export class PersonTable {
   @Column({ default: '' })
   name!: Generated<string>;
 
-  @Column({ default: '' })
-  thumbnailPath!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  thumbnailPath!: string | null;
 
   @Column({ type: 'boolean', default: false })
   isHidden!: Generated<boolean>;

--- a/server/src/schema/tables/session.table.ts
+++ b/server/src/schema/tables/session.table.ts
@@ -35,11 +35,11 @@ export class SessionTable {
   @ForeignKeyColumn(() => SessionTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE', nullable: true })
   parentId!: string | null;
 
-  @Column({ default: '' })
-  deviceType!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  deviceType!: string | null;
 
-  @Column({ default: '' })
-  deviceOS!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  deviceOS!: string | null;
 
   @Column({ nullable: true })
   appVersion!: string | null;


### PR DESCRIPTION
## Description

When a person is created without a thumbnail (before the thumbnail job runs),
the database now stores `NULL` instead of an empty string `""`.

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Response schema: allows null to reflect actual stored value
- TypeScript type: updated Person type to match

Fixes #28832 (person.thumbnailPath column)

## How Has This Been Tested?

- [ ] Existing test suite passes
- [ ] Pattern follows the same approach as the already-merged person.name fix

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None. I manually wrote the code following the established pattern from a previously merged PR for the same issue.