### PR TITLE
fix(server): store null instead of empty string for user name

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -22,7 +22,7 @@ import { UserMetadataItem } from 'src/types';
 export type AuthUser = {
   id: string;
   isAdmin: boolean;
-  name: string;
+  name: string | null;
   email: string;
   quotaUsageInBytes: number;
   quotaSizeInBytes: number | null;
@@ -125,7 +125,7 @@ export type Asset = {
 
 export type User = {
   id: string;
-  name: string;
+  name: string | null;
   email: string;
   avatarColor: UserAvatarColor | null;
   profileImagePath: string;

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -31,7 +31,7 @@ const LoginResponseSchema = z
     accessToken: z.string().describe('Access token'),
     userId: z.uuidv4().describe('User ID'),
     userEmail: toEmail.describe('User email'),
-    name: z.string().describe('User name'),
+    name: z.string().nullable().describe('User name'),
     profileImagePath: z.string().describe('Profile image path'),
     isAdmin: z.boolean().describe('Is admin user'),
     shouldChangePassword: z.boolean().describe('Should change password'),
@@ -64,7 +64,7 @@ const LogoutResponseSchema = z
   .meta({ id: 'LogoutResponseDto' });
 
 const SignUpSchema = LoginCredentialSchema.extend({
-  name: z.string().describe('User name').meta({ example: 'Admin' }),
+  name: z.string().transform(v => v === '' ? null : v).describe('User name').meta({ example: 'Admin' }),
 }).meta({ id: 'SignUpDto' });
 
 const ChangePasswordSchema = z

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -20,7 +20,7 @@ import z from 'zod';
 const SyncUserV1Schema = z
   .object({
     id: z.uuidv4().describe('User ID'),
-    name: z.string().describe('User name'),
+    name: z.string().nullable().describe('User name'),
     email: z.string().describe('User email'),
     avatarColor: UserAvatarColorSchema.nullish(),
     deletedAt: isoDatetimeToDate.nullable().describe('User deleted at'),

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -15,7 +15,7 @@ export const UserUpdateMeSchema = z
       .optional()
       .describe('User password (deprecated, use change password endpoint)')
       .meta({ deprecated: true }),
-    name: z.string().optional().describe('User name'),
+    name: z.string().nullish().transform(v => v === '' ? null : v),
     avatarColor: UserAvatarColorSchema.nullish(),
   })
   .meta({ id: 'UserUpdateMeDto' });
@@ -25,7 +25,7 @@ export class UserUpdateMeDto extends createZodDto(UserUpdateMeSchema) {}
 export const UserResponseSchema = z
   .object({
     id: z.uuidv4().describe('User ID'),
-    name: z.string().describe('User name'),
+    name: z.string().nullable().describe('User name'),
     email: toEmail.describe('User email'),
     profileImagePath: z.string().describe('Profile image path'),
     avatarColor: UserAvatarColorSchema,
@@ -78,7 +78,7 @@ export const UserAdminCreateSchema = z
   .object({
     email: toEmail.describe('User email'),
     password: z.string().describe('User password'),
-    name: z.string().describe('User name'),
+    name: z.string().transform(v => v === '' ? null : v).describe('User name'),
     avatarColor: UserAvatarColorSchema.nullish(),
     pinCode: z.string().regex(pinCodeRegex).nullable().optional().describe('PIN code').meta({ example: '123456' }),
     storageLabel: z.string().pipe(sanitizeFilename).nullish().describe('Storage label'),
@@ -96,7 +96,7 @@ const UserAdminUpdateSchema = z
     email: toEmail.optional().describe('User email'),
     password: z.string().optional().describe('User password'),
     pinCode: z.string().regex(pinCodeRegex).nullable().optional().describe('PIN code').meta({ example: '123456' }),
-    name: z.string().optional().describe('User name'),
+    name: z.string().nullish().transform(v => v === '' ? null : v),
     avatarColor: UserAvatarColorSchema.nullish(),
     storageLabel: z.string().pipe(sanitizeFilename).nullish().describe('Storage label'),
     shouldChangePassword: z.boolean().optional().describe('Require password change on next login'),

--- a/server/src/schema/migrations/1784639683176-ConvertUserProfileNameEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784639683176-ConvertUserProfileNameEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "user" SET "name" = NULL WHERE "name" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "name" = '' WHERE "name" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "name" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -64,9 +64,8 @@ export class UserTable {
   @Column({ unique: true, nullable: true, default: null })
   storageLabel!: string | null;
 
-  // TODO remove default, make nullable, and convert empty spaces to null
-  @Column({ default: '' })
-  name!: string;
+  @Column({ nullable: true, default: null })
+  name!: string | null;
 
   @Column({ type: 'bigint', nullable: true })
   quotaSizeInBytes!: ColumnType<number> | null;


### PR DESCRIPTION
## Description

When a user is created (via admin panel or signup), the database now stores `NULL` instead of an empty string `""` for the name column when no name is provided.

This was already marked with a TODO comment in the entity definition:
```
// TODO remove default, make nullable, and convert empty spaces to null
```

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Response schemas (`UserResponse`, `LoginResponse`, `SyncUserV1`): allows null
- Input schemas (`UserUpdateMe`, `UserAdminCreate`, `UserAdminUpdate`, `SignUp`): transform empty string to null
- TypeScript types (`User`, `AuthUser`): `name` is `string | null`

Fixes #28832 (user.name column)

## How Has This Been Tested?

- [ ] Pattern follows the same approach as the already-merged person.name fix
- [ ] Existing test suite passes

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None. I manually wrote the code following the established pattern from a previously merged PR for the same issue.