### PR TITLE
chore(mobile): force swift-structured-queries lock to 0.34.0

### DIFF
--- a/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
-        "version" : "0.31.1"
+        "revision" : "dafddd843f10630aa6b5be47c1b6a59cc4ab6586",
+        "version" : "0.34.0"
       }
     },
     {


### PR DESCRIPTION
Force swift-structured-queries lock to 0.34.0.

This was partially addressed (implicitly) by #29780, but did not have the accompanying lock change to allow new pulls to properly resolve the package.

No functionality changes, and some of us were already building using this package.