### PR TITLE
fix(mobile): stale local renders after editing a photo on device

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -159,7 +159,13 @@ ImageProvider getFullImageProvider(
     provider = FileImage(File(localFilePath));
   } else if (_shouldUseLocalAsset(asset)) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).localId!;
-    provider = LocalFullImageProvider(id: id, size: size, assetType: asset.type, isAnimated: asset.isAnimatedImage);
+    provider = LocalFullImageProvider(
+      id: id,
+      size: size,
+      assetType: asset.type,
+      isAnimated: asset.isAnimatedImage,
+      checksum: asset.checksum,
+    );
   } else {
     final String assetId;
     final String thumbhash;
@@ -187,7 +193,7 @@ ImageProvider getFullImageProvider(
 ImageProvider? getThumbnailImageProvider(BaseAsset asset, {Size size = kThumbnailResolution, bool edited = true}) {
   if (_shouldUseLocalAsset(asset)) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).localId!;
-    return LocalThumbProvider(id: id, size: size, assetType: asset.type);
+    return LocalThumbProvider(id: id, size: size, assetType: asset.type, checksum: asset.checksum);
   }
 
   final assetId = asset is RemoteAsset ? asset.id : (asset as LocalAsset).remoteId;

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -14,7 +14,10 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
   final Size size;
   final AssetType assetType;
 
-  LocalThumbProvider({required this.id, required this.assetType, this.size = kThumbnailResolution});
+  // an edit on the device keeps the id and changes the bytes, so the checksum is what separates two renders
+  final String? checksum;
+
+  LocalThumbProvider({required this.id, required this.assetType, this.checksum, this.size = kThumbnailResolution});
 
   @override
   Future<LocalThumbProvider> obtainKey(ImageConfiguration configuration) {
@@ -44,13 +47,13 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
       return true;
     }
     if (other is LocalThumbProvider) {
-      return id == other.id;
+      return id == other.id && checksum == other.checksum;
     }
     return false;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => id.hashCode ^ checksum.hashCode;
 }
 
 class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProvider>
@@ -59,8 +62,15 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
   final Size size;
   final AssetType assetType;
   final bool isAnimated;
+  final String? checksum;
 
-  LocalFullImageProvider({required this.id, required this.assetType, required this.size, required this.isAnimated});
+  LocalFullImageProvider({
+    required this.id,
+    required this.assetType,
+    required this.size,
+    required this.isAnimated,
+    this.checksum,
+  });
 
   @override
   Future<LocalFullImageProvider> obtainKey(ImageConfiguration configuration) {
@@ -73,7 +83,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       return AnimatedImageStreamCompleter(
         stream: _animatedCodec(key, decode),
         scale: 1.0,
-        initialImage: getInitialImage(LocalThumbProvider(id: key.id, assetType: key.assetType)),
+        initialImage: getInitialImage(LocalThumbProvider(id: key.id, assetType: key.assetType, checksum: key.checksum)),
         informationCollector: () => <DiagnosticsNode>[
           DiagnosticsProperty<ImageProvider>('Image provider', this),
           DiagnosticsProperty<String>('Id', key.id),
@@ -86,7 +96,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
 
     return OneFramePlaceholderImageStreamCompleter(
       _codec(key, decode),
-      initialImage: getInitialImage(LocalThumbProvider(id: key.id, assetType: key.assetType)),
+      initialImage: getInitialImage(LocalThumbProvider(id: key.id, assetType: key.assetType, checksum: key.checksum)),
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<String>('Id', key.id),
@@ -163,11 +173,11 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       return true;
     }
     if (other is LocalFullImageProvider) {
-      return id == other.id && size == other.size && isAnimated == other.isAnimated;
+      return id == other.id && size == other.size && isAnimated == other.isAnimated && checksum == other.checksum;
     }
     return false;
   }
 
   @override
-  int get hashCode => id.hashCode ^ size.hashCode ^ isAnimated.hashCode;
+  int get hashCode => id.hashCode ^ size.hashCode ^ isAnimated.hashCode ^ checksum.hashCode;
 }

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -53,7 +53,7 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
   }
 
   @override
-  int get hashCode => id.hashCode ^ checksum.hashCode;
+  int get hashCode => Object.hash(id, checksum);
 }
 
 class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProvider>
@@ -179,5 +179,5 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
   }
 
   @override
-  int get hashCode => id.hashCode ^ size.hashCode ^ isAnimated.hashCode ^ checksum.hashCode;
+  int get hashCode => Object.hash(id, size, isAnimated, checksum);
 }

