### PR TITLE
fix(mobile): correct mislabeled Bengali locale entry

### DIFF
--- a/mobile/lib/constants/locales.dart
+++ b/mobile/lib/constants/locales.dart
@@ -7,7 +7,7 @@ const Map<String, Locale> locales = {
   'Arabic (ar)': Locale('ar'),
   'Basque (eu)': Locale('eu'),
   'Belarusian (be)': Locale('be'),
-  'Bosnian (bl)': Locale('bn'),
+  'Bengali (bn)': Locale('bn'),
   'Brazilian Portuguese (pt_BR)': Locale('pt', 'BR'),
   'Bulgarian (bg)': Locale('bg'),
   'Catalan (ca)': Locale('ca'),


### PR DESCRIPTION
## Description

`mobile/lib/constants/locales.dart` contains a mislabeled locale entry:

```dart
'Bosnian (bl)': Locale('bn'),
```

The display label reads "Bosnian" but the actual `Locale` value (`bn`) is Bengali's
ISO 639-1 code — Bosnian's real code is `bs`, not `bl`, so the label itself was
already invalid even before considering it pointed at the wrong language. As a
result, Bengali speakers had no way to find their language in the picker, while
selecting "Bosnian (bl)" silently loaded Bengali translations instead.

This PR relabels the entry to match what it actually loads:

```dart
'Bengali (bn)': Locale('bn'),
```

Bengali has solid translation coverage on Weblate (2,282 strings — 54% complete,
11,611 words — 63%, 71,543 characters — 64%), making this a straightforward
correction rather than a new-language addition.

This is a label correction only — no change to the underlying `Locale` value,
translation assets, or app logic. Genuine Bosnian (`bs`) support is out of
scope: it exists as a separate, currently untranslated (0%) component on
Weblate and isn't referenced anywhere in `locales.dart` — a real Bosnian entry
would be a separate addition once someone starts translating it.

Fixes # (issue)

## How Has This Been Tested?

- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed` — no changes needed
- [x] `flutter test` — all 1249 tests pass
- [x] Rebuilt and ran the app on an Android emulator: confirmed the language
      picker now lists "Bengali (bn)" in place of the mislabeled "Bosnian (bl)"
      entry, and that selecting it switches the entire UI to Bangla (header →
      "ভাষা", search placeholder → "ভাষা অনুসন্ধান করুন...", Apply button →
      "প্রয়োগ করুন")

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude assisted in investigating the root cause (cross-referencing the language
picker, Weblate translations, and `locales.dart`), running the mobile test/lint
suite, and building + driving an Android emulator to visually verify the fix.
The one-line change and this description were author-reviewed before submission.
