### PR TITLE
fix(mobile): properly align iOS widget loading state

### DIFF
--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -18,15 +18,21 @@ struct ImmichWidgetView: View {
 
   var body: some View {
     if entry.image == nil {
-      VStack {
-        Image("LaunchImage")
-          .tintedWidgetImageModifier()
-        Text(entry.metadata.error?.errorDescription ?? "")
-          .minimumScaleFactor(0.25)
-          .multilineTextAlignment(.center)
-          .foregroundStyle(.secondary)
-      }
-      .padding(16)
+      Image("LaunchImage")
+        .tintedWidgetImageModifier()
+        .overlay(alignment: .bottom) {
+          if let error = entry.metadata.error?.errorDescription {
+            Text(error)
+              .minimumScaleFactor(0.25)
+              .multilineTextAlignment(.center)
+              .foregroundStyle(.secondary)
+              .fixedSize()
+              .alignmentGuide(.bottom) { dimensions in
+                // Place the text below the bottom of the image
+                dimensions[.top] - 8
+              }
+          }
+        }
     } else {
       ZStack(alignment: .leading) {
         Color.clear.overlay(


### PR DESCRIPTION
The presence of error text misaligned the loading state for iOS widgets. Center the logo

### Before

<img width="385" height="222" alt="image" src="https://github.com/user-attachments/assets/5e9f19f4-554b-4c82-8843-a7ec4463ce6c" />

### After

<img width="415" height="225" alt="image" src="https://github.com/user-attachments/assets/5f0143cc-f1b5-48af-9057-097ab7b0df97" />

<img width="409" height="203" alt="image" src="https://github.com/user-attachments/assets/6d4846e3-ad9b-4523-aeb8-042aab8379e5" />
