### PR TITLE
fix(server): strip password from DB_URL in backup service, fix socket URL crash

### DIFF
--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -209,7 +209,7 @@ describe(DatabaseBackupService.name, () => {
       const args = call[1] as string[];
       expect(args).toMatchInlineSnapshot(`
         [
-          "postgresql://postgres:pwd@host:5432/immich?sslmode=require",
+          "postgresql://postgres@host:5432/immich?sslmode=require",
           "--clean",
           "--if-exists",
         ]
@@ -488,7 +488,7 @@ describe(DatabaseBackupService.name, () => {
         await expect(sut.buildPostgresLaunchArguments('pg_dump')).resolves.toMatchInlineSnapshot(`
           {
             "args": [
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--clean",
               "--if-exists",
             ],
@@ -507,7 +507,7 @@ describe(DatabaseBackupService.name, () => {
           {
             "args": [
               "--dbname",
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--single-transaction",
               "--set",
               "ON_ERROR_STOP=on",
@@ -521,6 +521,13 @@ describe(DatabaseBackupService.name, () => {
             "databaseVersion": "14.10 (Debian 14.10-1.pgdg120+1)",
           }
         `);
+      });
+
+      it('should not leak the password in the args (argv is visible via ps)', async () => {
+        const { args } = await sut.buildPostgresLaunchArguments('pg_dump');
+        for (const arg of args) {
+          expect(arg).not.toContain('mypwd');
+        }
       });
     });
 

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -129,6 +129,7 @@ export class DatabaseBackupService {
 
     const args: string[] = [];
     let databaseUsername;
+    let databasePassword: string | undefined;
 
     if (isUrlConnection) {
       if (bin !== 'pg_dump') {
@@ -142,6 +143,11 @@ export class DatabaseBackupService {
         parsedUrl.searchParams.delete('uselibpqcompat');
 
         databaseUsername = parsedUrl.username || parsedUrl.searchParams.get('user');
+        databasePassword = parsedUrl.password;
+
+        // Strip the password from the URL before it reaches argv so it cannot leak via `ps`.
+        // The password is supplied to the child process via the PGPASSWORD env var below.
+        parsedUrl.password = '';
 
         url = parsedUrl.href;
       }
@@ -214,7 +220,7 @@ export class DatabaseBackupService {
       bin: `/usr/lib/postgresql/${databaseMajorVersion}/bin/${bin}`,
       args,
       databaseUsername,
-      databasePassword: isUrlConnection ? new URL(databaseConfig.url).password : databaseConfig.password,
+      databasePassword: isUrlConnection ? (databasePassword ?? '') : databaseConfig.password,
       databaseVersion,
       databaseMajorVersion,
     };


### PR DESCRIPTION
The database backup service constructs a connection URL from DB_URL and passes it as a command-line argument to pg_dump/psql. The URL still contains the cleartext password at that point, so anyone with access to ps on the host can read it.

This patch strips the password from the URL before it reaches argv. The password is still supplied to the child process via the PGPASSWORD environment variable, so authentication is unaffected.

While fixing that, I noticed the return statement also called new URL(databaseConfig.url).password to extract the password for PGPASSWORD. That call throws TypeError when DB_URL uses a scheme Node's URL parser does not support (e.g. socket://... for Unix domain sockets), which crashes the backup job entirely. I moved the password extraction into the existing URL.canParse branch so it is captured before the password is cleared, and the return statement reuses it instead of re-parsing.

Closes #30333
Closes #30331
