### PR TITLE
fix: prevent logo from being draggable in navigation bar

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/NavigationBar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/NavigationBar.svelte
@@ -76,7 +76,12 @@
         }}
         class="sidebar:hidden"
       />
-      <a data-sveltekit-preload-data="hover" href={Route.photos()}>
+      <a
+        data-sveltekit-preload-data="hover"
+        href={Route.photos()}
+        draggable="false"
+        ondragstart={(event) => event.preventDefault()}
+      >
         <Logo variant={mediaQueryManager.isFullSidebar ? 'inline' : 'icon'} class="max-md:h-12" />
       </a>
     </div>

--- a/web/src/lib/components/shared-components/navigation-bar/NavigationBar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/NavigationBar.svelte
@@ -45,6 +45,10 @@
   });
 
   const { Cast } = $derived(getGlobalActions($t));
+
+  const preventLogoDrag = (node: HTMLElement) => {
+    node.querySelector('img')?.setAttribute('draggable', 'false');
+  };
 </script>
 
 <svelte:window bind:innerWidth />
@@ -80,7 +84,8 @@
         data-sveltekit-preload-data="hover"
         href={Route.photos()}
         draggable="false"
-        ondragstart={(event) => event.preventDefault()}
+        class="logo-link"
+        use:preventLogoDrag
       >
         <Logo variant={mediaQueryManager.isFullSidebar ? 'inline' : 'icon'} class="max-md:h-12" />
       </a>
@@ -190,3 +195,13 @@
     </div>
   </div>
 </nav>
+
+<style>
+  .logo-link,
+  .logo-link :global(img) {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+</style>


### PR DESCRIPTION
## Description

Prevents the navbar logo from being draggable by cancelling the browser's native `dragstart` event.


Fixes # (#30289)

## How Has This Been Tested?

- [x] Manually dragged the logo in the browser and confirmed no drag, and the logo still navigates to `/photos` on click.


## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Used Claude to check if there were any other best approaches.
...
