### PR TITLE
fix(mobile): open asset deep links in main timeline for L/R navigation

### DIFF
--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -51,6 +51,9 @@ class TimelineFactory {
 
   TimelineService main(List<String> timelineUsers) => TimelineService(_timelineRepository.main(timelineUsers, groupBy));
 
+  Future<int?> getMainTimelineAssetIndex(List<String> userIds, String remoteId) =>
+      _timelineRepository.getMainTimelineAssetIndex(userIds, remoteId);
+
   TimelineService localAlbum({required String albumId}) =>
       TimelineService(_timelineRepository.localAlbum(albumId, groupBy));
 
@@ -97,6 +100,8 @@ class TimelineService {
   int _bufferOffset = 0;
   List<BaseAsset> _buffer = [];
   StreamSubscription? _bucketSubscription;
+  Completer<void>? _readyCompleter;
+  bool _hasReceivedBuckets = false;
 
   int _totalAssets = 0;
   int get totalAssets => _totalAssets;
@@ -130,9 +135,20 @@ class TimelineService {
 
         // change the state's total assets count only after the buffer is reloaded
         _totalAssets = totalAssets;
+        _hasReceivedBuckets = true;
+        _readyCompleter?.complete();
+        _readyCompleter = null;
         EventStream.shared.emit(const TimelineReloadEvent());
       });
     });
+  }
+
+  /// Waits until the first bucket snapshot has been applied.
+  Future<void> ensureReady() {
+    if (_hasReceivedBuckets) {
+      return Future.value();
+    }
+    return (_readyCompleter ??= Completer<void>()).future;
   }
 
   Stream<List<Bucket>> Function() get watchBuckets => _bucketSource;
@@ -238,5 +254,9 @@ class TimelineService {
     _bucketSubscription = null;
     _buffer = [];
     _bufferOffset = 0;
+    if (_readyCompleter != null && !_readyCompleter!.isCompleted) {
+      _readyCompleter!.complete();
+    }
+    _readyCompleter = null;
   }
 }

--- a/mobile/lib/infrastructure/entities/merged_asset.drift
+++ b/mobile/lib/infrastructure/entities/merged_asset.drift
@@ -139,3 +139,64 @@ FROM
 )
 GROUP BY bucket_date
 ORDER BY bucket_date DESC;
+
+-- 0-based index of a remote asset in the main timeline (same filters/order as mergedAsset).
+-- NULL when the asset is not part of the main timeline (archived, non-primary stack, etc.).
+mergedAssetIndex(:remote_id AS TEXT):
+SELECT CASE
+	WHEN NOT EXISTS (
+		SELECT 1
+		FROM remote_asset_entity rae
+		LEFT JOIN stack_entity se ON rae.stack_id = se.id
+		WHERE rae.id = :remote_id
+			AND rae.deleted_at IS NULL
+			AND rae.visibility = 0
+			AND rae.owner_id IN :user_ids
+			AND (
+				rae.stack_id IS NULL
+				OR rae.id = se.primary_asset_id
+			)
+	) THEN NULL
+	ELSE (
+		SELECT COUNT(*)
+		FROM (
+			SELECT
+				rae.created_at as created_at
+			FROM
+				remote_asset_entity rae
+			LEFT JOIN
+				stack_entity se ON rae.stack_id = se.id
+			WHERE
+				rae.deleted_at IS NULL
+				AND rae.visibility = 0
+				AND rae.owner_id IN :user_ids
+				AND (
+					rae.stack_id IS NULL
+					OR rae.id = se.primary_asset_id
+				)
+
+			UNION ALL
+
+			SELECT
+				lae.created_at as created_at
+			FROM
+				local_asset_entity lae
+			WHERE NOT EXISTS (
+				SELECT 1 FROM remote_asset_entity rae WHERE rae.checksum = lae.checksum AND rae.owner_id IN :user_ids
+			)
+			AND EXISTS (
+				SELECT 1 FROM local_album_asset_entity laa
+				INNER JOIN local_album_entity la on laa.album_id = la.id
+				WHERE laa.asset_id = lae.id AND la.backup_selection = 0
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM local_album_asset_entity laa
+				INNER JOIN local_album_entity la on laa.album_id = la.id
+				WHERE laa.asset_id = lae.id AND la.backup_selection = 2
+			)
+		)
+		WHERE created_at > (
+			SELECT created_at FROM remote_asset_entity WHERE id = :remote_id
+		)
+	)
+END AS asset_index;

