### PR TITLE
fix(mobile): allow URL validation to pass when scheme is not provided

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -96,12 +96,12 @@ class ApiService {
   ///  port   - optional (default: based on schema)
   ///  path   - optional
   Future<String> resolveEndpoint(String serverUrl) async {
-    String url = sanitizeUrl(serverUrl);
+    String url = normalizeServerUrl(serverUrl);
 
     // Check for /.well-known/immich
     final wellKnownEndpoint = await _getWellKnownEndpoint(url);
     if (wellKnownEndpoint.isNotEmpty) {
-      url = sanitizeUrl(wellKnownEndpoint);
+      url = normalizeServerUrl(wellKnownEndpoint);
     }
 
     if (!await _isEndpointAvailable(url)) {

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -2,30 +2,31 @@ import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:punycode/punycode.dart';
 
-String sanitizeUrl(String url) {
+/// Normalizes a server URL, guaranteeing that it has a schema and no trailing slashes
+String normalizeServerUrl(String url) {
+  final trimmedUrl = url.trim();
+
   // Add schema if none is set
-  final urlWithSchema = url.trimLeft().startsWith(RegExp(r"https?://")) ? url : "https://$url";
+  final urlWithSchema = trimmedUrl.contains('://') ? trimmedUrl : "https://$trimmedUrl";
 
   // Remove trailing slash(es)
-  return urlWithSchema.trimRight().replaceFirst(RegExp(r"/+$"), "");
+  return urlWithSchema.replaceFirst(RegExp(r"/+$"), "");
 }
 
 /// Validates a user-entered server URL
-bool isValidServerUrl(String? url) {
+bool _validateServerUrl(String url) {
+  final parsedUrl = Uri.tryParse(url);
+  return parsedUrl != null && parsedUrl.scheme.startsWith(RegExp(r'^https?$')) && parsedUrl.host.isNotEmpty;
+}
+
+/// Normalizes and validates that a server URL is supported
+bool normalizeAndValidateServerUrl(String? url) {
   if (url == null || url.isEmpty) {
     return true;
   }
 
-  if (!url.contains('://')) {
-    // Prepend conforming scheme for URL validation
-    // Uri.tryParse will not parse out host without a scheme provided, even though we assume http(s) when connecting
-    url = 'http://$url';
-  }
-
-  final parsedUrl = Uri.tryParse(url);
-  return parsedUrl != null &&
-      (parsedUrl.scheme.isEmpty || parsedUrl.scheme.startsWith(RegExp(r'https?'))) &&
-      parsedUrl.host.isNotEmpty;
+  final normalizedUrl = normalizeServerUrl(url);
+  return _validateServerUrl(normalizedUrl);
 }
 
 String? getServerUrl() {

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -10,6 +10,24 @@ String sanitizeUrl(String url) {
   return urlWithSchema.trimRight().replaceFirst(RegExp(r"/+$"), "");
 }
 
+/// Validates a user-entered server URL
+bool isValidServerUrl(String? url) {
+  if (url == null || url.isEmpty) {
+    return true;
+  }
+
+  if (!url.contains('://')) {
+    // Prepend conforming scheme for URL validation
+    // Uri.tryParse will not parse out host without a scheme provided, even though we assume http(s) when connecting
+    url = 'http://$url';
+  }
+
+  final parsedUrl = Uri.tryParse(url);
+  return parsedUrl != null &&
+      (parsedUrl.scheme.isEmpty || parsedUrl.scheme.startsWith(RegExp(r'https?'))) &&
+      parsedUrl.host.isNotEmpty;
+}
+
 String? getServerUrl() {
   final serverUrl = punycodeDecodeUrl(Store.tryGet(StoreKey.serverEndpoint));
   final serverUri = serverUrl != null ? Uri.tryParse(serverUrl) : null;

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -43,18 +43,7 @@ class LoginForm extends HookConsumerWidget {
 
   final log = Logger('LoginForm');
 
-  String? _validateUrl(String? url) {
-    if (url == null || url.isEmpty) {
-      return null;
-    }
-
-    final parsedUrl = Uri.tryParse(url);
-    if (parsedUrl == null || !parsedUrl.isAbsolute || !parsedUrl.scheme.startsWith("http") || parsedUrl.host.isEmpty) {
-      return 'login_form_err_invalid_url'.tr();
-    }
-
-    return null;
-  }
+  String? _validateUrl(String? url) => isValidServerUrl(url) ? null : 'login_form_err_invalid_url'.tr();
 
   String? _validateEmail(String? email) {
     if (email == null || email == '') {

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -43,7 +43,7 @@ class LoginForm extends HookConsumerWidget {
 
   final log = Logger('LoginForm');
 
-  String? _validateUrl(String? url) => isValidServerUrl(url) ? null : 'login_form_err_invalid_url'.tr();
+  String? _validateUrl(String? url) => normalizeAndValidateServerUrl(url) ? null : 'login_form_err_invalid_url'.tr();
 
   String? _validateEmail(String? email) {
     if (email == null || email == '') {
@@ -90,7 +90,7 @@ class LoginForm extends HookConsumerWidget {
     /// Fetch the server login credential and enables oAuth login if necessary
     /// Returns true if successful, false otherwise
     Future<void> getServerAuthSettings() async {
-      final sanitizeServerUrl = sanitizeUrl(serverEndpointController.text);
+      final sanitizeServerUrl = normalizeServerUrl(serverEndpointController.text);
       final serverUrl = punycodeEncodeUrl(sanitizeServerUrl);
 
       // Guard empty URL
@@ -293,7 +293,7 @@ class LoginForm extends HookConsumerWidget {
 
       try {
         oAuthServerUrl = await oAuthService.getOAuthServerUrl(
-          sanitizeUrl(serverEndpointController.text),
+          normalizeServerUrl(serverEndpointController.text),
           state,
           codeChallenge,
         );
@@ -425,7 +425,7 @@ class LoginForm extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.only(bottom: ImmichSpacing.md),
                   child: Text(
-                    sanitizeUrl(serverEndpointController.text),
+                    normalizeServerUrl(serverEndpointController.text),
                     style: context.textTheme.displaySmall,
                     textAlign: TextAlign.center,
                   ),

--- a/mobile/test/modules/utils/url_helper_test.dart
+++ b/mobile/test/modules/utils/url_helper_test.dart
@@ -77,6 +77,40 @@ void main() {
     });
   });
 
+  group('isValidServerUrl', () {
+    test('should treat null as valid', () {
+      expect(isValidServerUrl(null), isTrue);
+    });
+
+    test('should treat empty string as valid', () {
+      expect(isValidServerUrl(''), isTrue);
+    });
+
+    test('should accept a bare host', () {
+      expect(isValidServerUrl('demo.immich.app'), isTrue);
+    });
+
+    test('should accept a bare host with a port', () {
+      expect(isValidServerUrl('192.168.1.1:2283'), isTrue);
+    });
+
+    test('should accept an http URL', () {
+      expect(isValidServerUrl('http://demo.immich.app'), isTrue);
+    });
+
+    test('should accept an https URL', () {
+      expect(isValidServerUrl('https://demo.immich.app:2283/api'), isTrue);
+    });
+
+    test('should reject a non-http scheme', () {
+      expect(isValidServerUrl('ftp://demo.immich.app'), isFalse);
+    });
+
+    test('should reject scheme only input', () {
+      expect(isValidServerUrl('https://'), isFalse);
+    });
+  });
+
   group('punycodeDecodeUrl', () {
     test('should return null for null input', () {
       expect(punycodeDecodeUrl(null), isNull);

--- a/mobile/test/modules/utils/url_helper_test.dart
+++ b/mobile/test/modules/utils/url_helper_test.dart
@@ -77,37 +77,37 @@ void main() {
     });
   });
 
-  group('isValidServerUrl', () {
+  group('normalizeAndValidateServerUrl', () {
     test('should treat null as valid', () {
-      expect(isValidServerUrl(null), isTrue);
+      expect(normalizeAndValidateServerUrl(null), isTrue);
     });
 
     test('should treat empty string as valid', () {
-      expect(isValidServerUrl(''), isTrue);
+      expect(normalizeAndValidateServerUrl(''), isTrue);
     });
 
     test('should accept a bare host', () {
-      expect(isValidServerUrl('demo.immich.app'), isTrue);
+      expect(normalizeAndValidateServerUrl('demo.immich.app'), isTrue);
     });
 
     test('should accept a bare host with a port', () {
-      expect(isValidServerUrl('192.168.1.1:2283'), isTrue);
+      expect(normalizeAndValidateServerUrl('192.168.1.1:2283'), isTrue);
     });
 
     test('should accept an http URL', () {
-      expect(isValidServerUrl('http://demo.immich.app'), isTrue);
+      expect(normalizeAndValidateServerUrl('http://demo.immich.app'), isTrue);
     });
 
     test('should accept an https URL', () {
-      expect(isValidServerUrl('https://demo.immich.app:2283/api'), isTrue);
+      expect(normalizeAndValidateServerUrl('https://demo.immich.app:2283/api'), isTrue);
     });
 
     test('should reject a non-http scheme', () {
-      expect(isValidServerUrl('ftp://demo.immich.app'), isFalse);
+      expect(normalizeAndValidateServerUrl('ftp://demo.immich.app'), isFalse);
     });
 
     test('should reject scheme only input', () {
-      expect(isValidServerUrl('https://'), isFalse);
+      expect(normalizeAndValidateServerUrl('https://'), isFalse);
     });
   });
 


### PR DESCRIPTION
We previously supported auto-populating a non-specified server schema as `https://`, but this was broken by a change to URL input validation. Restore this functionality by validating URLs that do not start with an explicit scheme.

Outside of the scope of the PR is allowing the autofill to check against `http://` (after first trying `https://`), though I'm not sure if that's desired given I don't think we had this before.