### PR TITLE
fix: hypertext link to example docker-compose.rootless.yml

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -409,7 +409,7 @@ To decrease Redis logs, you can add the following line to the `redis:` section o
 
 You can change the user in the container by setting the `user` argument in `docker-compose.yml` for each service.
 
-[Example docker-compose.yml file](https://github.com/immich-app/immich/blob/main/docker/docker-compose.rootless.yml)
+[Example docker-compose.rootless.yml file](https://github.com/immich-app/immich/blob/main/docker/docker-compose.rootless.yml)
 
 You may need to add mount points or docker volumes for the following internal container paths:
 


### PR DESCRIPTION
## Description
Already spoke with @mmomjian who told me to go ahead and make the change.
Currently the FAQ does a great job with helping people convert their immich docker setup to rootless/non-root user.  However, in the FAQ the displayed hyperlink text for the rootless docker compose yml looks like it takes you to the regular docker compose yml (when it actually takes you to the correct rootless one).  
I added the word "rootless" in the hyperlink text to match the actual .yml name to decrease confusion as to where the link was taking you.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
as above -- decreases confusion when reading the FAQ as to which yml you'll be served after clicking the hyperlink under rootless instructions.
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue) #30144

## How Has This Been Tested?
Just a word added in the faq to the hyperlink, it renders properly

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
n/a
- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
n/a
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->
n/a
## Checklist:

- [ x] I have carefully read CONTRIBUTING.md
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation if applicable
- [ x] I have no unrelated changes in the PR.
- [ x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable) n/a
- [ ] I have followed naming conventions/patterns in the surrounding code n/a
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.  n/a
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) n/a

## Please describe to which degree, if any, an LLM was used in creating this pull request.
none
...
