### PR TITLE
fix(ml): register CUDA EP library to avoid plugin EP lookup warning

### DIFF
--- a/machine-learning/immich_ml/sessions/ort.py
+++ b/machine-learning/immich_ml/sessions/ort.py
@@ -15,9 +15,54 @@ from ..config import log, settings
 
 MigraphxInputSignature = tuple[tuple[str, str, tuple[int, ...]], ...]
 
+# Provider libraries that expose an OrtEpFactory and are looked up as plugin EP devices
+# before the built-in provider is used. See _register_ep_library().
+_EP_LIBRARIES = {"CUDAExecutionProvider": "libonnxruntime_providers_cuda.so"}
+
+_ep_library_lock = Lock()
+_registered_ep_libraries: set[str] = set()
+
 _migraphx_registry_lock = Lock()
 _migraphx_model_locks: dict[str, Lock] = {}
 _migraphx_compiled_inputs: set[tuple[str, MigraphxInputSignature]] = set()
+
+
+def _register_ep_library(provider: str) -> None:
+    """Register the provider's shared library as a plugin EP library.
+
+    Since ORT 1.23 a session first looks for a registered plugin EP device matching the
+    provider name and its `device_id` option, and only then falls back to the built-in
+    provider. Without a registered library that lookup logs a warning on every session:
+
+        No registered plugin EP device found for 'CUDAExecutionProvider' with device_id=0
+
+    Registering the library makes the device discoverable, so the lookup succeeds and the
+    provider options are applied to the session as usual.
+    """
+
+    library = _EP_LIBRARIES.get(provider)
+    register = getattr(ort, "register_execution_provider_library", None)
+    if library is None or register is None:
+        return
+
+    with _ep_library_lock:
+        if provider in _registered_ep_libraries:
+            return
+        # Mark as attempted regardless of the outcome: a failure here is not fatal, the
+        # provider is still created from the built-in implementation, and retrying it for
+        # every session is pointless.
+        _registered_ep_libraries.add(provider)
+
+        try:
+            library_path = Path(ort.__file__).parent / "capi" / library
+            if not library_path.is_file():
+                log.debug(f"EP library {library} not found, skipping plugin EP registration for {provider}")
+                return
+
+            register(provider, library_path.as_posix())
+            log.debug(f"Registered plugin EP library {library_path} for {provider}")
+        except Exception as e:
+            log.debug(f"Could not register plugin EP library {library} for {provider}: {e}")
 
 
 def _migraphx_get_model_lock(model_key: str) -> Lock:
@@ -59,6 +104,8 @@ class OrtSession:
         self.providers = providers if providers is not None else self._providers_default
         self.provider_options = provider_options if provider_options is not None else self._provider_options_default
         self.sess_options = sess_options if sess_options is not None else self._sess_options_default
