### PR TITLE
chore(server): update zod to 4.4.3 and nestjs-zod to 5.5.0

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4947,7 +4947,6 @@
             "in": "query",
             "description": "Return edited asset if available",
             "schema": {
-              "default": false,
               "type": "boolean"
             }
           },
@@ -5035,7 +5034,6 @@
             "in": "query",
             "description": "Return edited asset if available",
             "schema": {
-              "default": false,
               "type": "boolean"
             }
           },
@@ -25478,7 +25476,6 @@
             "type": "string"
           },
           "expiresAt": {
-            "default": null,
             "description": "Expiration date",
             "example": "2024-01-01T00:00:00.000Z",
             "format": "date-time",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4486,7 +4486,6 @@
             "in": "query",
             "description": "Return edited asset if available",
             "schema": {
-              "default": false,
               "type": "boolean"
             }
           },
@@ -4574,7 +4573,6 @@
             "in": "query",
             "description": "Return edited asset if available",
             "schema": {
-              "default": false,
               "type": "boolean"
             }
           },
@@ -23057,7 +23055,6 @@
             "type": "string"
           },
           "expiresAt": {
-            "default": null,
             "description": "Expiration date",
             "example": "2024-01-01T00:00:00.000Z",
             "format": "date-time",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,8 +572,8 @@ importers:
         specifier: ^8.0.0
         version: 8.1.0(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(rxjs@7.8.2)
       nestjs-zod:
-        specifier: ^5.3.0
-        version: 5.5.0(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.3.6)
+        specifier: ^5.5.0
+        version: 5.5.0(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.4.3)
       nodemailer:
         specifier: ^9.0.0
         version: 9.0.3
@@ -638,8 +638,8 @@ importers:
         specifier: ^13.12.0
         version: 13.15.35
       zod:
-        specifier: 4.3.6
-        version: 4.3.6
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.0
@@ -13049,8 +13049,8 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
@@ -23372,12 +23372,12 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  nestjs-zod@5.5.0(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.3.6):
+  nestjs-zod@5.5.0(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.4.3):
     dependencies:
       '@nestjs/common': 11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
       deepmerge: 4.3.1
       rxjs: 7.8.2
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       '@nestjs/swagger': 11.4.6(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2)
 
@@ -27090,7 +27090,7 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,8 +575,8 @@ importers:
         specifier: ^8.0.0
         version: 8.1.0(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(rxjs@7.8.2)
       nestjs-zod:
-        specifier: ^5.3.0
-        version: 5.5.0(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.3.6)
+        specifier: ^5.5.0
+        version: 5.5.0(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.4.3)
       nodemailer:
         specifier: ^9.0.0
         version: 9.0.5
@@ -641,8 +641,8 @@ importers:
         specifier: ^13.12.0
         version: 13.15.35
       zod:
-        specifier: 4.3.6
-        version: 4.3.6
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.0
@@ -13066,8 +13066,8 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
@@ -23363,12 +23363,12 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  nestjs-zod@5.5.0(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.3.6):
+  nestjs-zod@5.5.0(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/swagger@11.4.6(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2))(rxjs@7.8.2)(zod@4.4.3):
     dependencies:
       '@nestjs/common': 11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
       deepmerge: 4.3.1
       rxjs: 7.8.2
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       '@nestjs/swagger': 11.4.6(@nestjs/common@11.1.29(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.29)(@typescript/typescript6@6.0.2)(reflect-metadata@0.2.2)
 
@@ -27081,7 +27081,7 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -94,7 +94,7 @@
     "nestjs-cls": "^6.0.0",
     "nestjs-kysely": "3.1.2",
     "nestjs-otel": "^8.0.0",
-    "nestjs-zod": "^5.3.0",
+    "nestjs-zod": "^5.5.0",
     "nodemailer": "^9.0.0",
     "openid-client": "^6.3.3",
     "pg": "^8.11.3",
@@ -116,7 +116,7 @@
     "ua-parser-js": "^2.0.0",
     "uuid": "^14.0.0",
     "validator": "^13.12.0",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -1,7 +1,7 @@
 import { createZodDto } from 'nestjs-zod';
 import { HistoryBuilder } from 'src/decorators';
 import { AssetMetadataUpsertItemSchema } from 'src/dtos/asset.dto';
-import { AssetVisibilitySchema } from 'src/enum';
+import { ApiCustomExtension, AssetVisibilitySchema } from 'src/enum';
 import { isoDatetimeToDate, JsonParsed, stringToBool } from 'src/validation';
 import z from 'zod';
 
@@ -40,8 +40,15 @@ const AssetMediaBaseSchema = z.object({
   fileModifiedAt: isoDatetimeToDate.describe('File modification date'),
   duration: z.coerce.number().int().min(0).optional().describe('Duration in milliseconds (for videos)'),
   filename: z.string().optional().describe('Filename'),
-  /** The properties below are added to correctly generate the API docs and client SDKs. Validation should be handled in the controller. */
-  [UploadFieldName.ASSET_DATA]: z.any().describe('Asset file data').meta({ type: 'string', format: 'binary' }),
+  /**
+   * The properties below are added to correctly generate the API docs and client SDKs. Validation should be handled
+   * in the controller. File parts never reach the request body, so they must be optional here
+   */
+  [UploadFieldName.ASSET_DATA]: z
+    .any()
+    .optional()
+    .describe('Asset file data')
+    .meta({ type: 'string', format: 'binary', [ApiCustomExtension.Required]: true }),
 });
 
 const AssetMediaCreateSchema = AssetMediaBaseSchema.extend({

--- a/server/src/dtos/config.dto.ts
+++ b/server/src/dtos/config.dto.ts
@@ -36,15 +36,12 @@ import z from 'zod';
 const { Admin, User, Public } = ConfigVisibility;
 
 const configBool = z
-  .preprocess((val) => {
-    if (val === 'true') {
-      return true;
-    }
-    if (val === 'false') {
-      return false;
-    }
-    return val;
-  }, z.boolean())
+  .preprocess(
+    (val) => z.stringbool({ truthy: ['true'], falsy: ['false'], case: 'sensitive' }).safeParse(val).data ?? val,
+    z.boolean(),
+  )
+
+  .nonoptional()
   .meta({ type: 'boolean' });
 
 const cronExpressionSchema = z

--- a/server/src/dtos/download.dto.ts
+++ b/server/src/dtos/download.dto.ts
@@ -31,6 +31,7 @@ const DownloadArchiveSchema = z
     // which would limit this DTO to a maximum of 1000 assets.
     assetIds: z
       .preprocess((val) => (typeof val === 'string' ? val.split(',') : val), z.array(z.uuidv4()))
+      .nonoptional()
       .describe('Asset IDs'),
     edited: z
       .preprocess((val) => {

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -25,15 +25,12 @@ import z from 'zod';
 
 /** Coerces 'true'/'false' strings to boolean, but also allows booleans. */
 const configBool = z
-  .preprocess((val) => {
-    if (val === 'true') {
-      return true;
-    }
-    if (val === 'false') {
-      return false;
-    }
-    return val;
-  }, z.boolean())
+  .preprocess(
+    (val) => z.stringbool({ truthy: ['true'], falsy: ['false'], case: 'sensitive' }).safeParse(val).data ?? val,
+    z.boolean(),
+  )
+
+  .nonoptional()
   .meta({ type: 'boolean' });
 
 const JobSettingsSchema = z

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -603,6 +603,7 @@ export enum ApiCustomExtension {
   AdminOnly = 'x-immich-admin-only',
   History = 'x-immich-history',
   State = 'x-immich-state',
+  Required = 'x-immich-required',
 }
 
 export enum MetadataKey {

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -211,6 +211,22 @@ const patchOpenAPI = (document: OpenAPIObject) => {
 
     for (const schema of Object.values(schemas)) {
       delete (schema as Record<string, unknown>).id;
+
+      // `x-immich-required` documents a property as required even though it is optional during body validation,
+      // i.e. multipart file fields, which are validated in the controller instead of the request body schema.
+      for (const [key, value] of Object.entries(schema.properties ?? {})) {
+        if (typeof value === 'string' || !isSchema(value) || !(ApiCustomExtension.Required in value)) {
+          continue;
+        }
+
+        if (
+          (value as Record<string, unknown>)[ApiCustomExtension.Required] === true &&
+          !schema.required?.includes(key)
+        ) {
+          schema.required = [...(schema.required ?? []), key];
+        }
+        delete (value as Record<string, unknown>)[ApiCustomExtension.Required];
+      }
     }
 
     document.components.schemas = sortKeys(schemas);

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -212,20 +212,12 @@ const patchOpenAPI = (document: OpenAPIObject) => {
     for (const schema of Object.values(schemas)) {
       delete (schema as Record<string, unknown>).id;
 
-      // `x-immich-required` documents a property as required even though it is optional during body validation,
-      // i.e. multipart file fields, which are validated in the controller instead of the request body schema.
+      // documents a property as required even though it is optional during body validation
       for (const [key, value] of Object.entries(schema.properties ?? {})) {
-        if (typeof value === 'string' || !isSchema(value) || !(ApiCustomExtension.Required in value)) {
-          continue;
+        if (ApiCustomExtension.Required in value) {
+          delete (value as Record<string, unknown>)[ApiCustomExtension.Required];
+          (schema.required ??= []).push(key);
         }
-
-        if (
-          (value as Record<string, unknown>)[ApiCustomExtension.Required] === true &&
-          !schema.required?.includes(key)
-        ) {
-          schema.required = [...(schema.required ?? []), key];
-        }
-        delete (value as Record<string, unknown>)[ApiCustomExtension.Required];
       }
     }
 

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -214,10 +214,12 @@ const patchOpenAPI = (document: OpenAPIObject) => {
 
       // documents a property as required even though it is optional during body validation
       for (const [key, value] of Object.entries(schema.properties ?? {})) {
-        if (ApiCustomExtension.Required in value) {
-          delete (value as Record<string, unknown>)[ApiCustomExtension.Required];
-          (schema.required ??= []).push(key);
+        if (!(ApiCustomExtension.Required in value)) {
+        	continue;
         }
+
+        delete (value as Record<string, unknown>)[ApiCustomExtension.Required];
+        (schema.required ??= []).push(key);
       }
     }
 

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -215,7 +215,7 @@ const patchOpenAPI = (document: OpenAPIObject) => {
       // documents a property as required even though it is optional during body validation
       for (const [key, value] of Object.entries(schema.properties ?? {})) {
         if (!(ApiCustomExtension.Required in value)) {
-        	continue;
+          continue;
         }
 
         delete (value as Record<string, unknown>)[ApiCustomExtension.Required];


### PR DESCRIPTION
Updates zod 4.3.6 to 4.4.3 and nestjs-zod 5.3.0 to 5.5.0. Three zod 4.4.x behavior changes required adaptations (nestjs-zod alone changes nothing):

#### 1. `z.preprocess` fields no longer `required` in the generated spec

Since 4.4.3 ([#5941](https://github.com/colinhacks/zod/pull/5941)), preprocess pipes report their input as optional, so they are dropped from `required`.

- add `.nonoptional()`  to keep spec, client types and runtime in agreement
- `configBool` now delegates string coercion to `z.stringbool` instead of being hand-rolled

#### 2. `z.any()` object keys now required at parse time

zod 4.4.0 ([#5661](https://github.com/colinhacks/zod/pull/5661)) made `z.any()`/`z.unknown()` keys required. This broke every `POST /assets`: `assetData` is a docs-only placeholder that never reaches the request body due to the multi-part processing split of text and file properties

- make `assetData` optional, matching what the body schema actually sees
- add `x-immich-required`: a meta marker to re-add the property to `required` in the published spec, so SDKs still document the file as mandatory

#### 3. Codec `.default()` no longer emitted in input schemas

Output defaults aren't valid input values for codecs, so 4.4.2 ([#5929](https://github.com/colinhacks/zod/pull/5929)) stopped emitting them. Purely cosmetic in docs, runtime defaults still apply.

### Verification

- runtime validation behavior and error messages unchanged (verified against 4.3.6)
- regenerated spec/SDKs
- no client type changes needed
