### PR TITLE
fix: min faces user preference

### DIFF
--- a/server/src/schema/migrations/1784836013770-MinFacePreferenceMigration.ts
+++ b/server/src/schema/migrations/1784836013770-MinFacePreferenceMigration.ts
@@ -1,0 +1,25 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    INSERT INTO "user_metadata" ("userId", "key", "value")
+    SELECT "user"."id", 'preferences', jsonb_build_object('people', jsonb_build_object('minimumFaces', "config"."minFaces"))
+    FROM "user"
+    CROSS JOIN (
+      SELECT "value"->'machineLearning'->'facialRecognition'->'minFaces' AS "minFaces"
+      FROM "system_metadata"
+      WHERE "key" = 'system-config'
+        AND "value"->'machineLearning'->'facialRecognition'->'minFaces' IS NOT NULL
+    ) AS "config"
+    ON CONFLICT ("userId", "key") DO UPDATE
+    SET "value" = "user_metadata"."value" || jsonb_build_object(
+      'people',
+      COALESCE("user_metadata"."value"->'people', '{}'::jsonb) || (EXCLUDED."value"->'people')
+    )
+    WHERE "user_metadata"."value"->'people'->'minimumFaces' IS NULL
+  `.execute(db);
+}
+
+export async function down(): Promise<void> {
+  // not supported
+}


### PR DESCRIPTION
Add a migration to default the user preference for minFaces to the value in system config.

Tested by running the migration
- with default settings and no user preferences were changed
- with minFaces: 5 and user preferences were updated to 5 (one user had a user preference record and one didn't)
- with minFaces: 5 and user preferences (now set to 5) were unchanged


---
### Background
Users have been using the system config `machineLearning.minFaces` property to control/manage show/hide faces on the /people page. #27452 was added so that this can be a user managed preference and separate from the system config option which is used for tuning face clustering. This PR adds a migration to preserve the user preference for those users who had changed their system config setting for this purpose. Currently users are upgrading and being surprised to see a different set of people because the preference defaults to 3 which may be different than the system config setting.

