### PR TITLE
fix(server): remove the asset row when an upload fails after creating it

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -8,20 +8,22 @@ import { AssetFile } from 'src/database';
 import { AssetMediaStatus, AssetRejectReason, AssetUploadAction } from 'src/dtos/asset-media-response.dto';
 import { AssetMediaCreateDto, AssetMediaSize, UploadFieldName } from 'src/dtos/asset-media.dto';
 import { MapAsset } from 'src/dtos/asset-response.dto';
+import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetType, AssetVisibility, CacheControl, JobName } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
-import { UploadBody } from 'src/types';
+import { UploadBody, UploadFile } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
+import { AlbumFactory } from 'test/factories/album.factory';
 import { AssetFileFactory } from 'test/factories/asset-file.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
 import { authStub } from 'test/fixtures/auth.stub';
 import { fileStub } from 'test/fixtures/file.stub';
 import { userStub } from 'test/fixtures/user.stub';
-import { getForAsset } from 'test/mappers';
+import { getForAlbum, getForAsset } from 'test/mappers';
 import { newTestService, ServiceMocks } from 'test/utils';
 
 const file1 = Buffer.from('d2947b871a706081be194569951b7db246907957', 'hex');
@@ -317,6 +319,11 @@ describe(AssetMediaService.name, () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(mocks.asset.create).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: [file.originalPath, undefined] },
+      });
+      expect(mocks.event.emit).not.toHaveBeenCalled();
       expect(mocks.user.updateUsage).not.toHaveBeenCalledWith(authStub.user1.user.id, file.size);
       expect(mocks.storage.utimes).not.toHaveBeenCalledWith(
         file.originalPath,
@@ -343,6 +350,7 @@ describe(AssetMediaService.name, () => {
       });
 
       expect(mocks.asset.create).toHaveBeenCalled();
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file });
       expect(mocks.storage.utimes).toHaveBeenCalledWith(
         file.originalPath,
         expect.any(Date),
@@ -374,6 +382,7 @@ describe(AssetMediaService.name, () => {
         name: JobName.FileDelete,
         data: { files: ['fake_path/asset_1.jpeg', undefined] },
       });
+      expect(mocks.event.emit).not.toHaveBeenCalled();
       expect(mocks.user.updateUsage).not.toHaveBeenCalled();
     });
 
