### PR TITLE
fix(server): align futo email layout with server import/lint rules

### DIFF
--- a/server/src/emails/components/futo.layout.tsx
+++ b/server/src/emails/components/futo.layout.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from '@react-email/components';
 import * as React from 'react';
-import { ImmichFooter } from './footer.template';
+import { ImmichFooter } from 'src/emails/components/footer.template';
 
 interface FutoLayoutProps {
   children: React.ReactNode;
@@ -24,6 +24,7 @@ export const FutoLayout = ({ children, preview }: FutoLayoutProps) => (
   <Html>
     <Tailwind
       config={{
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module
         presets: [require('tailwindcss-preset-email')],
         theme: {
           extend: {


### PR DESCRIPTION
server/src/emails/components/futo.layout.tsx was the only file in server/src that still tripped the repo ESLint config — it imported ImmichFooter through a relative path ("./footer.template") and called require() for the tailwind preset without a disable comment, so no-restricted-imports, @typescript-eslint/no-require-imports, and unicorn/prefer-module all fired. The neighboring immich.layout.tsx already handles this the same way, importing footer.template via the "src/emails/..." alias and adding an inline eslint-disable-next-line for the require(). This just ports that exact pattern over so futo.layout.tsx stops being the lone exception. Confirmed with `npx eslint src/ --quiet` — server/src is now clean (was 3 errors before).