### PR TITLE
fix: apply disabled styling to UI buttons

### DIFF
--- a/mobile/packages/ui/lib/src/components/column_button.dart
+++ b/mobile/packages/ui/lib/src/components/column_button.dart
@@ -43,21 +43,10 @@ class _ImmichColumnButtonState extends State<ImmichColumnButton> {
     }
   }
 
-  Future<void>? _onPressed() {
-    if (_isDisabled) {
-      return null;
-    }
+  VoidCallback? get _onPressed => _isDisabled ? null : () => _runAction(widget.onPressed);
 
-    return _runAction(widget.onPressed);
-  }
-
-  Future<void>? _onLongPress() {
-    if (_isDisabled || widget.onLongPress == null) {
-      return null;
-    }
-
-    return _runAction(widget.onLongPress!);
-  }
+  VoidCallback? get _onLongPress =>
+      _isDisabled || widget.onLongPress == null ? null : () => _runAction(widget.onLongPress!);
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/packages/ui/lib/src/components/icon_button.dart
+++ b/mobile/packages/ui/lib/src/components/icon_button.dart
@@ -44,21 +44,10 @@ class _ImmichIconButtonState extends State<ImmichIconButton> {
     }
   }
 
-  Future<void>? _onPressed() {
-    if (_isDisabled) {
-      return null;
-    }
+  VoidCallback? get _onPressed => _isDisabled ? null : () => _runAction(widget.onPressed);
 
-    return _runAction(widget.onPressed);
-  }
-
-  Future<void>? _onLongPress() {
-    if (_isDisabled || widget.onLongPress == null) {
-      return null;
-    }
-
-    return _runAction(widget.onLongPress!);
-  }
+  VoidCallback? get _onLongPress =>
+      _isDisabled || widget.onLongPress == null ? null : () => _runAction(widget.onLongPress!);
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/packages/ui/lib/src/components/text_button.dart
+++ b/mobile/packages/ui/lib/src/components/text_button.dart
@@ -46,21 +46,10 @@ class _ImmichTextButtonState extends State<ImmichTextButton> {
     }
   }
 
-  Future<void>? _onPressed() {
-    if (_isDisabled) {
-      return null;
-    }
+  VoidCallback? get _onPressed => _isDisabled ? null : () => _runAction(widget.onPressed);
 
-    return _runAction(widget.onPressed);
-  }
-
-  Future<void>? _onLongPress() {
-    if (_isDisabled || widget.onLongPress == null) {
-      return null;
-    }
-
-    return _runAction(widget.onLongPress!);
-  }
+  VoidCallback? get _onLongPress =>
+      _isDisabled || widget.onLongPress == null ? null : () => _runAction(widget.onLongPress!);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
The handlers on the UI buttons handled disabled state incorrectly, resulting in incorrect styling applied to icons used within the buttons. The handlers now properly return null when disabled
