### PR TITLE
fix(web): collapse stacked assets on the person, partner, and map views

### DIFF
--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -86,6 +86,7 @@
     isFavorite: $mapSettings.onlyFavorites || undefined,
     withPartners: $mapSettings.withPartners || undefined,
     assetFilter: selectedClusterIds,
+    withStacked: true,
   });
 
   $effect.pre(() => {
@@ -113,6 +114,7 @@
       onEscape={handleEscape}
       assetInteraction={assetMultiSelectManager}
       showArchiveIcon
+      withStacked
     />
   </div>
 </aside>

--- a/web/src/routes/(user)/partners/[userId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/partners/[userId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -37,7 +37,13 @@
 </script>
 
 <main class="relative h-dvh overflow-hidden px-2 pt-(--navbar-height) max-md:pt-(--navbar-height-md) md:px-6">
-  <Timeline enableRouting={true} {options} assetInteraction={assetMultiSelectManager} onEscape={handleEscape} />
+  <Timeline
+    enableRouting={true}
+    {options}
+    assetInteraction={assetMultiSelectManager}
+    onEscape={handleEscape}
+    withStacked
+  />
 </main>
 
 {#if assetMultiSelectManager.selectionActive}

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -67,7 +67,7 @@
   let thumbnailData = $derived(getPeopleThumbnailUrl(person));
 
   let timelineManager = $state<TimelineManager>() as TimelineManager;
-  const options = $derived({ visibility: AssetVisibility.Timeline, personId: data.person.id });
+  const options = $derived({ visibility: AssetVisibility.Timeline, personId: data.person.id, withStacked: true });
 
   let viewMode: PersonPageViewMode = $state(PersonPageViewMode.VIEW_ASSETS);
   let isEditingName = $state(false);
@@ -354,6 +354,7 @@
       singleSelect={viewMode === PersonPageViewMode.SELECT_PERSON}
       onSelect={handleSelectFeaturePhoto}
       onEscape={handleEscape}
+      withStacked
     >
       {#if viewMode === PersonPageViewMode.VIEW_ASSETS}
         <!-- Person information block -->


### PR DESCRIPTION
## Description

Stacked assets (high-speed bursts, RAW+JPEG pairs, manual stacks) collapse into a single entry on the main photos timeline, but several other timeline views show every stack member as an individual thumbnail — or collapse them without the stack badge. Root cause: the photos page requests time buckets with `withStacked: true` **and** passes the `withStacked` prop to `<Timeline>` (which forwards it as `showStackedIcon` to thumbnails); other views do one, neither, or only half of that. The server already supports `withStacked` in combination with every `TimeBucketDto` filter (`asset.repository.ts` keeps only stack primaries and returns per-asset `[stackId, assetCount]` badge tuples), so these are purely client-side changes mirroring the photos page.

This PR fixes the three views where collapsing is unambiguously safe (derived/automatic collections):

| View | Before | Change |
|---|---|---|
| `/people/[personId]` | options only had `{ visibility, personId }`; no `withStacked` prop | add `withStacked: true` to options + `withStacked` prop |
| `/partners/[userId]` | options already had `withStacked: true` (stacks collapsed) but the prop was missing → **no stack badge** | add `withStacked` prop only (no behavioral change beyond the icon) |
| `/map` timeline panel | neither option nor prop | add both |

**Deliberately not changed** — user-curated collections, verified on live data that the server-side collapse is not scoped to the filtered set:

- **Albums** (cf. #10135) and **tags**: an album containing only 3 non-primary members of a 12-asset stack (primary not in the album) returns **0 assets** with `withStacked=true` — hand-picked assets would silently vanish. These need a server-side change (e.g. only collapse stacks whose primary also matches the filter), which is out of scope.
- **Archive / locked / trash**: stack members can have mixed visibility; collapsing would hide non-primary members whose primary is outside the view.

## How Has This Been Tested?

Against a live self-hosted v3.0.3 instance (137k assets, ~45k auto-stacked), using the admin API and a purpose-built fixture (album + tag containing all 12 members of one stack; the stack's primary asset has GPS at 40.078, 116.367):

| Query | `withStacked=false` | `withStacked=true` | Badge on primary |
|---|---|---|---|
| `GET /api/timeline/buckets?personId=<865-person library>` | 8,929 | 5,149 (−3,780) | — |
| `…?albumId=<12-member test album>` | 12 | 1 | `["<stackId>","12"]` ✓ |
| `…?tagId=<12-member test tag>` | 12 | 1 | `["<stackId>","12"]` ✓ |
| `…?bbox=116.36,40.07,116.38,40.09&visibility=timeline` | 10,514 | 10,187 (−327) | `["<stackId>","12"]` ✓ |
| `…?albumId=<partial stack, 3 non-primary members>` | 3 | **0** ⚠️ (why albums/tags are excluded) | — |

- [x] Person/partner/map changes reviewed line-by-line against the photos page usage of `withStacked` (option + prop always go together).
- [x] No API changes, no new dependencies. The map panel's cluster drill-down filters client-side (`assetFilter` is not a server parameter), so cluster selection continues to work on the collapsed set; bursts photographed at one location collapse to their primary, which shares the cluster's coordinates.
- [x] Manual check recommended for reviewers: open `/people/<id>` for a person with stacked bursts — one thumbnail per stack with the badge; stack member switching in the viewer unaffected.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable) — not applicable; prop/option changes mirroring the photos page, no existing web tests cover these routes
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. — not applicable (web-only change)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) — not applicable (web-only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI coding assistant (Kimi Code) was used to inventory all `<Timeline>` consumers, diagnose the missing option/prop combinations, author the changes, and draft this PR description. All server-side behavior claims above were verified against a live, self-hosted Immich v3.0.3 instance (including the album/tag exclusion rationale) before submission, and the diff was manually reviewed.
