### PR TITLE
fix(server): prefer null over empty string for asset_exif.description

### DIFF
--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -29,7 +29,12 @@ const UpdateAssetBaseSchema = z
           .updated('v3', 'Using 0 as a rating is no longer valid.')
           .getExtensions(),
       }),
-    description: z.string().optional().describe('Asset description'),
+    description: z
+      .string()
+      .nullable()
+      .transform((value) => (value === '' ? null : value))
+      .optional()
+      .describe('Asset description'),
   })
   .refine(
     (data) =>

--- a/server/src/schema/migrations/1784986754475-ConvertAssetExifDescriptionEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1784986754475-ConvertAssetExifDescriptionEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "asset_exif" SET "description" = NULL WHERE "description" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "asset_exif" SET "description" = '' WHERE "description" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET DEFAULT ''::text;`.execute(db);
+  await sql`ALTER TABLE "asset_exif" ALTER COLUMN "description" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/tables/asset-exif.table.ts
+++ b/server/src/schema/tables/asset-exif.table.ts
@@ -74,8 +74,8 @@ export class AssetExifTable {
   @Column({ type: 'character varying', nullable: true })
   country!: string | null;
 
-  @Column({ type: 'text', default: '' })
-  description!: Generated<string>; // or caption
+  @Column({ type: 'text', nullable: true, default: null })
+  description!: string | null; // or caption
 
   @Column({ type: 'double precision', nullable: true })
   fps!: number | null;

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -506,7 +506,7 @@ export class AssetService extends BaseService {
 
   private async updateExif(dto: {
     id: string;
-    description?: string;
+    description?: string | null;
     dateTimeOriginal?: string;
     latitude?: number;
     longitude?: number;

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1296,7 +1296,7 @@ describe(MetadataService.name, () => {
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
         expect.objectContaining({
           exif: expect.objectContaining({
-            description: '',
+            description: null,
           }),
           lockedPropertiesBehavior: 'skip',
         }),

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -303,7 +303,7 @@ export class MetadataService extends BaseService {
       focalLength: validate(exifTags.FocalLength),
 
       // comments
-      description: String(exifTags.ImageDescription || exifTags.Description || '').trim(),
+      description: String(exifTags.ImageDescription || exifTags.Description || '').trim() || null,
       profileDescription: exifTags.ProfileDescription || null,
       rating: exifTags.Rating === 0 ? null : validateRange(exifTags.Rating, 1, 5),
 

--- a/server/test/factories/asset-exif.factory.ts
+++ b/server/test/factories/asset-exif.factory.ts
@@ -21,7 +21,7 @@ export class AssetExifFactory {
       colorspace: null,
       country: 'United States of America',
       dateTimeOriginal: factory.date(),
-      description: '',
+      description: null,
       exifImageHeight: 420,
       exifImageWidth: 42,
       exposureTime: null,

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -111,7 +111,7 @@ describe(MetadataService.name, () => {
       const { filePath } = await createTestFile(exifData);
       const { user } = await ctx.newUser();
       const { asset } = await ctx.newAsset({ originalPath: filePath, ownerId: user.id });
-      await ctx.newExif({ assetId: asset.id, description: '' });
+      await ctx.newExif({ assetId: asset.id, description: null });
 
       await sut.handleMetadataExtraction({ id: asset.id });
 
@@ -138,7 +138,7 @@ describe(MetadataService.name, () => {
       const { filePath } = await createTestFile({ CreateDate: '42603:05:04 04:12:48' });
       const { user } = await ctx.newUser();
       const { asset } = await ctx.newAsset({ originalPath: filePath, ownerId: user.id });
-      await ctx.newExif({ assetId: asset.id, description: '' });
+      await ctx.newExif({ assetId: asset.id, description: null });
 
       await sut.handleMetadataExtraction({ id: asset.id });
 
@@ -159,7 +159,7 @@ describe(MetadataService.name, () => {
     const { filePath } = await createTestFile({ LensModel: 1.8 });
     const { user } = await ctx.newUser();
     const { asset } = await ctx.newAsset({ originalPath: filePath, ownerId: user.id });
-    await ctx.newExif({ assetId: asset.id, description: '' });
+    await ctx.newExif({ assetId: asset.id, description: null });
 
     await sut.handleMetadataExtraction({ id: asset.id });
 

--- a/server/test/medium/specs/sync/sync-album-asset-exif.spec.ts
+++ b/server/test/medium/specs/sync/sync-album-asset-exif.spec.ts
@@ -51,7 +51,7 @@ describe(SyncRequestType.AlbumAssetExifsV1, () => {
           city: null,
           country: null,
           dateTimeOriginal: null,
-          description: '',
+          description: null,
           exifImageHeight: null,
           exifImageWidth: null,
           exposureTime: null,

--- a/server/test/medium/specs/sync/sync-asset-exif.spec.ts
+++ b/server/test/medium/specs/sync/sync-asset-exif.spec.ts
@@ -32,7 +32,7 @@ describe(SyncRequestType.AssetExifsV1, () => {
           city: null,
           country: null,
           dateTimeOriginal: null,
-          description: '',
+          description: null,
           exifImageHeight: null,
           exifImageWidth: null,
           exposureTime: null,

--- a/server/test/medium/specs/sync/sync-partner-asset-exif.spec.ts
+++ b/server/test/medium/specs/sync/sync-partner-asset-exif.spec.ts
@@ -34,7 +34,7 @@ describe(SyncRequestType.PartnerAssetExifsV1, () => {
           city: null,
           country: null,
           dateTimeOriginal: null,
-          description: '',
+          description: null,
           exifImageHeight: null,
           exifImageWidth: null,
           exposureTime: null,


### PR DESCRIPTION
Fixes #28832\n\nChanges the default handling of asset EXIF description to prefer `null` over an empty string, which avoids downstream validation issues and keeps the API response cleaner.