### PR TITLE
fix(server): store null instead of empty string for user password

### DIFF
--- a/server/src/schema/migrations/1784986754473-ConvertUserPasswordEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784986754473-ConvertUserPasswordEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "user" SET "password" = NULL WHERE "password" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "password" = '' WHERE "password" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "password" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -31,8 +31,8 @@ export class UserTable {
   @Column({ unique: true })
   email!: string;
 
-  @Column({ default: '' })
-  password!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  password!: string | null;
 
   @Column({ nullable: true })
   pinCode!: string | null;


### PR DESCRIPTION
## Description

When a user account is created without a password (e.g. via OAuth), the database now stores `NULL` instead of an empty string `""`.

Note: password is never exposed in any API response, and the login flow already handles `null` via `user?.password ?? LOGIN_DUMMY_HASH`, so this change is fully backwards-compatible.

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Entity type: `string | null` (already handled by existing service code)

Fixes #28832 (user.password column — last remaining column)

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.