### PR TITLE
fix(server): store null instead of empty string for user profileImagePath

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -128,7 +128,7 @@ export type User = {
   name: string;
   email: string;
   avatarColor: UserAvatarColor | null;
-  profileImagePath: string;
+  profileImagePath: string | null;
   profileChangedAt: Date;
 };
 

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -32,7 +32,7 @@ const LoginResponseSchema = z
     userId: z.uuidv4().describe('User ID'),
     userEmail: toEmail.describe('User email'),
     name: z.string().describe('User name'),
-    profileImagePath: z.string().describe('Profile image path'),
+    profileImagePath: z.string().nullable().describe('Profile image path'),
     isAdmin: z.boolean().describe('Is admin user'),
     shouldChangePassword: z.boolean().describe('Should change password'),
     isOnboarded: z.boolean().describe('Is onboarded'),

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -27,7 +27,7 @@ export const UserResponseSchema = z
     id: z.uuidv4().describe('User ID'),
     name: z.string().describe('User name'),
     email: toEmail.describe('User email'),
-    profileImagePath: z.string().describe('Profile image path'),
+    profileImagePath: z.string().nullable().describe('Profile image path'),
     avatarColor: UserAvatarColorSchema,
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     profileChangedAt: z.string().meta({ format: 'date-time' }).describe('Profile change date'),

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -123,7 +123,7 @@ type UserEvent = {
   deletedAt: Date | null;
   status: UserStatus;
   email: string;
-  profileImagePath: string;
+  profileImagePath: string | null;
   isAdmin: boolean;
   shouldChangePassword: boolean;
   avatarColor: UserAvatarColor | null;

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -81,7 +81,7 @@ export class UserRepository {
     return this.db
       .selectFrom('user')
       .select(['id', 'profileImagePath'])
-      .where('profileImagePath', '!=', sql.lit(''))
+      .where('profileImagePath', 'is not', null)
       .limit(sql.lit(3))
       .execute();
   }

--- a/server/src/schema/migrations/1784738477790-ConvertUserProfileImagePathEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784738477790-ConvertUserProfileImagePathEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "user" SET "profileImagePath" = NULL WHERE "profileImagePath" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "profileImagePath" = '' WHERE "profileImagePath" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "profileImagePath" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -40,8 +40,8 @@ export class UserTable {
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
 
-  @Column({ default: '' })
-  profileImagePath!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  profileImagePath!: string | null;
 
   @Column({ type: 'boolean', default: false })
   isAdmin!: Generated<boolean>;

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -189,7 +189,9 @@ export class CliService extends BaseService {
     }
 
     for (const user of users) {
-      paths.push(user.profileImagePath);
+      if (user.profileImagePath) {
+        paths.push(user.profileImagePath);
+      }
     }
 
     for (const asset of assets) {

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -134,10 +134,10 @@ export class UserService extends BaseService {
 
   async deleteProfileImage(auth: AuthDto): Promise<void> {
     const user = await this.findOrFail(auth.user.id, { withDeleted: false });
-    if (user.profileImagePath === '') {
+    if (user.profileImagePath == null) {
       throw new BadRequestException("Can't delete a missing profile Image");
     }
-    await this.userRepository.update(auth.user.id, { profileImagePath: '', profileChangedAt: new Date() });
+    await this.userRepository.update(auth.user.id, { profileImagePath: null, profileChangedAt: new Date() });
     await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [user.profileImagePath] } });
   }
 


### PR DESCRIPTION
## Description

When a user is created without a profile image, the database now stores `NULL` instead of an empty string `""`.

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Response schemas (`UserResponse`, `LoginResponse`): allows null
- Repository: query filter changed from `!= ""` to `IS NOT NULL`
- Service: delete profile image logic updated to check for null instead of empty string
- TypeScript types (`User`, `AuthUserEvent`): `profileImagePath` is `string | null`

Fixes #28832 (user.profileImagePath column)

## How Has This Been Tested?

- [ ] Pattern follows the same approach as the other columns in #28832
- [ ] Existing test suite passes

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None. I manually wrote the code following the established pattern from a previously merged PR for the same issue.