### PR TITLE
fix(server): resolve eslint errors in FutoLayout email template

### DIFF
--- a/server/src/emails/components/futo.layout.tsx
+++ b/server/src/emails/components/futo.layout.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from '@react-email/components';
 import * as React from 'react';
-import { ImmichFooter } from './footer.template';
+import { ImmichFooter } from 'src/emails/components/footer.template';
 
 interface FutoLayoutProps {
   children: React.ReactNode;
@@ -24,6 +24,7 @@ export const FutoLayout = ({ children, preview }: FutoLayoutProps) => (
   <Html>
     <Tailwind
       config={{
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module
         presets: [require('tailwindcss-preset-email')],
         theme: {
           extend: {


### PR DESCRIPTION
futo.layout.tsx currently fails eslint with three errors that the adjacent immich.layout.tsx does not: a relative ./footer.template import (no-restricted-imports) and an unguarded require('tailwindcss-preset-email') which trips @typescript-eslint/no-require-imports and unicorn/prefer-module. Running npx eslint src/emails/components/futo.layout.tsx on main reproduces all three; the rest of server/src passes cleanly.

This aligns futo.layout.tsx with immich.layout.tsx, which already uses the absolute src/emails/components/footer.template import and carries the matching eslint-disable-next-line comment for the require call. After the change the whole src/emails/ tree lints clean, and tsc --noEmit reports no new errors.

The require itself is kept as-is rather than converted to a static import because tailwindcss-preset-email only ships a CommonJS entry point and immich.layout.tsx deliberately uses the same disable comment for that reason.

Verified with npx eslint src/emails/ and npx tsc --noEmit -p tsconfig.json.