### PR TITLE
fix: sync search results when deleting assets with the delete key

### DIFF
--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -311,7 +311,7 @@
   <section id="search-content">
     {#if searchResultAssets.length > 0}
       <GalleryViewer
-        assets={searchResultAssets}
+        bind:assets={searchResultAssets}
         assetInteraction={assetMultiSelectManager}
         onEndReached={loadNextPage}
         showArchiveIcon={true}


### PR DESCRIPTION
On the search page, deleting selected photos with the Delete key appears to work, but the page keeps the deleted assets in its own list. As soon as something causes that list to refresh (for example, adding a photo to an album while the "not in any album" filter is active), the deleted photos come back as *ghosts*. They really are in the trash, they just shouldn't be displayed anymore.

I noticed that deleting from the menu behaves differently, and correctly.

The cause is that `GalleryViewer` declares `assets` as `$bindable()` and reassigns it when the delete shortcut is used, but the search page was passing the prop without `bind:`. The reassignment therefore stayed local to the component, and the parent list was never updated. Deleting through the context menu was unaffected because that path goes through the `onAssetDelete` callback.

So it's a one-line fix: use `bind:assets`, as the component expects.

I tested on two instances, both on 3.03, one of them patched:

1. Search with the "not in any album" filter
2. Select a few photos and press Delete, they disappear
3. Add another photo to an album

On 3.03 the deleted photos reappeared; on the patched one, they stayed gone.