### PR TITLE
fix(server): strip password from DB_URL before passing to pg_dump/psql

### DIFF
--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -209,7 +209,7 @@ describe(DatabaseBackupService.name, () => {
       const args = call[1] as string[];
       expect(args).toMatchInlineSnapshot(`
         [
-          "postgresql://postgres:pwd@host:5432/immich?sslmode=require",
+          "postgresql://postgres@host:5432/immich?sslmode=require",
           "--clean",
           "--if-exists",
         ]
@@ -488,7 +488,7 @@ describe(DatabaseBackupService.name, () => {
         await expect(sut.buildPostgresLaunchArguments('pg_dump')).resolves.toMatchInlineSnapshot(`
           {
             "args": [
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--clean",
               "--if-exists",
             ],
@@ -507,7 +507,7 @@ describe(DatabaseBackupService.name, () => {
           {
             "args": [
               "--dbname",
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--single-transaction",
               "--set",
               "ON_ERROR_STOP=on",
@@ -521,6 +521,13 @@ describe(DatabaseBackupService.name, () => {
             "databaseVersion": "14.10 (Debian 14.10-1.pgdg120+1)",
           }
         `);
+      });
+
+      it('should not leak the password in the args (argv is visible via ps)', async () => {
+        const { args } = await sut.buildPostgresLaunchArguments('pg_dump');
+        for (const arg of args) {
+          expect(arg).not.toContain('mypwd');
+        }
       });
     });
 

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -143,6 +143,10 @@ export class DatabaseBackupService {
 
         databaseUsername = parsedUrl.username || parsedUrl.searchParams.get('user');
 
+        // Strip the password from the URL before it reaches argv so it cannot leak via `ps`.
+        // The password is supplied to the child process via the PGPASSWORD env var below.
+        parsedUrl.password = '';
+
         url = parsedUrl.href;
       }
 


### PR DESCRIPTION
When Immich connects to PostgreSQL via DB_URL, buildPostgresLaunchArguments was passing the full URL — password included — as a command-line argument to pg_dump/psql/pg_dumpall. Since argv is visible through ps to any user on the host, the database password leaked to every process.

The password is already supplied to the child via the PGPASSWORD env var, so clearing parsedUrl.password before serializing the URL removes the leak without changing how authentication works. The bad-URL fallback path is untouched because it never enters the URL.canParse branch.

Updated the existing URL-connection snapshot tests (which had the plaintext password baked in) and added a small test asserting the password never appears in args.

Fixes #30333