### PR TITLE
fix(server): transcode hidden live photo videos in batch job

### DIFF
--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -328,8 +328,7 @@ export class AssetJobRepository {
                   .where('asset_file.type', '=', sql.lit(AssetFileType.EncodedVideo)),
               ),
             ),
-          )
-          .where('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+          ),
       )
       .where('asset.deletedAt', 'is', null)
       .stream();


### PR DESCRIPTION
## Description
Fixes #22985

The background `AssetEncodeVideoQueueAll` job was previously skipping Live Photo videos when scanning for missing transcodes because `streamForVideoConversion` strictly excluded `AssetVisibility.Hidden` assets unless `force=true`. This meant users who uploaded Live Photos with transcoding disabled could never retroactively transcode them. 

Removing the visibility exclusion allows the batch job to pick up missing encoded videos for Live Photos just as `metadata.service.ts` does upon direct upload.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Verified that `streamForVideoConversion` correctly picks up `AssetType.Video` assets that are `AssetVisibility.Hidden` when they do not have an `EncodedVideo` file.
- [x] Ensured `force=true` behavior remains intact (re-transcodes all videos regardless of encoded status).
- [x] Verified `streamForThumbnailJob` and `streamForEncodeClip` still correctly exclude `Hidden` assets where appropriate.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The analysis of the bug and the creation of this PR was assisted by an AI agent that traced the `AssetVisibility.Hidden` logic through the repository to identify the missing transcoding for Live Photo videos.
