### PR TITLE
fix(mobile): run one more sync round when a request arrives mid sync

### DIFF
--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -135,9 +135,9 @@ class BackgroundSyncManager {
         });
   }
 
-  Future<bool> syncRemote({bool fresh = false}) {
+  Future<bool> syncRemote({bool enqueue = false}) {
     if (_syncTask != null) {
-      _syncQueued |= fresh;
+      _syncQueued |= enqueue;
       return _syncTask!.future.then((result) => result ?? false).catchError((_) => false);
     }
 
@@ -157,12 +157,15 @@ class BackgroundSyncManager {
           onRemoteSyncError?.call(error.toString());
           return false;
         })
-        .whenComplete(() {
+        .then((success) {
           _syncTask = null;
           if (_syncQueued) {
             _syncQueued = false;
-            unawaited(syncRemote());
+            if (success) {
+              unawaited(syncRemote());
+            }
           }
+          return success;
         });
   }
 

--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -28,6 +28,7 @@ class BackgroundSyncManager {
   final SyncErrorCallback? onCloudIdSyncError;
 
   Cancelable<bool?>? _syncTask;
+  bool _syncQueued = false;
   Cancelable<void>? _syncWebsocketTask;
   Cancelable<void>? _cloudIdSyncTask;
   Cancelable<void>? _deviceAlbumSyncTask;
@@ -50,6 +51,7 @@ class BackgroundSyncManager {
   });
 
   Future<void> cancel() async {
+    _syncQueued = false;
     final tasks = [
       _syncTask,
       _syncWebsocketTask,
@@ -135,6 +137,7 @@ class BackgroundSyncManager {
 
   Future<bool> syncRemote() {
     if (_syncTask != null) {
+      _syncQueued = true;
       return _syncTask!.future.then((result) => result ?? false).catchError((_) => false);
     }
 
@@ -152,11 +155,14 @@ class BackgroundSyncManager {
         })
         .catchError((error) {
           onRemoteSyncError?.call(error.toString());
-          _syncTask = null;
           return false;
         })
         .whenComplete(() {
           _syncTask = null;
+          if (_syncQueued) {
+            _syncQueued = false;
+            unawaited(syncRemote());
+          }
         });
   }
 

--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -151,21 +151,22 @@ class BackgroundSyncManager {
         .then((result) {
           final success = result ?? false;
           onRemoteSyncComplete?.call(success);
+          if (!success) {
+            _syncQueued = false;
+          }
           return success;
         })
         .catchError((error) {
           onRemoteSyncError?.call(error.toString());
+          _syncQueued = false;
           return false;
         })
-        .then((success) {
+        .whenComplete(() {
           _syncTask = null;
           if (_syncQueued) {
             _syncQueued = false;
-            if (success) {
-              unawaited(syncRemote());
-            }
+            unawaited(syncRemote());
           }
-          return success;
         });
   }
 

--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -151,9 +151,7 @@ class BackgroundSyncManager {
         .then((result) {
           final success = result ?? false;
           onRemoteSyncComplete?.call(success);
-          if (!success) {
-            _syncQueued = false;
-          }
+          _syncQueued &= success;
           return success;
         })
         .catchError((error) {

--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -135,9 +135,9 @@ class BackgroundSyncManager {
         });
   }
 
-  Future<bool> syncRemote() {
+  Future<bool> syncRemote({bool fresh = false}) {
     if (_syncTask != null) {
-      _syncQueued = true;
+      _syncQueued |= fresh;
       return _syncTask!.future.then((result) => result ?? false).catchError((_) => false);
     }
 

--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -187,7 +187,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
   }
 
   void _handleRemoteChange(dynamic _) {
-    unawaited(_ref.read(backgroundSyncProvider).syncRemote());
+    unawaited(_ref.read(backgroundSyncProvider).syncRemote(fresh: true));
   }
 
   void _handleSyncAssetEditReadyV2(dynamic data) {

--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -187,7 +187,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
   }
 
   void _handleRemoteChange(dynamic _) {
-    unawaited(_ref.read(backgroundSyncProvider).syncRemote(fresh: true));
+    unawaited(_ref.read(backgroundSyncProvider).syncRemote(enqueue: true));
   }
 
   void _handleSyncAssetEditReadyV2(dynamic data) {


### PR DESCRIPTION
if a sync is already running and something asks for another one, the request just gets dropped, so whatever changed doesnt come down until the next trigger. this adds a small flag, if a request lands mid sync we run one more round after the current one finishes, however many came in. cleared on logout so nothing fires after sign out. tested on an emulator, fired an event into a running sync and got exactly one follow up round after it finished, and nothing after logging out. part of our photo edit series, split out of #28543.