### PR TITLE
fix: assetFileFilter path matching

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -89,7 +89,8 @@ const methods = wrapper<Manifest>({
     }
   },
 
-  assetFileFilter: ({ data, config }) => matchValueResult(data.asset.originalFileName || '', config),
+  assetFileFilter: ({ data, config }) =>
+    matchValueResult(config.usePath ? data.asset.originalPath : data.asset.originalFileName, config),
 
   assetLocationFilter: ({ config, data }) => {
     if (


### PR DESCRIPTION
Fixes a regression in #29295 which didn't include the filter by asset path method option