@@ -457,6 +466,179 @@ describe(AssetMediaService.name, () => {
         new Date(createDto.fileModifiedAt),
       );
       expect(mocks.asset.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        step: 'metadata upsert',
+        arrange: (error: Error) => mocks.asset.upsertMetadata.mockRejectedValue(error),
+        dto: {
+          ...createDto,
+          metadata: [{ key: 'description', value: { text: 'a description' } }],
+        } as AssetMediaCreateDto,
+      },
+      {
+        step: 'sidecar write',
+        arrange: (error: Error) => mocks.asset.upsertFile.mockRejectedValue(error),
+        sidecarFile: fileStub.photoSidecar,
+      },
+      {
+        step: 'setting file times',
+        arrange: (error: Error) => mocks.storage.utimes.mockRejectedValue(error),
+      },
+      {
+        step: 'setting sidecar file times',
+        arrange: (error: Error) => mocks.storage.utimes.mockRejectedValue(error),
+        sidecarFile: fileStub.photoSidecar,
+      },
+      {
+        step: 'exif upsert',
+        arrange: (error: Error) => mocks.asset.upsertExif.mockRejectedValue(error),
+      },
+      {
+        step: 'shared link add',
+        arrange: (error: Error) => mocks.sharedLink.addAssets.mockRejectedValue(error),
+        auth: authStub.adminSharedLink,
+      },
+      {
+        step: 'album shared link add',
+        arrange: (error: Error) => {
+          mocks.album.getById.mockResolvedValue(getForAlbum(AlbumFactory.from().build()));
+          mocks.album.addAssetIds.mockRejectedValue(error);
+        },
+        auth: {
+          ...authStub.adminSharedLink,
+          sharedLink: { ...authStub.adminSharedLink.sharedLink, albumId: 'album-1' },
+        } as AuthDto,
+      },
+    ] as {
+      step: string;
+      arrange: (error: Error) => void;
+      dto?: AssetMediaCreateDto;
+      auth?: AuthDto;
+      sidecarFile?: UploadFile;
+    }[])('should keep the asset and its files when the $step fails', async ({ arrange, dto, auth, sidecarFile }) => {
+      const error = new Error('step failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      arrange(error);
+
+      await expect(sut.uploadAsset(auth ?? authStub.user1, dto ?? createDto, fileStub.photo, sidecarFile)).rejects.toBe(
+        error,
+      );
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetExtractMetadata,
+        data: { id: assetEntity.id, source: 'upload' },
+      });
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
+    });
+
+    it('should requeue the metadata job when queueing it fails', async () => {
+      const error = new Error('queue unavailable');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.job.queue.mockRejectedValueOnce(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(2);
+      expect(mocks.job.queue).toHaveBeenNthCalledWith(1, {
+        name: JobName.AssetExtractMetadata,
+        data: { id: assetEntity.id, source: 'upload' },
+      });
+      expect(mocks.job.queue).toHaveBeenNthCalledWith(2, {
+        name: JobName.AssetExtractMetadata,
+        data: { id: assetEntity.id, source: 'upload' },
+      });
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
+    });
+
+    it('should rethrow the step error when the metadata job cannot be queued at all', async () => {
+      const error = new Error('queue unavailable');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.job.queue.mockRejectedValueOnce(error).mockRejectedValue(new Error('queue still unavailable'));
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(2);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
+    });
+
+    it('should rethrow the step error when the create event also fails', async () => {
+      const error = new Error('exif write failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+      mocks.event.emit.mockRejectedValue(new Error('listener failed'));
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should rethrow a falsey step rejection', async () => {
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(undefined);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBeUndefined();
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
+    });
+
+    it('should not let an uninterpolable event error mask the step error', async () => {
+      const error = new Error('exif write failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+      mocks.event.emit.mockRejectedValue(Symbol('listener failed'));
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+    });
+
+    it('should not delete the files when the create event fails', async () => {
+      const error = new Error('listener failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.event.emit.mockRejectedValue(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+    });
+
+    it('should not queue the metadata job again when a later step fails', async () => {
+      const error = new Error('shared link write failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.sharedLink.addAssets.mockRejectedValue(error);
+
+      await expect(sut.uploadAsset(authStub.adminSharedLink, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetExtractMetadata,
+        data: { id: assetEntity.id, source: 'upload' },
+      });
+    });
+
+    it('should still repair and announce when a step rejects with an uninterpolable value', async () => {
+      const error = Symbol('step failed');
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetExtractMetadata,
+        data: { id: assetEntity.id, source: 'upload' },
+      });
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
     });
   });
 

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -12,7 +12,7 @@ import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetType, AssetVisibility, CacheControl, JobName } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
-import { UploadBody, UploadFile } from 'src/types';
+import { UploadBody } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
 import { AssetFileFactory } from 'test/factories/asset-file.factory';
@@ -349,7 +349,6 @@ describe(AssetMediaService.name, () => {
       });
 
       expect(mocks.asset.create).toHaveBeenCalled();
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file });
       expect(mocks.storage.utimes).toHaveBeenCalledWith(
         file.originalPath,
         expect.any(Date),
@@ -377,12 +376,10 @@ describe(AssetMediaService.name, () => {
         status: AssetMediaStatus.DUPLICATE,
       });
 
-      expect(mocks.asset.remove).not.toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
         data: { files: ['fake_path/asset_1.jpeg', undefined] },
       });
-      expect(mocks.event.emit).not.toHaveBeenCalled();
       expect(mocks.user.updateUsage).not.toHaveBeenCalled();
     });
 
