### PR TITLE
fix(server): normalize probePackets values to prevent int32 overflow

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -287,8 +287,13 @@ export class MediaRepository {
   /**
    * Needed for accurate segments, especially when remuxing, seeking and/or VFR is involved.
    * Scanning packets for keyframes in JS is much faster than -skip_frame nokey since it avoids decoding the video.
+   *
+   * Values are normalized to fit int32 columns: (1) PTS values are made relative by subtracting the
+   * first packet's PTS (handles MPEG-TS absolute PTS clock), and (2) when timeBase exceeds 90 kHz,
+   * all values are rescaled to 90 kHz or lower (handles nanosecond time_base from IP cameras, etc.).
+   * See https://github.com/immich-app/immich/issues/29600
    */
-  probePackets(input: string, streamIndex: number): Promise<VideoPacketInfo | null> {
+  probePackets(input: string, streamIndex: number, timeBase?: number): Promise<VideoPacketInfo | null> {
     const ffprobe = spawn(
       'ffprobe',
       [
@@ -305,7 +310,15 @@ export class MediaRepository {
       { stdio: ['ignore', 'pipe', 'pipe'] },
     );
 
+    // Normalize to 90 kHz target to prevent int32 overflow in asset_keyframe columns.
+    // Two overflow paths: (1) nanosecond time_base (1/1e9) → totalDuration overflow,
+    // (2) MPEG-TS absolute PTS clock → pts array overflow. See #29600.
+    const TARGET_TIME_BASE = 90_000;
+    const rescaleFactor = timeBase && timeBase > TARGET_TIME_BASE ? Math.ceil(timeBase / TARGET_TIME_BASE) : 1;
+    const rescaledTimeBase = timeBase ? Math.floor(timeBase / rescaleFactor) : 0;
+
     let totalDuration = 0;
+    let firstPts: number | null = null;
     const keyframePts: number[] = [];
     const keyframeAccDuration: number[] = [];
     const keyframeOwnDuration: number[] = [];
@@ -315,10 +328,21 @@ export class MediaRepository {
         return;
       }
       const [ptsStr, durationStr, flags] = line.split(',', 3);
-      const pts = Number.parseInt(ptsStr);
-      const duration = Number.parseInt(durationStr);
+      let pts = Number.parseInt(ptsStr);
+      let duration = Number.parseInt(durationStr);
       if (Number.isNaN(pts) || Number.isNaN(duration) || !flags) {
         return;
+      }
+      // Make PTS relative to the first packet to handle MPEG-TS absolute PTS clock
+      // (PTS can start at ~5.5e9 with 90kHz time_base, overflowing int32).
+      if (firstPts === null) {
+        firstPts = pts;
+      }
+      pts -= firstPts;
+      // Rescale for large time_base (e.g. nanosecond 1/1e9 → ~90kHz)
+      if (rescaleFactor > 1) {
+        pts = Math.floor(pts / rescaleFactor);
+        duration = Math.floor(duration / rescaleFactor);
       }
       // Discarded packets don't contribute to packet count, but still contribute to video duration
       totalDuration += duration;
@@ -367,6 +391,7 @@ export class MediaRepository {
           keyframePts,
           keyframeAccDuration,
           keyframeOwnDuration,
+          timeBase: rescaledTimeBase,
         });
       });
     });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -69,6 +69,7 @@ const emptyPackets = {
   keyframePts: [],
   keyframeAccDuration: [],
   keyframeOwnDuration: [],
+  timeBase: 0,
 };
 
 describe(MetadataService.name, () => {
@@ -713,6 +714,7 @@ describe(MetadataService.name, () => {
         keyframePts: [-590, 10, 611, 1211],
         keyframeAccDuration: [10, 610, 6110, 12_080],
         keyframeOwnDuration: [10, 10, 10, 10],
+        timeBase: 600,
       });
       mockReadTags({});
 
@@ -744,6 +746,44 @@ describe(MetadataService.name, () => {
 
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
         expect.not.objectContaining({ keyframes: expect.anything() }),
+      );
+    });
+
+    it('should use rescaled timeBase from probePackets for nanosecond time_base videos', async () => {
+      const asset = AssetFactory.create({ type: AssetType.Video });
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      // Video with nanosecond time_base (1/1e9) - causes int32 overflow without rescaling
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.videoStreamHDR10,
+        videoStreams: [
+          {
+            ...videoInfoStub.videoStreamHDR10.videoStreams[0],
+            timeBase: 1_000_000_000,
+          },
+        ],
+      });
+      // probePackets rescales to ~90kHz and returns adjusted timeBase
+      mocks.media.probePackets.mockResolvedValue({
+        totalDuration: 270_000,
+        packetCount: 81,
+        outputFrames: 82,
+        keyframePts: [0, 90_000, 180_000],
+        keyframeAccDuration: [90_000, 180_000, 270_000],
+        keyframeOwnDuration: [90_000, 90_000, 90_000],
+        timeBase: 90_000,
+      });
+      mockReadTags({});
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          video: expect.objectContaining({ timeBase: 90_000 }),
+          keyframes: expect.objectContaining({
+            totalDuration: 270_000,
+            pts: [0, 90_000, 180_000],
+          }),
+        }),
       );
     });
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -329,7 +329,7 @@ export class MetadataService extends BaseService {
             assetId: asset.id,
             bitrate: video.bitrate,
             frameCount: video.frameCount,
-            timeBase: video.timeBase,
+            timeBase: packets?.timeBase ?? video.timeBase,
             index: video.index,
             profile: video.profile,
             level: video.level,
@@ -1094,7 +1094,7 @@ export class MetadataService extends BaseService {
     const { videoStreams, audioStreams, format } = await this.mediaRepository.probe(originalPath);
     const video = videoStreams[0];
     const audio = audioStreams[0];
-    const packets = video?.timeBase ? await this.mediaRepository.probePackets(originalPath, video.index) : null;
+    const packets = video?.timeBase ? await this.mediaRepository.probePackets(originalPath, video.index, video.timeBase) : null;
 
     const tags: Pick<ImmichTags, 'Duration' | 'Orientation' | 'ImageWidth' | 'ImageHeight'> = {};
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -128,6 +128,8 @@ export interface VideoPacketInfo {
   keyframeAccDuration: number[];
   /** Each keyframe's own packet duration (needed for VFR). */
   keyframeOwnDuration: number[];
+  /** Rescaled timeBase denominator (adjusted when source time_base would overflow int32). */
+  timeBase?: number;
 }
 
 export interface VideoFormat {


### PR DESCRIPTION
## Description

Follow-up to #29600. `probePackets()` in `media.repository.ts` accumulates raw ffprobe packet
values (PTS, duration) in time_base units without normalization. These are stored in `integer`
(int32) columns in `asset_keyframe` (`totalDuration`, `pts[]`, `accDuration[]`, `ownDuration[]`).
When the time_base denominator is large or PTS values use an absolute clock, the values overflow
int32, causing `PostgresError: value "..." is out of range for type integer` during
`AssetExtractMetadata`.

This cascades: the entire metadata upsert (audio + video + keyframe + exif in one CTE) fails
atomically, so `asset_video` is never written, and `thumbnailGeneration` then fails with
`Missing video metadata`. The video plays fine but has no thumbnail and no smart-search embedding.

Two overflow paths, both documented in #29600:

- **Nanosecond time_base** (`1/1000000000`, common in IP cameras, Pixel Motion Photos, iPhone
  HEIC Live Photos): `totalDuration` overflows for any clip longer than ~2.1s.
- **MPEG-TS absolute PTS clock** (`1/90000`, but PTS starts at ~5.5e9): `pts` array overflows
  on the first keyframe regardless of clip length.

Changes:
- Subtract the first packet's PTS from all subsequent packets, making PTS values relative.
  This handles the MPEG-TS absolute clock. Only relative PTS positions matter for keyframe
  segmentation, so this is safe.
- When `timeBase > 90000`, rescale all packet values by `ceil(timeBase / 90000)` to bring them
  into the 90kHz range. The rescaled `timeBase` is returned in `VideoPacketInfo` and used for
  `asset_video.timeBase`, preserving the `fps = packetCount * timeBase / totalDuration` ratio
  used by HLS.

No schema migration needed. Values remain in int32 range by construction.

Fixes #29600

## How Has This Been Tested?

- [x] Added unit test: nanosecond time_base video with rescaled timeBase verification.
- [x] `server` typecheck, eslint, and the `metadata.service` vitest suite pass locally (2251 tests).
- [x] Ran against the files that were actually crashing my instance (IP camera clips with
  `time_base=1/1000000000`).

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help trace through the media pipeline and write the unit tests. The root cause
analysis, the fix, and testing on my own instance are mine.