### PR TITLE
fix: don't swallow fetch errors

### DIFF
--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -180,9 +180,7 @@ export class MachineLearningRepository {
           `Machine learning request to "${url}" failed with status ${response.status}: ${response.statusText}`,
         );
       } catch (error: Error | unknown) {
-        this.logger.warn(
-          `Machine learning request to "${url}" failed: ${error instanceof Error ? error.message : error}`,
-        );
+        this.logger.warn(`Machine learning request to "${url}" failed`, error);
       }
 
       this.setHealthy(url, false);

--- a/server/src/repositories/oauth.repository.ts
+++ b/server/src/repositories/oauth.repository.ts
@@ -122,8 +122,7 @@ export class OAuthRepository {
         );
       }
 
-      this.logger.error(`OAuth login failed: ${error.message}`);
-      this.logger.error(error);
+      this.logger.error('OAuth login failed', error);
 
       throw new Error('OAuth login failed', { cause: error });
     }
@@ -222,7 +221,7 @@ export class OAuthRepository {
         },
       );
     } catch (error: any | AggregateError) {
-      this.logger.error(`Error in OAuth discovery: ${error}`, error?.stack, error?.errors);
+      this.logger.error('Error in OAuth discovery', error);
       throw new InternalServerErrorException(`Error in OAuth discovery: ${error}`, { cause: error });
     }
   }


### PR DESCRIPTION
Previously, it would just log "fetch failed" without any details about the cause.