### PR TITLE
fix(server): handle null person thumbnailPath in queries and services

### DIFF
--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -130,7 +130,12 @@ export class PersonRepository {
       .selectFrom('person')
       .selectAll('person')
       .$if(!!options.ownerId, (qb) => qb.where('person.ownerId', '=', options.ownerId!))
-      .$if(options.thumbnailPath !== undefined, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
+      .$if(options.thumbnailPath !== undefined, (qb) => {
+        if (options.thumbnailPath === null) {
+          return qb.where('person.thumbnailPath', 'is', null);
+        }
+        return qb.where('person.thumbnailPath', '=', options.thumbnailPath!);
+      })
       .$if(options.faceAssetId === null, (qb) => qb.where('person.faceAssetId', 'is', null))
       .$if(!!options.faceAssetId, (qb) => qb.where('person.faceAssetId', '=', options.faceAssetId!))
       .$if(options.isHidden !== undefined, (qb) => qb.where('person.isHidden', '=', options.isHidden!))
@@ -142,7 +147,7 @@ export class PersonRepository {
     return this.db
       .selectFrom('person')
       .select(['id', 'thumbnailPath'])
-      .where('thumbnailPath', '!=', sql.lit(''))
+      .where('thumbnailPath', 'is not', null)
       .limit(sql.lit(3))
       .execute();
   }

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -187,7 +187,7 @@ export class CliService extends BaseService {
       this.userRepository.getFileSamples(),
     ]);
 
-    const paths = Array.from(people, (person) => person.thumbnailPath);
+    const paths = Array.from(people, (person) => person.thumbnailPath).filter(Boolean) as string[];
 
     for (const user of users) {
       paths.push(user.profileImagePath);

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -96,7 +96,7 @@ export class MediaService extends BaseService {
 
     await queueAll();
 
-    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: '' });
+    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: null });
 
     for await (const person of people) {
       if (!person.faceAssetId) {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -251,8 +251,12 @@ export class PersonService extends BaseService {
   }
 
   @Chunked()
-  private async removeAllPeople(people: { id: string; thumbnailPath: string }[]) {
-    await Promise.all(people.map((person) => this.storageRepository.unlink(person.thumbnailPath)));
+  private async removeAllPeople(people: { id: string; thumbnailPath: string | null }[]) {
+    await Promise.all(
+      people.map((person) =>
+        person.thumbnailPath ? this.storageRepository.unlink(person.thumbnailPath) : Promise.resolve(),
+      ),
+    );
     await this.personRepository.delete(people.map((person) => person.id));
     this.logger.debug(`Deleted ${people.length} people`);
   }


### PR DESCRIPTION
## Description

Follow-up to the person.thumbnailPath null preference change. The server code had several places that still assumed thumbnailPath is a non-null string, which would break once the DB column changes.

Changes:
- PersonRepository.getAll: handle null filter value correctly (use IS NULL instead of = NULL)
- PersonRepository.getFileSamples: use IS NOT NULL instead of != "" to find people with thumbnails
- MediaService: pass null instead of "" when filtering for people without thumbnails
- PersonService.removeAllPeople: skip unlinking if thumbnailPath is null
- CliService: filter out null thumbnail paths

Part of #28832 (person.thumbnailPath follow-up)

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.