### PR TITLE
perf(server): batch deleteBulkMetadata to avoid per-item N+1 deletes

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -97,8 +97,10 @@ where
 begin
 delete from "asset_metadata"
 where
-  "assetId" = $1
-  and "key" = $2
+  (
+    "assetId" = $1
+    and "key" = $2
+  )
 commit
 
 -- AssetRepository.getByDayOfYear

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -435,9 +435,15 @@ export class AssetRepository {
       return;
     }
 
+    // Batch deletes into chunked single statements instead of one round-trip per item (N+1),
+    // kept inside the transaction to preserve atomicity.
     await this.db.transaction().execute(async (tx) => {
-      for (const { assetId, key } of items) {
-        await tx.deleteFrom('asset_metadata').where('assetId', '=', assetId).where('key', '=', key).execute();
+      for (let i = 0; i < items.length; i += 500) {
+        const chunk = items.slice(i, i + 500);
+        await tx
+          .deleteFrom('asset_metadata')
+          .where((eb) => eb.or(chunk.map(({ assetId, key }) => eb.and([eb('assetId', '=', assetId), eb('key', '=', key)]))))
+          .execute();
       }
     });
   }


### PR DESCRIPTION
## Description

`AssetRepository.deleteBulkMetadata` issued one `DELETE` per item inside a transaction — N round-trips for N items, despite the "bulk" name. This batches the deletes into chunked single statements (an `OR` of `(assetId, key)` pairs), kept inside the transaction to preserve atomicity:

```ts
await this.db.transaction().execute(async (tx) => {
  for (let i = 0; i < items.length; i += 500) {
    const chunk = items.slice(i, i + 500);
    await tx.deleteFrom('asset_metadata')
      .where((eb) => eb.or(chunk.map(({ assetId, key }) =>
        eb.and([eb('assetId','=',assetId), eb('key','=',key)]))))
      .execute();
  }
});
```

Same result set (exactly the same `(assetId, key)` rows). N round-trips -> ceil(N/500). Chunked to avoid an unbounded `WHERE`.

Fixes # (no issue — performance improvement)

## How Has This Been Tested?

- [x] Regenerated the `@GenerateSql` snapshot (`src/queries/asset.repository.sql`). Verified byte-for-byte by compiling the new Kysely query and running it through `sql-formatter` (postgresql) — output matches the committed snapshot exactly.
- [ ] I did not run the full local test suite (no local DB set up). The change is behaviour-preserving; happy to iterate if CI surfaces anything.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — backend-only change.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (behaviour-preserving; SQL snapshot regenerated & verified)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The N+1 was surfaced by a static-analysis tool ([cleanscore](https://github.com/yoo-minho/cleanscore), which flags sequential `await` of DB calls inside loops) and verified by hand. The fix and the SQL-snapshot regeneration were written and verified by hand (Kysely compile + sql-formatter); this PR description was drafted with LLM assistance (Claude Code).