+        for provider in self.providers:
+            _register_ep_library(provider)
         self.session = ort.InferenceSession(
             self.model_path.as_posix(),
             providers=self.providers,

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -30,6 +30,7 @@ from immich_ml.models.ocr.detection import TextDetector
 from immich_ml.models.ocr.recognition import TextRecognizer
 from immich_ml.models.ocr.schemas import OcrOptions
 from immich_ml.schemas import ModelFormat, ModelPrecision, ModelTask, ModelType
+from immich_ml.sessions import ort as ort_module
 from immich_ml.sessions.ann import AnnSession
 from immich_ml.sessions.ort import OrtSession
 from immich_ml.sessions.rknn import RknnSession, run_inference
@@ -329,6 +330,40 @@ class TestOrtSession:
         session = OrtSession("ViT-B-32__openai", providers=["CUDAExecutionProvider"])
 
         assert session.provider_options == [{"arena_extend_strategy": "kSameAsRequested", "device_id": "1"}]
+
+    def test_registers_cuda_ep_library(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict(ort_module._registered_ep_libraries, clear=True)
+        mocker.patch("immich_ml.sessions.ort.Path.is_file", return_value=True)
+        register = mocker.patch("immich_ml.sessions.ort.ort.register_execution_provider_library")
+
+        OrtSession("ViT-B-32__openai", providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+        OrtSession("ViT-B-32__openai", providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+        register.assert_called_once()
+        provider, library_path = register.call_args[0]
+        assert provider == "CUDAExecutionProvider"
+        assert library_path.endswith("/capi/libonnxruntime_providers_cuda.so")
+
+    def test_does_not_register_cuda_ep_library_if_missing(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict(ort_module._registered_ep_libraries, clear=True)
+        mocker.patch("immich_ml.sessions.ort.Path.is_file", return_value=False)
+        register = mocker.patch("immich_ml.sessions.ort.ort.register_execution_provider_library")
+
+        OrtSession("ViT-B-32__openai", providers=["CUDAExecutionProvider"])
+
+        register.assert_not_called()
+
+    def test_ignores_cuda_ep_library_registration_failure(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict(ort_module._registered_ep_libraries, clear=True)
+        mocker.patch("immich_ml.sessions.ort.Path.is_file", return_value=True)
+        mocker.patch(
+            "immich_ml.sessions.ort.ort.register_execution_provider_library",
+            side_effect=RuntimeError("registration failed"),
+        )
+
+        session = OrtSession("ViT-B-32__openai", providers=["CUDAExecutionProvider"])
+
+        assert session.providers == ["CUDAExecutionProvider"]
 
     def test_sets_provider_options_for_rocm(self, mocker: MockerFixture) -> None:
         model_path = "/cache/ViT-B-32__openai/textual/model.onnx"


### PR DESCRIPTION
## Description

Fixes # (no issue filed — the warning is described in full below)

The CUDA machine-learning container logs a warning for every ORT session it creates:

```
[W:onnxruntime:Default, onnxruntime_pybind_state.cc:711 operator()] No registered plugin EP device found for 'CUDAExecutionProvider' with device_id=0
```

Since ONNX Runtime 1.26 (`onnxruntime-gpu` is pinned to `>=1.23.2,<2`, currently locked at 1.26.0), `CreateExecutionProviderFactoryInstance()` first looks for a registered *plugin EP device* matching the provider name and its `device_id` provider option, and only afterwards falls back to the built-in provider:

```cpp
const OrtEpDevice* selected_device = FindRegisteredPluginEpDevice(type, provider_options);
if (selected_device == nullptr) {
  if (provider_options != nullptr) {
    if (const auto device_id_it = provider_options->find("device_id"); device_id_it != provider_options->end()) {
      LOGS_DEFAULT(WARNING) << "No registered plugin EP device found for '" << type
                            << "' with device_id=" << device_id_it->second;
    }
  }
  ...
```

`EpLibraryInternal::CreateInternalEps()` only registers the CPU, WebGPU and DML providers, so for CUDA the lookup can never succeed unless the provider library is registered explicitly. Since we always pass `device_id` in the provider options, the warning is emitted for every session — for CLIP, facial recognition and OCR alike.

The provider library itself does expose an `OrtEpFactory` (`CudaEpFactory` in `cuda_provider_factory.cc`), so registering it via `ort.register_execution_provider_library()` makes the device discoverable and the lookup succeeds. The provider options are still applied to the session (ORT copies them to the session options for the selected device), so behaviour is unchanged apart from the warning being gone.

## Implementation

* `_register_ep_library()` registers `libonnxruntime_providers_cuda.so` once per process, on first session creation for the CUDA provider.
* Registration happens lazily inside `OrtSession.__init__` rather than at import time, so it runs in the gunicorn worker after `pre_fork` — nothing touches CUDA in the arbiter process.
* Everything is best-effort: if the API is unavailable (older ORT), the library is missing (CPU/other builds), or registration fails, it is logged at debug level and the built-in provider is used exactly as before.
* Only CUDA is affected — it is the only provider for which ORT does this plugin EP lookup.

## How Has This Been Tested?

- [x] `pytest` — 101 passed, 3 skipped, including three new tests covering successful registration, a missing provider library, and a failing registration
- [x] `ruff check` / `ruff format --check` / `mypy` clean for the touched module
- [x] Run on real hardware: NVIDIA GB10 (DGX Spark, aarch64, driver 595.84), CUDA 13.3.1, onnxruntime-gpu 1.28.0 built from source. The warning is gone from the container logs, `get_providers()` still reports `['CUDAExecutionProvider', 'CPUExecutionProvider']`, and CLIP, facial recognition and OCR return unchanged results.
- [x] The warning and its origin were traced through the ONNX Runtime sources for the pinned version (1.26.0) and for 1.28.0; it is absent in 1.23.2, where the pin's lower bound sits.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable — log output only, quoted above.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable — not applicable, no user-facing behaviour changes
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. — no new dependencies
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. — not applicable, this is the Python `machine-learning` package
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) — not applicable, same reason

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. The root cause analysis, the implementation, the tests and this description were produced in a session with Claude Code, and I reviewed and verified all of it: the ONNX Runtime source references were checked against the 1.26.0 and 1.28.0 sources, the test suite was run locally, and the change was validated on real GB10 hardware before this PR was opened.
