### PR TITLE
fix(server): store null instead of empty string for album description

### DIFF
--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -34,7 +34,7 @@ const AlbumUserCreateSchema = z
 const CreateAlbumSchema = z
   .object({
     albumName: z.string().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    description: z.string().nullish().transform(v => v === '' ? null : v).describe('Album description'),
     albumUsers: z.array(AlbumUserCreateSchema).optional().describe('Album users'),
     assetIds: z.array(z.uuidv4()).optional().describe('Initial asset IDs'),
   })
@@ -57,7 +57,7 @@ const AlbumsAddAssetsResponseSchema = z
 const UpdateAlbumSchema = z
   .object({
     albumName: z.string().optional().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    description: z.string().nullish().transform(v => v === '' ? null : v).describe('Album description'),
     albumThumbnailAssetId: z.uuidv4().optional().describe('Album thumbnail asset ID'),
     isActivityEnabled: z.boolean().optional().describe('Enable activity feed'),
     order: AssetOrderSchema.optional(),
@@ -110,7 +110,7 @@ export const AlbumResponseSchema = z
   .object({
     id: z.uuidv4().describe('Album ID'),
     albumName: z.string().describe('Album name'),
-    description: z.string().describe('Album description'),
+    description: z.string().nullable().describe('Album description'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     createdAt: z.string().meta({ format: 'date-time' }).describe('Creation date'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
@@ -171,7 +171,7 @@ export type MapAlbumDto = {
   assets?: ShallowDehydrateObject<MapAsset>[];
   sharedLinks?: ShallowDehydrateObject<AuthSharedLink>[];
   albumName: string;
-  description: string;
+  description: string | null;
   albumThumbnailAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -130,7 +130,12 @@ export class PersonRepository {
       .selectFrom('person')
       .selectAll('person')
       .$if(!!options.ownerId, (qb) => qb.where('person.ownerId', '=', options.ownerId!))
-      .$if(options.thumbnailPath !== undefined, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
+      .$if(options.thumbnailPath !== undefined, (qb) => {
+        if (options.thumbnailPath === null) {
+          return qb.where('person.thumbnailPath', 'is', null);
+        }
+        return qb.where('person.thumbnailPath', '=', options.thumbnailPath!);
+      })
       .$if(options.faceAssetId === null, (qb) => qb.where('person.faceAssetId', 'is', null))
       .$if(!!options.faceAssetId, (qb) => qb.where('person.faceAssetId', '=', options.faceAssetId!))
       .$if(options.isHidden !== undefined, (qb) => qb.where('person.isHidden', '=', options.isHidden!))
@@ -142,7 +147,7 @@ export class PersonRepository {
     return this.db
       .selectFrom('person')
       .select(['id', 'thumbnailPath'])
-      .where('thumbnailPath', '!=', sql.lit(''))
+      .where('thumbnailPath', 'is not', null)
       .limit(sql.lit(3))
       .execute();
   }

--- a/server/src/schema/migrations/1785243141267-ConvertAlbumDescriptionEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1785243141267-ConvertAlbumDescriptionEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "album" SET "description" = NULL WHERE "description" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "album" SET "description" = '' WHERE "description" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -36,8 +36,8 @@ export class AlbumTable {
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>;
+  @Column({ type: 'text', nullable: true, default: null })
+  description!: string | null;
 
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -187,7 +187,7 @@ export class CliService extends BaseService {
       this.userRepository.getFileSamples(),
     ]);
 
-    const paths = Array.from(people, (person) => person.thumbnailPath);
+    const paths = Array.from(people, (person) => person.thumbnailPath).filter(Boolean) as string[];
 
     for (const user of users) {
       paths.push(user.profileImagePath);

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -96,7 +96,7 @@ export class MediaService extends BaseService {
 
     await queueAll();
 
-    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: '' });
+    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: null });
 
     for await (const person of people) {
       if (!person.faceAssetId) {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -251,8 +251,12 @@ export class PersonService extends BaseService {
   }
 
   @Chunked()
-  private async removeAllPeople(people: { id: string; thumbnailPath: string }[]) {
-    await Promise.all(people.map((person) => this.storageRepository.unlink(person.thumbnailPath)));
+  private async removeAllPeople(people: { id: string; thumbnailPath: string | null }[]) {
+    await Promise.all(
+      people.map((person) =>
+        person.thumbnailPath ? this.storageRepository.unlink(person.thumbnailPath) : Promise.resolve(),
+      ),
+    );
     await this.personRepository.delete(people.map((person) => person.id));
     this.logger.debug(`Deleted ${people.length} people`);
   }


### PR DESCRIPTION
## Description

Server-side follow-up to PR #28817 (which only fixed the mobile app). The album description column now stores `NULL` instead of an empty string `""` when no description is provided.

Changes:
- DB column: nullable with default NULL; migration updates existing rows
- Input schemas (`CreateAlbum`, `UpdateAlbum`): transform empty string to null
- Response schema (`AlbumResponse`): allows null
- Type: update `MapAlbumDto` to reflect nullable description

Related to #28832 (album.description server-side)

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None.