### PR TITLE
(partially) fix #23462: configure onnxruntime to stop VRAM usage from growing

### DIFF
--- a/machine-learning/immich_ml/sessions/ort.py
+++ b/machine-learning/immich_ml/sessions/ort.py
@@ -93,7 +93,12 @@ class OrtSession:
 
             outputs = self.session.run(output_names, input_feed, run_options)
             return outputs
-
+        if "CUDAExecutionProvider" in self.providers:
+            if run_options is None:
+                run_options = ort.RunOptions()
+            # This is one part of 2 which "fix" whats effectively a memory leak
+            # see https://github.com/microsoft/onnxruntime/blob/47faa11b035d53c49f3f93e815d004e616d360ca/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h#L27
+            run_options.add_run_config_entry("memory.enable_memory_arena_shrinkage", f"gpu:{settings.device_id}")
         outputs = self.session.run(output_names, input_feed, run_options)
         return outputs
 
@@ -182,6 +187,8 @@ class OrtSession:
     def _sess_options_default(self) -> ort.SessionOptions:
         sess_options = ort.SessionOptions()
         sess_options.enable_cpu_mem_arena = settings.model_arena
+        # having this enabled will consume memory for each input shape (image dimensions, for example): https://github.com/k2-fsa/sherpa-onnx/issues/1939#issuecomment-3678334527
+        sess_options.enable_mem_pattern = False
 
         # avoid thread contention between models
         # Set inter_op threads


### PR DESCRIPTION
## Description

Fixes #23462 (partially?)

After noticing GPU OOM errors while running remote-machine-learning, i found #23462 and decided i wanted to know what was going on.

It seems that theres a few options in onnxruntime which default to values that are far from optimal for the kinds of workloads immich is throwing at it.

Heres the issues i found:
- https://github.com/k2-fsa/sherpa-onnx/issues/1939
- https://github.com/microsoft/onnxruntime/issues/25996
- https://github.com/microsoft/onnxruntime/issues/12207
- https://github.com/microsoft/onnxruntime/issues/23339
- https://github.com/triton-inference-server/onnxruntime_backend/issues/103
- https://github.com/microsoft/onnxruntime/issues/23339

Thers 2 factors which both contributed to the constantly growing memory usage of immich-ml:

1. `session.enable_mem_pattern` defaults to `True`, which means onnxruntime tries to optimize the memory layout for each input shape, which apprently does consume some memory. I initially thought this didn't do anythig, until i tried 2., after which i noticed the effect of this setting is far less extreme than 2.
2. after 1. didn't *seem* to work, i continued searching and found that onnxruntime for some reason defaults to never freeing the memory used for different inference runs. I think it does re-use it, but definitely not perfectly. Luckily, others have run into this so i was able to find the "run option" `memory.enable_memory_arena_shrinkage`, which is set to the list of devices for which to shrink memory usage.

Caveats:
- I've only tested this on Nvidia/CUDA, since thats what i have access to. For this reason, i've limited the `enable_memory_arena_shrinkage` run option to only apply when `CUDAExecutionProvider` is enabled.
- `session.enable_mem_pattern` is a legitimate optimization, just one apparently not well suited for dynamic shapes like image resolution (which the OCR model at least seems to accept, though it has an upper limit). That means by disabling this for every run we're loosing out on the optimization for models where it *could* work, like CLIP which afaik has a fixed size.

## How Has This Been Tested?

- [x] remote machine learning container with the modified file mounted into it, on Linux with an Nvidia GPU.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

At some point my block for the google LLM that shows up in search results stopped working, but i didn't really look at it. Besides that, entirely handcrafted.