--- a/mobile/lib/infrastructure/entities/merged_asset.drift.dart
+++ b/mobile/lib/infrastructure/entities/merged_asset.drift.dart
@@ -101,6 +101,34 @@ class MergedAssetDrift extends i1.ModularAccessor {
     );
   }
 
+  i0.Selectable<int?> mergedAssetIndex({
+    required String remoteId,
+    required List<String> userIds,
+  }) {
+    var $arrayStartIndex = 2;
+    final expandeduserIds = $expandVar($arrayStartIndex, userIds.length);
+    $arrayStartIndex += userIds.length;
+    final expandeduserIds2 = $expandVar($arrayStartIndex, userIds.length);
+    $arrayStartIndex += userIds.length;
+    final expandeduserIds3 = $expandVar($arrayStartIndex, userIds.length);
+    return customSelect(
+      'SELECT CASE WHEN NOT EXISTS (SELECT 1 FROM remote_asset_entity AS rae LEFT JOIN stack_entity AS se ON rae.stack_id = se.id WHERE rae.id = ?1 AND rae.deleted_at IS NULL AND rae.visibility = 0 AND rae.owner_id IN ($expandeduserIds) AND(rae.stack_id IS NULL OR rae.id = se.primary_asset_id)) THEN NULL ELSE (SELECT COUNT(*) FROM (SELECT rae.created_at AS created_at FROM remote_asset_entity AS rae LEFT JOIN stack_entity AS se ON rae.stack_id = se.id WHERE rae.deleted_at IS NULL AND rae.visibility = 0 AND rae.owner_id IN ($expandeduserIds2) AND(rae.stack_id IS NULL OR rae.id = se.primary_asset_id)UNION ALL SELECT lae.created_at AS created_at FROM local_asset_entity AS lae WHERE NOT EXISTS (SELECT 1 FROM remote_asset_entity AS rae WHERE rae.checksum = lae.checksum AND rae.owner_id IN ($expandeduserIds3)) AND EXISTS (SELECT 1 FROM local_album_asset_entity AS laa INNER JOIN local_album_entity AS la ON laa.album_id = la.id WHERE laa.asset_id = lae.id AND la.backup_selection = 0) AND NOT EXISTS (SELECT 1 FROM local_album_asset_entity AS laa INNER JOIN local_album_entity AS la ON laa.album_id = la.id WHERE laa.asset_id = lae.id AND la.backup_selection = 2)) WHERE created_at > (SELECT created_at FROM remote_asset_entity WHERE id = ?1)) END AS asset_index',
+      variables: [
+        i0.Variable<String>(remoteId),
+        for (var $ in userIds) i0.Variable<String>($),
+        for (var $ in userIds) i0.Variable<String>($),
+        for (var $ in userIds) i0.Variable<String>($),
+      ],
+      readsFrom: {
+        remoteAssetEntity,
+        stackEntity,
+        localAssetEntity,
+        localAlbumAssetEntity,
+        localAlbumEntity,
+      },
+    ).map((i0.QueryRow row) => row.readNullable<int>('asset_index'));
+  }
+
   i4.$RemoteAssetEntityTable get remoteAssetEntity => i1.ReadDatabaseContainer(
     attachedDatabase,
   ).resultSet<i4.$RemoteAssetEntityTable>('remote_asset_entity');

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -53,6 +53,15 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     origin: TimelineOrigin.main,
   );
 
