### PR TITLE
fix(mobile): align iOS widget text box with widget's corners

### DIFF
--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -29,21 +29,20 @@ private struct ImmichWidgetLoadingView: View {
   let message: String?
 
   var body: some View {
-    Image("LaunchImage")
-      .tintedWidgetImageModifier()
-      .overlay(alignment: .bottom) {
-        if let message {
-          Text(message)
-            .minimumScaleFactor(0.25)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
-            .fixedSize()
-            .alignmentGuide(.bottom) { dimensions in
-              // Place the text below the bottom of the image
-              dimensions[.top] - 8
-            }
-        }
-      }
+    let messageText = Text(message ?? "")
+      .minimumScaleFactor(0.25)
+      .multilineTextAlignment(.center)
+      .foregroundStyle(.secondary)
+
+    VStack(spacing: 8) {
+      // This is used as a nicer way to center the image, rather than using offsets
+      messageText.hidden()
+
+      Image("LaunchImage")
+        .tintedWidgetImageModifier()
+
+      messageText
+    }
   }
 }
 
@@ -59,24 +58,26 @@ private struct ImmichWidgetContentView: View {
           .resizable()
           .tintedWidgetImageModifier()
           .scaledToFill()
-        )
-        VStack {
-          Spacer()
-          if let subtitle = subtitle {
-            Text(subtitle)
-              .foregroundColor(.white)
-              .padding(6)
-              .background(ContainerRelativeShape().fill(Color.black.opacity(0.6)))
-              .font(.system(size: 16))
-          }
+      )
+
+      VStack {
+        Spacer()
+        if let subtitle {
+          Text(subtitle)
+            .foregroundColor(.white)
+            .padding(6)
+            .background(ContainerRelativeShape().fill(Color.black.opacity(0.6)))
+            .font(.system(size: 16))
         }
-          .padding(16)
-        }
+      }
+      .padding(16)
+    }
     .widgetURL(deepLink)
   }
 }
 
 #Preview(
