### PR TITLE
chore: pin photo_manager to 3.9.0

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   path_provider: ^2.1.5
   path_provider_foundation: ^2.6.0
   permission_handler: ^11.4.0
-  photo_manager: ^3.9.0
+  photo_manager: 3.9.0
   pinput: ^5.0.2
   punycode: ^1.0.0
   scroll_date_picker: ^3.8.0


### PR DESCRIPTION
`photo_manager` [3.10.0](https://pub.dev/packages/photo_manager/changelog#3100) has breaking changes for Immich. Prevent the dependency from updating under us until we have measures in place to handle this properly