### PR TITLE
chore(mobile): enable Xcode displaying issues from Flutter inline

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+			shellScript = "/bin/bash \"$SRCROOT/scripts/xcode_flutter_build.sh\"\n";
 		};
 		BAEA01ACA3F5C9CD3D732370 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mobile/ios/scripts/xcode_flutter_build.sh
+++ b/mobile/ios/scripts/xcode_flutter_build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Makes Flutter's builds through the Xcode GUI properly display errors and warnings
+# in the Issue navigator
+#
+# Flutter's `xcode_backend.dart` runs `flutter assemble` with `allowFail: true`,
+# which intentionally does not prefix output with `error:`. Unsure why they do this,
+# but this script rebuilds the expected output so Xcode can parse and display the errors
+
+set -o pipefail
+
+# The Immich mobile root (containing the Dart `lib` directory). This is used to make
+# absolute paths for Xcode linking
+app_root="${FLUTTER_APPLICATION_PATH:-$SRCROOT/..}"
+
+/bin/sh "$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh" build 2>&1 \
+  | awk -v app_root="$app_root" '
+    # Match Dart CFE diagnostics: <path>.dart:<line>:<col>: <Kind>: <message>
+    # Written for macOS/POSIX/BSD awk
+    {
+      # Always pass the original line through to preserve the original build log
+      print
+
+      if ($0 ~ /^.*\.dart:[0-9]+:[0-9]+: (Error|Warning|Context|Info):/) {
+        # Locate the ": Kind:" separator to split location from message.
+        rest = $0
+        if      (match(rest, /: Error:/))   { kind = "Error";   keyword = "error"   }
+        else if (match(rest, /: Warning:/)) { kind = "Warning"; keyword = "warning" }
+        else if (match(rest, /: Context:/)) { kind = "Context"; keyword = "note"    }
+        else if (match(rest, /: Info:/))    { kind = "Info";    keyword = "note"    }
+
+        # location = everything before ": Kind:" (e.g. "lib/foo.dart:12:5")
+        location = substr(rest, 1, RSTART - 1)
+        # message = everything after ": Kind:" (leading space preserved)
+        message = substr(rest, RSTART + length(": " kind ":"))
+
+        # Make the path absolute so Xcode links to it
+        if (location !~ /^\//)
+          location = app_root "/" location
+
+        printf "%s: %s:%s\n", location, keyword, message
+      }
+    }
+  '
+
+exit "${PIPESTATUS[0]}"


### PR DESCRIPTION
For some reason Flutter seems to have intentionally made it so Flutter build issues are not emitted in a way that Xcode understands. I find this to be quite annoying, so instead I run the normal Flutter + Xcode build system, and rewrite stdio to contain the necessary information.

### Before

<img width="1379" height="1048" alt="image" src="https://github.com/user-attachments/assets/c3c85e89-76ca-4b62-b79d-b19854d9956c" />

### After

<img width="1002" height="669" alt="image" src="https://github.com/user-attachments/assets/c632f4fa-a7fe-4fdf-8144-1e5cedbae84a" />
