### PR TITLE
fix(mobile): sync stack changes from the websocket

### DIFF
--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -103,7 +103,8 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
         socket.on('AssetUploadReadyV2', _handleSyncAssetUploadReadyV2);
         socket.on('AssetEditReadyV1', _handleSyncAssetEditReadyV1);
         socket.on('AssetEditReadyV2', _handleSyncAssetEditReadyV2);
-        socket.on('on_album_update', _handleAlbumUpdate);
+        socket.on('on_album_update', _handleRemoteChange);
+        socket.on('on_asset_stack_update', _handleRemoteChange);
         socket.on('on_config_update', _handleOnConfigUpdate);
         socket.on('on_new_release', _handleReleaseUpdates);
       } catch (e) {
@@ -185,7 +186,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
     unawaited(_ref.read(backgroundSyncProvider).syncWebsocketEditV1(data));
   }
 
-  void _handleAlbumUpdate(dynamic _) {
+  void _handleRemoteChange(dynamic _) {
     unawaited(_ref.read(backgroundSyncProvider).syncRemote());
   }
 


### PR DESCRIPTION
the server tells us over the socket when a stack changes but the app never listened, so stacking from web didnt show on the phone until you restarted. the data was fine, sync already handles stacks, it just wasnt live. this subscribes to that event and runs the same resync we already do for album updates. tested on the ios simulator with the app open, stacked from web and it showed up in about two seconds, before that it needed a restart. goes after the sync queue pr, part of our photo edit series, split out of #28543.