### PR TITLE
Fix album search to include descriptions in "add to album" modal

### DIFF
--- a/web/src/lib/components/album-page/AlbumsList.svelte
+++ b/web/src/lib/components/album-page/AlbumsList.svelte
@@ -17,9 +17,14 @@
     SortOrder,
     type AlbumViewSettings,
   } from '$lib/stores/preferences.store';
-  import { getSelectedAlbumGroupOption, sortAlbums, stringToSortOrder, type AlbumGroup } from '$lib/utils/album-utils';
+  import {
+    filterAlbums,
+    getSelectedAlbumGroupOption,
+    sortAlbums,
+    stringToSortOrder,
+    type AlbumGroup,
+  } from '$lib/utils/album-utils';
   import type { ContextMenuPosition } from '$lib/utils/context-menu';
-  import { normalizeSearchString } from '$lib/utils/string-utils';
   import { AlbumUserRole, type AlbumResponseDto, type SharedLinkResponseDto } from '@immich/sdk';
   import { modalManager } from '@immich/ui';
   import { mdiDeleteOutline, mdiDownload, mdiRenameOutline, mdiShareVariantOutline } from '@mdi/js';
@@ -138,16 +143,7 @@
       }
     }
   });
-  const normalizedSearchQuery = $derived(normalizeSearchString(searchQuery));
-  let filteredAlbums = $derived(
-    normalizedSearchQuery
-      ? albums.filter(
-          ({ albumName, description }) =>
-            normalizeSearchString(albumName).includes(normalizedSearchQuery) ||
-            normalizeSearchString(description).includes(normalizedSearchQuery),
-        )
-      : albums,
-  );
+  let filteredAlbums = $derived(filterAlbums(albums, searchQuery));
 
   let albumGroupOption = $derived(getSelectedAlbumGroupOption(userSettings));
   let groupedAlbums = $derived.by(() => {

--- a/web/src/lib/components/asset-viewer/AlbumListItem.svelte
+++ b/web/src/lib/components/asset-viewer/AlbumListItem.svelte
@@ -40,6 +40,10 @@
   const albumNameArray: string[] = $derived.by(() => {
     let { albumName } = album;
     let findIndex = normalizeSearchString(albumName).indexOf(normalizeSearchString(searchQuery));
+    if (findIndex === -1) {
+      // the search query only matched the album description
+      return [albumName, '', ''];
+    }
     let findLength = searchQuery.length;
     return [
       albumName.slice(0, findIndex),

--- a/web/src/lib/components/shared-components/album-selection/album-selection-utils.spec.ts
+++ b/web/src/lib/components/shared-components/album-selection/album-selection-utils.spec.ts
@@ -108,6 +108,19 @@ describe('Album Modal', () => {
     ]);
   });
 
+  it('search matches album descriptions', () => {
+    const converter = new AlbumModalRowConverter(AlbumSortBy.MostRecentPhoto, SortOrder.Desc);
+    const foodAlbum = albumFactory.build({ albumName: 'Food', description: 'Cooking, Baking, Eating' });
+    const holidayAlbum = albumFactory.build({ albumName: 'Holidays', description: '' });
+    const modalRows = converter.toModalRows('baking', [], [foodAlbum, holidayAlbum], -1, []);
+
+    expect(modalRows).toStrictEqual([
+      createNewAlbumRow(false),
+      createSectionRow('ALBUMS'),
+      createAlbumRow(foodAlbum, false),
+    ]);
+  });
+
   it('selection can select new album row', () => {
     const converter = new AlbumModalRowConverter(AlbumSortBy.MostRecentPhoto, SortOrder.Desc);
     const holidayAlbum = albumFactory.build({ albumName: 'Holidays' });

--- a/web/src/lib/components/shared-components/album-selection/album-selection-utils.ts
+++ b/web/src/lib/components/shared-components/album-selection/album-selection-utils.ts
@@ -1,8 +1,7 @@
 import type { AlbumResponseDto } from '@immich/sdk';
 import { t } from 'svelte-i18n';
 import { get } from 'svelte/store';
-import { sortAlbums } from '$lib/utils/album-utils';
-import { normalizeSearchString } from '$lib/utils/string-utils';
+import { filterAlbums, sortAlbums } from '$lib/utils/album-utils';
 
 export const SCROLL_PROPERTIES: ScrollIntoViewOptions = { block: 'center', behavior: 'smooth' };
 
@@ -46,14 +45,7 @@ export class AlbumModalRowConverter {
     const recentAlbumsToShow = search.length === 0 ? recentAlbums : [];
     const rows: AlbumModalRow[] = [{ type: AlbumModalRowType.NEW_ALBUM, selected: selectedRowIndex === 0 }];
 
-    const filteredAlbums = sortAlbums(
-      search.length > 0 && albums.length > 0
-        ? albums.filter((album) => {
-            return normalizeSearchString(album.albumName).includes(normalizeSearchString(search));
-          })
-        : albums,
-      { sortBy: this.sortBy, orderBy: this.orderBy },
-    );
+    const filteredAlbums = sortAlbums(filterAlbums(albums, search), { sortBy: this.sortBy, orderBy: this.orderBy });
 
     if (filteredAlbums.length > 0) {
       if (recentAlbumsToShow.length > 0) {

--- a/web/src/lib/utils/album-utils.spec.ts
+++ b/web/src/lib/utils/album-utils.spec.ts
@@ -1,0 +1,28 @@
+import { filterAlbums } from '$lib/utils/album-utils';
+import { albumFactory } from '@test-data/factories/album-factory';
+
+describe('filterAlbums', () => {
+  const foodAlbum = albumFactory.build({ albumName: 'Food', description: 'Cooking, Baking, Eating' });
+  const holidayAlbum = albumFactory.build({ albumName: 'Holidays', description: '' });
+  const albums = [foodAlbum, holidayAlbum];
+
+  it('returns all albums when the search is empty', () => {
+    expect(filterAlbums(albums, '')).toStrictEqual(albums);
+  });
+
+  it('matches album names', () => {
+    expect(filterAlbums(albums, 'holi')).toStrictEqual([holidayAlbum]);
+  });
+
+  it('matches album descriptions', () => {
+    expect(filterAlbums(albums, 'baking')).toStrictEqual([foodAlbum]);
+  });
+
+  it('ignores case and accents', () => {
+    expect(filterAlbums(albums, 'HÔLI')).toStrictEqual([holidayAlbum]);
+  });
+
+  it('returns nothing when neither name nor description matches', () => {
+    expect(filterAlbums(albums, 'matches_nothing')).toStrictEqual([]);
+  });
+});

--- a/web/src/lib/utils/album-utils.ts
+++ b/web/src/lib/utils/album-utils.ts
@@ -16,6 +16,7 @@ import {
   type AlbumViewSettings,
 } from '$lib/stores/preferences.store';
 import { handleError } from '$lib/utils/handle-error';
+import { normalizeSearchString } from '$lib/utils/string-utils';
 
 /**
  * -------------------------
@@ -43,6 +44,23 @@ export const createAlbumAndRedirect = async (name?: string, assetIds?: string[])
   if (newAlbum) {
     await goto(Route.viewAlbum(newAlbum));
   }
+};
+
+/**
+ * ---------------
+ * Album Searching
+ * ---------------
+ */
+export const filterAlbums = (albums: AlbumResponseDto[], searchQuery: string) => {
+  const normalizedSearch = normalizeSearchString(searchQuery);
+  if (!normalizedSearch) {
+    return albums;
+  }
+  return albums.filter(
+    ({ albumName, description }) =>
+      normalizeSearchString(albumName).includes(normalizedSearch) ||
+      normalizeSearchString(description).includes(normalizedSearch),
+  );
 };
 
 /**


### PR DESCRIPTION
## TL;DR

From "photos in no album" → select → **Add to album**, the modal only searches album
names, never descriptions. The albums page searches both. I use album descriptions
precisely to make albums easier to find, so this bugged me enough to fix it.

## Description

Album search on the albums page matches both name and description (added in #25187).
The "Add to album" modal rolls its own filter, and that one only looks at the name.
So an album you can find by description on the albums page is simply invisible in the
picker for the exact same query.

This moves the filter into a shared `filterAlbums` helper in `album-utils.ts` and uses
it in both places, so the two search boxes can't quietly drift apart again.

## How Has This Been Tested?

- [x] Unit tests for the new `filterAlbums` helper: name match, description match, case
      and accent folding, empty search, no match. Plus one test going through the album
      picker modal converter with a query that only appears in the description. All
      existing web tests still pass.
- [x] Manual test against a real server: web dev server proxied to my own Immich instance.

Regular album search box, still happily matching name and description:

<img width="849" height="388" alt="image" src="https://github.com/user-attachments/assets/aede854d-ff39-4aa7-b92e-4d2d90772fcf" />

Add to Album modal, now equally enlightened:

<img width="426" height="514" alt="image" src="https://github.com/user-attachments/assets/fa497b16-c9ca-4511-8440-dd209094eb17" />

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Heavily, but on a short leash. Full transcript, abridged:

```
me:  there's a bug in immich, I think. search the issues for it, closed ones included
llm: no candidates except this one and that one, neither related to your case

me:  find the code behind it
llm: found it, here's a solution

me:  it kind of works, but your solution is ugly. why not do it like this instead?
llm: right. here's the new one, DRY/SSOT/KISS

me:  much better. but there's a bug here
llm: you're right, here's a fix

me:  now start the dev instance pointed at my server on acme.local
llm: server is running

me:  there's a bug here...
llm: right, fixed

me:  let's review that code... you can fix that too
llm: fixed

me:  now write the PR. casual english, no llm obvious crappy stuff
llm: here's a proposal

me:  good. commit and push, I'll open the PR.
```

Short version: the LLM was an eager junior dev. It wrote most of the characters,
I decided which ones survived.