### PR TITLE
chore(mobile): depend on OpenAPI generation in appropriate codegen tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -69,7 +69,7 @@ sources = [
   "patch/*",
   "bin/generate-dart-sdk.sh",
 ]
-outputs = ["../mobile/openapi/lib/"]
+outputs = ["../mobile/generated/openapi/"]
 run = "bash ./bin/generate-dart-sdk.sh"
 
 [tasks.open-api]

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -17,7 +17,7 @@ windows-x64 = { asset_pattern = "dcm-windows-release.zip" }
 [tasks.codegen]
 alias = "codegen"
 description = "Generate all codegen artifacts"
-depends = ["codegen:dart", "codegen:drift:schema", "codegen:pigeon", "codegen:translation"]
+depends = ["//:open-api-dart", "codegen:dart", "codegen:drift:schema", "codegen:pigeon", "codegen:translation"]
 
 [tasks."codegen:dart"]
 description = "Execute build_runner to auto-generate dart code"
@@ -32,12 +32,14 @@ run = [
   "dart run build_runner build --delete-conflicting-outputs",
   "dart format lib/routing/router.gr.dart",
 ]
+depends = ["//:open-api-dart"]
 
 [tasks."codegen:drift:schema"]
 description = "Generate Drift migration schema test code"
 sources = ["drift_schemas/main/*.json"]
 outputs = { auto = true }
 run = "dart run drift_dev schema generate --data-classes --companions drift_schemas/main/ test/drift/main/generated/"
+depends = ["//:open-api-dart"]
 
 [tasks."codegen:watch"]
 alias = "watch"
@@ -51,6 +53,7 @@ run = [
   "ls pigeon/*.dart | xargs -n1 -P4 -I{} dart run pigeon --input {}",
   "dart format lib/platform/",
 ]
+depends = ["//:open-api-dart"]
 
 [tasks."codegen:translation"]
 alias = "translation"
@@ -123,6 +126,7 @@ run = [
   "dart run easy_localization:generate -S ../i18n",
   "dart format lib/generated/codegen_loader.g.dart",
 ]
+depends = ["//:open-api-dart"]
 
 [tasks."i18n:keys"]
 description = "Generate i18n keys"


### PR DESCRIPTION
I don't think it makes a difference, but semantically this should be in a `run` block, not `depends`, but I tried that and some tasks were no longer handling stdio correctly.