### PR TITLE
fix(server): promote unit when a size rounds up to a full 1024

### DIFF
--- a/server/src/utils/bytes.spec.ts
+++ b/server/src/utils/bytes.spec.ts
@@ -1,0 +1,40 @@
+import { asHumanReadable } from 'src/utils/bytes';
+
+const KiB = 1024;
+const MiB = 1024 * KiB;
+const GiB = 1024 * MiB;
+const TiB = 1024 * GiB;
+
+describe('asHumanReadable', () => {
+  it('renders bytes without decimals', () => {
+    expect(asHumanReadable(0)).toBe('0 B');
+    expect(asHumanReadable(1)).toBe('1 B');
+    expect(asHumanReadable(1023)).toBe('1023 B');
+  });
+
+  it('renders whole units', () => {
+    expect(asHumanReadable(KiB)).toBe('1.0 KiB');
+    expect(asHumanReadable(MiB)).toBe('1.0 MiB');
+    expect(asHumanReadable(GiB)).toBe('1.0 GiB');
+    expect(asHumanReadable(TiB)).toBe('1.0 TiB');
+  });
+
+  it('renders partial units at the requested precision', () => {
+    expect(asHumanReadable(512 * KiB)).toBe('512.0 KiB');
+    expect(asHumanReadable(1.5 * MiB)).toBe('1.5 MiB');
+    expect(asHumanReadable(1.5 * MiB, 3)).toBe('1.500 MiB');
+  });
+
+  it('promotes a value that rounds up to a full unit', () => {
+    // Rounding for display reaches 1024 of the chosen unit, which it cannot
+    // hold -- these used to render as "1024.0 KiB", "1024.0 MiB", "1024.0 GiB".
+    expect(asHumanReadable(MiB - 1)).toBe('1.0 MiB');
+    expect(asHumanReadable(GiB - 1)).toBe('1.0 GiB');
+    expect(asHumanReadable(TiB - 1)).toBe('1.0 TiB');
+  });
+
+  it('does not promote when the rounded value still fits', () => {
+    expect(asHumanReadable(MiB - KiB)).toBe('1023.0 KiB');
+    expect(asHumanReadable(MiB - 1, 6)).toBe('1023.999023 KiB');
+  });
+});

--- a/server/src/utils/bytes.ts
+++ b/server/src/utils/bytes.ts
@@ -20,6 +20,14 @@ export function asHumanReadable(bytes: number, precision = 1): string {
     }
   }
 
+  // Rounding for display can reach a full 1024 of the chosen unit, which that
+  // unit cannot hold: 1 MiB - 1 byte would render as "1024.0 KiB". Promote to
+  // the next unit instead.
+  if (magnitude + 1 < units.length && Number(remainder.toFixed(magnitude === 0 ? 0 : precision)) >= 1024) {
+    magnitude++;
+    remainder /= 1024;
+  }
+
   return `${remainder.toFixed(magnitude == 0 ? 0 : precision)} ${units[magnitude]}`;
 }
 


### PR DESCRIPTION
## Description

`asHumanReadable` picks a unit while the raw value is `>= 1024`, then formats with `toFixed`. Rounding at display precision can push the value back up to a full 1024 of the unit it just chose — a value that unit cannot hold:

| bytes | current | expected |
|---|---|---|
| `1 MiB - 1` | `1024.0 KiB` | `1.0 MiB` |
| `1 GiB - 1` | `1024.0 MiB` | `1.0 GiB` |
| `1 TiB - 1` | `1024.0 GiB` | `1.0 TiB` |

`server.service.ts` uses it for `diskAvailable`, `diskSize` and `diskUse`, so any disk figure landing within rounding distance below a power of 1024 is reported with the wrong unit.

This change promotes once more when the value formatted at the requested precision reaches 1024, respecting the `units` table bound so nothing runs off the end. Values that do not overflow are untouched — `512 KiB` still renders as `512.0 KiB`, and `1 MiB - 1` at precision 6 still renders as `1023.999023 KiB`, since at that precision it does not round up.

Fixes # (no existing issue — found while reading `server/src/utils/`; happy to open one if you would prefer it tracked)

## How Has This Been Tested?

The module had no tests; this adds `server/src/utils/bytes.spec.ts`.

- [x] `npx vitest run --config test/vitest.config.mjs src/utils/bytes.spec.ts` → 5 passed.
- [x] Red→green: reverting only `bytes.ts` fails `promotes a value that rounds up to a full unit` with `expected '1024.0 KiB' to be '1.0 MiB'`. The other four tests pass either way — they pin the behaviour this change must not alter.
- [x] Full server suite: **92 files, 2255 passed / 2 skipped** with this change, vs **91 files, 2250 passed / 2 skipped** on `main`. Both fully green; the difference is exactly the added spec file.
- [x] `prettier --check` and `eslint --max-warnings 0` clean on both changed files.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable — not applicable, internal formatting helper
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary — none added.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. — no `src/services/` changes.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic — no `src/repositories/` changes.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. The bug was found by an LLM (Claude Code) reading `server/src/utils/`, and it wrote the fix, the spec file and this description. I reviewed the diff and the reasoning before opening the PR, and every number quoted above comes from a command actually run locally — including the `main` baseline, captured by checking out `main` and re-running the suite, and the red→green check done by reverting only `bytes.ts`.

Worth flagging for review: the promotion condition formats the value twice (once to test for overflow, once to render). That is deliberate — the decision has to be made on the *rounded* value, not the raw one — but it is the part most worth a second pair of eyes.
