### PR TITLE
fix(mobile): Actually use `hasWifi` for wifi check

### DIFF
--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -88,8 +88,8 @@ class ForegroundUploadService {
     }
 
     final networkCapabilities = await _connectivityApi.getCapabilities();
-    final hasWifi = networkCapabilities.isUnmetered;
-    _logger.info('Network capabilities: $networkCapabilities, hasWifi/isUnmetered: $hasWifi');
+    final hasWifi = networkCapabilities.hasWifi;
+    _logger.info('Network capabilities: $networkCapabilities, hasWifi: $hasWifi');
 
     if (useSequentialUpload) {
       await _uploadSequentially(items: candidates, cancelToken: cancelToken, hasWifi: hasWifi, callbacks: callbacks);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the code for `hasWifi` checks if the connection is unmetered, which contradicts itself. This results in issues when using a VPN over wifi, as they are counted as metered. The code originally had a wifi check, like this PR does, but it got [changed](https://github.com/immich-app/immich/pull/23380) to unmetered to "fix vpn", with no further explanation provided on why this change was done.

Fixes https://github.com/immich-app/immich/issues/27948
Related to https://github.com/immich-app/immich/pull/29558

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] The upload is blocked when using cellular and the cellular options are disabled
- [x] The upload is blocked when using a vpn over cellular and the cellular options are disabled
- [x] The upload is allowed when using cellular and the cellular options are enabled
- [x] The upload is allowed when using a vpn over cellular and the cellular options are enabled
- [x] The upload is allowed when using wifi
- [x] The upload is allowed when using a vpn over wifi

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM was used to create these changes.