### PR TITLE
fix: action provider overrides

### DIFF
--- a/mobile/lib/presentation/actions/action.dart
+++ b/mobile/lib/presentation/actions/action.dart
@@ -33,6 +33,7 @@ final assetsActionProvider = Provider.family.autoDispose<AssetFilter<BaseAsset>,
       null => const <BaseAsset>{},
     },
   }),
+  dependencies: [multiSelectProvider],
 );
 
 final clearSelectionProvider = Provider.family.autoDispose<VoidCallback, ActionSource>((ref, source) {
@@ -41,10 +42,11 @@ final clearSelectionProvider = Provider.family.autoDispose<VoidCallback, ActionS
   }
 
   return () {};
-});
+}, dependencies: [multiSelectProvider]);
 
 final ownedAssetsActionProvider = Provider.family.autoDispose<AssetFilter<RemoteAsset>, ActionSource>(
   (ref, source) => ref.watch(assetsActionProvider(source)).owned(ref.watch(authUserProvider).id),
+  dependencies: [assetsActionProvider],
 );
 
 abstract class AssetActionBuilder extends ActionBuilder {

--- a/mobile/lib/presentation/actions/archive.action.dart
+++ b/mobile/lib/presentation/actions/archive.action.dart
@@ -22,7 +22,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
       .map((asset) => asset.id)
       .toList(growable: false);
   return assetIds.isEmpty ? null : (shouldArchive: shouldArchive, assetIds: assetIds);
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class ArchiveAction extends AssetActionBuilder {
   const ArchiveAction({required super.source});

--- a/mobile/lib/presentation/actions/delete.action.dart
+++ b/mobile/lib/presentation/actions/delete.action.dart
@@ -40,7 +40,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
   final trash = trashEnabled && !ownedRemote.every((asset) => asset.isTrashed || asset.isLocked);
 
   return (localIds: localIds, remoteIds: ownedRemote.map((asset) => asset.id).toList(growable: false), trash: trash);
-});
+}, dependencies: [assetsActionProvider]);
 
 class DeleteAction extends AssetActionBuilder {
   const DeleteAction({required super.source});
@@ -149,7 +149,7 @@ final _cleanupStateProvider = Provider.family.autoDispose<List<String>?, ActionS
   final assets = ref.watch(assetsActionProvider(source));
   final assetIds = assets.backedUp().map((asset) => asset.localId).nonNulls.toList(growable: false);
   return assetIds.isEmpty ? null : assetIds;
-});
+}, dependencies: [assetsActionProvider]);
 
 class CleanupLocalAction extends AssetActionBuilder {
   const CleanupLocalAction({required super.source});

--- a/mobile/lib/presentation/actions/download.action.dart
+++ b/mobile/lib/presentation/actions/download.action.dart
@@ -14,7 +14,7 @@ final _stateProvider = Provider.family.autoDispose<List<RemoteAsset>?, ActionSou
   final assets = ref.watch(assetsActionProvider(source));
   final remote = assets.remote().toList(growable: false);
   return remote.isEmpty ? null : remote;
-});
+}, dependencies: [assetsActionProvider]);
 
 class DownloadAction extends AssetActionBuilder {
   const DownloadAction({required super.source});

--- a/mobile/lib/presentation/actions/edit_asset.action.dart
+++ b/mobile/lib/presentation/actions/edit_asset.action.dart
@@ -28,7 +28,7 @@ final _stateProvider = Provider.family.autoDispose<RemoteAsset?, ActionSource>((
 
   final assets = ref.watch(ownedAssetsActionProvider(source));
   return assets.where((asset) => asset.isEditable).singleOrNull;
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class EditAssetAction extends AssetActionBuilder {
   const EditAssetAction({required super.source});

--- a/mobile/lib/presentation/actions/edit_datetime.action.dart
+++ b/mobile/lib/presentation/actions/edit_datetime.action.dart
@@ -21,7 +21,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
   }
 
   return (assetIds: assets.map((asset) => asset.id).toList(growable: false), origin: assets.singleOrNull);
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class EditDateTimeAction extends AssetActionBuilder {
   const EditDateTimeAction({required super.source});

--- a/mobile/lib/presentation/actions/edit_location.action.dart
+++ b/mobile/lib/presentation/actions/edit_location.action.dart
@@ -21,7 +21,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
   }
 
   return (assetIds: assets.map((asset) => asset.id).toList(growable: false), origin: assets.singleOrNull);
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class EditLocationAction extends AssetActionBuilder {
   const EditLocationAction({required super.source});

--- a/mobile/lib/presentation/actions/favorite.action.dart
+++ b/mobile/lib/presentation/actions/favorite.action.dart
@@ -18,7 +18,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
   final shouldFavorite = assets.favorite(isFavorite: false).isNotEmpty;
   final assetIds = assets.favorite(isFavorite: !shouldFavorite).map((asset) => asset.id).toList(growable: false);
   return (shouldFavorite: shouldFavorite, assetIds: assetIds);
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class FavoriteAction extends AssetActionBuilder {
   const FavoriteAction({required super.source});

--- a/mobile/lib/presentation/actions/lock.action.dart
+++ b/mobile/lib/presentation/actions/lock.action.dart
@@ -23,7 +23,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
     // Only locking has an on-device copy to clean up; unlocking leaves the device alone.
     localIds: shouldLock ? targets.map((asset) => asset.localId).nonNulls.toList(growable: false) : const [],
   );
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class LockAction extends AssetActionBuilder {
   const LockAction({required super.source});

--- a/mobile/lib/presentation/actions/remove_from_album.action.dart
+++ b/mobile/lib/presentation/actions/remove_from_album.action.dart
@@ -11,7 +11,7 @@ final _stateProvider = Provider.family.autoDispose<List<String>?, ActionSource>(
   final assets = ref.watch(assetsActionProvider(source));
   final assetIds = assets.remote().map((asset) => asset.id).toList(growable: false);
   return assetIds.isEmpty ? null : assetIds;
-});
+}, dependencies: [assetsActionProvider]);
 
 class RemoveFromAlbumAction extends AssetActionBuilder {
   final String albumId;

--- a/mobile/lib/presentation/actions/restore.action.dart
+++ b/mobile/lib/presentation/actions/restore.action.dart
@@ -11,7 +11,7 @@ final _stateProvider = Provider.family.autoDispose<List<String>?, ActionSource>(
   final assets = ref.watch(ownedAssetsActionProvider(source));
   final assetIds = assets.trashed().map((asset) => asset.id).toList(growable: false);
   return assetIds.isEmpty ? null : assetIds;
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class RestoreAction extends AssetActionBuilder {
   const RestoreAction({required super.source});

--- a/mobile/lib/presentation/actions/set_album_cover.action.dart
+++ b/mobile/lib/presentation/actions/set_album_cover.action.dart
@@ -11,7 +11,7 @@ import 'package:immich_mobile/utils/error_handler.dart';
 final _stateProvider = Provider.family.autoDispose<String?, ActionSource>((ref, source) {
   final assets = ref.watch(assetsActionProvider(source));
   return assets.remote().map((asset) => asset.id).singleOrNull;
-});
+}, dependencies: [assetsActionProvider]);
 
 class SetAlbumCoverAction extends AssetActionBuilder {
   final String albumId;

--- a/mobile/lib/presentation/actions/share.action.dart
+++ b/mobile/lib/presentation/actions/share.action.dart
@@ -16,7 +16,7 @@ final _stateProvider = Provider.family.autoDispose<List<BaseAsset>?, ActionSourc
   final assets = ref.watch(assetsActionProvider(source));
   final shareable = assets.toList(growable: false);
   return shareable.isEmpty ? null : shareable;
-});
+}, dependencies: [assetsActionProvider]);
 
 class ShareAction extends AssetActionBuilder {
   const ShareAction({required super.source});

--- a/mobile/lib/presentation/actions/share_link.action.dart
+++ b/mobile/lib/presentation/actions/share_link.action.dart
@@ -12,7 +12,7 @@ final _stateProvider = Provider.family.autoDispose<List<String>?, ActionSource>(
   final assets = ref.watch(assetsActionProvider(source));
   final remoteIds = assets.remote().map((asset) => asset.id).toList(growable: false);
   return remoteIds.isEmpty ? null : remoteIds;
-});
+}, dependencies: [assetsActionProvider]);
 
 class ShareLinkAction extends AssetActionBuilder {
   const ShareLinkAction({required super.source});

--- a/mobile/lib/presentation/actions/stack.action.dart
+++ b/mobile/lib/presentation/actions/stack.action.dart
@@ -23,7 +23,7 @@ final _stateProvider = Provider.family.autoDispose<_State?, ActionSource>((ref, 
     assetIds: assets.map((asset) => asset.id).toList(growable: false),
     stackIds: assets.map((asset) => asset.stackId).nonNulls.toList(growable: false),
   );
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class StackAction extends AssetActionBuilder {
   const StackAction({required super.source});

--- a/mobile/lib/presentation/actions/tag.action.dart
+++ b/mobile/lib/presentation/actions/tag.action.dart
@@ -21,7 +21,7 @@ final _stateProvider = Provider.family.autoDispose<List<String>?, ActionSource>(
   final assets = ref.watch(ownedAssetsActionProvider(source));
   final assetIds = assets.map((asset) => asset.id).toList(growable: false);
   return assetIds.isEmpty ? null : assetIds;
-});
+}, dependencies: [ownedAssetsActionProvider]);
 
 class TagAction extends AssetActionBuilder {
   const TagAction({required super.source});

--- a/mobile/lib/presentation/actions/upload.action.dart
+++ b/mobile/lib/presentation/actions/upload.action.dart
@@ -16,7 +16,7 @@ final _stateProvider = Provider.family.autoDispose<List<LocalAsset>?, ActionSour
   final assets = ref.watch(assetsActionProvider(source));
   final local = assets.backedUp(isBackedUp: false).local().toList(growable: false);
   return local.isEmpty ? null : local;
-});
+}, dependencies: [assetsActionProvider]);
 
 class UploadAction extends AssetActionBuilder {
   final bool showProgress;

--- a/mobile/test/unit/presentation/presentation_context.dart
+++ b/mobile/test/unit/presentation/presentation_context.dart
@@ -101,15 +101,18 @@ extension PumpPresentationWidget on WidgetTester {
         useFallbackTranslations: true,
         assetLoader: const CodegenLoader(),
         child: ProviderScope(
-          overrides: [...context.overrides, ...overrides],
+          overrides: context.overrides,
           child: Builder(
-            builder: (context) => MaterialApp(
-              debugShowCheckedModeBanner: false,
-              scaffoldMessengerKey: scaffoldMessengerKey,
-              localizationsDelegates: context.localizationDelegates,
-              supportedLocales: context.supportedLocales,
-              locale: context.locale,
-              home: Scaffold(body: widget),
+            builder: (context) => ProviderScope(
+              overrides: overrides,
+              child: MaterialApp(
+                debugShowCheckedModeBanner: false,
+                scaffoldMessengerKey: scaffoldMessengerKey,
+                localizationsDelegates: context.localizationDelegates,
+                supportedLocales: context.supportedLocales,
+                locale: context.locale,
+                home: Scaffold(body: widget),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
The final refactor had the actions use a private provider per action which needs it's dependencies list populated because of the transitive dependency on `multiSelectProvider`. We don't have `riverpod_lints` nor our tests used nested scopes to detect this. The tests have been upgraded to use nested scopes which now catches this class of bugs properly