### PR TITLE
fix(transcoding): convert to nv12 for VAAPI sw decode without scaling

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -3218,6 +3218,30 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should convert to nv12 for sw decode vaapi when input is not yuv420p and scaling is not required', async () => {
+      mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.videoStream10Bit });
+      mocks.systemMetadata.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHardwareAcceleration.Vaapi, accelDecode: false },
+      });
+
+      await sut.handleVideoConversion({ id: 'video-id' });
+
+      expect(mocks.media.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        expect.any(String),
+        expect.objectContaining({
+          outputOptions: expect.arrayContaining([
+            '-c:v',
+            'h264_vaapi',
+            expect.stringContaining('hwupload=extra_hw_frames=64'),
+            expect.stringContaining('scale_vaapi='),
+            expect.stringContaining('format=nv12'),
+          ]),
+          twoPass: false,
+        }),
+      );
+    });
+
     it('should set vbr options for vaapi when max bitrate is enabled', async () => {
       mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.matroskaContainer });
       mocks.systemMetadata.get.mockResolvedValue({

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -923,11 +923,19 @@ export class VaapiSwDecodeConfig extends BaseHWConfig {
   }
 
   getFilterOptions(videoStream: VideoStreamInfo) {
-    const options = this.getToneMapping(videoStream);
-    options.push('hwupload=extra_hw_frames=64');
-    if (this.shouldScale(videoStream)) {
-      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:out_range=pc:format=nv12`);
-    }
+    const tonemapOptions = this.getToneMapping(videoStream);
+    // VAAPI encoders (notably the AMD Mesa driver) require nv12 input; a software-decoded
+    // source whose pixel format is not yuv420p must be converted even when no scaling is
+    // needed, otherwise encoding fails with an invalid VASurfaceID error. Tone mapping
+    // already produces nv12, so the explicit conversion is only needed without it.
+    const needsNv12Conversion = tonemapOptions.length === 0 && !videoStream.pixelFormat.endsWith('420p');
+    const options = [
+      ...tonemapOptions,
+      'hwupload=extra_hw_frames=64',
+      ...(this.shouldScale(videoStream) || needsNv12Conversion
+        ? [`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:out_range=pc:format=nv12`]
+        : []),
+    ];
 
     return options;
   }


### PR DESCRIPTION
## Description

When VAAPI falls back to software decoding for a source that doesn't need scaling (smaller than the target resolution), `VaapiSwDecodeConfig` only uploads the frame via `hwupload` and skips the `scale_vaapi` filter. That filter is also what appends `format=nv12`, so a non-yuv420p source ends up fed straight to `h264_vaapi`. The AMD Mesa driver rejects anything but nv12 there, which surfaces as an invalid VASurfaceID error and the transcode fails before falling back to pure CPU.

The hw-decode path already handles this correctly by forcing the `scale_vaapi` conversion whenever the pixel format isn't yuv420p. This change brings the sw-decode path in line with that: when no tonemap chain is active (tonemap already produces nv12) and the pixel format doesn't end in 420p, the `scale_vaapi=nv12` conversion is applied even when the source fits within the target resolution.

Fixes #27895

## How Has This Been Tested?

- [x] Added a unit test in `media.service.spec.ts` using the existing 480x480 `yuv420p10Bit` stub, which is below the default 720 target (so `shouldScale` is false) and uses a 10-bit format. Before the fix the generated filter chain lacked any `format=nv12`; after the fix it asserts the `scale_vaapi` conversion with `format=nv12` is present.
- [x] `pnpm run check` (tsc) passes.
- [x] `pnpm run lint` passes with no warnings.
- [x] `pnpm run format` passes.
- [x] Full `media.service.spec.ts` suite (194 tests) passes.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used in creating this pull request.