### PR TITLE
fix(server): use GeoNames for reverse-geocoded country names

### DIFF
--- a/e2e/src/specs/server/api/map.e2e-spec.ts
+++ b/e2e/src/specs/server/api/map.e2e-spec.ts
@@ -72,7 +72,7 @@ describe('/map', () => {
       expect(body).toEqual([
         {
           city: 'Palisade',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(39.115),
           lon: expect.closeTo(-108.400968),
@@ -80,7 +80,7 @@ describe('/map', () => {
         },
         {
           city: 'Ralston',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(41.2203),
           lon: expect.closeTo(-96.071625),
@@ -120,7 +120,7 @@ describe('/map', () => {
       expect(body).toEqual([
         {
           city: 'Palisade',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(39.115),
           lon: expect.closeTo(-108.400968),
@@ -128,7 +128,7 @@ describe('/map', () => {
         },
         {
           city: 'Ralston',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(41.2203),
           lon: expect.closeTo(-96.071625),

--- a/e2e/src/specs/server/api/map.e2e-spec.ts
+++ b/e2e/src/specs/server/api/map.e2e-spec.ts
@@ -65,7 +65,7 @@ describe('/map', () => {
       expect(body).toEqual([
         {
           city: 'Palisade',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(39.115),
           lon: expect.closeTo(-108.400968),
@@ -73,7 +73,7 @@ describe('/map', () => {
         },
         {
           city: 'Ralston',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(41.2203),
           lon: expect.closeTo(-96.071625),
@@ -113,7 +113,7 @@ describe('/map', () => {
       expect(body).toEqual([
         {
           city: 'Palisade',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(39.115),
           lon: expect.closeTo(-108.400968),
@@ -121,7 +121,7 @@ describe('/map', () => {
         },
         {
           city: 'Ralston',
-          country: 'United States of America',
+          country: 'United States',
           id: expect.any(String),
           lat: expect.closeTo(41.2203),
           lon: expect.closeTo(-96.071625),

--- a/e2e/src/specs/server/api/search.e2e-spec.ts
+++ b/e2e/src/specs/server/api/search.e2e-spec.ts
@@ -491,6 +491,7 @@ describe('/search', () => {
         .get('/search/suggestions?type=country&includeNull=true')
         .set('Authorization', `Bearer ${admin.accessToken}`);
       expect(body).toEqual([
+        'China',
         'Cuba',
         'France',
         'Georgia',
@@ -498,12 +499,11 @@ describe('/search', () => {
         'Ghana',
         'Japan',
         'Morocco',
-        "People's Republic of China",
-        'Russian Federation',
+        'Russia',
         'Singapore',
         'Spain',
         'Switzerland',
-        'United States of America',
+        'United States',
         null,
       ]);
       expect(status).toBe(200);
@@ -514,6 +514,7 @@ describe('/search', () => {
         .get('/search/suggestions?type=country')
         .set('Authorization', `Bearer ${admin.accessToken}`);
       expect(body).toEqual([
+        'China',
         'Cuba',
         'France',
         'Georgia',
@@ -521,12 +522,11 @@ describe('/search', () => {
         'Ghana',
         'Japan',
         'Morocco',
-        "People's Republic of China",
-        'Russian Federation',
+        'Russia',
         'Singapore',
         'Spain',
         'Switzerland',
-        'United States of America',
+        'United States',
       ]);
       expect(status).toBe(200);
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,9 +526,6 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.3.0
-      i18n-iso-countries:
-        specifier: ^7.6.0
-        version: 7.14.0
       ioredis:
         specifier: ^5.8.2
         version: 5.11.1
@@ -7274,9 +7271,6 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
-  diacritics@1.3.0:
-    resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
-
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -8398,10 +8392,6 @@ packages:
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
-
-  i18n-iso-countries@7.14.0:
-    resolution: {integrity: sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==}
-    engines: {node: '>= 12'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -20334,8 +20324,6 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
-  diacritics@1.3.0: {}
-
   didyoumean@1.2.2: {}
 
   diff-sequences@29.6.3: {}
@@ -21855,10 +21843,6 @@ snapshots:
   human-signals@2.1.0: {}
 
   hyperdyperid@1.2.0: {}
-
-  i18n-iso-countries@7.14.0:
-    dependencies:
-      diacritics: 1.3.0
 
   iconv-lite@0.4.24:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,9 +529,6 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.3.0
-      i18n-iso-countries:
-        specifier: ^7.6.0
-        version: 7.14.0
       ioredis:
         specifier: ^5.8.2
         version: 5.11.1(supports-color@8.1.1)
@@ -7272,9 +7269,6 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
-  diacritics@1.3.0:
-    resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
-
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -8395,10 +8389,6 @@ packages:
   hyperdyperid@1.2.0:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
-
-  i18n-iso-countries@7.14.0:
-    resolution: {integrity: sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==}
-    engines: {node: '>= 12'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -20227,8 +20217,6 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
-  diacritics@1.3.0: {}
-
   didyoumean@1.2.2: {}
 
   diff-sequences@29.6.3: {}
@@ -21763,10 +21751,6 @@ snapshots:
   human-signals@2.1.0: {}
 
   hyperdyperid@1.2.0: {}
-
-  i18n-iso-countries@7.14.0:
-    dependencies:
-      diacritics: 1.3.0
 
   iconv-lite@0.4.24:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -79,7 +79,6 @@
     "geo-tz": "^8.0.0",
     "handlebars": "^4.7.8",
     "helmet": "^8.1.0",
-    "i18n-iso-countries": "^7.6.0",
     "ioredis": "^5.8.2",
     "jose": "^6.0.0",
     "js-yaml": "^4.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -81,7 +81,6 @@
     "geo-tz": "^8.0.0",
     "handlebars": "^4.7.8",
     "helmet": "^8.1.0",
-    "i18n-iso-countries": "^7.6.0",
     "ioredis": "^5.8.2",
     "jose": "^6.0.0",
     "js-yaml": "^5.0.0",

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -90,6 +90,7 @@ export interface EnvData {
       admin1: string;
       admin2: string;
       cities500: string;
+      countryInfo: string;
       naturalEarthCountriesPath: string;
     };
     web: {
@@ -342,6 +343,7 @@ const getEnv = (): EnvData => {
         admin1: join(folders.geodata, 'admin1CodesASCII.txt'),
         admin2: join(folders.geodata, 'admin2Codes.txt'),
         cities500: join(folders.geodata, citiesFile),
+        countryInfo: join(folders.geodata, 'countryInfo.txt'),
         naturalEarthCountriesPath: join(folders.geodata, 'ne_10m_admin_0_countries.geojson'),
       },
       web: {

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { getName } from 'i18n-iso-countries';
 import { Expression, Insertable, Kysely, NotNull, sql, SqlBool } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { createReadStream, existsSync } from 'node:fs';
@@ -38,8 +37,15 @@ interface MapDB extends DB {
   naturalearth_countries_tmp: NaturalEarthCountriesTable;
 }
 
+interface CountryNames {
+  byAlpha2: Map<string, string>;
+  byAlpha3: Map<string, string>;
+}
+
 @Injectable()
 export class MapRepository {
+  private countryNames?: Promise<CountryNames>;
+
   constructor(
     private configRepository: ConfigRepository,
     private metadataRepository: SystemMetadataRepository,
@@ -148,6 +154,8 @@ export class MapRepository {
   async reverseGeocode(point: GeoPoint): Promise<ReverseGeocodeResult> {
     this.logger.debug(`Request: ${point.latitude},${point.longitude}`);
 
+    const countryNames = await this.loadCountryNames();
+
     const response = await this.db
       .selectFrom('geodata_places')
       .selectAll()
@@ -166,7 +174,7 @@ export class MapRepository {
       this.logger.verboseFn(() => `Raw: ${JSON.stringify(response, null, 2)}`);
 
       const { countryCode, name: city, admin1Name } = response;
-      const country = getName(countryCode, 'en') ?? null;
+      const country = countryNames.byAlpha2.get(countryCode) ?? null;
       const state = admin1Name;
 
       return { country, state, city };
@@ -194,11 +202,56 @@ export class MapRepository {
     this.logger.verboseFn(() => `Raw: ${JSON.stringify(ne_response, ['id', 'admin', 'admin_a3', 'type'], 2)}`);
 
     const { admin_a3 } = ne_response;
-    const country = getName(admin_a3, 'en') ?? null;
+    const country = countryNames.byAlpha3.get(admin_a3) ?? null;
     const state = null;
     const city = null;
 
     return { country, state, city };
+  }
+
+  // Country names come from the GeoNames countryInfo.txt file, the same provider as the city and
+  // state names, giving neutral forms such as "Taiwan" and "Hong Kong" rather than the ISO 3166
+  // official names ("Taiwan, Province of China"). Loaded lazily and cached: init() skips the
+  // geodata import when it is already up to date, but reverse geocoding still needs the lookup.
+  private loadCountryNames(): Promise<CountryNames> {
+    this.countryNames ??= this.readCountryNames();
+    return this.countryNames;
+  }
+
+  private async readCountryNames(): Promise<CountryNames> {
+    const byAlpha2 = new Map<string, string>();
+    const byAlpha3 = new Map<string, string>();
+
+    const { resourcePaths } = this.configRepository.getEnv();
+    const filePath = resourcePaths.geodata.countryInfo;
+    if (!existsSync(filePath)) {
+      this.logger.error(`Geodata file ${filePath} not found; country names will be empty`);
+      return { byAlpha2, byAlpha3 };
+    }
+
+    const lineReader = readLine.createInterface({ input: createReadStream(filePath) });
+    for await (const line of lineReader) {
+      if (line.startsWith('#')) {
+        continue;
+      }
+      // Columns: ISO alpha-2, ISO alpha-3, ISO numeric, fips, Country, ...
+      const fields = line.split('\t', 5);
+      const alpha2 = fields[0];
+      const alpha3 = fields[1];
+      const name = fields[4];
+      if (!name) {
+        continue;
+      }
+      if (alpha2) {
+        byAlpha2.set(alpha2, name);
+      }
+      if (alpha3) {
+        byAlpha3.set(alpha3, name);
+      }
+    }
+
+    this.logger.log(`Loaded ${byAlpha2.size} country names from ${filePath}`);
+    return { byAlpha2, byAlpha3 };
   }
 
   private async importNaturalEarthCountries() {

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { getName } from 'i18n-iso-countries';
 import { Expression, Insertable, Kysely, NotNull, sql, SqlBool } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { createReadStream, existsSync } from 'node:fs';
@@ -38,8 +37,15 @@ interface MapDB extends DB {
   naturalearth_countries_tmp: NaturalEarthCountriesTable;
 }
 
+interface CountryNames {
+  byAlpha2: Map<string, string>;
+  byAlpha3: Map<string, string>;
+}
+
 @Injectable()
 export class MapRepository {
+  private countryNames?: Promise<CountryNames>;
+
   constructor(
     private configRepository: ConfigRepository,
     private metadataRepository: SystemMetadataRepository,
@@ -148,6 +154,8 @@ export class MapRepository {
   async reverseGeocode(point: GeoPoint): Promise<ReverseGeocodeResult> {
     this.logger.debug(`Request: ${point.latitude},${point.longitude}`);
 
+    const countryNames = await this.loadCountryNames();
+
     const response = await this.db
       .selectFrom('geodata_places')
       .selectAll()
@@ -166,7 +174,7 @@ export class MapRepository {
       this.logger.verboseFn(() => `Raw: ${JSON.stringify(response, null, 2)}`);
 
       const { countryCode, name: city, admin1Name } = response;
-      const country = getName(countryCode, 'en') ?? null;
+      const country = countryNames.byAlpha2.get(countryCode) ?? null;
       const state = admin1Name;
 
       return { country, state, city };
@@ -194,11 +202,57 @@ export class MapRepository {
     this.logger.verboseFn(() => `Raw: ${JSON.stringify(ne_response, ['id', 'admin', 'admin_a3', 'type'], 2)}`);
 
     const { admin_a3 } = ne_response;
-    const country = getName(admin_a3, 'en') ?? null;
+    const country = countryNames.byAlpha3.get(admin_a3) ?? null;
     const state = null;
     const city = null;
 
     return { country, state, city };
+  }
+
+  // init() skips the geodata import when it is up to date, so load the names on demand
+  private async loadCountryNames(): Promise<CountryNames> {
+    this.countryNames ??= this.readCountryNames();
+    try {
+      return await this.countryNames;
+    } catch (error) {
+      this.countryNames = undefined;
+      throw error;
+    }
+  }
+
+  private async readCountryNames(): Promise<CountryNames> {
+    const byAlpha2 = new Map<string, string>();
+    const byAlpha3 = new Map<string, string>();
+
+    const { resourcePaths } = this.configRepository.getEnv();
+    const filePath = resourcePaths.geodata.countryInfo;
+    if (!existsSync(filePath)) {
+      throw new Error(`Geodata file ${filePath} not found`);
+    }
+
+    const lineReader = readLine.createInterface({ input: createReadStream(filePath) });
+    for await (const line of lineReader) {
+      if (line.startsWith('#')) {
+        continue;
+      }
+      // Columns: ISO alpha-2, ISO alpha-3, ISO numeric, fips, Country, ...
+      const fields = line.split('\t', 5);
+      const alpha2 = fields[0];
+      const alpha3 = fields[1];
+      const name = fields[4]?.trim();
+      if (!name) {
+        continue;
+      }
+      if (alpha2) {
+        byAlpha2.set(alpha2, name);
+      }
+      if (alpha3) {
+        byAlpha3.set(alpha3, name);
+      }
+    }
+
+    this.logger.log(`Loaded ${byAlpha2.size} country names from ${filePath}`);
+    return { byAlpha2, byAlpha3 };
   }
 
   private async importNaturalEarthCountries() {

--- a/server/src/schema/migrations/1788364234133-RenameGeoNamesCountries.ts
+++ b/server/src/schema/migrations/1788364234133-RenameGeoNamesCountries.ts
@@ -1,0 +1,56 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // (#30199) Reverse geocoding now uses the GeoNames names, so rewrite the stored ones
+  await sql`
+    WITH renames ("old", "new") AS (
+      VALUES
+        ('Åland Islands', 'Aland Islands'),
+        ('Bonaire, Sint Eustatius and Saba', 'Bonaire, Saint Eustatius and Saba'),
+        ('Brunei Darussalam', 'Brunei'),
+        ('Cape Verde', 'Cabo Verde'),
+        ('Cocos (Keeling) Islands', 'Cocos Islands'),
+        ('Cote d''Ivoire', 'Ivory Coast'),
+        ('Cote D''Ivoire', 'Ivory Coast'),
+        ('Curaçao', 'Curacao'),
+        ('Czech Republic', 'Czechia'),
+        ('Falkland Islands (Malvinas)', 'Falkland Islands'),
+        ('Holy See (Vatican City State)', 'Vatican'),
+        ('Islamic Republic of Iran', 'Iran'),
+        ('Lao People''s Democratic Republic', 'Laos'),
+        ('Micronesia, Federated States of', 'Micronesia'),
+        ('Moldova, Republic of', 'Moldova'),
+        ('Netherlands', 'The Netherlands'),
+        ('People''s Republic of China', 'China'),
+        ('Republic of The Gambia', 'Gambia'),
+        ('Russian Federation', 'Russia'),
+        ('Saint Barthélemy', 'Saint Barthelemy'),
+        ('Saint Martin (French part)', 'Saint Martin'),
+        ('Sint Maarten (Dutch part)', 'Sint Maarten'),
+        ('State of Palestine', 'Palestinian Territory'),
+        ('Syrian Arab Republic', 'Syria'),
+        ('Taiwan, Province of China', 'Taiwan'),
+        ('The Republic of North Macedonia', 'North Macedonia'),
+        ('Timor-Leste', 'Timor Leste'),
+        ('Türkiye', 'Turkey'),
+        ('United Republic of Tanzania', 'Tanzania'),
+        ('United States of America', 'United States'),
+        ('Virgin Islands, British', 'British Virgin Islands'),
+        ('Virgin Islands, U.S.', 'U.S. Virgin Islands')
+    ),
+    exif AS (
+      UPDATE "asset_exif"
+      SET "country" = renames."new"
+      FROM renames
+      WHERE "country" = renames."old"
+    )
+    UPDATE "workflow_step"
+    SET "config" = jsonb_set("config", '{region,country}', to_jsonb(renames."new"))
+    FROM renames
+    WHERE "config"->'region'->>'country' = renames."old"
+  `.execute(db);
+}
+
+export async function down(): Promise<void> {
+  // Not implemented: the old names came from a removed dependency
+}

--- a/server/src/schema/migrations/ORDER
+++ b/server/src/schema/migrations/ORDER
@@ -94,3 +94,4 @@
 1786972746372-AssetOcrSyncReset
 1787148183729-ClusterGroups
 1787148183730-DeleteMismatchedMemoryAssets
+1788364234133-RenameGeoNamesCountries

--- a/server/test/factories/asset-exif.factory.ts
+++ b/server/test/factories/asset-exif.factory.ts
@@ -19,7 +19,7 @@ export class AssetExifFactory {
       bitsPerSample: null,
       city: 'Austin',
       colorspace: null,
-      country: 'United States of America',
+      country: 'United States',
       dateTimeOriginal: factory.date(),
       description: '',
       exifImageHeight: 420,

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -70,6 +70,7 @@ export const envData: EnvData = {
       admin1: '/build/geodata/admin1CodesASCII.txt',
       admin2: '/build/geodata/admin2Codes.txt',
       cities500: '/build/geodata/cities500.txt',
+      countryInfo: '/build/geodata/countryInfo.txt',
       naturalEarthCountriesPath: 'build/ne_10m_admin_0_countries.geojson',
     },
     web: {


### PR DESCRIPTION
## Description

Reverse-geocoded locations show politically loaded country names such as "Taiwan, Province of China".

The city and state come from the GeoNames geodata, but the country name does not. `map.repository.ts` resolves it with `i18n-iso-countries`'s `getName()`, which returns ISO 3166 official names.
As @plutoids1 traced in #25943, GeoNames itself has no "Province of China" for Taiwan; the string comes from that library, not the geodata.

This resolves the country name from GeoNames's `countryInfo.txt` instead, so the whole address comes from one source. `i18n-iso-countries` is no longer needed, and the file's alpha-3 column also covers the Natural Earth fallback lookup, so nothing new is added.

`countryInfo.txt` is added to the geodata bundle in a companion PR: immich-app/base-images#364. This PR depends on that merging first.

This is not an editorial change. The country name now comes verbatim from GeoNames, the same neutral geographic database already used for city and state. Immich takes no position and maintains no list. The effect is to drop ISO 3166's formal state titles consistently, not to favour any one country:

| ISO | Before (`i18n-iso-countries`) | After (GeoNames) |
| --- | --- | --- |
| TW | Taiwan, Province of China | Taiwan |
| CN | People's Republic of China | China |
| IR | Islamic Republic of Iran | Iran |
| SY | Syrian Arab Republic | Syria |
| LA | Lao People's Democratic Republic | Laos |
| KP | North Korea | North Korea |
| HK | Hong Kong | Hong Kong |

It is also not advocacy in the other direction: the result is the plain "Taiwan", not "Republic of China" or "Taiwan (ROC)".

Fixes #29182. Closes #24001, #10994. Addresses discussion #25943.

## How Has This Been Tested?

- [x] `countryInfo.txt` lookup checked against GeoNames on both paths: TW/TWN gives Taiwan, HK/HKG gives Hong Kong, CN/CHN gives China, and non-ISO Natural Earth codes (e.g. KOS) give null (unchanged from before).
- [x] Server unit tests pass.
- [x] `search` and `map` e2e specs (real reverse geocoding of the test assets) pass with `countryInfo.txt` present in the geodata directory.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Server-side data change only; no UI changes.

</details>

## API Changes
None

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used for code review