### PR TITLE
chore: enable merge queue batching

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,2 +1,7 @@
 merge_queue:
   status_comments: outcomes
+
+queue_rules:
+  - name: default
+    batch_size: 3
+    batch_max_wait_time: 2 min


### PR DESCRIPTION
This waits for up to 2 min to group up to 3 PRs into the same draft. That should cut down on the amount of draft PRs that get created. The main downsides are the 2 minute wait when only queueing one PR, and less failure isolation: on an error, mergify has to do bisect runs to figure out which PR failed the batch, which takes more time than purely sequential operation. All of this can be tuned further of course.