### PR TITLE
fix: redis cli ping command

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -156,7 +156,7 @@ services:
     container_name: immich_redis
     image: docker.io/valkey/valkey:9@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
     healthcheck:
-      test: redis-cli ping || exit 1
+      test: redis-cli ping | grep -q PONG || exit 1
 
   database:
     container_name: immich_postgres

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -58,7 +58,7 @@ services:
     container_name: immich_redis
     image: docker.io/valkey/valkey:9@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
     healthcheck:
-      test: redis-cli ping || exit 1
+      test: redis-cli ping | grep -q PONG || exit 1
     restart: always
 
   database:

--- a/docker/docker-compose.rootless.yml
+++ b/docker/docker-compose.rootless.yml
@@ -70,7 +70,7 @@ services:
     volumes:
       - ./redis:/data
     healthcheck:
-      test: redis-cli ping || exit 1
+      test: redis-cli ping | grep -q PONG || exit 1
     restart: always
 
   database:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     container_name: immich_redis
     image: docker.io/valkey/valkey:9@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
     healthcheck:
-      test: redis-cli ping || exit 1
+      test: redis-cli ping | grep -q PONG || exit 1
     restart: always
 
   database:


### PR DESCRIPTION
## Description
We should discuss if this is something we want to deploy. It is true that in some cases `redis-cli` does return 0 after an error, but `-e` is not as portable based on my research. Either way I am not sure this is actually fixing/causing any issues as is, but it is arguably more robust.

```
redis-cli ping
PONG
I have no name!@immich-redis:/data$ redis-cli pinfg
(error) ERR unknown command 'pinfg', with args beginning with:
I have no name!@immich-redis:/data$ echo $?
0
I have no name!@immich-redis:/data$ redis-cli -e ping
ERR unknown command 'pinfg', with args beginning with:
I have no name!@immich-redis:/data$ echo $?
1
I have no name!@immich-redis:/data$ redis-cli ping | grep -q PONG; echo $?
0
```
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #30326

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