@@ -466,53 +463,6 @@ describe(AssetMediaService.name, () => {
         new Date(createDto.fileModifiedAt),
       );
       expect(mocks.asset.update).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      {
-        step: 'metadata upsert',
-        arrange: (error: Error) => mocks.asset.upsertMetadata.mockRejectedValue(error),
-        dto: {
-          ...createDto,
-          metadata: [{ key: 'description', value: { text: 'a description' } }],
-        } as AssetMediaCreateDto,
-      },
-      {
-        step: 'sidecar write',
-        arrange: (error: Error) => mocks.asset.upsertFile.mockRejectedValue(error),
-        sidecarFile: fileStub.photoSidecar,
-      },
-      {
-        step: 'setting file times',
-        arrange: (error: Error) => mocks.storage.utimes.mockRejectedValue(error),
-      },
-      {
-        step: 'setting sidecar file times',
-        arrange: (error: Error) => mocks.storage.utimes.mockRejectedValue(error),
-        sidecarFile: fileStub.photoSidecar,
-      },
-      {
-        step: 'exif upsert',
-        arrange: (error: Error) => mocks.asset.upsertExif.mockRejectedValue(error),
-      },
-    ] as {
-      step: string;
-      arrange: (error: Error) => void;
-      dto?: AssetMediaCreateDto;
-      sidecarFile?: UploadFile;
-    }[])('should remove the created asset when the $step fails', async ({ arrange, dto, sidecarFile }) => {
-      const error = new Error('step failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      arrange(error);
-
-      await expect(sut.uploadAsset(authStub.user1, dto ?? createDto, fileStub.photo, sidecarFile)).rejects.toBe(error);
-
-      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.FileDelete,
-        data: { files: [fileStub.photo.originalPath, sidecarFile?.originalPath] },
-      });
-      expect(mocks.event.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -8,7 +8,6 @@ import { AssetFile } from 'src/database';
 import { AssetMediaStatus, AssetRejectReason, AssetUploadAction } from 'src/dtos/asset-media-response.dto';
 import { AssetMediaCreateDto, AssetMediaSize, UploadFieldName } from 'src/dtos/asset-media.dto';
 import { MapAsset } from 'src/dtos/asset-response.dto';
-import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetType, AssetVisibility, CacheControl, JobName } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
@@ -16,14 +15,13 @@ import { AssetMediaService } from 'src/services/asset-media.service';
 import { UploadBody, UploadFile } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
-import { AlbumFactory } from 'test/factories/album.factory';
 import { AssetFileFactory } from 'test/factories/asset-file.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
 import { authStub } from 'test/fixtures/auth.stub';
 import { fileStub } from 'test/fixtures/file.stub';
 import { userStub } from 'test/fixtures/user.stub';
-import { getForAlbum, getForAsset } from 'test/mappers';
+import { getForAsset } from 'test/mappers';
 import { newTestService, ServiceMocks } from 'test/utils';
 
 const file1 = Buffer.from('d2947b871a706081be194569951b7db246907957', 'hex');
@@ -319,6 +317,7 @@ describe(AssetMediaService.name, () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(mocks.asset.create).not.toHaveBeenCalled();
+      expect(mocks.asset.remove).not.toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
         data: { files: [file.originalPath, undefined] },
@@ -378,6 +377,7 @@ describe(AssetMediaService.name, () => {
         status: AssetMediaStatus.DUPLICATE,
       });
 
+      expect(mocks.asset.remove).not.toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
         data: { files: ['fake_path/asset_1.jpeg', undefined] },
@@ -495,150 +495,24 @@ describe(AssetMediaService.name, () => {
         step: 'exif upsert',
         arrange: (error: Error) => mocks.asset.upsertExif.mockRejectedValue(error),
       },
-      {
-        step: 'shared link add',
-        arrange: (error: Error) => mocks.sharedLink.addAssets.mockRejectedValue(error),
-        auth: authStub.adminSharedLink,
-      },
-      {
-        step: 'album shared link add',
-        arrange: (error: Error) => {
-          mocks.album.getById.mockResolvedValue(getForAlbum(AlbumFactory.from().build()));
-          mocks.album.addAssetIds.mockRejectedValue(error);
-        },
-        auth: {
-          ...authStub.adminSharedLink,
-          sharedLink: { ...authStub.adminSharedLink.sharedLink, albumId: 'album-1' },
-        } as AuthDto,
-      },
     ] as {
       step: string;
       arrange: (error: Error) => void;
       dto?: AssetMediaCreateDto;
-      auth?: AuthDto;
       sidecarFile?: UploadFile;
-    }[])('should keep the asset and its files when the $step fails', async ({ arrange, dto, auth, sidecarFile }) => {
+    }[])('should remove the created asset when the $step fails', async ({ arrange, dto, sidecarFile }) => {
       const error = new Error('step failed');
       mocks.asset.create.mockResolvedValue(assetEntity);
       arrange(error);
 
-      await expect(sut.uploadAsset(auth ?? authStub.user1, dto ?? createDto, fileStub.photo, sidecarFile)).rejects.toBe(
-        error,
-      );
+      await expect(sut.uploadAsset(authStub.user1, dto ?? createDto, fileStub.photo, sidecarFile)).rejects.toBe(error);
 
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
+      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
       expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetExtractMetadata,
-        data: { id: assetEntity.id, source: 'upload' },
+        name: JobName.FileDelete,
+        data: { files: [fileStub.photo.originalPath, sidecarFile?.originalPath] },
       });
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
-    });
-
-    it('should requeue the metadata job when queueing it fails', async () => {
-      const error = new Error('queue unavailable');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.job.queue.mockRejectedValueOnce(error);
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.job.queue).toHaveBeenCalledTimes(2);
-      expect(mocks.job.queue).toHaveBeenNthCalledWith(1, {
-        name: JobName.AssetExtractMetadata,
-        data: { id: assetEntity.id, source: 'upload' },
-      });
-      expect(mocks.job.queue).toHaveBeenNthCalledWith(2, {
-        name: JobName.AssetExtractMetadata,
-        data: { id: assetEntity.id, source: 'upload' },
-      });
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
-    });
-
-    it('should rethrow the step error when the metadata job cannot be queued at all', async () => {
-      const error = new Error('queue unavailable');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.job.queue.mockRejectedValueOnce(error).mockRejectedValue(new Error('queue still unavailable'));
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.job.queue).toHaveBeenCalledTimes(2);
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
-    });
-
-    it('should rethrow the step error when the create event also fails', async () => {
-      const error = new Error('exif write failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.asset.upsertExif.mockRejectedValue(error);
-      mocks.event.emit.mockRejectedValue(new Error('listener failed'));
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-    });
-
-    it('should rethrow a falsey step rejection', async () => {
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.asset.upsertExif.mockRejectedValue(undefined);
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBeUndefined();
-
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
-    });
-
-    it('should not let an uninterpolable event error mask the step error', async () => {
-      const error = new Error('exif write failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.asset.upsertExif.mockRejectedValue(error);
-      mocks.event.emit.mockRejectedValue(Symbol('listener failed'));
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-    });
-
-    it('should not delete the files when the create event fails', async () => {
-      const error = new Error('listener failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.event.emit.mockRejectedValue(error);
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
-    });
-
-    it('should not queue the metadata job again when a later step fails', async () => {
-      const error = new Error('shared link write failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.sharedLink.addAssets.mockRejectedValue(error);
-
-      await expect(sut.uploadAsset(authStub.adminSharedLink, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetExtractMetadata,
-        data: { id: assetEntity.id, source: 'upload' },
-      });
-    });
-
-    it('should still repair and announce when a step rejects with an uninterpolable value', async () => {
-      const error = Symbol('step failed');
-      mocks.asset.create.mockResolvedValue(assetEntity);
-      mocks.asset.upsertExif.mockRejectedValue(error);
-
-      await expect(sut.uploadAsset(authStub.user1, createDto, fileStub.photo)).rejects.toBe(error);
-
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FileDelete }));
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetExtractMetadata,
-        data: { id: assetEntity.id, source: 'upload' },
-      });
-      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
-      expect(mocks.event.emit).toHaveBeenCalledWith('AssetCreate', { asset: assetEntity, file: fileStub.photo });
+      expect(mocks.event.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -29,7 +29,7 @@ import {
 } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { BaseService } from 'src/services/base.service';
-import { JobItem, UploadFile, UploadRequest } from 'src/types';
+import { UploadFile, UploadRequest } from 'src/types';
 import { requireUploadAccess } from 'src/utils/access';
 import { asUploadRequest, onBeforeLink } from 'src/utils/asset.util';
 import { isAssetChecksumConstraint } from 'src/utils/database';
@@ -128,7 +128,7 @@ export class AssetMediaService extends BaseService {
     file: UploadFile,
     sidecarFile?: UploadFile,
   ): Promise<AssetMediaResponseDto> {
-    let asset: Asset;
+    let asset: Asset | undefined;
     try {
       await this.requireAccess({
         auth,
@@ -165,6 +165,34 @@ export class AssetMediaService extends BaseService {
         livePhotoVideoId: dto.livePhotoVideoId,
         originalFileName: dto.filename || file.originalName,
       });
+
+      if (dto.metadata?.length) {
+        await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
+      }
+
+      if (sidecarFile) {
+        await this.assetRepository.upsertFile({
+          assetId: asset.id,
+          path: sidecarFile.originalPath,
+          type: AssetFileType.Sidecar,
+        });
+        await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
+      }
+      await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
+      await this.assetRepository.upsertExif({
+        exif: { assetId: asset.id, fileSizeInByte: file.size },
+        lockedPropertiesBehavior: 'override',
+      });
+
+      await this.jobRepository.queue({ name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } });
+
+      if (auth.sharedLink) {
+        await this.addToSharedLink(auth.sharedLink, asset.id);
+      }
+
+      await this.eventRepository.emit('AssetCreate', { asset, file });
+
+      return { id: asset.id, status: AssetMediaStatus.CREATED };
     } catch (error: any) {
       // clean up files
       await this.jobRepository.queue({
@@ -188,69 +216,14 @@ export class AssetMediaService extends BaseService {
         return { status: AssetMediaStatus.DUPLICATE, id: duplicateId };
       }
 
+      // clean up the asset row if one was created
+      if (asset) {
+        await this.assetRepository.remove({ id: asset.id });
+      }
+
       this.logger.error(`Error uploading file ${error}`, error?.stack);
       throw error;
     }
-
-    // the row exists from here on: keep its files, queue its metadata job, and announce it
-    const metadataJob: JobItem = { name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } };
-    let metadataJobQueued = false;
-    let failure: { error: unknown } | undefined;
-    try {
-      if (dto.metadata?.length) {
-        await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
-      }
-
-      if (sidecarFile) {
-        await this.assetRepository.upsertFile({
-          assetId: asset.id,
-          path: sidecarFile.originalPath,
-          type: AssetFileType.Sidecar,
-        });
-        await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
-      }
-      await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
-      await this.assetRepository.upsertExif({
-        exif: { assetId: asset.id, fileSizeInByte: file.size },
-        lockedPropertiesBehavior: 'override',
-      });
-
-      await this.jobRepository.queue(metadataJob);
-      metadataJobQueued = true;
-
-      if (auth.sharedLink) {
-        await this.addToSharedLink(auth.sharedLink, asset.id);
-      }
-    } catch (error: any) {
-      failure = { error };
-      this.logger.error('Error uploading file', error?.stack);
-
-      if (!metadataJobQueued) {
-        // repair is best effort, it must not replace the original error
-        try {
-          await this.jobRepository.queue(metadataJob);
-        } catch (queueError: any) {
-          this.logger.error(`Error queueing metadata extraction for asset ${asset.id}`, queueError?.stack);
-        }
-      }
-    }
-
-    // a listener failure must not replace the error that got us here
-    try {
-      await this.eventRepository.emit('AssetCreate', { asset, file });
-    } catch (emitError: any) {
-      if (!failure) {
-        this.logger.error('Error uploading file', emitError?.stack);
-        throw emitError;
-      }
-      this.logger.error(`Error emitting create event for asset ${asset.id}`, emitError?.stack);
-    }
-
-    if (failure) {
-      throw failure.error;
-    }
-
-    return { id: asset.id, status: AssetMediaStatus.CREATED };
   }
 
   async downloadOriginal(auth: AuthDto, id: string, dto: AssetDownloadOriginalDto): Promise<ImmichFileResponse> {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import sanitize from 'sanitize-filename';
 import { StorageCore } from 'src/cores/storage.core';
-import { AuthSharedLink } from 'src/database';
+import { Asset, AuthSharedLink } from 'src/database';
 import {
   AssetBulkUploadCheckResponseDto,
   AssetMediaResponseDto,
@@ -29,7 +29,7 @@ import {
 } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { BaseService } from 'src/services/base.service';
-import { UploadFile, UploadRequest } from 'src/types';
+import { JobItem, UploadFile, UploadRequest } from 'src/types';
 import { requireUploadAccess } from 'src/utils/access';
 import { asUploadRequest, onBeforeLink } from 'src/utils/asset.util';
 import { isAssetChecksumConstraint } from 'src/utils/database';
@@ -128,6 +128,7 @@ export class AssetMediaService extends BaseService {
     file: UploadFile,
     sidecarFile?: UploadFile,
   ): Promise<AssetMediaResponseDto> {
+    let asset: Asset;
     try {
       await this.requireAccess({
         auth,
@@ -145,7 +146,7 @@ export class AssetMediaService extends BaseService {
         );
       }
 
-      const asset = await this.assetRepository.create({
+      asset = await this.assetRepository.create({
         ownerId: auth.user.id,
         libraryId: null,
 
@@ -164,34 +165,6 @@ export class AssetMediaService extends BaseService {
         livePhotoVideoId: dto.livePhotoVideoId,
         originalFileName: dto.filename || file.originalName,
       });
-
-      if (dto.metadata?.length) {
-        await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
-      }
-
-      if (sidecarFile) {
-        await this.assetRepository.upsertFile({
-          assetId: asset.id,
-          path: sidecarFile.originalPath,
-          type: AssetFileType.Sidecar,
-        });
-        await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
-      }
-      await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
-      await this.assetRepository.upsertExif({
-        exif: { assetId: asset.id, fileSizeInByte: file.size },
-        lockedPropertiesBehavior: 'override',
-      });
-
-      await this.jobRepository.queue({ name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } });
-
-      if (auth.sharedLink) {
-        await this.addToSharedLink(auth.sharedLink, asset.id);
-      }
-
-      await this.eventRepository.emit('AssetCreate', { asset, file });
-
-      return { id: asset.id, status: AssetMediaStatus.CREATED };
     } catch (error: any) {
       // clean up files
       await this.jobRepository.queue({
@@ -218,6 +191,66 @@ export class AssetMediaService extends BaseService {
       this.logger.error(`Error uploading file ${error}`, error?.stack);
       throw error;
     }
+
+    // the row exists from here on: keep its files, queue its metadata job, and announce it
+    const metadataJob: JobItem = { name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } };
+    let metadataJobQueued = false;
+    let failure: { error: unknown } | undefined;
+    try {
+      if (dto.metadata?.length) {
+        await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
+      }
+
+      if (sidecarFile) {
+        await this.assetRepository.upsertFile({
+          assetId: asset.id,
+          path: sidecarFile.originalPath,
+          type: AssetFileType.Sidecar,
+        });
+        await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
+      }
+      await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
+      await this.assetRepository.upsertExif({
+        exif: { assetId: asset.id, fileSizeInByte: file.size },
+        lockedPropertiesBehavior: 'override',
+      });
+
+      await this.jobRepository.queue(metadataJob);
+      metadataJobQueued = true;
+
+      if (auth.sharedLink) {
+        await this.addToSharedLink(auth.sharedLink, asset.id);
+      }
+    } catch (error: any) {
+      failure = { error };
+      this.logger.error('Error uploading file', error?.stack);
+
+      if (!metadataJobQueued) {
+        // repair is best effort, it must not replace the original error
+        try {
+          await this.jobRepository.queue(metadataJob);
+        } catch (queueError: any) {
+          this.logger.error(`Error queueing metadata extraction for asset ${asset.id}`, queueError?.stack);
+        }
+      }
+    }
+
+    // a listener failure must not replace the error that got us here
+    try {
+      await this.eventRepository.emit('AssetCreate', { asset, file });
+    } catch (emitError: any) {
+      if (!failure) {
+        this.logger.error('Error uploading file', emitError?.stack);
+        throw emitError;
+      }
+      this.logger.error(`Error emitting create event for asset ${asset.id}`, emitError?.stack);
+    }
+
+    if (failure) {
+      throw failure.error;
+    }
+
+    return { id: asset.id, status: AssetMediaStatus.CREATED };
   }
 
   async downloadOriginal(auth: AuthDto, id: string, dto: AssetDownloadOriginalDto): Promise<ImmichFileResponse> {

--- a/server/test/medium/specs/services/asset-media.service.spec.ts
+++ b/server/test/medium/specs/services/asset-media.service.spec.ts
@@ -2,7 +2,7 @@ import { Kysely } from 'kysely';
 import { randomBytes } from 'node:crypto';
 import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
 import { AssetMediaSize } from 'src/dtos/asset-media.dto';
-import { AssetFileType, JobName, SharedLinkType } from 'src/enum';
+import { AssetFileType, SharedLinkType } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
@@ -98,83 +98,6 @@ describe(AssetService.name, () => {
       ).resolves.toEqual({
         id: expect.any(String),
         status: AssetMediaStatus.CREATED,
-      });
-    });
-
-    it('should remove the created asset and its sidecar record when a post-create step fails', async () => {
-      const { sut, ctx } = setup();
-
-      ctx.getMock(EventRepository).emit.mockResolvedValue();
-      ctx.getMock(JobRepository).queue.mockResolvedValue();
-      // the sidecar utimes succeeds, the main file's utimes fails
-      ctx.getMock(StorageRepository).utimes.mockResolvedValueOnce().mockRejectedValueOnce(new Error('utimes failed'));
-
-      const { user } = await ctx.newUser();
-      const auth = factory.auth({ user: { id: user.id } });
-      const dto = {
-        fileModifiedAt: new Date(),
-        fileCreatedAt: new Date(),
-        assetData: Buffer.from('some data'),
-      };
-      const file = mediumFactory.uploadFile({ originalPath: '/path/to/main.jpg' });
-      const sidecar = mediumFactory.uploadFile({ originalPath: '/path/to/main.jpg.xmp' });
-
-      await expect(sut.uploadAsset(auth, dto, file, sidecar)).rejects.toThrow('utimes failed');
-
-      await expect(
-        ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute(),
-      ).resolves.toHaveLength(0);
-      await expect(
-        ctx.database.selectFrom('asset_file').selectAll().where('path', '=', '/path/to/main.jpg.xmp').execute(),
-      ).resolves.toHaveLength(0);
-      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
-        name: JobName.FileDelete,
-        data: { files: ['/path/to/main.jpg', '/path/to/main.jpg.xmp'] },
-      });
-      expect(ctx.getMock(EventRepository).emit).not.toHaveBeenCalled();
-    });
-
-    it('should upload cleanly when the same file is retried after a post-create failure', async () => {
-      const { sut, ctx } = setup();
-
-      ctx.getMock(StorageRepository).utimes.mockResolvedValue();
-      ctx.getMock(EventRepository).emit.mockResolvedValue();
-      // the first upload fails to queue its metadata job
-      ctx.getMock(JobRepository).queue.mockRejectedValueOnce(new Error('queue down')).mockResolvedValue();
-
-      const { user } = await ctx.newUser();
-      const auth = factory.auth({ user: { id: user.id } });
-      const dto = {
-        fileModifiedAt: new Date(),
-        fileCreatedAt: new Date(),
-        assetData: Buffer.from('some data'),
-      };
-      const file = mediumFactory.uploadFile({ originalPath: '/path/to/first.jpg' });
-
-      await expect(sut.uploadAsset(auth, dto, file)).rejects.toThrow('queue down');
-
-      // nothing survives the failed attempt
-      await expect(
-        ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute(),
-      ).resolves.toHaveLength(0);
-      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
-        name: JobName.FileDelete,
-        data: { files: ['/path/to/first.jpg', undefined] },
-      });
-      expect(ctx.getMock(EventRepository).emit).not.toHaveBeenCalled();
-
-      const retryFile = mediumFactory.uploadFile({ originalPath: '/path/to/second.jpg', checksum: file.checksum });
-      await expect(sut.uploadAsset(auth, dto, retryFile)).resolves.toEqual({
-        id: expect.any(String),
-        status: AssetMediaStatus.CREATED,
-      });
-
-      const [asset] = await ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute();
-      expect(asset).toMatchObject({ checksum: retryFile.checksum, originalPath: retryFile.originalPath });
-      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledTimes(1);
-      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledWith('AssetCreate', {
-        asset: expect.objectContaining({ id: asset.id }),
-        file: expect.objectContaining({ size: retryFile.size }),
       });
     });
 

--- a/server/test/medium/specs/services/asset-media.service.spec.ts
+++ b/server/test/medium/specs/services/asset-media.service.spec.ts
@@ -2,7 +2,7 @@ import { Kysely } from 'kysely';
 import { randomBytes } from 'node:crypto';
 import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
 import { AssetMediaSize } from 'src/dtos/asset-media.dto';
-import { AssetFileType, SharedLinkType } from 'src/enum';
+import { AssetFileType, JobName, SharedLinkType } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
@@ -99,6 +99,51 @@ describe(AssetService.name, () => {
         id: expect.any(String),
         status: AssetMediaStatus.CREATED,
       });
+    });
+
+    it('should keep the asset and its files when a post-create step fails and the upload is retried', async () => {
+      const { sut, ctx } = setup();
+
+      ctx.getMock(StorageRepository).utimes.mockResolvedValue();
+      ctx.getMock(EventRepository).emit.mockResolvedValue();
+      // the first upload fails to queue its metadata job; the repair path queues it again
+      ctx.getMock(JobRepository).queue.mockRejectedValueOnce(new Error('queue down')).mockResolvedValue();
+
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const dto = {
+        fileModifiedAt: new Date(),
+        fileCreatedAt: new Date(),
+        assetData: Buffer.from('some data'),
+      };
+      const file = mediumFactory.uploadFile({ originalPath: '/path/to/first.jpg' });
+
+      await expect(sut.uploadAsset(auth, dto, file)).rejects.toThrow('queue down');
+
+      const [asset] = await ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute();
+      expect(asset).toMatchObject({ checksum: file.checksum, originalPath: file.originalPath });
+      expect(ctx.getMock(JobRepository).queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FileDelete }),
+      );
+      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledTimes(2);
+      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledTimes(1);
+      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledWith('AssetCreate', {
+        asset: expect.objectContaining({ id: asset.id }),
+        file: expect.objectContaining({ size: file.size }),
+      });
+
+      const retry = await sut.uploadAsset(
+        auth,
+        dto,
+        mediumFactory.uploadFile({ originalPath: '/path/to/second.jpg', checksum: file.checksum }),
+      );
+
+      expect(retry).toEqual({ id: asset.id, status: AssetMediaStatus.DUPLICATE });
+      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: ['/path/to/second.jpg', undefined] },
+      });
+      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledTimes(1);
     });
 
     it('should add to a shared link', async () => {

--- a/server/test/medium/specs/services/asset-media.service.spec.ts
+++ b/server/test/medium/specs/services/asset-media.service.spec.ts
@@ -101,12 +101,45 @@ describe(AssetService.name, () => {
       });
     });
 
