### PR TITLE
fix(web): restore correct back route when opening person asset via direct URL

### DIFF
--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -95,6 +95,8 @@
     const getPreviousRoute = $page.url.searchParams.get(QueryParameter.PREVIOUS_ROUTE);
     if (getPreviousRoute && !isExternalUrl(getPreviousRoute)) {
       previousRoute = getPreviousRoute;
+    } else if ($page.params.assetId) {
+      previousRoute = Route.viewPerson(data.person);
     }
     if (action == 'merge') {
       viewMode = PersonPageViewMode.MERGE_PEOPLE;


### PR DESCRIPTION
## Description

Fixes #30126.

When opening an asset inside a People page via a direct URL (bookmark, share link), clicking the back arrow navigates to `/explore` instead of returning to the person's gallery.

The person gallery (`/people/[personId]`) and the asset viewer within it (`/people/[personId]/photos/[assetId]`) share the same SvelteKit route ID. `afterNavigate` only updates `previousRoute` when `from.route.id !== $page.route.id`, so this transition never sets it — leaving the default `Route.explore()` in place. On direct URL access there is no prior navigation at all, so the fallback is never overridden.

In `onMount`, if no `PREVIOUS_ROUTE` query param is present and the URL contains an `assetId` param, fall back to the person's gallery URL rather than `/explore`. Normal in-app navigation (which passes `PREVIOUS_ROUTE`) is unaffected.

## How Has This Been Tested?

- [ ] Opened an asset directly from a People page via a bookmarked URL — back button now returns to the person's gallery
- [ ] Opened an asset via normal in-app navigation (clicking thumbnail) — back button behaviour unchanged

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- N/A — routing fix, no visual change -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.