### PR TITLE
fix(web): use RTL transform origin in AdaptiveImage

### DIFF
--- a/web/src/lib/components/AdaptiveImage.svelte
+++ b/web/src/lib/components/AdaptiveImage.svelte
@@ -63,6 +63,7 @@
   import { toTimelineAsset } from '$lib/utils/timeline-util';
   import type { AssetResponseDto, SharedLinkResponseDto } from '@immich/sdk';
   import { untrack, type Snippet } from 'svelte';
+  import { languageManager } from '$lib/managers/language-manager.svelte';
 
   type Props = {
     asset: AssetResponseDto;
@@ -232,7 +233,7 @@
       style:width={rasterWidth}
       style:height={rasterHeight}
       style:transform="scale({rasterScale})"
-      style:transform-origin="0 0"
+      style:transform-origin={languageManager.rtl ? 'right top' : 'left top'}
       style:will-change={maxRasterPixels > 0 ? 'transform' : undefined}
     >
       {#if show.alphaBackground}


### PR DESCRIPTION
## Description

Fixes incorrect positioning of adaptive images in RTL layouts.

`AdaptiveImage.svelte` used a hardcoded `transform-origin: 0 0`, which always anchors transformations to the top-left corner. In RTL layouts, this caused clipped images.

Fixes #29479 #27678

## How Has This Been Tested?

Tested manually in the Immich web image viewer.

- [x] Verified that adaptive images are displayed correctly in an Arabic RTL layout
- [x] Verified that zooming and transformations remain anchored to the correct side in RTL
- [x] Verified that image positioning remains unchanged in an English LTR layout
- [x] Verified that the image is no longer clipped by the viewer boundary

<details><summary><h2>Screenshots</h2></summary>

Before:
<img width="1170" height="2532" alt="localhost_3000_photos_0d23e74d-b65a-429f-a6f4-04aa416b3357(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/b0885da3-d384-4630-8d4e-ce42b3cd8fb3" />
 After:
<img width="1170" height="2532" alt="localhost_3000_photos_0d23e74d-b65a-429f-a6f4-04aa416b3357(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/e48b0225-b47d-4c42-87d4-60acf615f272" />
 

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.