### PR TITLE
fix(web): fix black screen on photo viewer in Hebrew/RTL UI

### DIFF
--- a/web/src/lib/components/AdaptiveImage.svelte
+++ b/web/src/lib/components/AdaptiveImage.svelte
@@ -197,6 +197,11 @@
 
   $effect(() => {
     assetViewerManager.imageLoaderStatus = status;
+    return () => {
+      if (assetViewerManager.imageLoaderStatus === status) {
+        assetViewerManager.imageLoaderStatus = undefined;
+      }
+    };
   });
 
   $effect(() => {

--- a/web/src/lib/components/asset-viewer/PhotoViewer.svelte
+++ b/web/src/lib/components/asset-viewer/PhotoViewer.svelte
@@ -213,6 +213,7 @@
 <div
   bind:this={element}
   class="relative size-full select-none"
+  dir="ltr"
   bind:clientWidth={containerWidth}
   bind:clientHeight={containerHeight}
   role="presentation"


### PR DESCRIPTION
## Description

Previously, photos opened in the **Photo Viewer** would appear as a black screen when the UI language was set to a right-to-left language such as Hebrew.

This change keeps the photo viewer in an LTR coordinate system while leaving the rest of the UI in RTL. It also cleans up the image loading state when the viewer is destroyed, preventing the related `derived_inert` console warning during asset navigation.

Fixes #30219 

## How Has This Been Tested?

* Set the UI language to Hebrew and verify that photos open correctly in the photo viewer.
* Open photos from both the timeline and the **People** page and verify that they render correctly.
* Switch the UI language back to English and verify that the viewer continues to work as expected.
* Navigate between multiple photos and verify that the `derived_inert` console warning no longer appears.
* Verify that the rest of the UI continues to follow the selected RTL language.

## Screenshots (if appropriate)

<img width="434" height="355" alt="Screenshot (329)" src="https://github.com/user-attachments/assets/85415c07-ba96-437b-a87c-9816236c800a" />
before fix
<img width="283" height="284" alt="Screenshot (330)" src="https://github.com/user-attachments/assets/b151cc53-d32c-4179-8e44-812578e95d29" />

after fix


## Checklist:

* [x] I have carefully read CONTRIBUTING.md
* [x] I have performed a self-review of my own code
* [ ] I have made corresponding changes to the documentation if applicable
* [x] I have no unrelated changes in the PR.
* [x] I have confirmed that any new dependencies are strictly necessary.
* [ ] I have written tests for new code (if applicable)
* [x] I have followed naming conventions/patterns in the surrounding code
* [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
* [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help understand the code and improve the wording of this PR. The implementation, testing, and final changes were completed and verified by me.