### PR TITLE
fix(web): Fix face thumbnail when swapping merge direction

### DIFF
--- a/web/src/lib/modals/PersonMergeSuggestionModal.svelte
+++ b/web/src/lib/modals/PersonMergeSuggestionModal.svelte
@@ -63,13 +63,16 @@
   <div class="flex items-center justify-center gap-2 py-4 md:h-36">
     {#if !choosePersonToMerge}
       <div class="flex size-20 items-center px-1 md:size-24 md:px-2">
-        <ImageThumbnail
-          circle
-          shadow
-          url={getPeopleThumbnailUrl(personToMerge)}
-          altText={personToMerge.name}
-          widthStyle="100%"
-        />
+        <!-- Trigger a re-render on person change as <Image> captures only the first src -->
+        {#key personToMerge.id}
+          <ImageThumbnail
+            circle
+            shadow
+            url={getPeopleThumbnailUrl(personToMerge)}
+            altText={personToMerge.name}
+            widthStyle="100%"
+          />
+        {/key}
       </div>
 
       <div class="grid grid-rows-3">
@@ -101,14 +104,16 @@
           }
         }}
       >
-        <ImageThumbnail
-          border={potentialMergePeople.length > 0}
-          circle
-          shadow
-          url={getPeopleThumbnailUrl(personToBeMergedInto)}
-          altText={personToBeMergedInto.name}
-          widthStyle="100%"
-        />
+        {#key personToBeMergedInto.id}
+          <ImageThumbnail
+            border={potentialMergePeople.length > 0}
+            circle
+            shadow
+            url={getPeopleThumbnailUrl(personToBeMergedInto)}
+            altText={personToBeMergedInto.name}
+            widthStyle="100%"
+          />
+        {/key}
       </button>
     {:else}
       <div class="grid w-full grid-cols-1 gap-2">

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/FaceThumbnail.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/FaceThumbnail.svelte
@@ -40,7 +40,10 @@
     class:dark:border-immich-dark-primary={border}
     class:border-immich-primary={border}
   >
-    <ImageThumbnail {circle} url={getPeopleThumbnailUrl(person)} altText={person.name} widthStyle="100%" shadow />
+    <!-- Trigger a re-render on person change as <Image> captures only the first src -->
+    {#key person.id}
+      <ImageThumbnail {circle} url={getPeopleThumbnailUrl(person)} altText={person.name} widthStyle="100%" shadow />
+    {/key}
   </div>
 
   <div


### PR DESCRIPTION
## Description

Fixes #27381 by forcing a remount of the `ImageThumbnail` component when the `person` prop changes within `FaceThumbnail`. This PR also fixes the same issue on the suggested merge modal (when naming a face the same name as an existing face).

For more context, the `MergeFaceSelector` component contains `FaceThumbnail`, which contains `ImageThumbnail`, which contains `Image`. The change in this PR is needed because `Image` locks onto the first provided `src` prop as shown here:

```svelte
  let { src, onStart, onLoad, onError, ref = $bindable(), ...rest }: Props = $props();

  let capturedSource: string | undefined = $state();

  $effect(() => {
    if (src === undefined || capturedSource !== undefined) {
      return;
    }

    capturedSource = src;
    untrack(() => {
      onStart?.();
    });
  });
```

This means that when the `person` prop changes in `MergeFaceSelector` (due to the user pressing the swap merge direction button), the image source is not changed.

I am unsure if it would be smarter to push this remount check (using `#key`) one component down into `ImageThumbnail`, using `url` as the key. My current implementation fixes the issue with the least changes to non-person thumbnails, however it requires the same fix to be duplicated to fix multiple different face thumbnails.

## How Has This Been Tested?

Tested in a development environment using `mise dev`, the swap button now switches the profile images as expected. When I run `mise //web:checklist`, I get 20 failed tests out of 498, but they all fail on `origin/main` for me as well, and all tests look unrelated to my change.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used to write any code in this PR, nor was it used to write this PR message.
