### PR TITLE
fix(server): ignore REDIS_HOSTNAME/PORT/etc when REDIS_SOCKET is set

### DIFF
--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -181,6 +181,17 @@ describe('getEnv', () => {
       expect(redis).toEqual(sentinelConfig);
     });
 
+    it('should ignore other redis env vars when REDIS_SOCKET is set', () => {
+      process.env.REDIS_SOCKET = '/var/run/redis/redis.sock';
+      process.env.REDIS_HOSTNAME = 'redis-host';
+      process.env.REDIS_PORT = '6380';
+      process.env.REDIS_DBINDEX = '1';
+      process.env.REDIS_USERNAME = 'redis-user';
+      process.env.REDIS_PASSWORD = 'redis-password';
+      const { redis } = getEnv();
+      expect(redis).toEqual({ path: '/var/run/redis/redis.sock' });
+    });
+
     it('should reject invalid json', () => {
       process.env.REDIS_URL = `ioredis://${Buffer.from('{ "invalid json"').toString('base64')}`;
       expect(() => getEnv()).toThrowError('Failed to decode redis options');

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -199,7 +199,7 @@ const getEnv = (): EnvData => {
     web: join(buildFolder, 'www'),
   };
 
-  let redisConfig = {
+  let redisConfig: RedisOptions = {
     host: dto.REDIS_HOSTNAME || 'redis',
     port: dto.REDIS_PORT || 6379,
     db: dto.REDIS_DBINDEX || 0,
@@ -207,6 +207,14 @@ const getEnv = (): EnvData => {
     password: dto.REDIS_PASSWORD || undefined,
     path: dto.REDIS_SOCKET || undefined,
   };
+
+  // When a Unix socket is configured, ioredis connects through it and the
+  // host/port/username/password/db fields are meaningless. Clear them so the
+  // configuration matches what the docs promise and stale defaults (e.g. the
+  // built-in "redis" hostname) don't leak into the connection options.
+  if (dto.REDIS_SOCKET) {
+    redisConfig = { path: dto.REDIS_SOCKET };
+  }
 
   const redisUrl = dto.REDIS_URL;
   if (redisUrl && redisUrl.startsWith('ioredis://')) {


### PR DESCRIPTION
The environment variable docs say that setting REDIS_SOCKET causes REDIS_HOSTNAME, REDIS_PORT, REDIS_USERNAME, REDIS_PASSWORD, and REDIS_DBINDEX to be ignored, but the config code never implemented this. It only added the socket path alongside the other fields, so stale defaults like host "redis" and port 6379 still ended up in the ioredis connection options.

This reduces the redis config to just { path } when REDIS_SOCKET is set, matching how REDIS_URL already replaces the entire config object. I added a test case covering the scenario alongside the existing REDIS_URL test.

Closes #30286.