-    it('should keep the asset and its files when a post-create step fails and the upload is retried', async () => {
+    it('should remove the created asset and its sidecar record when a post-create step fails', async () => {
+      const { sut, ctx } = setup();
+
+      ctx.getMock(EventRepository).emit.mockResolvedValue();
+      ctx.getMock(JobRepository).queue.mockResolvedValue();
+      // the sidecar utimes succeeds, the main file's utimes fails
+      ctx.getMock(StorageRepository).utimes.mockResolvedValueOnce().mockRejectedValueOnce(new Error('utimes failed'));
+
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const dto = {
+        fileModifiedAt: new Date(),
+        fileCreatedAt: new Date(),
+        assetData: Buffer.from('some data'),
+      };
+      const file = mediumFactory.uploadFile({ originalPath: '/path/to/main.jpg' });
+      const sidecar = mediumFactory.uploadFile({ originalPath: '/path/to/main.jpg.xmp' });
+
+      await expect(sut.uploadAsset(auth, dto, file, sidecar)).rejects.toThrow('utimes failed');
+
+      await expect(
+        ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute(),
+      ).resolves.toHaveLength(0);
+      await expect(
+        ctx.database.selectFrom('asset_file').selectAll().where('path', '=', '/path/to/main.jpg.xmp').execute(),
+      ).resolves.toHaveLength(0);
+      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: ['/path/to/main.jpg', '/path/to/main.jpg.xmp'] },
+      });
+      expect(ctx.getMock(EventRepository).emit).not.toHaveBeenCalled();
+    });
+
+    it('should upload cleanly when the same file is retried after a post-create failure', async () => {
       const { sut, ctx } = setup();
 
       ctx.getMock(StorageRepository).utimes.mockResolvedValue();
       ctx.getMock(EventRepository).emit.mockResolvedValue();
-      // the first upload fails to queue its metadata job; the repair path queues it again
+      // the first upload fails to queue its metadata job
       ctx.getMock(JobRepository).queue.mockRejectedValueOnce(new Error('queue down')).mockResolvedValue();
 
       const { user } = await ctx.newUser();
@@ -120,30 +153,29 @@ describe(AssetService.name, () => {
 
       await expect(sut.uploadAsset(auth, dto, file)).rejects.toThrow('queue down');
 
+      // nothing survives the failed attempt
+      await expect(
+        ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute(),
+      ).resolves.toHaveLength(0);
+      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: ['/path/to/first.jpg', undefined] },
+      });
+      expect(ctx.getMock(EventRepository).emit).not.toHaveBeenCalled();
+
+      const retryFile = mediumFactory.uploadFile({ originalPath: '/path/to/second.jpg', checksum: file.checksum });
+      await expect(sut.uploadAsset(auth, dto, retryFile)).resolves.toEqual({
+        id: expect.any(String),
+        status: AssetMediaStatus.CREATED,
+      });
+
       const [asset] = await ctx.database.selectFrom('asset').selectAll().where('ownerId', '=', user.id).execute();
-      expect(asset).toMatchObject({ checksum: file.checksum, originalPath: file.originalPath });
-      expect(ctx.getMock(JobRepository).queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.FileDelete }),
-      );
-      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledTimes(2);
+      expect(asset).toMatchObject({ checksum: retryFile.checksum, originalPath: retryFile.originalPath });
       expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledTimes(1);
       expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledWith('AssetCreate', {
         asset: expect.objectContaining({ id: asset.id }),
-        file: expect.objectContaining({ size: file.size }),
+        file: expect.objectContaining({ size: retryFile.size }),
       });
