### PR TITLE
fix(web): mirror onboarding navigation icons in RTL

### DIFF
--- a/web/src/routes/auth/onboarding/OnboardingCard.svelte
+++ b/web/src/routes/auth/onboarding/OnboardingCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { languageManager } from '$lib/managers/language-manager.svelte';
   import { Button, Icon } from '@immich/ui';
   import { mdiArrowLeft, mdiArrowRight, mdiCheck } from '@mdi/js';
   import type { Snippet } from 'svelte';
@@ -52,7 +53,7 @@
       <div class="flex w-full place-content-start">
         <Button
           shape="round"
-          leadingIcon={mdiArrowLeft}
+          leadingIcon={languageManager.rtl ? mdiArrowRight : mdiArrowLeft}
           class="flex place-content-center gap-2"
           onclick={() => {
             onLeave?.();
@@ -67,7 +68,7 @@
     <div class="flex w-full place-content-end">
       <Button
         shape="round"
-        trailingIcon={nextTitle ? mdiArrowRight : mdiCheck}
+        trailingIcon={nextTitle ? (languageManager.rtl ? mdiArrowLeft : mdiArrowRight) : mdiCheck}
         onclick={() => {
           onLeave?.();
           onNext?.();


### PR DESCRIPTION
## Description

Corrects the next and previous navigation icons in the onboarding flow when using an RTL language.

The onboarding navigation now uses the existing `languageManager` RTL state to display the arrows in the correct direction. This only changes the icon direction and does not alter the onboarding step order or navigation behavior.

## How Has This Been Tested?

- [x] Verified the next button icon in an RTL language
- [x] Verified the previous button icon in an RTL language
- [x] Verified both icons remain unchanged in an LTR language
- [x] Verified onboarding navigation still moves to the correct step

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

### RTL onboarding navigation

<!-- Add before/after screenshots here. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help review the wording of the commit and pull request description. The implementation and manual testing were performed by me.