### PR TITLE
fix(mobile): handle asset websocket events

### DIFF
--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -104,6 +104,11 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
         socket.on('AssetEditReadyV1', _handleSyncAssetEditReadyV1);
         socket.on('AssetEditReadyV2', _handleSyncAssetEditReadyV2);
         socket.on('on_album_update', _handleAlbumUpdate);
+        socket.on('on_asset_delete', _handleAlbumUpdate);
+        socket.on('on_asset_trash', _handleAlbumUpdate);
+        socket.on('on_asset_restore', _handleAlbumUpdate);
+        socket.on('on_asset_hidden', _handleAlbumUpdate);
+        socket.on('on_asset_update', _handleAlbumUpdate);
         socket.on('on_config_update', _handleOnConfigUpdate);
         socket.on('on_new_release', _handleReleaseUpdates);
       } catch (e) {


### PR DESCRIPTION
## Description

the asset websocket events got dropped in the timeline switch, so a trash, restore or delete from another device doesnt show on the phone until a manual refresh. this registers them again (delete, trash, restore, hidden, update) pointed at the same sync handler album updates already use. upload success stays out, uploads already flow through the batched handler and the server has a TODO to remove that event.

the edit stacking in #28543 needs this too.

tested on an emulator against a real server: trash, restore and delete from the web now update the timeline with no touch, and a bulk trash of 50 fires a single sync round.
