### PR TITLE
feat(server): automatically stack RAW and JPEG pairs

### DIFF
--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -1,17 +1,24 @@
 import { Injectable } from '@nestjs/common';
-import { ExpressionBuilder, Insertable, Kysely, Updateable } from 'kysely';
+import { ExpressionBuilder, Insertable, Kysely, sql, Updateable } from 'kysely';
 import { jsonArrayFrom } from 'kysely/helpers/postgres';
 import { InjectKysely } from 'nestjs-kysely';
+import { dirname, parse } from 'node:path';
 import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
+import { AssetStatus, AssetType } from 'src/enum';
 import { DB } from 'src/schema';
 import { StackTable } from 'src/schema/tables/stack.table';
 import { asUuid, withDefaultVisibility } from 'src/utils/database';
+import { mimeTypes } from 'src/utils/mime-types';
 
 export interface StackSearch {
   ownerId: string;
   primaryAssetId?: string;
 }
+
+const jpegExtensions = new Set(['.jpe', '.jpeg', '.jpg']);
+const isJpeg = (filename: string) => jpegExtensions.has(parse(filename).ext.toLowerCase());
+const getBasename = (filename: string) => parse(filename).name.toLowerCase();
 
 const withAssets = (eb: ExpressionBuilder<DB, 'stack'>, withTags = false) => {
   return jsonArrayFrom(
@@ -48,6 +55,122 @@ const withAssets = (eb: ExpressionBuilder<DB, 'stack'>, withTags = false) => {
 @Injectable()
 export class StackRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  private getRawPairAsset(db: Kysely<DB>, id: string) {
+    return db
+      .selectFrom('asset')
+      .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select([
+        'asset.id',
+        'asset.ownerId',
+        'asset.type',
+        'asset.originalPath',
+        'asset.originalFileName',
+        'asset.fileCreatedAt',
+        'asset.libraryId',
+        'asset.visibility',
+        'asset.stackId',
+        'asset.isEdited',
+        'asset_exif.make',
+        'asset_exif.model',
+      ])
+      .where('asset.id', '=', id)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.status', '=', AssetStatus.Active)
+      .executeTakeFirst();
+  }
+
+  /**
+   * Creates a stack for an unambiguous RAW+JPEG pair. Existing stacks are left
+   * alone so automatic pairing never changes a user's manual organization.
+   */
+  async autoStackRawPair(assetId: string): Promise<string | undefined> {
+    const initial = await this.getRawPairAsset(this.db, assetId);
+    if (
+      !initial ||
+      initial.type !== AssetType.Image ||
+      initial.isEdited ||
+      initial.stackId ||
+      (!mimeTypes.isRaw(initial.originalFileName) && !isJpeg(initial.originalFileName))
+    ) {
+      return;
+    }
+
+    const basename = getBasename(initial.originalFileName);
+    const directory = initial.libraryId ? dirname(initial.originalPath).toLowerCase() : '';
+    const lockKey = [
+      initial.ownerId,
+      initial.libraryId ?? '',
+      directory,
+      basename,
+      initial.fileCreatedAt.toISOString(),
+    ].join(':');
+
+    return this.db.transaction().execute(async (tx) => {
+      await sql`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`.execute(tx);
+
+      const current = await this.getRawPairAsset(tx, assetId);
+
+      if (!current || current.stackId || current.isEdited) {
+        return;
+      }
+
+      const currentIsRaw = mimeTypes.isRaw(current.originalFileName);
+      const candidates = await tx
+        .selectFrom('asset')
+        .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+        .select(['asset.id', 'asset.originalPath', 'asset.originalFileName', 'asset_exif.make', 'asset_exif.model'])
+        .where('asset.id', '!=', current.id)
+        .where('asset.ownerId', '=', current.ownerId)
+        .where('asset.type', '=', AssetType.Image)
+        .where('asset.fileCreatedAt', '=', current.fileCreatedAt)
+        .where('asset.visibility', '=', current.visibility)
+        .where('asset.stackId', 'is', null)
+        .where('asset.isEdited', '=', false)
+        .where('asset.deletedAt', 'is', null)
+        .where('asset.status', '=', AssetStatus.Active)
+        .$if(current.libraryId === null, (qb) => qb.where('asset.libraryId', 'is', null))
+        .$if(current.libraryId !== null, (qb) => qb.where('asset.libraryId', '=', current.libraryId!))
+        .execute();
+
+      const matches = candidates.filter((candidate) => {
+        const isComplement = currentIsRaw
+          ? isJpeg(candidate.originalFileName)
+          : mimeTypes.isRaw(candidate.originalFileName);
+        const isSameDirectory =
+          current.libraryId === null ||
+          dirname(current.originalPath).toLowerCase() === dirname(candidate.originalPath).toLowerCase();
+
+        return (
+          isComplement &&
+          isSameDirectory &&
+          getBasename(candidate.originalFileName) === getBasename(current.originalFileName) &&
+          candidate.make === current.make &&
+          candidate.model === current.model
+        );
+      });
+
+      if (matches.length !== 1) {
+        return;
+      }
+
+      const match = matches[0];
+      const primaryAssetId = currentIsRaw ? match.id : current.id;
+      const { id } = await tx
+        .insertInto('stack')
+        .values({ ownerId: current.ownerId, primaryAssetId })
+        .returning('id')
+        .executeTakeFirstOrThrow();
+
+      await tx
+        .updateTable('asset')
+        .set({ stackId: id, updatedAt: new Date() })
+        .where('id', 'in', [current.id, match.id])
+        .execute();
+
+      return id;
+    });
+  }
 
   @GenerateSql({ params: [{ ownerId: DummyValue.UUID }] })
   search(query: StackSearch) {

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ExpressionBuilder, Insertable, Kysely, sql, Updateable } from 'kysely';
+import { ExpressionBuilder, Insertable, Kysely, Updateable } from 'kysely';
 import { jsonArrayFrom } from 'kysely/helpers/postgres';
 import { InjectKysely } from 'nestjs-kysely';
 import { dirname, parse } from 'node:path';
@@ -71,8 +71,6 @@ export class StackRepository {
         'asset.visibility',
         'asset.stackId',
         'asset.isEdited',
-        'asset_exif.make',
-        'asset_exif.model',
       ])
       .where('asset.id', '=', id)
       .where('asset.deletedAt', 'is', null)
@@ -96,52 +94,41 @@ export class StackRepository {
       return;
     }
 
-    const basename = getBasename(initial.originalFileName);
-    const directory = initial.libraryId ? dirname(initial.originalPath).toLowerCase() : '';
-    const lockKey = [
-      initial.ownerId,
-      initial.libraryId ?? '',
-      directory,
-      basename,
-      initial.fileCreatedAt.toISOString(),
-    ].join(':');
-
     return this.db.transaction().execute(async (tx) => {
-      await sql`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`.execute(tx);
-
-      const current = await this.getRawPairAsset(tx, assetId);
-
-      if (!current || current.stackId || current.isEdited) {
-        return;
-      }
-
-      const currentIsRaw = mimeTypes.isRaw(current.originalFileName);
-      const candidates = await tx
+      const assets = await tx
         .selectFrom('asset')
         .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
         .select(['asset.id', 'asset.originalPath', 'asset.originalFileName', 'asset_exif.make', 'asset_exif.model'])
-        .where('asset.id', '!=', current.id)
-        .where('asset.ownerId', '=', current.ownerId)
+        .where('asset.ownerId', '=', initial.ownerId)
         .where('asset.type', '=', AssetType.Image)
-        .where('asset.fileCreatedAt', '=', current.fileCreatedAt)
-        .where('asset.visibility', '=', current.visibility)
+        .where('asset.fileCreatedAt', '=', initial.fileCreatedAt)
+        .where('asset.visibility', '=', initial.visibility)
         .where('asset.stackId', 'is', null)
         .where('asset.isEdited', '=', false)
         .where('asset.deletedAt', 'is', null)
         .where('asset.status', '=', AssetStatus.Active)
-        .$if(current.libraryId === null, (qb) => qb.where('asset.libraryId', 'is', null))
-        .$if(current.libraryId !== null, (qb) => qb.where('asset.libraryId', '=', current.libraryId!))
+        .$if(initial.libraryId === null, (qb) => qb.where('asset.libraryId', 'is', null))
+        .$if(initial.libraryId !== null, (qb) => qb.where('asset.libraryId', '=', initial.libraryId!))
+        .orderBy('asset.id')
+        .forUpdate('asset')
         .execute();
 
-      const matches = candidates.filter((candidate) => {
+      const current = assets.find(({ id }) => id === assetId);
+      if (!current) {
+        return;
+      }
+
+      const currentIsRaw = mimeTypes.isRaw(current.originalFileName);
+      const matches = assets.filter((candidate) => {
         const isComplement = currentIsRaw
           ? isJpeg(candidate.originalFileName)
           : mimeTypes.isRaw(candidate.originalFileName);
         const isSameDirectory =
-          current.libraryId === null ||
+          initial.libraryId === null ||
           dirname(current.originalPath).toLowerCase() === dirname(candidate.originalPath).toLowerCase();
 
         return (
+          candidate.id !== current.id &&
           isComplement &&
           isSameDirectory &&
           getBasename(candidate.originalFileName) === getBasename(current.originalFileName) &&
@@ -158,7 +145,7 @@ export class StackRepository {
       const primaryAssetId = currentIsRaw ? match.id : current.id;
       const { id } = await tx
         .insertInto('stack')
-        .values({ ownerId: current.ownerId, primaryAssetId })
+        .values({ ownerId: initial.ownerId, primaryAssetId })
         .returning('id')
         .executeTakeFirstOrThrow();
 

--- a/server/src/services/stack.service.spec.ts
+++ b/server/src/services/stack.service.spec.ts
@@ -20,6 +20,31 @@ describe(StackService.name, () => {
     expect(sut).toBeDefined();
   });
 
+  describe('onAssetMetadataExtracted', () => {
+    it('should emit an event when a RAW+JPEG stack is created', async () => {
+      const assetId = newUuid();
+      const userId = newUuid();
+      const stackId = newUuid();
+      mocks.stack.autoStackRawPair.mockResolvedValue(stackId);
+
+      await sut.onAssetMetadataExtracted({ assetId, userId });
+
+      expect(mocks.stack.autoStackRawPair).toHaveBeenCalledWith(assetId);
+      expect(mocks.event.emit).toHaveBeenCalledWith('StackCreate', { stackId, userId });
+    });
+
+    it('should not emit an event when an asset has no RAW+JPEG pair', async () => {
+      const assetId = newUuid();
+      const userId = newUuid();
+      mocks.stack.autoStackRawPair.mockResolvedValue(undefined);
+
+      await sut.onAssetMetadataExtracted({ assetId, userId });
+
+      expect(mocks.stack.autoStackRawPair).toHaveBeenCalledWith(assetId);
+      expect(mocks.event.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('search', () => {
     it('should search stacks', async () => {
       const auth = AuthFactory.create();

--- a/server/src/services/stack.service.ts
+++ b/server/src/services/stack.service.ts
@@ -1,13 +1,23 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { OnEvent } from 'src/decorators';
 import { BulkIdsDto } from 'src/dtos/asset-ids.response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { StackCreateDto, StackResponseDto, StackSearchDto, StackUpdateDto, mapStack } from 'src/dtos/stack.dto';
 import { Permission } from 'src/enum';
+import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { UUIDAssetIDParamDto } from 'src/validation';
 
 @Injectable()
 export class StackService extends BaseService {
+  @OnEvent({ name: 'AssetMetadataExtracted' })
+  async onAssetMetadataExtracted({ assetId, userId }: ArgOf<'AssetMetadataExtracted'>) {
+    const stackId = await this.stackRepository.autoStackRawPair(assetId);
+    if (stackId) {
+      await this.eventRepository.emit('StackCreate', { stackId, userId });
+    }
+  }
+
   async search(auth: AuthDto, dto: StackSearchDto): Promise<StackResponseDto[]> {
     const stacks = await this.stackRepository.search({
       ownerId: auth.user.id,

--- a/server/test/medium/specs/repositories/stack.repository.spec.ts
+++ b/server/test/medium/specs/repositories/stack.repository.spec.ts
@@ -1,0 +1,239 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(StackRepository) };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(StackRepository.name, () => {
+  describe('autoStackRawPair', () => {
+    it.each(['RAF', 'RAW', 'CR3'])('should stack a .%s file under its matching JPEG', async (extension) => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const capturedAt = new Date('2026-07-18T22:26:06.000Z');
+      const [{ asset: jpeg }, { asset: raw }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_1234.JPG',
+          originalPath: '/upload/one.jpg',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: `IMG_1234.${extension}`,
+          originalPath: '/upload/two.raw',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: jpeg.id, make: 'FUJIFILM', model: 'X-T5' }),
+        ctx.newExif({ assetId: raw.id, make: 'FUJIFILM', model: 'X-T5' }),
+      ]);
+
+      const stackId = await sut.autoStackRawPair(raw.id);
+
+      expect(stackId).toBeDefined();
+      await expect(
+        ctx.database.selectFrom('stack').selectAll().where('id', '=', stackId!).executeTakeFirstOrThrow(),
+      ).resolves.toEqual(expect.objectContaining({ id: stackId, ownerId: user.id, primaryAssetId: jpeg.id }));
+      await expect(
+        ctx.database
+          .selectFrom('asset')
+          .select(['id', 'stackId'])
+          .where('id', 'in', [jpeg.id, raw.id])
+          .orderBy('id')
+          .execute(),
+      ).resolves.toEqual([
+        { id: [jpeg.id, raw.id].sort()[0], stackId },
+        { id: [jpeg.id, raw.id].sort()[1], stackId },
+      ]);
+    });
+
+    it('should create only one stack when both metadata events run concurrently', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const capturedAt = new Date('2026-07-18T22:26:06.000Z');
+      const [{ asset: jpeg }, { asset: raw }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'DSCF0001.jpeg',
+          originalPath: '/upload/one.jpg',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'DSCF0001.raf',
+          originalPath: '/upload/two.raf',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: jpeg.id, make: 'FUJIFILM', model: 'X-T5' }),
+        ctx.newExif({ assetId: raw.id, make: 'FUJIFILM', model: 'X-T5' }),
+      ]);
+
+      const results = await Promise.all([sut.autoStackRawPair(jpeg.id), sut.autoStackRawPair(raw.id)]);
+      const stackIds = results.filter((id) => id !== undefined);
+
+      expect(stackIds).toHaveLength(1);
+      await expect(
+        ctx.database.selectFrom('stack').select('id').where('ownerId', '=', user.id).execute(),
+      ).resolves.toEqual([{ id: stackIds[0] }]);
+    });
+
+    it('should leave existing manual stacks unchanged', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const capturedAt = new Date('2026-07-18T22:26:06.000Z');
+      const [{ asset: jpeg }, { asset: raw }, { asset: other }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_1234.JPG',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_1234.RAF',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+        ctx.newAsset({ ownerId: user.id, originalFileName: 'other.jpg' }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: jpeg.id, make: 'FUJIFILM', model: 'X-T5' }),
+        ctx.newExif({ assetId: raw.id, make: 'FUJIFILM', model: 'X-T5' }),
+      ]);
+      const { result: manualStack } = await ctx.newStack({ ownerId: user.id }, [jpeg.id, other.id]);
+
+      await expect(sut.autoStackRawPair(raw.id)).resolves.toBeUndefined();
+      await expect(
+        ctx.database.selectFrom('stack').select('id').where('ownerId', '=', user.id).execute(),
+      ).resolves.toEqual([{ id: manualStack.id }]);
+    });
+
+    it.each([
+      {
+        name: 'different basenames',
+        jpeg: { originalFileName: 'IMG_1235.JPG' },
+        raw: {},
+        jpegExif: {},
+        rawExif: {},
+      },
+      {
+        name: 'different capture times',
+        jpeg: { fileCreatedAt: new Date('2026-07-18T22:26:07.000Z') },
+        raw: {},
+        jpegExif: {},
+        rawExif: {},
+      },
+      {
+        name: 'different camera models',
+        jpeg: {},
+        raw: {},
+        jpegExif: { model: 'X-T4' },
+        rawExif: {},
+      },
+      {
+        name: 'different visibility',
+        jpeg: { visibility: AssetVisibility.Archive },
+        raw: {},
+        jpegExif: {},
+        rawExif: {},
+      },
+    ])('should not stack assets with $name', async ({ jpeg, raw, jpegExif, rawExif }) => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const capturedAt = new Date('2026-07-18T22:26:06.000Z');
+      const [{ asset: jpegAsset }, { asset: rawAsset }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_1234.JPG',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+          ...jpeg,
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_1234.RAF',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+          ...raw,
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: jpegAsset.id, make: 'FUJIFILM', model: 'X-T5', ...jpegExif }),
+        ctx.newExif({ assetId: rawAsset.id, make: 'FUJIFILM', model: 'X-T5', ...rawExif }),
+      ]);
+
+      await expect(sut.autoStackRawPair(rawAsset.id)).resolves.toBeUndefined();
+      await expect(
+        ctx.database.selectFrom('stack').select('id').where('ownerId', '=', user.id).execute(),
+      ).resolves.toEqual([]);
+    });
+
+    it('should not stack external-library assets from different directories', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const library = await ctx.database
+        .insertInto('library')
+        .values({
+          ownerId: user.id,
+          name: 'Photos',
+          importPaths: ['/photos'],
+          exclusionPatterns: [],
+        })
+        .returning('id')
+        .executeTakeFirstOrThrow();
+      const capturedAt = new Date('2026-07-18T22:26:06.000Z');
+      const [{ asset: jpeg }, { asset: raw }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          libraryId: library.id,
+          originalFileName: 'IMG_1234.JPG',
+          originalPath: '/photos/jpeg/IMG_1234.JPG',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          libraryId: library.id,
+          originalFileName: 'IMG_1234.RAF',
+          originalPath: '/photos/raw/IMG_1234.RAF',
+          fileCreatedAt: capturedAt,
+          localDateTime: capturedAt,
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: jpeg.id, make: 'FUJIFILM', model: 'X-T5' }),
+        ctx.newExif({ assetId: raw.id, make: 'FUJIFILM', model: 'X-T5' }),
+      ]);
+
+      await expect(sut.autoStackRawPair(raw.id)).resolves.toBeUndefined();
+      await expect(
+        ctx.database.selectFrom('stack').select('id').where('ownerId', '=', user.id).execute(),
+      ).resolves.toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
# LLM EXPLORATION 

Sorry I didn't mean to publish this PR just now, it's an exploration by an LLM I still want to test it out locally and read / understand the code before submitting it properly. 



## Summary

Automatically stack an unambiguous RAW + JPEG pair after metadata extraction. The JPEG is selected as the stack primary, so the pair appears once in the main timeline while both original files remain available.

## Matching rules

- Same owner, visibility, capture timestamp, basename, and camera make/model
- RAW formats supported by Immich, paired with JPEG/JPG
- External-library pairs must be in the same directory
- Existing/manual stacks are untouched
- Concurrent metadata events create at most one stack

## Important behavior

The RAW remains a normal asset and can still be downloaded/opened. Immich may retain its normal hidden thumbnail/preview derivatives for that asset; this PR does not create a second user-visible JPEG asset or replace the RAW original.

The existing stack badge remains generic. A format-specific `RAF+JPEG`/`CR3+JPEG` indicator would be a separate UI/API enhancement.

## Validation

- Focused StackService and PostgreSQL-backed repository tests
- Full server unit suite: 2,255 passed, 2 skipped
- Formatting, ESLint, TypeScript, and code checks
- Live isolated-dev upload of a genuine Canon CR2 + JPEG
- Timeline API returned one visible JPEG plus stack count 2
- Both originals downloaded with identical SHA-256 hashes
