### PR TITLE
fix(web): prevent face name label clipping near image boundaries

### DIFF
--- a/web/src/lib/components/asset-viewer/PhotoViewer.svelte
+++ b/web/src/lib/components/asset-viewer/PhotoViewer.svelte
@@ -16,7 +16,7 @@
   import { getNaturalSize, scaleToFit, type Size } from '$lib/utils/container-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { getOcrBoundingBoxes } from '$lib/utils/ocr-utils';
-  import { getBoundingBox, type BoundingBox } from '$lib/utils/people-utils';
+  import { getBoundingBox, getRelativeFaceLabelLeft, type BoundingBox } from '$lib/utils/people-utils';
   import { type SharedLinkResponseDto } from '@immich/sdk';
   import { toastManager } from '@immich/ui';
   import { onDestroy, untrack } from 'svelte';
@@ -61,6 +61,8 @@
 
   let containerWidth = $state(0);
   let containerHeight = $state(0);
+  // Only one face label is visible at a time (isActive guard), so a single shared width is sufficient.
+  let labelWidth = $state(0);
 
   const container = $derived({
     width: containerWidth,
@@ -269,10 +271,17 @@
           onpointerleave={() => assetViewerManager.clearHighlightedFaces()}
         >
           {#if isActive && boundingbox.name}
+            {@const labelLeft = getRelativeFaceLabelLeft(
+              boundingbox.left,
+              boundingbox.width,
+              labelWidth,
+              overlaySize.width,
+            )}
             <div
               aria-hidden="true"
+              bind:clientWidth={labelWidth}
               class="absolute rounded-sm bg-white/90 px-2 py-1 text-sm font-medium whitespace-nowrap text-black shadow-lg"
-              style="top: {boundingbox.height + 4}px; right: 0;"
+              style="top: {boundingbox.height + 4}px; left: {labelLeft}px;"
             >
               {boundingbox.name}
             </div>

--- a/web/src/lib/components/asset-viewer/PhotoViewer.svelte
+++ b/web/src/lib/components/asset-viewer/PhotoViewer.svelte
@@ -64,6 +64,13 @@
   // Only one face label is visible at a time (isActive guard), so a single shared width is sufficient.
   let labelWidth = $state(0);
 
+  $effect(() => {
+    // Reset label width when highlighted faces change to prevent carry-over from previous face labels
+    if (assetViewerManager.highlightedFaces) {
+      labelWidth = 0;
+    }
+  });
+
   const container = $derived({
     width: containerWidth,
     height: containerHeight,
@@ -280,8 +287,8 @@
             <div
               aria-hidden="true"
               bind:clientWidth={labelWidth}
-              class="absolute rounded-sm bg-white/90 px-2 py-1 text-sm font-medium whitespace-nowrap text-black shadow-lg"
-              style="top: {boundingbox.height + 4}px; left: {labelLeft}px;"
+              class="absolute rounded-sm bg-white/90 px-2 py-1 text-sm font-medium whitespace-nowrap text-black shadow-lg transition-opacity duration-75"
+              style="top: {boundingbox.height + 4}px; left: {labelLeft}px; opacity: {labelWidth > 0 ? 1 : 0};"
             >
               {boundingbox.name}
             </div>

--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -85,10 +85,12 @@ describe('getRelativeFaceLabelLeft', () => {
   });
 
   it('should clamp right edge when label overflows container right boundary', () => {
-    // box: left 950, width 40; label: width 200; overlay: 1000
-    // preferred absolute X = 950 + 40 - 200 = 790
-    // clamped absolute X = min(790, 800) = 790
-    expect(getRelativeFaceLabelLeft(950, 40, 200, 1000)).toBe(-160);
+    // box: left 950, width 100; label: width 80; overlay: 1000
+    // preferred absolute X = 950 + 100 - 80 = 970
+    // max allowed X = 1000 - 80 = 920
+    // clamped absolute X = 920
+    // localLeft = 920 - 950 = -30
+    expect(getRelativeFaceLabelLeft(950, 100, 80, 1000)).toBe(-30);
   });
 
   it('should handle boundary case when label exactly fits inside face box', () => {

--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -1,6 +1,6 @@
 import type { Faces } from '$lib/managers/asset-viewer-manager.svelte';
 import type { Size } from '$lib/utils/container-utils';
-import { getBoundingBox } from '$lib/utils/people-utils';
+import { getBoundingBox, getRelativeFaceLabelLeft } from '$lib/utils/people-utils';
 
 const makeFace = (overrides: Partial<Faces> = {}): Faces => ({
   id: 'face-1',
@@ -66,5 +66,43 @@ describe('getBoundingBox', () => {
 
     expect(boxes).toHaveLength(2);
     expect(boxes[0].left).toBeLessThan(boxes[1].left);
+  });
+});
+
+describe('getRelativeFaceLabelLeft', () => {
+  it('should right align face label by default inside container bounds', () => {
+    // box: left 100, width 50; label: width 80; overlay: 1000
+    // preferred absolute X = 100 + 50 - 80 = 70 (clamped: 70)
+    // localLeft = 70 - 100 = -30
+    expect(getRelativeFaceLabelLeft(100, 50, 80, 1000)).toBe(-30);
+  });
+
+  it('should clamp left edge when label overflows container left boundary', () => {
+    // box: left 10, width 40; label: width 150; overlay: 1000
+    // preferred absolute X = 10 + 40 - 150 = -100 -> clamped to 0
+    // localLeft = 0 - 10 = -10 (label left edge aligns to 0px in container)
+    expect(getRelativeFaceLabelLeft(10, 40, 150, 1000)).toBe(-10);
+  });
+
+  it('should clamp right edge when label overflows container right boundary', () => {
+    // box: left 950, width 40; label: width 200; overlay: 1000
+    // preferred absolute X = 950 + 40 - 200 = 790
+    // clamped absolute X = min(790, 800) = 790
+    expect(getRelativeFaceLabelLeft(950, 40, 200, 1000)).toBe(-160);
+  });
+
+  it('should handle boundary case when label exactly fits inside face box', () => {
+    // box: left 100, width 100; label: width 100; overlay: 1000
+    // preferred absolute X = 100 + 100 - 100 = 100
+    // localLeft = 100 - 100 = 0
+    expect(getRelativeFaceLabelLeft(100, 100, 100, 1000)).toBe(0);
+  });
+
+  it('should clamp gracefully when label width exceeds narrow overlay width', () => {
+    // box: left 10, width 30; label: width 160; overlay: 80 (narrow viewport)
+    // maxX = max(0, 80 - 160) = 0
+    // preferred absolute X = 10 + 30 - 160 = -120 -> clamped to 0
+    // localLeft = 0 - 10 = -10
+    expect(getRelativeFaceLabelLeft(10, 30, 160, 80)).toBe(-10);
   });
 });

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -21,6 +21,23 @@ export const getBoundingBox = (faces: Faces[], imageSize: Size): BoundingBox[] =
   return boxes;
 };
 
+/**
+ * Calculates the horizontal left offset relative to the face bounding box wrapper,
+ * keeping the label bounded within the container overlay [0, overlayWidth].
+ */
+export const getRelativeFaceLabelLeft = (
+  boxLeft: number,
+  boxWidth: number,
+  labelWidth: number,
+  overlayWidth: number,
+): number => {
+  const preferredLabelLeft = boxLeft + boxWidth - labelWidth;
+  const minX = 0;
+  const maxX = Math.max(0, overlayWidth - labelWidth);
+  const clampedAbsoluteX = Math.max(minX, Math.min(preferredLabelLeft, maxX));
+  return clampedAbsoluteX - boxLeft;
+};
+
 export const zoomImageToBase64 = async (
   face: AssetFaceResponseDto,
   assetId: string,


### PR DESCRIPTION
## Description

fixes the face name label being clipped when a tagged face is positioned near the left edge of an asset.
previously, the label was always right-aligned relative to the face bounding box. For faces close to the left edge of the image, long labels could extend beyond the image boundary and be clipped.
this change introduces a small utility to calculate the label's horizontal position relative to the face bounding box while clamping it within the image overlay bounds. This preserves the existing right-aligned behavior whenever there is enough space, while preventing overflow on both the left and right edges.
the positioning logic is covered by unit tests for the default, left-overflow, right-overflow, exact-boundary, and narrow-overlay cases.

Fixes #30483

## How Has This Been Tested?

- [x] Verified that face labels near the left edge remain fully visible.
- [x] Verified that labels retain their existing alignment when sufficient space is available.
- [x] Verified that labels near the right edge remain within the image bounds.
- [x] Added unit tests covering normal, left-overflow, right-overflow, boundary, and narrow-overlay scenarios.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Add before/after screenshots here -->
###before:
<img width="287" height="421" alt="Screenshot (355)" src="https://github.com/user-attachments/assets/43e46585-08e8-4389-9641-05ecb70d7fb7" />


###after:
<img width="269" height="404" alt="Screenshot (356)" src="https://github.com/user-attachments/assets/07e7db6a-66d4-4199-b848-0375df1404bf" />



</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to discuss the overall approach and improve the wording of this PR. The implementation, testing, and final review were completed and verified by me.

...
