### PR TITLE
feat: Display the number of selected items in AlbumPickerModal  title

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,6 +30,7 @@
   "add_to_album_bottom_sheet_added": "Added to {album}",
   "add_to_album_bottom_sheet_already_exists": "Already in {album}",
   "add_to_album_bottom_sheet_some_local_assets": "Some local assets could not be added to album",
+  "add_to_album_item_count": "Add {count, plural, one {# item} other {# items}} to album",
   "add_to_albums": "Add to albums",
   "add_to_albums_count": "Add to albums ({count})",
   "add_to_bottom_bar": "Add to",

--- a/web/src/lib/components/SchemaAlbumPicker.svelte
+++ b/web/src/lib/components/SchemaAlbumPicker.svelte
@@ -14,7 +14,7 @@
   let { array, label, description, albumIds = $bindable([]) }: Props = $props();
 
   const onAlbums = async () => {
-    const albums = await modalManager.show(AlbumPickerModal);
+    const albums = await modalManager.show(AlbumPickerModal, {});
     if (!albums || albums.length === 0) {
       return;
     }

--- a/web/src/lib/modals/AlbumPickerModal.spec.ts
+++ b/web/src/lib/modals/AlbumPickerModal.spec.ts
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
+import AlbumPickerModal from './AlbumPickerModal.svelte';
+
+describe('AlbumPickerModal component', () => {
+  const onClose = vi.fn();
+
+  beforeAll(async () => {
+    await init({ fallbackLocale: 'en-US' });
+    register('en-US', () => import('$i18n/en.json'));
+    await waitLocale('en-US');
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
+    vi.resetAllMocks();
+    Element.prototype.animate = getAnimateMock();
+  });
+
+  afterAll(async () => {
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
+  });
+
+  it('shows the singular selection count title when selectedItemsCount is 1', async () => {
+    // Called by onMount()
+    sdkMock.getAllAlbums.mockResolvedValueOnce([]);
+
+    render(AlbumPickerModal, { props: { onClose, selectedItemsCount: 1 } });
+
+    expect(await screen.findByText('Add 1 item to album')).toBeInTheDocument();
+    expect(screen.queryByText('Select albums')).not.toBeInTheDocument();
+  });
+
+  it('shows the plural selection count title when selectedItemsCount is greater than 1', async () => {
+    sdkMock.getAllAlbums.mockResolvedValueOnce([]);
+
+    render(AlbumPickerModal, { props: { onClose, selectedItemsCount: 3 } });
+
+    expect(await screen.findByText('Add 3 items to album')).toBeInTheDocument();
+    expect(screen.queryByText('Select albums')).not.toBeInTheDocument();
+  });
+
+  it('shows the generic title when selectedItemsCount is not provided', async () => {
+    sdkMock.getAllAlbums.mockResolvedValueOnce([]);
+
+    render(AlbumPickerModal, { props: { onClose } });
+
+    expect(await screen.findByText('Select albums')).toBeInTheDocument();
+    expect(screen.queryByText('Add 1 item to album')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -23,9 +23,10 @@
 
   type Props = {
     onClose: (albums?: AlbumResponseDto[]) => void;
+    selectedItemsCount?: number;
   };
 
-  let { onClose }: Props = $props();
+  let { onClose, selectedItemsCount }: Props = $props();
 
   onMount(async () => {
     albums = await getAllAlbums({});
@@ -147,9 +148,15 @@
       }
     }
   };
+
+  const title = $derived(
+    selectedItemsCount === undefined
+      ? $t('select_albums')
+      : $t('add_to_album_item_count', { values: { count: selectedItemsCount } }),
+  );
 </script>
 
-<Modal title={$t('add_to_album')} {onClose} size="small">
+<Modal {title} {onClose} size="small">
   <ModalBody>
     <div class="mb-2 flex max-h-100 flex-col">
       {#if loading}

--- a/web/src/lib/modals/AssetAddToAlbumModal.svelte
+++ b/web/src/lib/modals/AssetAddToAlbumModal.svelte
@@ -24,4 +24,4 @@
   };
 </script>
 
-<AlbumPickerModal onClose={handleClose} />
+<AlbumPickerModal selectedItemsCount={assetIds.length} onClose={handleClose} />


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Until now the `AlbumPickerModal` modal had a static title `add_to_album` (`Add to album`). 
This MR makes the title of this modal dynamic.

**Proposed change**

- When the modal is open from `AssetAddToAlbumModal` it receives a new prop `selectionData` which includes the number of items which were selected. We create a new translation key `add_to_album_item_count` used in the title: `"Add {count} items to album"`. This addresses the base use case where we want to be able to tell how many items where selected while keeping the modal open.
- When the modal is open from `SchemaAlbumPicker`  it uses the already existing key `select_albums` (`Select albums`). This improves the semantic of the title: This happens in the workflow builder which allows to choose which albums a step like "Add to albums" will add the items to. So in this situation the action is not "Add (some items) to album" but "Select albums (where to add the items)"
  This is not a strictly necessary change, this case could keep the current `add_to_title`

**Translation key**

Being a new comer to this codebase I'm not entirely sure what is the policy about introducing new translation keys
The new translation key `add_to_album_item_count` is close to several existing ones which don't quite match our use case:

```
  "add_to_album": "Add to album",
  "add_to_albums": "Add to albums",
  "add_to_albums_count": "Add to albums ({count})",
```

Particularly `add_to_albums_count` uses a count to show _in how many albums_ the items are going to be transferred not _how many items_ are about to be transferred.

I added the key in `en.json` and my understanding is that Webslate will picking the translation later on.

<!--- Why is this change required? What problem does it solve? -->
**Motivation**

This change is motivated by an issue I have encountered several times while sorting my photos. Flow:

- Multi select some pictures
- Add them to an album
- (Forget to press `<Esc>` so the multi selection is still active)
- Scroll the screen so you don't see any selection anymore
- `<Shift>+click` a picture to create a new multi selection
- This select all pictures from your initial multi selection to the new one
- Add many unexpected pictures to the album
- The notification toast shows `Added 923 pictures to album`
- Realize you messed up something and go to remove the pictures from the album

Being able to tell in the "Add to album" modal how many items I'm moving would have prevented that.

<!--- If it fixes an open issue, please link to the issue here. -->

I haven't found any existing issue or MR related to this change.

**Open questions**

- Feature parity with mobile: I haven't looked into the mobile app code for now, I assumed it's not necessary. 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### New `AlbumPickerModal.spec.ts` suite
So far the component was not tested. I took inspiration from `AssetChangeDateModal.spec.ts` and `AssetSelectionChangeDateModal.spec.ts` to create a test suite.

I limited the tests scope to only the title behavior. I'm open to create a more comprehensive test suite in a follow up MR.

### Manual testing

Case1
- In a timeline (e.g. in an album or the "Photos" tab)
- Select 1 or more items, the top bar shows a + sign which opens the modal with the new title showing the selected items count (screenshot 1)
- Tested with single and multi selection

Case2
- Go to Workflows page (`/workflows` route).
- Create a workflow
- add a step
  - this opens `WorkflowAddStepModal` or `WorkflowEditStepModal` if editing the step.
  - Choose "Add to Album(s)"
  - Click “Choose” button, this opens the modal with the "Select albums" title (screenshot 2)

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->
<img width="420" height="568" alt="AssetAddToAlbumModal" src="https://github.com/user-attachments/assets/054f5d5c-7573-4c77-b072-e388b57bf550" />
<img width="429" height="582" alt="SchemaAlbumPicker" src="https://github.com/user-attachments/assets/f0f89735-3bdf-4828-b828-65b808fde911" />
</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
  - I haven't found relevant documentation
- [x] I have no unrelated changes in the PR.
- [ ] ~I have confirmed that any new dependencies are strictly necessary.~
  - No new dependency
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
  - No changes in `src/services`
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~
  - No changes in `src/repositories`

## Please describe to which degree, if any, an LLM was used in creating this pull request.

All code changes and commit messages and this MR description are written exclusively by me,. 
I understand every line I wrote (tho I'm a human I might misunderstand things). 
I ran the tests in my browser against my own immich instance.

I also ran the CI on my own fork https://github.com/statox/immich/pull/1 which shows 2 failing tests
- "Static Code Analysis" I think I'm missing a 3rd party API key here
- "Tests/Lint Web" I'm not sure why the job can't get an available runner.

I used an LLM for the following tasks

- Initial repo exploration and feature mapping (no code change, only produces onboarding documentation)
- Quick extraction of the getting started step to get a dev server running and talking to my remote api server (output: some bash commands)
- Helped me find the UI path to open the modal from its different callers (output: textual step by step guide)
- Explained to me the stubs and mocks usage in the tests. (output: textual code explanation and source code references)
  - I wrote myself the final code mixing what I found in other test files.
- Double check of the open MR/issues to find duplicate work. (None found, like in confirming my manual search)