### PR TITLE
fix(docs): remove listing unraid as an "official" deployment

### DIFF
--- a/docs/docs/install/unraid.md
+++ b/docs/docs/install/unraid.md
@@ -1,13 +1,19 @@
 ---
-sidebar_position: 60
+sidebar_position: 70
 ---
 
-# Unraid
+# Unraid [ Community ]
+
+:::note
+This is a community contribution and not officially supported by the Immich team, but included here for convenience.
+
+Community support can be found in the dedicated channel on the [Discord Server](https://discord.immich.app/).
+:::
 
 Immich can easily be installed and updated on Unraid via:
 
-1. [Docker Compose Manager](https://forums.unraid.net/topic/114415-plugin-docker-compose-manager/) plugin from the Unraid Community Apps
-2. Community made template on the Unraid Community Apps
+1. Community made template on the Unraid Community Apps
+2. [Docker Compose Manager](https://forums.unraid.net/topic/114415-plugin-docker-compose-manager/) plugin from the Unraid Community Apps
 
 ## Community Applications Template
 
@@ -23,7 +29,7 @@ Once you have Redis and PostgreSQL running, search for Immich on the Unraid CA, 
 
 For more information about setting up the community image see [here](https://github.com/imagegenius/docker-immich#application-setup)
 
-## Docker-Compose Method (Official)
+## Docker-Compose Method
 
 :::info
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -160,6 +160,9 @@ ENV IMMICH_SOURCE_REF=${BUILD_SOURCE_REF}
 ENV IMMICH_SOURCE_COMMIT=${BUILD_SOURCE_COMMIT}
 ENV IMMICH_SOURCE_URL=https://github.com/immich-app/immich/commit/${BUILD_SOURCE_COMMIT}
 
+# store matplotlib config in /cache subfolder to enable rootless deployment with a single volume
+ENV MPLCONFIGDIR=/cache/matplotlib
+
 ENTRYPOINT ["tini", "--"]
 CMD ["python", "-m", "immich_ml"]
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -160,9 +160,6 @@ ENV IMMICH_SOURCE_REF=${BUILD_SOURCE_REF}
 ENV IMMICH_SOURCE_COMMIT=${BUILD_SOURCE_COMMIT}
 ENV IMMICH_SOURCE_URL=https://github.com/immich-app/immich/commit/${BUILD_SOURCE_COMMIT}
 
-# store matplotlib config in /cache subfolder to enable rootless deployment with a single volume
-ENV MPLCONFIGDIR=/cache/matplotlib
-
 ENTRYPOINT ["tini", "--"]
 CMD ["python", "-m", "immich_ml"]
 


### PR DESCRIPTION
## Description
Not sure why Unraid was highlighted in this way. 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
