### PR TITLE
fix: limit ocr overlay to images

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -101,7 +101,7 @@ class ViewerBottomBar extends ConsumerWidget {
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          OcrToggleButton(asset: asset),
+                          if (asset.isImage) OcrToggleButton(asset: asset),
                           if (asset.isVideo) VideoControls(videoPlayerName: asset.heroTag),
                           if (!isReadonlyModeEnabled)
                             Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: actions),


### PR DESCRIPTION
## Description

Limits OCR to image assets on mobile to match web.