### PR TITLE
fix(web): handle null values from server-side null preference changes

### DIFF
--- a/web/src/lib/components/shared-components/UserAvatar.svelte
+++ b/web/src/lib/components/shared-components/UserAvatar.svelte
@@ -11,7 +11,7 @@
     id: string;
     name: string;
     email: string;
-    profileImagePath: string;
+    profileImagePath: string | null;
     avatarColor: UserAvatarColor;
     profileChangedAt: string;
   }

--- a/web/src/lib/components/user-settings-page/DeviceCard.svelte
+++ b/web/src/lib/components/user-settings-page/DeviceCard.svelte
@@ -36,9 +36,9 @@
       <Icon icon={mdiAndroid} size="40" />
     {:else if session.deviceOS === 'iOS' || session.deviceOS === 'macOS'}
       <Icon icon={mdiApple} size="40" />
-    {:else if session.deviceOS.includes('Safari')}
+    {:else if session.deviceOS?.includes('Safari')}
       <Icon icon={mdiAppleSafari} size="40" />
-    {:else if session.deviceOS.includes('Windows')}
+    {:else if session.deviceOS?.includes('Windows')}
       <Icon icon={mdiMicrosoftWindows} size="40" />
     {:else if session.deviceOS === 'Linux'}
       <Icon icon={mdiLinux} size="40" />

--- a/web/src/lib/modals/AvatarEditModal.svelte
+++ b/web/src/lib/modals/AvatarEditModal.svelte
@@ -16,7 +16,7 @@
 
   const onSave = async (color: UserAvatarColor) => {
     try {
-      if (authManager.user.profileImagePath !== '') {
+      if (authManager.user.profileImagePath) {
         await deleteProfileImage();
       }
 
@@ -38,7 +38,7 @@
         <button type="button" onclick={() => onSave(color)}>
           <UserAvatar
             label={color}
-            user={{ ...authManager.user, profileImagePath: '', avatarColor: color }}
+            user={{ ...authManager.user, profileImagePath: null, avatarColor: color }}
             size="xl"
           />
         </button>

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -201,7 +201,7 @@
       personIds.map(async (personId) => {
         const person = await getPerson({ id: personId });
 
-        if (person.name == '') {
+        if (!person.name) {
           return $t('no_name');
         }
 


### PR DESCRIPTION
## Description

Follow-up to the #28832 null preference changes. The web app had several places that compared against empty string `""` instead of checking for null, which would break now that the server stores `null` instead of `""`.

Changes:
- **AvatarEditModal**: check for falsy (handles both null and empty string) before deleting profile image
- **UserAvatar**: update type to allow `profileImagePath` to be `string | null`; pass `null` instead of empty string
- **DeviceCard**: use optional chaining on `deviceOS?.includes()` to avoid crash when deviceOS is null
- **SearchPage**: check for falsy instead of `== ""` for person name

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.