+  /// 0-based index in the main timeline, or null if the asset is not in it.
+  Future<int?> getMainTimelineAssetIndex(List<String> userIds, String remoteId) {
+    if (userIds.isEmpty) {
+      return Future.value();
+    }
+
+    return _db.mergedAssetDrift.mergedAssetIndex(remoteId: remoteId, userIds: userIds).getSingleOrNull();
+  }
+
   Stream<List<Bucket>> _watchMainBucket(List<String> userIds, {GroupAssetsBy groupBy = GroupAssetsBy.day}) {
     if (groupBy == GroupAssetsBy.none) {
       throw UnsupportedError("GroupAssetsBy.none is not supported for watchMainBucket");

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -1,5 +1,9 @@
+import 'dart:math' as math;
+
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart' as beta_asset_service;
@@ -7,6 +11,7 @@ import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/domain/services/people.service.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart' as beta_asset_provider;
@@ -117,6 +122,36 @@ class DeepLinkService {
     }
 
     final album = albumId != null ? await _betaRemoteAlbumService.get(albumId) : null;
+
+    // Album-scoped links keep album context; widgets/generic asset links open the main
+    // timeline so the viewer supports left/right navigation (Fixes #20289).
+    if (album == null) {
+      final userIds = await ref.read(timelineUsersProvider.future);
+      final index = userIds.isEmpty
+          ? null
+          : await _betaTimelineFactory.getMainTimelineAssetIndex(userIds, assetId);
+
+      if (index != null) {
+        final timelineService = ref.read(timelineServiceProvider);
+        await timelineService.ensureReady();
+
+        if (timelineService.totalAssets > 0) {
+          final loadIndex = math.min(index, timelineService.totalAssets - 1);
+          await timelineService.loadAssets(math.max(0, loadIndex - 25), 50);
+          final exactIndex = timelineService.getIndex(asset.heroTag) ?? loadIndex;
+
+          AssetViewer.setAsset(ref, asset);
+          SchedulerBinding.instance.addPostFrameCallback((_) {
+            EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
+          });
+
+          return AssetViewerRoute(
+            initialIndex: exactIndex,
+            timelineService: timelineService,
+          );
+        }
+      }
+    }
 
     AssetViewer.setAsset(ref, asset);
     return AssetViewerRoute(


### PR DESCRIPTION
## Description

Asset deep links from home-screen widgets (`immich://asset?id=…`) opened the viewer with a single-asset timeline (`fromAssets([asset])`), so left/right swipes did nothing and dismissing the viewer on a cold start landed at the top of the Photos timeline.

This change resolves the asset's 0-based index in the main timeline (same filters/order as `mergedAsset`), opens `AssetViewerRoute` with the shared main `TimelineService`, and emits `ScrollToDateEvent` so the underlay timeline is positioned near that day after dismiss.

Album-scoped `my.immich.app` links that include an album id keep the previous single-asset + album context behavior.

Fixes #20289

## How Has This Been Tested?

Built an installable Android APK from the fork, installed it on a real device, and verified the widget deep-link flow end-to-end.

- [x] Tap Random / Memories Android widget photo → viewer opens that asset
- [x] Swipe left/right through neighboring timeline assets
- [x] Swipe down / back from cold start → Photos timeline near that day (not forced to library start)
- [x] Warm start deep link still works
- [ ] Album deep link with album context still opens with album context (unchanged path; not re-tested in this APK pass)

**Result:** works great on device. The widget is more useful — one tap into a photo, then browse neighboring moments left/right, which makes it easier to re-engage with the library.

**Code commit:** https://github.com/LuckyCoders/immich/commit/2af5c34ed3135baf8ff743dabbf1c0be23611399

**APK artifact:** https://github.com/LuckyCoders/immich/actions/runs/30050226611 (`immich-personal-apk`)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM assistance was used for exploration of the deep-link / timeline code paths and drafting the change. The implementation was reviewed and adjusted manually against Immich's existing `mergedAsset` / `TimelineService` / `viewInTimeline` patterns before opening this PR.
