### PR TITLE
docs: enhance docker logs tip

### DIFF
--- a/docs/docs/guides/docker-help.md
+++ b/docs/docs/guides/docker-help.md
@@ -25,5 +25,5 @@ docker logs immich_machine_learning
 ```
 
 :::tip Follow a log
-Adding `--follow` to a `docker logs <id or name>` command will stream new logs, instead of immediately exiting, which is often useful for debugging.
+Adding `--tail <lines wanted>` to a `docker logs <id or name>` will make it only show the newest lines instead of all of the logs (`docker logs <id or name> --tail 100` will show the 100 latest lines) and `--follow`  will make it stream new logs, instead of immediately exiting, which is often useful for debugging.
 :::


### PR DESCRIPTION
Updated the docker logs command section to include the --tail option for displaying the latest log lines.

## Description
Just more help in the dock so people don't make docker spit out all of the logs

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Github colpilot added the title
