### PR TITLE
fix(deployment): Add huggingface cache directory to Dockerfile

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -160,8 +160,7 @@ ENV IMMICH_SOURCE_REF=${BUILD_SOURCE_REF}
 ENV IMMICH_SOURCE_COMMIT=${BUILD_SOURCE_COMMIT}
 ENV IMMICH_SOURCE_URL=https://github.com/immich-app/immich/commit/${BUILD_SOURCE_COMMIT}
 
-# store matplotlib and huggingface in /cache subfolder to enable rootless deployment with a single volume
-ENV MPLCONFIGDIR=/cache/matplotlib
+# store huggingface in /cache subfolder to enable rootless deployment with a single volume
 ENV HF_HOME=/cache/hf-cache
 
 ENTRYPOINT ["tini", "--"]

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -160,8 +160,9 @@ ENV IMMICH_SOURCE_REF=${BUILD_SOURCE_REF}
 ENV IMMICH_SOURCE_COMMIT=${BUILD_SOURCE_COMMIT}
 ENV IMMICH_SOURCE_URL=https://github.com/immich-app/immich/commit/${BUILD_SOURCE_COMMIT}
 
-# store matplotlib config in /cache subfolder to enable rootless deployment with a single volume
+# store matplotlib and huggingface in /cache subfolder to enable rootless deployment with a single volume
 ENV MPLCONFIGDIR=/cache/matplotlib
+ENV HF_HOME=/cache/hf-cache
 
 ENTRYPOINT ["tini", "--"]
 CMD ["python", "-m", "immich_ml"]


### PR DESCRIPTION
Updated Dockerfile to include huggingface cache directory.

Matplotlib is now removed from Immich so no longer needed

Covered in https://huggingface.co/docs/datasets/en/cache

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
