### PR TITLE
fix(server): store null instead of empty string for user oauthId

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -139,7 +139,7 @@ export type UserAdmin = User & {
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
-  oauthId: string;
+  oauthId: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;
   status: UserStatus;

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -33,7 +33,7 @@ const SyncAuthUserV1Schema = SyncUserV1Schema.merge(
   z.object({
     isAdmin: z.boolean().describe('User is admin'),
     pinCode: z.string().nullable().describe('User pin code'),
-    oauthId: z.string().describe('User OAuth ID'),
+    oauthId: z.string().nullable().describe('User OAuth ID'),
     storageLabel: z.string().nullable().describe('User storage label'),
     quotaSizeInBytes: z.int().nullable().describe('Quota size in bytes'),
     quotaUsageInBytes: z.int().describe('Quota usage in bytes'),

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -122,7 +122,7 @@ const UserAdminResponseSchema = UserResponseSchema.extend({
   createdAt: isoDatetimeToDate.describe('Creation date'),
   deletedAt: isoDatetimeToDate.nullable().describe('Deletion date'),
   updatedAt: isoDatetimeToDate.describe('Last update date'),
-  oauthId: z.string().describe('OAuth ID'),
+  oauthId: z.string().nullable().describe('OAuth ID'),
   quotaSizeInBytes: z.int().min(0).nullable().describe('Storage quota in bytes'),
   quotaUsageInBytes: z.int().min(0).nullable().describe('Storage usage in bytes'),
   status: UserStatusSchema,

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -127,7 +127,7 @@ type UserEvent = {
   isAdmin: boolean;
   shouldChangePassword: boolean;
   avatarColor: UserAvatarColor | null;
-  oauthId: string;
+  oauthId: string | null;
   storageLabel: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;

--- a/server/src/schema/migrations/1784809679001-ConvertUserOAuthIdEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784809679001-ConvertUserOAuthIdEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "user" SET "oauthId" = NULL WHERE "oauthId" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "oauthId" = '' WHERE "oauthId" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -55,8 +55,8 @@ export class UserTable {
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;
 
-  @Column({ default: '' })
-  oauthId!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  oauthId!: string | null;
 
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;

--- a/server/src/services/auth-admin.service.ts
+++ b/server/src/services/auth-admin.service.ts
@@ -5,7 +5,6 @@ import { BaseService } from 'src/services/base.service';
 @Injectable()
 export class AuthAdminService extends BaseService {
   async unlinkAll(_auth: AuthDto) {
-    // TODO replace '' with null
-    await this.userRepository.updateAll({ oauthId: '' });
+    await this.userRepository.updateAll({ oauthId: null });
   }
 }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -439,7 +439,7 @@ export class AuthService extends BaseService {
       await this.sessionRepository.update(auth.session.id, { oauthSid: null });
     }
 
-    const user = await this.userRepository.update(auth.user.id, { oauthId: '' });
+    const user = await this.userRepository.update(auth.user.id, { oauthId: null });
     return mapUserAdmin(user);
   }
 


### PR DESCRIPTION
## Description

When a user signs up via email (without OAuth), the database now stores `NULL` instead of an empty string `""` for the OAuth ID column.

This was already marked with a TODO comment in the admin service:
```ts
// TODO replace  with null
```

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Response schemas (`UserAdminResponse`, `SyncUserV1`): allows null
- Admin service: unlinkAll now sets to null instead of empty string
- Auth service: unlink OAuth now sets to null instead of empty string
- TypeScript types (`UserAdmin`, `AuthUserEvent`): `oauthId` is `string | null`

Fixes #28832 (user.oauthId column)

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.