+  "Medium",
   as: .systemMedium,
   widget: {
     ImmichRandomWidget()
@@ -94,6 +95,53 @@ private struct ImmichWidgetContentView: View {
 )
 
 #Preview(
+  "Medium No Data",
+  as: .systemMedium,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: nil
+    )
+  }
+)
+
+#Preview(
+  "Medium No Data Error",
+  as: .systemMedium,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: nil,
+      metadata: EntryMetadata(error: WidgetError.fetchFailed)
+    )
+  }
+)
+
+#Preview(
+  "Medium Loading",
+  as: .systemMedium,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: nil
+    )
+  }
+)
+
+#Preview(
+  "Small",
   as: .systemSmall,
   widget: {
     ImmichRandomWidget()
@@ -111,6 +159,23 @@ private struct ImmichWidgetContentView: View {
 )
 
 #Preview(
+  "Small No Data Error",
+  as: .systemSmall,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: nil,
+      metadata: EntryMetadata(error: WidgetError.fetchFailed)
+    )
+  }
+)
+
+#Preview(
+  "Large",
   as: .systemLarge,
   widget: {
     ImmichRandomWidget()

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -17,46 +17,62 @@ struct ImmichWidgetView: View {
   var entry: ImageEntry
 
   var body: some View {
-    if entry.image == nil {
-      Image("LaunchImage")
-        .tintedWidgetImageModifier()
-        .overlay(alignment: .bottom) {
-          if let error = entry.metadata.error?.errorDescription {
-            Text(error)
-              .minimumScaleFactor(0.25)
-              .multilineTextAlignment(.center)
-              .foregroundStyle(.secondary)
-              .fixedSize()
-              .alignmentGuide(.bottom) { dimensions in
-                // Place the text below the bottom of the image
-                dimensions[.top] - 8
-              }
-          }
-        }
+    if let image = entry.image {
+      ImmichWidgetContentView(image: image, subtitle: entry.metadata.subtitle, deepLink: entry.metadata.deepLink)
     } else {
-      ZStack(alignment: .leading) {
-        Color.clear.overlay(
-          Image(uiImage: entry.image!)
-            .resizable()
-            .tintedWidgetImageModifier()
-            .scaledToFill()
+      ImmichWidgetLoadingView(message: entry.metadata.error?.errorDescription)
+    }
+  }
+}
 
+private struct ImmichWidgetLoadingView: View {
+  let message: String?
+
+  var body: some View {
+    Image("LaunchImage")
+      .tintedWidgetImageModifier()
+      .overlay(alignment: .bottom) {
+        if let message {
+          Text(message)
+            .minimumScaleFactor(0.25)
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .fixedSize()
+            .alignmentGuide(.bottom) { dimensions in
+              // Place the text below the bottom of the image
+              dimensions[.top] - 8
+            }
+        }
+      }
+  }
+}
+
+private struct ImmichWidgetContentView: View {
+  let image: UIImage
+  let subtitle: String?
+  let deepLink: URL?
+
+  var body: some View {
+    ZStack(alignment: .leading) {
+      Color.clear.overlay(
+        Image(uiImage: image)
+          .resizable()
+          .tintedWidgetImageModifier()
+          .scaledToFill()
         )
         VStack {
           Spacer()
-          if let subtitle = entry.metadata.subtitle {
+          if let subtitle = subtitle {
             Text(subtitle)
               .foregroundColor(.white)
-              .padding(8)
-              .background(Color.black.opacity(0.6))
-              .cornerRadius(8)
+              .padding(6)
+              .background(ContainerRelativeShape().fill(Color.black.opacity(0.6)))
               .font(.system(size: 16))
           }
         }
-        .padding(16)
-      }
-      .widgetURL(entry.metadata.deepLink)
-    }
+          .padding(16)
+        }
+    .widgetURL(deepLink)
   }
 }
 
@@ -69,9 +85,43 @@ struct ImmichWidgetView: View {
     let date = Date()
     ImageEntry(
       date: date,
-      image: UIImage(named: "ImmichLogo"),
+      image: UIImage(named: "LaunchImage"),
       metadata: EntryMetadata(
         subtitle: "1 year ago"
+      )
+    )
+  }
+)
+
+#Preview(
+  as: .systemSmall,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: UIImage(named: "LaunchImage"),
+      metadata: EntryMetadata(
+        subtitle: "Yesterday"
+      )
+    )
+  }
+)
+
+#Preview(
+  as: .systemLarge,
+  widget: {
+    ImmichRandomWidget()
+  },
+  timeline: {
+    let date = Date()
+    ImageEntry(
+      date: date,
+      image: UIImage(named: "LaunchImage"),
+      metadata: EntryMetadata(
+        subtitle: "2000 seconds ago"
       )
     )
   }

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -126,21 +126,6 @@ private struct ImmichWidgetContentView: View {
 )
 
 #Preview(
-  "Medium Loading",
-  as: .systemMedium,
-  widget: {
-    ImmichRandomWidget()
-  },
-  timeline: {
-    let date = Date()
-    ImageEntry(
-      date: date,
-      image: nil
-    )
-  }
-)
-
-#Preview(
   "Small",
   as: .systemSmall,
   widget: {

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -25,7 +25,7 @@ extension WidgetError: LocalizedError {
       return "Login to Immich"
 
     case .fetchFailed:
-      return "Unable to connect to your Immich instance"
+      return "Unable to connect to Immich"
 
     case .albumNotFound:
       return "Album not found"


### PR DESCRIPTION
The iOS widgets have rounded corners in text boxes that are not calculated based on their context, resulting in a mismatch of corner radii. Properly compute this and rearrange views a bit.

### Before

<img width="355" height="200" alt="image" src="https://github.com/user-attachments/assets/82d09f3a-747d-41ec-a453-42e11dc3ad5b" />


### After

<img width="348" height="194" alt="image" src="https://github.com/user-attachments/assets/992eb08f-a328-43cc-9e75-482f1c725032" />