-
-      const retry = await sut.uploadAsset(
-        auth,
-        dto,
-        mediumFactory.uploadFile({ originalPath: '/path/to/second.jpg', checksum: file.checksum }),
-      );
-
-      expect(retry).toEqual({ id: asset.id, status: AssetMediaStatus.DUPLICATE });
-      expect(ctx.getMock(JobRepository).queue).toHaveBeenCalledWith({
-        name: JobName.FileDelete,
-        data: { files: ['/path/to/second.jpg', undefined] },
-      });
-      expect(ctx.getMock(EventRepository).emit).toHaveBeenCalledTimes(1);
     });
 
     it('should add to a shared link', async () => {


### PR DESCRIPTION
## Description

if an upload fails after the asset row is created, the catch deletes the uploaded file but leaves the row behind. so the row points at nothing, and sync still hands it to every client, which then shows a photo that never loads.

worse on the retry. the same file goes up again, hits the checksum constraint, and gets duplicate success with the id of that broken row. mobile takes any success as backed up, so the user can clear space on the phone and lose the only copy.

the steps that can do this are the plain db calls after create, upsertMetadata, the sidecar upsertFile, utimes and upsertExif. rare, but the result is permanent.

fix is to remove the row in the catch when we created one. asset_file cascades so the sidecar record goes with it, and a retry then just uploads cleanly instead of adopting a corpse. the duplicate path is untouched, it only ever removes a row this request created.

reproduced on a throwaway stack before the fix, renamed asset_exif so upsertExif throws, row stayed, file got deleted, and the retry returned duplicate success for an asset that 404s.

tested with a throw at each db step after create (row removed, file cleanup unchanged, original error still thrown), the duplicate path leaving the existing asset alone, and a medium test on a real db for the sidecar record going with the row. removing the fix turns the suite red.
