### PR TITLE
fix(i18n): correct Arabic translation for confirm_new_pin_code

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -733,7 +733,7 @@
   "confirm_delete_face": "هل أنت متأكد من حذف وجه {name} من الأصول؟",
   "confirm_delete_shared_link": "هل أنت متأكد أنك تريد حذف هذا الرابط المشترك؟",
   "confirm_keep_this_delete_others": "سيتم حذف جميع الأصول الأخرى في المجموعة باستثناء هذا الأصل. هل أنت متأكد من أنك تريد المتابعة؟",
-  "confirm_new_pin_code": "ثبت رمز PIN الجديد",
+  "confirm_new_pin_code": "تأكيد رمز PIN الجديد",
   "confirm_password": "تأكيد كلمة المرور",
   "confirm_tag_face": "هل تريد وضع علامة على هذا الوجه {name}؟",
   "confirm_tag_face_unnamed": "هل تريد وضع علامة على هذا الوجه؟",


### PR DESCRIPTION
## Description

Correct the Arabic translation for `confirm_new_pin_code`.

The previous translation used the verb `ثبت`, which does not translate to "confirm" in this context. It has been replaced with `تأكيد` to accurately reflect the action of confirming a newly created PIN and to match common Arabic UI terminology.

Fixes # (issue)

## How Has This Been Tested?

- [x] Verified the updated translation appears correctly in the PIN confirmation screen.
- [x] Confirmed the wording is consistent with the surrounding Arabic translations.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Before/after screenshots -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)


## Please describe to which degree, if any, an LLM was used in creating this pull request.