### PR TITLE
fix(server): handle null deviceOS/deviceType in session cleanup log

### DIFF
--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -34,7 +34,7 @@ const AlbumUserCreateSchema = z
 const CreateAlbumSchema = z
   .object({
     albumName: z.string().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    description: z.string().nullish().transform(v => v === '' ? null : v).describe('Album description'),
     albumUsers: z.array(AlbumUserCreateSchema).optional().describe('Album users'),
     assetIds: z.array(z.uuidv4()).optional().describe('Initial asset IDs'),
   })
@@ -57,7 +57,7 @@ const AlbumsAddAssetsResponseSchema = z
 const UpdateAlbumSchema = z
   .object({
     albumName: z.string().optional().describe('Album name'),
-    description: z.string().optional().describe('Album description'),
+    description: z.string().nullish().transform(v => v === '' ? null : v).describe('Album description'),
     albumThumbnailAssetId: z.uuidv4().optional().describe('Album thumbnail asset ID'),
     isActivityEnabled: z.boolean().optional().describe('Enable activity feed'),
     order: AssetOrderSchema.optional(),
@@ -110,7 +110,7 @@ export const AlbumResponseSchema = z
   .object({
     id: z.uuidv4().describe('Album ID'),
     albumName: z.string().describe('Album name'),
-    description: z.string().describe('Album description'),
+    description: z.string().nullable().describe('Album description'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
     createdAt: z.string().meta({ format: 'date-time' }).describe('Creation date'),
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
@@ -171,7 +171,7 @@ export type MapAlbumDto = {
   assets?: ShallowDehydrateObject<MapAsset>[];
   sharedLinks?: ShallowDehydrateObject<AuthSharedLink>[];
   albumName: string;
-  description: string;
+  description: string | null;
   albumThumbnailAssetId: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -130,7 +130,12 @@ export class PersonRepository {
       .selectFrom('person')
       .selectAll('person')
       .$if(!!options.ownerId, (qb) => qb.where('person.ownerId', '=', options.ownerId!))
-      .$if(options.thumbnailPath !== undefined, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
+      .$if(options.thumbnailPath !== undefined, (qb) => {
+        if (options.thumbnailPath === null) {
+          return qb.where('person.thumbnailPath', 'is', null);
+        }
+        return qb.where('person.thumbnailPath', '=', options.thumbnailPath!);
+      })
       .$if(options.faceAssetId === null, (qb) => qb.where('person.faceAssetId', 'is', null))
       .$if(!!options.faceAssetId, (qb) => qb.where('person.faceAssetId', '=', options.faceAssetId!))
       .$if(options.isHidden !== undefined, (qb) => qb.where('person.isHidden', '=', options.isHidden!))
@@ -142,7 +147,7 @@ export class PersonRepository {
     return this.db
       .selectFrom('person')
       .select(['id', 'thumbnailPath'])
-      .where('thumbnailPath', '!=', sql.lit(''))
+      .where('thumbnailPath', 'is not', null)
       .limit(sql.lit(3))
       .execute();
   }

--- a/server/src/schema/migrations/1785243141267-ConvertAlbumDescriptionEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1785243141267-ConvertAlbumDescriptionEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "album" SET "description" = NULL WHERE "description" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "album" SET "description" = '' WHERE "description" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "album" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -36,8 +36,8 @@ export class AlbumTable {
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>;
+  @Column({ type: 'text', nullable: true, default: null })
+  description!: string | null;
 
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -187,7 +187,7 @@ export class CliService extends BaseService {
       this.userRepository.getFileSamples(),
     ]);
 
-    const paths = Array.from(people, (person) => person.thumbnailPath);
+    const paths = Array.from(people, (person) => person.thumbnailPath).filter(Boolean) as string[];
 
     for (const user of users) {
       paths.push(user.profileImagePath);

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -96,7 +96,7 @@ export class MediaService extends BaseService {
 
     await queueAll();
 
-    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: '' });
+    const people = this.personRepository.getAll(force ? undefined : { thumbnailPath: null });
 
     for await (const person of people) {
       if (!person.faceAssetId) {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -251,8 +251,12 @@ export class PersonService extends BaseService {
   }
 
   @Chunked()
-  private async removeAllPeople(people: { id: string; thumbnailPath: string }[]) {
-    await Promise.all(people.map((person) => this.storageRepository.unlink(person.thumbnailPath)));
+  private async removeAllPeople(people: { id: string; thumbnailPath: string | null }[]) {
+    await Promise.all(
+      people.map((person) =>
+        person.thumbnailPath ? this.storageRepository.unlink(person.thumbnailPath) : Promise.resolve(),
+      ),
+    );
     await this.personRepository.delete(people.map((person) => person.id));
     this.logger.debug(`Deleted ${people.length} people`);
   }

--- a/server/src/services/session.service.ts
+++ b/server/src/services/session.service.ts
@@ -19,7 +19,7 @@ export class SessionService extends BaseService {
   async handleCleanup(): Promise<JobStatus> {
     const sessions = await this.sessionRepository.cleanup();
     for (const session of sessions) {
-      this.logger.verbose(`Deleted expired session token: ${session.deviceOS}/${session.deviceType}`);
+      this.logger.verbose(`Deleted expired session token: ${session.deviceOS ?? 'Unknown'}/${session.deviceType ?? 'Unknown'}`);
     }
 
     this.logger.log(`Deleted ${sessions.length} expired session tokens`);

--- a/web/src/lib/components/shared-components/UserAvatar.svelte
+++ b/web/src/lib/components/shared-components/UserAvatar.svelte
@@ -69,7 +69,7 @@
 
   let colorClass = $derived(colorClasses[user.avatarColor]);
   let sizeClass = $derived(sizeClasses[size]);
-  let title = $derived(label ?? `${user.name} (${user.email})`);
+  let title = $derived(label ?? `${user.name ?? ''} (${user.email})`);
   let interactiveClass = $derived(
     interactive
       ? 'border-2 border-immich-primary hover:border-immich-dark-primary dark:hover:border-immich-primary dark:border-immich-dark-primary transition-colors'
@@ -100,7 +100,7 @@
       class:text-2xl={size === 'xxl'}
       class:text-3xl={size === 'xxxl'}
     >
-      {user.name[0] || ''}
+      {user.name?.[0] || ''}
     </span>
   {/if}
 </figure>

--- a/web/src/lib/components/shared-components/search-bar/SearchPeopleSection.svelte
+++ b/web/src/lib/components/shared-components/search-bar/SearchPeopleSection.svelte
@@ -48,7 +48,7 @@
 
   const filterPeople = (list: PersonResponseDto[], name: string) => {
     const nameLower = name.toLowerCase();
-    return name ? list.filter((p) => p.name.toLowerCase().includes(nameLower)) : list;
+    return name ? list.filter((p) => p.name?.toLowerCase().includes(nameLower)) : list;
   };
 
   const styles = tv({

--- a/web/src/lib/modals/PeoplePickerModal.svelte
+++ b/web/src/lib/modals/PeoplePickerModal.svelte
@@ -26,7 +26,7 @@
     people
       .filter((person) => !excludedIds.includes(person.id))
       .filter(
-        (person) => !searchName || normalizeSearchString(person.name).includes(normalizeSearchString(searchName)),
+        (person) => !searchName || normalizeSearchString(person.name ?? '').includes(normalizeSearchString(searchName)),
       ),
   );
 


### PR DESCRIPTION
Fix verbose log to show "Unknown" instead of "null" when deviceOS/deviceType is null.

Part of #28832 follow-up.