### PR TITLE
fix(server): transcode Live Photo videos in the bulk conversion job

### DIFF
--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -589,7 +589,17 @@ where
       "asset_file"."assetId" = "asset"."id"
       and "asset_file"."type" = 'encoded_video'
   )
-  and "asset"."visibility" != 'hidden'
+  and (
+    "asset"."visibility" != 'hidden'
+    or exists (
+      select
+        "motionParent"."id"
+      from
+        "asset" as "motionParent"
+      where
+        "motionParent"."livePhotoVideoId" = "asset"."id"
+    )
+  )
   and "asset"."deletedAt" is null
 
 -- AssetJobRepository.getForVideoConversion

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -329,7 +329,19 @@ export class AssetJobRepository {
               ),
             ),
           )
-          .where('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+          // Exclude hidden assets, except Live Photo motion videos (hidden by design but
+          // still in need of transcoding) — see #22985.
+          .where((eb) =>
+            eb.or([
+              eb('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+              eb.exists(
+                eb
+                  .selectFrom('asset as motionParent')
+                  .select('motionParent.id')
+                  .whereRef('motionParent.livePhotoVideoId', '=', 'asset.id'),
+              ),
+            ]),
+          ),
       )
       .where('asset.deletedAt', 'is', null)
       .stream();

--- a/server/test/medium/specs/repositories/asset-job.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset-job.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetFileType } from 'src/enum';
+import { AssetFileType, AssetType, AssetVisibility } from 'src/enum';
 import { AssetJobRepository } from 'src/repositories/asset-job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
@@ -108,6 +108,50 @@ describe(AssetJobRepository.name, () => {
       const stream = sut.streamForThumbnailJob({ force: false, fullsizeEnabled: true });
       await expect(consume(stream)).resolves.not.toEqual(
         expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+  });
+
+  describe('streamForVideoConversion', () => {
+    it('should queue a video asset', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id, type: AssetType.Video });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+
+    it('should skip a hidden video that is not a Live Photo motion video', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Hidden,
+      });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: asset.id })]),
+      );
+    });
+
+    it('should queue a hidden Live Photo motion video', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: motionAsset } = await ctx.newAsset({
+        ownerId: user.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Hidden,
+      });
+      await ctx.newAsset({ ownerId: user.id, livePhotoVideoId: motionAsset.id });
+
+      const stream = sut.streamForVideoConversion(false);
+      await expect(consume(stream)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: motionAsset.id })]),
       );
     });
   });


### PR DESCRIPTION
## Description

The bulk **Transcode Videos** job (`AssetJobRepository.streamForVideoConversion`, used when not running with "force") excludes any asset with `visibility = hidden`. The motion-video component of a Live Photo is stored as a separate asset with `visibility = hidden` by design, so it was never picked up by this job. In practice: if you upload a Live Photo while server-side transcoding is disabled, then enable transcoding later and run the bulk job, the Live Photo's video component never gets transcoded and playback stays broken (only the still frame/audio work). Uploading a new Live Photo with transcoding already enabled works fine, since the per-asset transcode path (triggered at upload) doesn't have this exclusion.

This PR keeps excluding hidden assets in general, but adds an exception for hidden videos that are the motion component of a Live Photo (i.e. referenced by another asset's `livePhotoVideoId`), so they're included in the bulk job too.

Fixes #22985

## How Has This Been Tested?

- [x] Added repository-level tests in `asset-job.repository.spec.ts` covering: a normal video is queued, a hidden non-Live-Photo video is still skipped, a hidden Live Photo motion video is now queued
- [x] Ran `pnpm test:medium test/medium/specs/repositories/asset-job.repository.spec.ts` — 10/10 passing
- [x] Ran `pnpm test src/services/media.service.spec.ts` — 193/193 passing, no regressions

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — server-side query change, no UI impact.

</details>

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) diagnosed the root cause by tracing the job's asset-selection query and the `AssetVisibility.Hidden` semantics, and wrote the initial implementation and tests. I reviewed the resulting diff line by line, understand why the fix works (the `EXISTS` subquery matches hidden videos that are referenced as another asset's `livePhotoVideoId`), and ran the test suite myself locally to confirm it passes before submitting.
