### PR TITLE
fix(web): Fix stale image blocks being rendered in AdaptiveImage.

### DIFF
--- a/web/src/lib/components/AdaptiveImage.svelte
+++ b/web/src/lib/components/AdaptiveImage.svelte
@@ -150,11 +150,24 @@
     return { width: 1, height: 1 };
   });
 
-  const { insetInlineStart, top, displayWidth, displayHeight, rasterWidth, rasterHeight, rasterScale } = $derived.by(
-    () => {
+  // The `will-change: transform` GPU-layer promotion below (see comment at
+  // the top of this file) keeps a persistent composited texture for the
+  // raster div. That texture is tile-rasterized, and Chromium only
+  // repaints the tiles it thinks are dirty. Consecutive assets can differ
+  // in aspect ratio/size, so a newly navigated-to asset doesn't always
+  // cover the same tile region as the previous one, and Chromium can leave
+  // stale tiles from the previous asset showing until a later full repaint
+  // (see https://github.com/immich-app/immich/issues/29834). Since zoom is
+  // always reset to 1 on asset navigation, only promoting the layer while
+  // actually zoomed in keeps the composited texture from persisting across
+  // navigations while still fixing the seam artifacts it was added for.
+  const isZoomed = $derived(assetViewerManager.zoom > 1);
+
+  const { insetInlineStart, top, displayWidth, displayHeight, rasterWidth, rasterHeight, rasterScale, useGpuLayer } =
+    $derived.by(() => {
       const scaleFn = objectFit === 'cover' ? scaleToCover : scaleToFit;
       const { width, height } = scaleFn(imageDimensions, container);
-      if (maxRasterPixels === 0) {
+      if (maxRasterPixels === 0 || !isZoomed) {
         return {
           insetInlineStart: (container.width - width) / 2 + 'px',
           top: (container.height - height) / 2 + 'px',
@@ -163,6 +176,7 @@
           rasterWidth: width + 'px',
           rasterHeight: height + 'px',
           rasterScale: 1,
+          useGpuLayer: false,
         };
       }
       const nativeRatio = imageDimensions.width / width;
@@ -176,9 +190,9 @@
         rasterWidth: width * rasterRatio + 'px',
         rasterHeight: height * rasterRatio + 'px',
         rasterScale: 1 / rasterRatio,
+        useGpuLayer: true,
       };
-    },
-  );
+    });
 
   const { status } = $derived(adaptiveImageLoader);
   const alt = $derived(status.urls.preview ? $getAltText(toTimelineAsset(asset)) : '');
@@ -234,7 +248,7 @@
       style:height={rasterHeight}
       style:transform="scale({rasterScale})"
       style:transform-origin={languageManager.rtl ? 'right top' : 'left top'}
-      style:will-change={maxRasterPixels > 0 ? 'transform' : undefined}
+      style:will-change={useGpuLayer ? 'transform' : undefined}
     >
       {#if show.alphaBackground}
         <AlphaBackground />


### PR DESCRIPTION
## Description

Attempt to fix #29834 by avoiding rendering on the GPU unless the image is zoomed. After implementing this fix I'm no longer able to reproduce the problem described in the issue.

Full disclosure: Claude Sonnet 5 was used to implement this. Please advise if I should leave the generated comment in or not.

Fixes #29834

## How Has This Been Tested?

Tested locally in Chrome. Able to reproduce issue before the fix, not able to reproduce after.

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Sonnet 5 was used for both debugging and implementation.
