### PR TITLE
fix(web): use correct date field for shift-click range in Recently Added

### DIFF
--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -1,6 +1,6 @@
-import { AssetOrder, type AssetResponseDto } from '@immich/sdk';
+import { AssetOrder, AssetOrderBy, type AssetResponseDto } from '@immich/sdk';
 import { DateTime } from 'luxon';
-import { plainDateTimeCompare, type TimelineYearMonth } from '$lib/utils/timeline-util';
+import { getOrderingDate, plainDateTimeCompare, type TimelineYearMonth } from '$lib/utils/timeline-util';
 import { TimelineManager } from '../timeline-manager.svelte';
 import type { TimelineMonth } from '../timeline-month.svelte';
 import type { AssetDescriptor, Direction, TimelineAsset } from '../types';
@@ -125,7 +125,8 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
     return [];
   }
   const assetOrder: AssetOrder = timelineManager.getAssetOrder();
-  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, startAsset.localDateTime, endAsset.localDateTime) < 0) {
+  const orderBy: AssetOrderBy = timelineManager.getOrderBy();
+  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, getOrderingDate(startAsset, orderBy), getOrderingDate(endAsset, orderBy)) < 0) {
     [startAsset, endAsset] = [endAsset, startAsset];
     // eslint-disable-next-line no-useless-assignment
     [startTimelineMonth, endTimelineMonth] = [endTimelineMonth, startTimelineMonth];

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -126,7 +126,13 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
   }
   const assetOrder: AssetOrder = timelineManager.getAssetOrder();
   const orderBy: AssetOrderBy = timelineManager.getOrderBy();
-  if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, getOrderingDate(startAsset, orderBy), getOrderingDate(endAsset, orderBy)) < 0) {
+  if (
+    plainDateTimeCompare(
+      assetOrder === AssetOrder.Desc,
+      getOrderingDate(startAsset, orderBy),
+      getOrderingDate(endAsset, orderBy),
+    ) < 0
+  ) {
     [startAsset, endAsset] = [endAsset, startAsset];
     // eslint-disable-next-line no-useless-assignment
     [startTimelineMonth, endTimelineMonth] = [endTimelineMonth, startTimelineMonth];

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { AssetVisibility, type AssetResponseDto, type TimeBucketAssetResponseDto } from '@immich/sdk';
+import { AssetOrderBy, AssetVisibility, type AssetResponseDto, type TimeBucketAssetResponseDto } from '@immich/sdk';
 import { tick } from 'svelte';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import { eventManager } from '$lib/managers/event-manager.svelte';
@@ -806,6 +806,46 @@ describe('TimelineManager', () => {
       a.setShowAssetOwners(true);
       const b = new TimelineManager();
       expect(b.showAssetOwners).toBe(true);
+    });
+  });
+
+  describe('retrieveRange', () => {
+    it('uses createdAt ordering in the Recently Added view (orderBy=CreatedAt)', async () => {
+      // Simulate the "Recently Added" bug: two assets whose localDateTime order is
+      // the reverse of their createdAt (upload) order. Before the fix, retrieveRange
+      // compared localDateTime and selected the wrong range direction.
+      const timelineManager = new TimelineManager();
+      sdkMock.getTimeBuckets.mockResolvedValue([]);
+      await timelineManager.updateOptions({ orderBy: AssetOrderBy.CreatedAt });
+
+      // assetA was taken recently (2024) but uploaded first (2025-01)
+      const assetA = timelineAssetFactory.build({
+        localDateTime: fromISODateTimeUTCToObject('2024-06-01T00:00:00.000Z'),
+        createdAt: fromISODateTimeUTCToObject('2025-01-20T00:00:00.000Z'),
+        fileCreatedAt: fromISODateTimeUTCToObject('2025-01-20T00:00:00.000Z'),
+      });
+      // assetB was taken long ago (2018) but uploaded second (2025-02)
+      const assetB = timelineAssetFactory.build({
+        localDateTime: fromISODateTimeUTCToObject('2018-03-15T00:00:00.000Z'),
+        createdAt: fromISODateTimeUTCToObject('2025-02-10T00:00:00.000Z'),
+        fileCreatedAt: fromISODateTimeUTCToObject('2025-02-10T00:00:00.000Z'),
+      });
+      // assetC is an unrelated asset that should not appear in the selection
+      const assetC = timelineAssetFactory.build({
+        localDateTime: fromISODateTimeUTCToObject('2022-01-01T00:00:00.000Z'),
+        createdAt: fromISODateTimeUTCToObject('2025-03-01T00:00:00.000Z'),
+        fileCreatedAt: fromISODateTimeUTCToObject('2025-03-01T00:00:00.000Z'),
+      });
+
+      timelineManager.upsertAssets([assetA, assetB, assetC]);
+
+      // Shift-click from assetB (uploaded most recently) to assetA — the range
+      // between them in the "Recently Added" timeline should contain only those two.
+      const range = await timelineManager.retrieveRange({ id: assetB.id }, { id: assetA.id });
+      const ids = range.map((a) => a.id);
+      expect(ids).toContain(assetA.id);
+      expect(ids).toContain(assetB.id);
+      expect(ids).not.toContain(assetC.id);
     });
   });
 });

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -625,6 +625,10 @@ export class TimelineManager extends VirtualScrollManager {
     return this.#options.order ?? AssetOrder.Desc;
   }
 
+  getOrderBy() {
+    return this.#options.orderBy ?? AssetOrderBy.TakenAt;
+  }
+
   protected postCreateSegments(): void {
     this.months.sort((a, b) => {
       return a.yearMonth.year === b.yearMonth.year


### PR DESCRIPTION
## Description

In the **Recently Added** view (`orderBy=CreatedAt`), assets are ordered by upload date (`createdAt`) rather than EXIF taken-at date (`localDateTime`). However `retrieveRange` always compared `localDateTime` to decide which of the two shift-clicked assets is the "start" of the range. When these two orderings diverge (e.g. a 2018 photo uploaded today) the iterator walks in the wrong direction and selects a much larger range than intended.

Fix: add `getOrderBy()` to `TimelineManager` and pass it to `getOrderingDate()` in `retrieveRange`, so the start/end comparison always uses the same date field the timeline is sorted by.

Fixes #30054

## How Has This Been Tested?

- [x] Regression test added: builds a Recently Added timeline with three assets whose `localDateTime` and `createdAt` orderings conflict, asserts that `retrieveRange` between the two targeted assets does not include the third.

## Screenshots (if appropriate)

N/A — logic-only fix, no UI changes.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.