### PR TITLE
fix(web): space between device type and version

### DIFF
--- a/web/src/lib/components/user-settings-page/DeviceCard.svelte
+++ b/web/src/lib/components/user-settings-page/DeviceCard.svelte
@@ -58,7 +58,7 @@
         {#if session.deviceType || session.deviceOS}
           <span
             >{session.deviceOS || $t('unknown')} • {session.deviceType || $t('unknown')}{session.appVersion
-              ? `(v${session.appVersion})`
+              ? ` (v${session.appVersion})`
               : ''}</span
           >
         {:else}


### PR DESCRIPTION
Before:

<img width="244" height="161" alt="image" src="https://github.com/user-attachments/assets/4e751a15-e0cd-4526-8877-3e81b3d58706" />