--- a/mobile/test/presentation/widgets/images/local_image_provider_test.dart
+++ b/mobile/test/presentation/widgets/images/local_image_provider_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
+import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
+
+class _StubCompleter extends ImageStreamCompleter {}
+
+void main() {
+  late ImageCache cache;
+  late int loads;
+
+  ImageStreamCompleter load() {
+    loads++;
+    return _StubCompleter();
+  }
+
+  setUp(() {
+    cache = ImageCache();
+    loads = 0;
+  });
+
+  group('LocalThumbProvider caching', () {
+    test('editing on device re-renders the thumbnail', () {
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image, checksum: 'before'), load);
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image, checksum: 'after'), load);
+
+      expect(loads, 2);
+    });
+
+    test('an unchanged thumbnail still comes from the cache', () {
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image, checksum: 'same'), load);
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image, checksum: 'same'), load);
+
+      expect(loads, 1);
+    });
+
+    // The rehash clears the checksum before writing the new one, so the tile has to
+    // follow that step too or it waits for the hash to land before showing the edit.
+    test('re-renders while the checksum is still being recomputed', () {
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image, checksum: 'before'), load);
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image), load);
+
+      expect(loads, 2);
+    });
+
+    test('stays cached while the checksum is missing', () {
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image), load);
+      cache.putIfAbsent(LocalThumbProvider(id: 'asset-1', assetType: AssetType.image), load);
+
+      expect(loads, 1);
+    });
+  });
+
+  group('factories', () {
+    test('thumbnails are keyed by the asset checksum', () {
+      final asset = LocalAsset(
+        id: 'asset-1',
+        name: 'a.jpg',
+        checksum: 'abc',
+        type: AssetType.image,
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        isEdited: false,
+        playbackStyle: AssetPlaybackStyle.image,
+      );
+
+      final provider = getThumbnailImageProvider(asset) as LocalThumbProvider;
+
+      expect(provider.checksum, 'abc');
+    });
+  });
+
+  group('LocalFullImageProvider caching', () {
+    test('editing on device re-renders the full image', () {
+      cache.putIfAbsent(
+        LocalFullImageProvider(
+          id: 'asset-1',
+          assetType: AssetType.image,
+          size: const Size(100, 100),
+          isAnimated: false,
+          checksum: 'before',
+        ),
+        load,
+      );
+      cache.putIfAbsent(
+        LocalFullImageProvider(
+          id: 'asset-1',
+          assetType: AssetType.image,
+          size: const Size(100, 100),
+          isAnimated: false,
+          checksum: 'after',
+        ),
+        load,
+      );
+
+      expect(loads, 2);
+    });
+  });
+}

--- a/mobile/test/presentation/widgets/images/local_image_provider_test.dart
+++ b/mobile/test/presentation/widgets/images/local_image_provider_test.dart
@@ -4,6 +4,8 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
 
+import '../../../unit/factories/local_asset_factory.dart';
+
 class _StubCompleter extends ImageStreamCompleter {}
 
 void main() {
@@ -54,16 +56,7 @@ void main() {
 
   group('factories', () {
     test('thumbnails are keyed by the asset checksum', () {
-      final asset = LocalAsset(
-        id: 'asset-1',
-        name: 'a.jpg',
-        checksum: 'abc',
-        type: AssetType.image,
-        createdAt: DateTime(2026),
-        updatedAt: DateTime(2026),
-        isEdited: false,
-        playbackStyle: AssetPlaybackStyle.image,
-      );
+      final asset = LocalAssetFactory.create().copyWith(checksum: 'abc');
 
       final provider = getThumbnailImageProvider(asset) as LocalThumbProvider;
 


### PR DESCRIPTION
## Description

edit a photo in ios photos and immich keeps showing the old picture. the image cache keys local renders by the asset id, and an edit keeps the id while changing the bytes, so the stale frame wins until an app restart.

now the checksum is part of the key. an edit nulls the checksum and the rehash writes a new one, so the key follows the bytes and the tile and full view pick up the edited render as soon as sync sees it. unchanged photos still hit the cache.

this is the first small piece of the ios photo edit work, split out of the draft in #28543 and rebuilt on main. the edits that feature uploads would render stale without this, but its a real bug on its own today.

## Testing

six unit tests against a real image cache: an edit misses, an unchanged photo still hits, the recompute window re-renders and stays stable, and the factories pass the checksum through. on the simulator and a real iphone 8, edited a photo with a filter in photos and the immich tile and full view followed within seconds, no reinstall, and a revert followed back once the rehash landed.
