### PR TITLE
feat(widget): add toggle to match icon theme

### DIFF
--- a/mobile/ios/WidgetExtension/ImageEntry.swift
+++ b/mobile/ios/WidgetExtension/ImageEntry.swift
@@ -12,7 +12,7 @@ struct ImageEntry: TimelineEntry {
     var subtitle: String? = nil
     var error: WidgetError? = nil
     var deepLink: URL? = nil
-    var matchIconTheme: Bool = true
+    var forceFullColor: Bool = true
   }
 
   static func build(
@@ -20,7 +20,7 @@ struct ImageEntry: TimelineEntry {
     asset: Asset,
     dateOffset: Int,
     subtitle: String? = nil,
-    matchIconTheme: Bool = true
+    forceFullColor: Bool = true
   )
     async throws -> Self
   {
@@ -37,7 +37,7 @@ struct ImageEntry: TimelineEntry {
       metadata: EntryMetadata(
         subtitle: subtitle,
         deepLink: asset.deepLink,
-        matchIconTheme: matchIconTheme
+        forceFullColor: forceFullColor
       )
     )
   }
@@ -122,8 +122,8 @@ extension ImageEntry.Metadata {
     error = try container.decodeIfPresent(WidgetError.self, forKey: .error)
     deepLink = try container.decodeIfPresent(URL.self, forKey: .deepLink)
 
-    matchIconTheme =
-      try container.decodeIfPresent(Bool.self, forKey: .matchIconTheme) ?? true
+    forceFullColor =
+      try container.decodeIfPresent(Bool.self, forKey: .forceFullColor) ?? true
   }
 }
 
@@ -133,7 +133,7 @@ func generateRandomEntries(
   count: Int,
   filter: SearchFilter = Album.NONE.filter,
   subtitle: String? = nil,
-  matchIconTheme: Bool = true
+  forceFullColor: Bool = true
 )
   async throws -> [ImageEntry]
 {
@@ -150,7 +150,7 @@ func generateRandomEntries(
           asset: asset,
           dateOffset: dateOffset,
           subtitle: subtitle,
-          matchIconTheme: matchIconTheme
+          forceFullColor: forceFullColor
         )
       }
     }

--- a/mobile/ios/WidgetExtension/ImageEntry.swift
+++ b/mobile/ios/WidgetExtension/ImageEntry.swift
@@ -12,13 +12,15 @@ struct ImageEntry: TimelineEntry {
     var subtitle: String? = nil
     var error: WidgetError? = nil
     var deepLink: URL? = nil
+    var matchIconTheme: Bool = true
   }
 
   static func build(
     api: ImmichAPI,
     asset: Asset,
     dateOffset: Int,
-    subtitle: String? = nil
+    subtitle: String? = nil,
+    matchIconTheme: Bool = true
   )
     async throws -> Self
   {
@@ -34,7 +36,8 @@ struct ImageEntry: TimelineEntry {
       image: image,
       metadata: EntryMetadata(
         subtitle: subtitle,
-        deepLink: asset.deepLink
+        deepLink: asset.deepLink,
+        matchIconTheme: matchIconTheme
       )
     )
   }
@@ -111,12 +114,26 @@ struct ImageEntry: TimelineEntry {
 
 }
 
+// Required so that we can decode older versions of the metadata
+extension ImageEntry.Metadata {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
+    error = try container.decodeIfPresent(WidgetError.self, forKey: .error)
+    deepLink = try container.decodeIfPresent(URL.self, forKey: .deepLink)
+
+    matchIconTheme =
+      try container.decodeIfPresent(Bool.self, forKey: .matchIconTheme) ?? true
+  }
+}
+
 func generateRandomEntries(
   api: ImmichAPI,
   now: Date,
   count: Int,
   filter: SearchFilter = Album.NONE.filter,
-  subtitle: String? = nil
+  subtitle: String? = nil,
+  matchIconTheme: Bool = true
 )
   async throws -> [ImageEntry]
 {
@@ -132,7 +149,8 @@ func generateRandomEntries(
           api: api,
           asset: asset,
           dateOffset: dateOffset,
-          subtitle: subtitle
+          subtitle: subtitle,
+          matchIconTheme: matchIconTheme
         )
       }
     }

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -3,10 +3,10 @@ import WidgetKit
 
 extension Image {
   @ViewBuilder
-  func tintedWidgetImageModifier(matchIconTheme: Bool) -> some View {
+  func tintedWidgetImageModifier(forceFullColor: Bool) -> some View {
     if #available(iOS 18.0, *) {
       self
-        .widgetAccentedRenderingMode(matchIconTheme ? .accentedDesaturated : .fullColor)
+        .widgetAccentedRenderingMode(forceFullColor ? .accentedDesaturated : .fullColor)
     } else {
       self
     }
@@ -22,12 +22,12 @@ struct ImmichWidgetView: View {
         image: image,
         subtitle: entry.metadata.subtitle,
         deepLink: entry.metadata.deepLink,
-        matchIconTheme: entry.metadata.matchIconTheme
+        forceFullColor: entry.metadata.forceFullColor
       )
     } else {
       ImmichWidgetLoadingView(
         message: entry.metadata.error?.errorDescription,
-        matchIconTheme: entry.metadata.matchIconTheme
+        forceFullColor: entry.metadata.forceFullColor
       )
     }
   }
