### PR TITLE
feat(web): add view similar button to main action bar

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
@@ -121,6 +121,7 @@
     <ActionButton action={Actions.Copy} />
     <ActionButton action={Actions.SharedLinkDownload} />
     <ActionButton action={Actions.Info} />
+    <ActionButton action={Actions.ViewSimilar} />
     <ActionButton action={Actions.Favorite} />
     <ActionButton action={Actions.Unfavorite} />
 
@@ -177,7 +178,6 @@
           <ArchiveAction {asset} {onAction} {preAction} />
         {/if}
         <ActionMenuItem action={Actions.ViewInTimeline} />
-        <ActionMenuItem action={Actions.ViewSimilar} />
 
         {#if !asset.isTrashed && isOwner}
           <SetVisibilityAction asset={toTimelineAsset(asset)} {onAction} {preAction} />


### PR DESCRIPTION
Fixes #21855 by exposing the view similar action directly on the top navbar instead of burying it in the more options menu. This makes the feature more discoverable and enables triggering it easily on partner assets.

## Description

Moved the `ViewSimilar` action out of the overflow `ButtonContextMenu` and into the main row of `ActionButton` components within `AssetViewerNavBar.svelte`. 

This solves the discoverability issue reported in #21855 where users could not easily find or trigger the "Similar Search" on partner assets. Having it prominently in the main navbar makes the feature accessible at a single glance/click.

Fixes #21855

## How Has This Been Tested?

- [x] Verified locally that the "Similar Search" (compare) icon appears in the main top action bar of the Asset Viewer.
- [x] Verified that clicking the button successfully routes to the search page with the correct `queryAssetId` for both owned assets and partner assets.


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI coding assistant helped me navigate the codebase to locate the `AssetViewerNavBar.svelte` component and suggested the one-line UI change to move the button out of the context menu.
