### PR TITLE
fix(web): mirror asset viewer navigation icons in RTL

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/NextAssetAction.svelte
+++ b/web/src/lib/components/asset-viewer/actions/NextAssetAction.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { shortcuts } from '$lib/actions/shortcut';
   import { Icon } from '@immich/ui';
-  import { mdiChevronRight } from '@mdi/js';
+  import { mdiChevronRight, mdiChevronLeft } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import NavigationArea from '../NavigationArea.svelte';
+  import { languageManager } from '$lib/managers/language-manager.svelte';
 
   interface Props {
     onNextAsset: () => void;
@@ -20,5 +21,5 @@
 />
 
 <NavigationArea onClick={onNextAsset} label={$t('view_next_asset')}>
-  <Icon icon={mdiChevronRight} size="36" aria-hidden />
+  <Icon icon={languageManager.rtl ? mdiChevronLeft : mdiChevronRight} size="36" aria-hidden />
 </NavigationArea>

--- a/web/src/lib/components/asset-viewer/actions/PreviousAssetAction.svelte
+++ b/web/src/lib/components/asset-viewer/actions/PreviousAssetAction.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { shortcuts } from '$lib/actions/shortcut';
   import { Icon } from '@immich/ui';
-  import { mdiChevronLeft } from '@mdi/js';
+  import { mdiChevronLeft, mdiChevronRight } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import NavigationArea from '../NavigationArea.svelte';
+  import { languageManager } from '$lib/managers/language-manager.svelte';
 
   interface Props {
     onPreviousAsset: () => void;
@@ -20,5 +21,5 @@
 />
 
 <NavigationArea onClick={onPreviousAsset} label={$t('view_previous_asset')}>
-  <Icon icon={mdiChevronLeft} size="36" aria-hidden />
+  <Icon icon={languageManager.rtl ? mdiChevronRight : mdiChevronLeft} size="36" aria-hidden />
 </NavigationArea>


### PR DESCRIPTION
## Description

Corrects the previous and next navigation icons in the asset viewer when using an RTL language.

The viewer now uses the existing `languageManager` RTL state to display the navigation icons in the correct direction. This only changes the icon direction and does not alter asset ordering or navigation behavior.

## How Has This Been Tested?

- [x] Verified the previous and next icons in an RTL language
- [x] Verified the icons remain unchanged in an LTR language
- [x] Verified previous and next navigation still opens the correct asset

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Add RTL and LTR screenshots here if available. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help review the wording of the commit and pull request description. The implementation and manual testing were performed by me.