@@ -35,7 +35,7 @@ struct ImmichWidgetView: View {
 
 private struct ImmichWidgetLoadingView: View {
   let message: String?
-  let matchIconTheme: Bool
+  let forceFullColor: Bool
 
   var body: some View {
     let messageText = Text(message ?? "")
@@ -48,7 +48,7 @@ private struct ImmichWidgetLoadingView: View {
       messageText.hidden()
 
       Image("LaunchImage")
-        .tintedWidgetImageModifier(matchIconTheme: matchIconTheme)
+        .tintedWidgetImageModifier(forceFullColor: forceFullColor)
 
       messageText
     }
@@ -59,14 +59,14 @@ private struct ImmichWidgetContentView: View {
   let image: UIImage
   let subtitle: String?
   let deepLink: URL?
-  let matchIconTheme: Bool
+  let forceFullColor: Bool
 
   var body: some View {
     ZStack(alignment: .leading) {
       Color.clear.overlay(
         Image(uiImage: image)
           .resizable()
-          .tintedWidgetImageModifier(matchIconTheme: matchIconTheme)
+          .tintedWidgetImageModifier(forceFullColor: forceFullColor)
           .scaledToFill()
       )
 

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -3,10 +3,10 @@ import WidgetKit
 
 extension Image {
   @ViewBuilder
-  func tintedWidgetImageModifier() -> some View {
+  func tintedWidgetImageModifier(matchIconTheme: Bool) -> some View {
     if #available(iOS 18.0, *) {
       self
-        .widgetAccentedRenderingMode(.accentedDesaturated)
+        .widgetAccentedRenderingMode(matchIconTheme ? .accentedDesaturated : .fullColor)
     } else {
       self
     }
@@ -18,15 +18,24 @@ struct ImmichWidgetView: View {
 
   var body: some View {
     if let image = entry.image {
-      ImmichWidgetContentView(image: image, subtitle: entry.metadata.subtitle, deepLink: entry.metadata.deepLink)
+      ImmichWidgetContentView(
+        image: image,
+        subtitle: entry.metadata.subtitle,
+        deepLink: entry.metadata.deepLink,
+        matchIconTheme: entry.metadata.matchIconTheme
+      )
     } else {
-      ImmichWidgetLoadingView(message: entry.metadata.error?.errorDescription)
+      ImmichWidgetLoadingView(
+        message: entry.metadata.error?.errorDescription,
+        matchIconTheme: entry.metadata.matchIconTheme
+      )
     }
   }
 }
 
 private struct ImmichWidgetLoadingView: View {
   let message: String?
+  let matchIconTheme: Bool
 
   var body: some View {
     let messageText = Text(message ?? "")
@@ -39,7 +48,7 @@ private struct ImmichWidgetLoadingView: View {
       messageText.hidden()
 
       Image("LaunchImage")
-        .tintedWidgetImageModifier()
+        .tintedWidgetImageModifier(matchIconTheme: matchIconTheme)
 
       messageText
     }
@@ -50,13 +59,14 @@ private struct ImmichWidgetContentView: View {
   let image: UIImage
   let subtitle: String?
   let deepLink: URL?
+  let matchIconTheme: Bool
 
   var body: some View {
     ZStack(alignment: .leading) {
       Color.clear.overlay(
         Image(uiImage: image)
           .resizable()
-          .tintedWidgetImageModifier()
+          .tintedWidgetImageModifier(matchIconTheme: matchIconTheme)
           .scaledToFill()
       )
 

--- a/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
@@ -2,7 +2,21 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
-struct ImmichMemoryProvider: TimelineProvider {
+// MARK: Widget Configuration
+
+struct MemoryConfigurationAppIntent: WidgetConfigurationIntent {
+  static var title: LocalizedStringResource { "Memories" }
+  static var description: IntentDescription {
+    "See memories from Immich."
+  }
+
+  @Parameter(title: "Match Icon Theme", default: true)
+  var matchIconTheme: Bool
+}
+
+// MARK: Provider
+
+struct ImmichMemoryProvider: AppIntentTimelineProvider {
   func getYearDifferenceSubtitle(assetYear: Int) -> String {
     let currentYear = Calendar.current.component(.year, from: Date.now)
     // construct a "X years ago" subtitle
@@ -15,144 +29,132 @@ struct ImmichMemoryProvider: TimelineProvider {
     ImageEntry(date: Date(), image: nil)
   }
 
-  func getSnapshot(
-    in context: Context,
-    completion: @escaping @Sendable (ImageEntry) -> Void
-  ) {
+  func snapshot(
+    for configuration: MemoryConfigurationAppIntent,
+    in context: Context
+  ) async -> ImageEntry {
     let cacheKey = "memory_\(context.family.rawValue)"
 
-    Task {
-      guard let api = try? await ImmichAPI() else {
-        completion(
-          ImageEntry.handleError(for: cacheKey, error: .noLogin).entries.first!
-        )
-        return
-      }
-
-      guard let memories = try? await api.fetchMemory(for: Date.now)
-      else {
-        completion(ImageEntry.handleError(for: cacheKey).entries.first!)
-        return
-      }
-
-      for memory in memories {
-        if let asset = memory.assets.first(where: { $0.type == .image }),
-          let entry = try? await ImageEntry.build(
-            api: api,
-            asset: asset,
-            dateOffset: 0,
-            subtitle: getYearDifferenceSubtitle(assetYear: memory.data.year)
-          )
-        {
-          completion(entry)
-          return
-        }
-      }
-
-      // fallback to random image
-      guard
-        let randomImage = try? await api.fetchSearchResults().first,
-        let imageEntry = try? await ImageEntry.build(
-          api: api,
-          asset: randomImage,
-          dateOffset: 0
-        )
-      else {
-        completion(ImageEntry.handleError(for: cacheKey).entries.first!)
-        return
-      }
-
-      completion(imageEntry)
+    guard let api = try? await ImmichAPI() else {
+      return ImageEntry.handleError(for: cacheKey, error: .noLogin).entries
+        .first!
     }
+
+    guard let memories = try? await api.fetchMemory(for: Date.now) else {
+      return ImageEntry.handleError(for: cacheKey).entries.first!
+    }
+
+    for memory in memories {
+      if let asset = memory.assets.first(where: { $0.type == .image }),
+        let entry = try? await ImageEntry.build(
+          api: api,
+          asset: asset,
+          dateOffset: 0,
+          subtitle: getYearDifferenceSubtitle(assetYear: memory.data.year),
+          matchIconTheme: configuration.matchIconTheme
+        )
+      {
+        return entry
+      }
+    }
+
+    // fallback to random image
+    guard
+      let randomImage = try? await api.fetchSearchResults().first,
+      let imageEntry = try? await ImageEntry.build(
+        api: api,
+        asset: randomImage,
+        dateOffset: 0,
+        matchIconTheme: configuration.matchIconTheme
+      )
+    else {
+      return ImageEntry.handleError(for: cacheKey).entries.first!
+    }
+
+    return imageEntry
   }
 
-  func getTimeline(
-    in context: Context,
-    completion: @escaping @Sendable (Timeline<ImageEntry>) -> Void
-  ) {
-    Task {
-      var entries: [ImageEntry] = []
-      let now = Date()
+  func timeline(
+    for configuration: MemoryConfigurationAppIntent,
+    in context: Context
+  ) async 
+    -> Timeline<ImageEntry> 
+  {
+    var entries: [ImageEntry] = []
+    let now = Date()
 
-      let cacheKey = "memory_\(context.family.rawValue)"
+    let cacheKey = "memory_\(context.family.rawValue)"
 
-      guard let api = try? await ImmichAPI() else {
-        completion(
-          ImageEntry.handleError(for: cacheKey, error: .noLogin)
-        )
-        return
-      }
-
-      let memories: [MemoryResult]
-      do {
-        memories = try await api.fetchMemory(for: Date.now)
-
-        await withTaskGroup(of: ImageEntry?.self) { group in
-          var totalAssets = 0
-
-          for memory in memories {
-            for asset in memory.assets {
-              if asset.type == .image && totalAssets < 12 {
-                group.addTask {
-                  try? await ImageEntry.build(
-                    api: api,
-                    asset: asset,
-                    dateOffset: totalAssets,
-                    subtitle: getYearDifferenceSubtitle(
-                      assetYear: memory.data.year
-                    )
-                  )
-                }
-
-                totalAssets += 1
-              }
-            }
-          }
-
-          for await result in group {
-            if let entry = result {
-              entries.append(entry)
-            }
-          }
-        }
-
-      } catch {
-        completion(ImageEntry.handleError(for: cacheKey))
-        return
-      }
-
-      // If we didn't add any memory images (some failure occurred or no images in memory),
-      // default to 12 hours of random photos
-      if entries.count == 0 {
-        // this must be a do/catch since we need to
-        // distinguish between a network fail and an empty search
-        do {
-          let search = try await generateRandomEntries(
-            api: api,
-            now: now,
-            count: 12
-          )
-
-          // Load or save a cached asset for when network conditions are bad
-          if search.count == 0 {
-            completion(
-              ImageEntry.handleError(for: cacheKey, error: .noAssetsAvailable)
-            )
-            return
-          }
-
-          entries.append(contentsOf: search)
-        } catch {
-          completion(ImageEntry.handleError(for: cacheKey))
-          return
-        }
-      }
-
-      // cache the last image
-      try? entries.last!.cache(for: cacheKey)
-
-      completion(Timeline(entries: entries, policy: .atEnd))
+    guard let api = try? await ImmichAPI() else {
+      return ImageEntry.handleError(for: cacheKey, error: .noLogin)
     }
+
+    let memories: [MemoryResult]
+    do {
+      memories = try await api.fetchMemory(for: Date.now)
+
+      await withTaskGroup(of: ImageEntry?.self) { group in
+        var totalAssets = 0
+
+        for memory in memories {
+          for asset in memory.assets {
+            if asset.type == .image && totalAssets < 12 {
+              group.addTask {
+                try? await ImageEntry.build(
+                  api: api,
+                  asset: asset,
+                  dateOffset: totalAssets,
+                  subtitle: getYearDifferenceSubtitle(
+                    assetYear: memory.data.year
+                  ),
+                  matchIconTheme: configuration.matchIconTheme
+                )
+              }
+
+              totalAssets += 1
+            }
+          }
+        }
+
+        for await result in group {
+          if let entry = result {
+            entries.append(entry)
+          }
+        }
+      }
+
+    } catch {
+      return ImageEntry.handleError(for: cacheKey)
+    }
+
+    // If we didn't add any memory images (some failure occurred or no images in memory),
+    // default to 12 hours of random photos
+    if entries.count == 0 {
+      // this must be a do/catch since we need to
+      // distinguish between a network fail and an empty search
+      do {
+        let search = try await generateRandomEntries(
+          api: api,
+          now: now,
+          count: 12,
+          matchIconTheme: configuration.matchIconTheme
+        )
+
+        // Load or save a cached asset for when network conditions are bad
+        if search.count == 0 {
+          return ImageEntry.handleError(for: cacheKey, error: .noAssetsAvailable)
+        }
+
+        entries.append(contentsOf: search)
+      } catch {
+        return ImageEntry.handleError(for: cacheKey)
+      }
+    }
+
+    // cache the last image
+    try? entries.last!.cache(for: cacheKey)
+
+    return Timeline(entries: entries, policy: .atEnd)
   }
 }
 
@@ -160,8 +162,9 @@ struct ImmichMemoryWidget: Widget {
   let kind: String = "com.immich.widget.memory"
 
   var body: some WidgetConfiguration {
-    StaticConfiguration(
+    AppIntentConfiguration(
       kind: kind,
+      intent: MemoryConfigurationAppIntent.self,
       provider: ImmichMemoryProvider()
     ) { entry in
       ImmichWidgetView(entry: entry)

--- a/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
@@ -10,8 +10,8 @@ struct MemoryConfigurationAppIntent: WidgetConfigurationIntent {
     "See memories from Immich."
   }
 
-  @Parameter(title: "Match Icon Theme", default: true)
-  var matchIconTheme: Bool
+  @Parameter(title: "Always Display in Full Color", default: true)
+  var forceFullColor: Bool
 }
 
 // MARK: Provider
@@ -51,7 +51,7 @@ struct ImmichMemoryProvider: AppIntentTimelineProvider {
           asset: asset,
           dateOffset: 0,
           subtitle: getYearDifferenceSubtitle(assetYear: memory.data.year),
-          matchIconTheme: configuration.matchIconTheme
+          forceFullColor: configuration.forceFullColor
         )
       {
         return entry
@@ -65,7 +65,7 @@ struct ImmichMemoryProvider: AppIntentTimelineProvider {
         api: api,
         asset: randomImage,
         dateOffset: 0,
-        matchIconTheme: configuration.matchIconTheme
+        forceFullColor: configuration.forceFullColor
       )
     else {
       return ImageEntry.handleError(for: cacheKey).entries.first!
@@ -107,7 +107,7 @@ struct ImmichMemoryProvider: AppIntentTimelineProvider {
                   subtitle: getYearDifferenceSubtitle(
                     assetYear: memory.data.year
                   ),
-                  matchIconTheme: configuration.matchIconTheme
+                  forceFullColor: configuration.forceFullColor
                 )
               }
 
@@ -137,7 +137,7 @@ struct ImmichMemoryProvider: AppIntentTimelineProvider {
           api: api,
           now: now,
           count: 12,
-          matchIconTheme: configuration.matchIconTheme
+          forceFullColor: configuration.forceFullColor
         )
 
         // Load or save a cached asset for when network conditions are bad

--- a/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
@@ -10,7 +10,7 @@ struct MemoryConfigurationAppIntent: WidgetConfigurationIntent {
     "See memories from Immich."
   }
 
-  @Parameter(title: "Always Display in Full Color", default: true)
+  @Parameter(title: "Always Display in Full Color", default: false)
   var forceFullColor: Bool
 }
 

--- a/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
@@ -47,6 +47,9 @@ struct RandomConfigurationAppIntent: WidgetConfigurationIntent {
 
   @Parameter(title: "Show Album Name", default: false)
   var showAlbumName: Bool
+
+  @Parameter(title: "Match Icon Theme", default: true)
+  var matchIconTheme: Bool
 }
 
 // MARK: Provider
@@ -76,7 +79,8 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
       let entry = try? await ImageEntry.build(
         api: api,
         asset: randomImage,
-        dateOffset: 0
+        dateOffset: 0,
+        matchIconTheme: configuration.matchIconTheme
       )
     else {
       return ImageEntry.handleError(for: cacheKey).entries.first!
@@ -114,7 +118,8 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
         now: now,
         count: 12,
         filter: album.filter,
-        subtitle: configuration.showAlbumName ? albumName : nil
+        subtitle: configuration.showAlbumName ? albumName : nil,
+        matchIconTheme: configuration.matchIconTheme
       )
 
       // Load or save a cached asset for when network conditions are bad

--- a/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
@@ -48,8 +48,8 @@ struct RandomConfigurationAppIntent: WidgetConfigurationIntent {
   @Parameter(title: "Show Album Name", default: false)
   var showAlbumName: Bool
 
-  @Parameter(title: "Match Icon Theme", default: true)
-  var matchIconTheme: Bool
+  @Parameter(title: "Always Display in Full Color", default: true)
+  var forceFullColor: Bool
 }
 
 // MARK: Provider
@@ -80,7 +80,7 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
         api: api,
         asset: randomImage,
         dateOffset: 0,
-        matchIconTheme: configuration.matchIconTheme
+        forceFullColor: configuration.forceFullColor
       )
     else {
       return ImageEntry.handleError(for: cacheKey).entries.first!
@@ -119,7 +119,7 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
         count: 12,
         filter: album.filter,
         subtitle: configuration.showAlbumName ? albumName : nil,
-        matchIconTheme: configuration.matchIconTheme
+        forceFullColor: configuration.forceFullColor
       )
 
       // Load or save a cached asset for when network conditions are bad

--- a/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
@@ -48,7 +48,7 @@ struct RandomConfigurationAppIntent: WidgetConfigurationIntent {
   @Parameter(title: "Show Album Name", default: false)
   var showAlbumName: Bool
 
-  @Parameter(title: "Always Display in Full Color", default: true)
+  @Parameter(title: "Always Display in Full Color", default: false)
   var forceFullColor: Bool
 }
 


### PR DESCRIPTION
## Description

Closes #25002


<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e4be351c-bb03-4ac0-a6bb-324abfc864f1" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c79e16f3-6c68-406e-a4d0-3779342fafff" />


Confirmed that old memory and random widgets migrate successfully and default to the tinted theme set in <=3.1.0