### PR TITLE
feat: store null instead of empty string for album.description

### DIFF
--- a/mobile/lib/repositories/drift_album_api_repository.dart
+++ b/mobile/lib/repositories/drift_album_api_repository.dart
@@ -25,7 +25,9 @@ class DriftAlbumApiRepository extends ApiRepository {
       _api.createAlbum(
         CreateAlbumDto(
           albumName: name,
-          description: description == null ? const Optional.absent() : Optional.present(description),
+          description: description == null
+              ? const Optional.absent()
+              : Optional.present(description.isEmpty ? null : description),
           assetIds: Optional.present(assetIds.toList()),
         ),
       ),
@@ -88,7 +90,9 @@ class DriftAlbumApiRepository extends ApiRepository {
         albumId,
         UpdateAlbumDto(
           albumName: name == null ? const Optional.absent() : Optional.present(name),
-          description: description == null ? const Optional.absent() : Optional.present(description),
+          description: description == null
+              ? const Optional.absent()
+              : Optional.present(description.isEmpty ? null : description),
           albumThumbnailAssetId: thumbnailAssetId == null
               ? const Optional.absent()
               : Optional.present(thumbnailAssetId),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16585,7 +16585,18 @@
           },
           "description": {
             "description": "Album description",
-            "type": "string"
+            "type": "string",
+            "x-immich-history": [
+              {
+                "version": "v1",
+                "state": "Added"
+              },
+              {
+                "version": "v3",
+                "state": "Updated",
+                "description": "An empty string is returned instead of null for backwards compatibility; null will be returned in v4."
+              }
+            ]
           },
           "endDate": {
             "description": "End date (latest asset)",
@@ -18443,7 +18454,19 @@
           },
           "description": {
             "description": "Album description",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-immich-history": [
+              {
+                "version": "v1",
+                "state": "Added"
+              },
+              {
+                "version": "v3",
+                "state": "Updated",
+                "description": "Sending an empty string is deprecated; send null instead. Empty strings will no longer be coerced to null in v4."
+              }
+            ]
           }
         },
         "required": [
@@ -27115,7 +27138,19 @@
           },
           "description": {
             "description": "Album description",
-            "type": "string"
+            "nullable": true,
+            "type": "string",
+            "x-immich-history": [
+              {
+                "version": "v1",
+                "state": "Added"
+              },
+              {
+                "version": "v3",
+                "state": "Updated",
+                "description": "Sending an empty string is deprecated; send null instead. Empty strings will no longer be coerced to null in v4."
+              }
+            ]
           },
           "isActivityEnabled": {
             "description": "Enable activity feed",

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -540,7 +540,7 @@ export type CreateAlbumDto = {
     /** Initial asset IDs */
     assetIds?: string[];
     /** Album description */
-    description?: string;
+    description?: string | null;
 };
 export type AlbumsAddAssetsDto = {
     /** Album IDs */
@@ -567,7 +567,7 @@ export type UpdateAlbumDto = {
     /** Album thumbnail asset ID */
     albumThumbnailAssetId?: string;
     /** Album description */
-    description?: string;
+    description?: string | null;
     /** Enable activity feed */
     isActivityEnabled?: boolean;
     order?: AssetOrder;

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -34,7 +34,22 @@ const AlbumUserCreateSchema = z
 const CreateAlbumSchema = z
   .object({
     albumName: z.string().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    // TODO: drop the empty-string-to-null transform in v4 (clients should send null)
+    description: z
+      .string()
+      .nullable()
+      .transform((value) => (value === '' ? null : value))
+      .optional()
+      .describe('Album description')
+      .meta({
+        ...new HistoryBuilder()
+          .added('v1')
+          .updated(
+            'v3',
+            'Sending an empty string is deprecated; send null instead. Empty strings will no longer be coerced to null in v4.',
+          )
+          .getExtensions(),
+      }),
     albumUsers: z.array(AlbumUserCreateSchema).optional().describe('Album users'),
     assetIds: z.array(z.uuidv4()).optional().describe('Initial asset IDs'),
   })
@@ -57,7 +72,22 @@ const AlbumsAddAssetsResponseSchema = z
 const UpdateAlbumSchema = z
   .object({
     albumName: z.string().optional().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    // TODO: drop the empty-string-to-null transform in v4 (clients should send null)
+    description: z
+      .string()
+      .nullable()
+      .transform((value) => (value === '' ? null : value))
+      .optional()
+      .describe('Album description')
+      .meta({
+        ...new HistoryBuilder()
+          .added('v1')
+          .updated(
+            'v3',
+            'Sending an empty string is deprecated; send null instead. Empty strings will no longer be coerced to null in v4.',
+          )
+          .getExtensions(),
+      }),
     albumThumbnailAssetId: z.uuidv4().optional().describe('Album thumbnail asset ID'),
     isActivityEnabled: z.boolean().optional().describe('Enable activity feed'),
     order: AssetOrderSchema.optional(),
@@ -110,7 +140,18 @@ export const AlbumResponseSchema = z
   .object({
     id: z.uuidv4().describe('Album ID'),
     albumName: z.string().describe('Album name'),
-    description: z.string().describe('Album description'),
+    description: z
+      .string()
+      .describe('Album description')
+      .meta({
+        ...new HistoryBuilder()
+          .added('v1')
+          .updated(
+            'v3',
+            'An empty string is returned instead of null for backwards compatibility; null will be returned in v4.',
+          )
+          .getExtensions(),
+      }),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     createdAt: z.string().meta({ format: 'date-time' }).describe('Creation date'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
@@ -171,7 +212,7 @@ export type MapAlbumDto = {
   assets?: ShallowDehydrateObject<MapAsset>[];
   sharedLinks?: ShallowDehydrateObject<AuthSharedLink>[];
   albumName: string;
-  description: string;
+  description: string | null;
   albumThumbnailAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -207,7 +248,8 @@ export const mapAlbum = (entity: MaybeDehydrated<MapAlbumDto>): AlbumResponseDto
 
   return {
     albumName: entity.albumName,
-    description: entity.description,
+    // TODO: return null instead of '' in v4
+    description: entity.description ?? '',
     albumThumbnailAssetId: entity.albumThumbnailAssetId,
     createdAt: asDateTimeString(entity.createdAt),
     updatedAt: asDateTimeString(entity.updatedAt),

--- a/server/src/schema/migrations/1784664555996-AlbumDescriptionNullable.ts
+++ b/server/src/schema/migrations/1784664555996-AlbumDescriptionNullable.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "album" SET "description" = NULL WHERE "description" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "album" SET "description" = '' WHERE "description" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT ''::text;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -36,8 +36,8 @@ export class AlbumTable {
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>;
+  @Column({ type: 'text', nullable: true })
+  description!: string | null;
 
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -441,7 +441,12 @@ export class SyncService extends BaseService {
     const upserts = this.syncRepository.album.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
       const albumUsers = await this.syncRepository.album.getAlbumUsers(data.id);
-      send(response, { type: upsertType, ids: [updateId], data: syncAlbumV2ToV1(data, albumUsers) });
+      send(response, {
+        type: upsertType,
+        ids: [updateId],
+        // TODO: return null instead of '' in v4
+        data: syncAlbumV2ToV1({ ...data, description: data.description ?? '' }, albumUsers),
+      });
     }
   }
 
@@ -455,7 +460,8 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.AlbumV2;
     const upserts = this.syncRepository.album.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
-      send(response, { type: upsertType, ids: [updateId], data });
+      // TODO: return null instead of '' in v4
+      send(response, { type: upsertType, ids: [updateId], data: { ...data, description: data.description ?? '' } });
     }
   }
 

--- a/web/src/lib/modals/AlbumEditModal.svelte
+++ b/web/src/lib/modals/AlbumEditModal.svelte
@@ -17,7 +17,7 @@
   let description = $state(album.description);
 
   const onSubmit = async () => {
-    const success = await handleUpdateAlbum(album, { albumName, description });
+    const success = await handleUpdateAlbum(album, { albumName, description: description || null });
     if (success) {
       onClose();
     }

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/AlbumDescription.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/AlbumDescription.svelte
@@ -20,7 +20,7 @@
       const response = await updateAlbumInfo({
         id,
         updateAlbumDto: {
-          description,
+          description: description || null,
         },
       });
       eventManager.emit('AlbumUpdate', response);


### PR DESCRIPTION
Hello everyone, 
I'm a big fan and supporter of this project, hopefully I can also lend a hand. I am a professional software developer but my stack is a different one than this, so I'm not familiar with a lot of the tools used here.
I picked what should be an easy task to hopefully provide a good contribution. 

This PR addresses the first column of issue #28832: album.description now stores and returns null instead of an empty string. I only addressed one column because I saw some feedback in a previous attempted fix that suggested tackling the issue one column by one.

## Description

`album.description` was a `NOT NULL text` column defaulting to `''`. After this change it is nullable and the API stores/returns `null` instead of an empty string.
In brief:
- `album.description` is now `nullable` with no default (copied from the `notification.description` column).
- a DB migration makes the column nullable and backfills existing `''` rows to `NULL`.
- album create/update coerce an incoming empty string to `null` (so existing clients that send `""` keep working); the album response and the album sync payloads (`SyncAlbumV1`/`V2`, which read `album.description` directly) are now nullable.

In the spirit of changing as little as possible, clients read the now-nullable field safely. Mobile keeps its local domain model and Drift DB non-nullable and coerces `null` to `''` at the API boundary.

### Note on the migration

Either I got something wrong or I found an issue, but `pnpm migrations:generate` alone produced an incomplete migration for this change.  It produced only `ALTER COLUMN "description" SET DEFAULT NULL` without dropping the `NOT NULL` constraint. 
Obviosuly insering `NULL` would have caused an error, so I manually fixed it. 
I'm flagging for clairty.

Fixes #28832  (`album.description` only)

## How Has This Been Tested?

- [x] `server` typecheck and build, whole small and medium suite (unit and integration?)
- [x] Migration verified on a real  Postgres DB via the actual migration runner

I did not test the mobile stuff, I don't have the whole setup. If it is mandatory I can work on that.

## API Changes

`AlbumResponseDto.description`, `CreateAlbumDto.description`, `UpdateAlbumDto.description`, and `SyncAlbumV1`/`SyncAlbumV2` `description` are now nullable. Sending `""` on create/update is still accepted and stored as `null`.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable) (I have updated the current ones)
- [x] I have followed naming conventions/patterns in the surrounding code.
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

As I said before, I am not familiar with this stack, and this application is quite big. Claude Code was used to mainly explore the codebase, in particular to find places that could be affected by the change, setting up some dependencies and running the verification steps described above. 
I reviewed every line that I did not write myself and understand and stand behind the change.