### PR TITLE
fix(mobile): stop disabling androidx.startup initializers

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -152,12 +152,6 @@
              This is used by the Flutter tool to
     generate GeneratedPluginRegistrant.java -->
     <meta-data android:name="flutterEmbedding" android:value="2" />
-    <!-- Disables default WorkManager initialization to use our custom initialization -->
-    <provider
-      android:name="androidx.startup.InitializationProvider"
-      android:authorities="${applicationId}.androidx-startup"
-      tools:node="remove" />
-
 
     <!-- Widgets -->
     <receiver

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/ImmichApp.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/ImmichApp.kt
@@ -3,17 +3,12 @@ package app.alextran.immich
 import android.app.Application
 import android.os.Handler
 import android.os.Looper
-import androidx.work.Configuration
-import androidx.work.WorkManager
 import app.alextran.immich.background.BackgroundEngineLock
 import app.alextran.immich.background.BackgroundWorkerApiImpl
 
 class ImmichApp : Application() {
   override fun onCreate() {
     super.onCreate()
-    val config = Configuration.Builder().build()
-    WorkManager.initialize(this, config)
-    // always start BackupWorker after WorkManager init; this fixes the following bug:
     // After the process is killed (by user or system), the first trigger (taking a new picture) is lost.
     // Thus, the BackupWorker is not started. If the system kills the process after each initialization
     // (because of low memory etc.), the backup is never performed.


### PR DESCRIPTION
The app doesn't have a custom `WorkManager` initialisation for us to disable the default one. The disabling also has a wider scope than just `WorkManager`. This results in crashes when okhttp 5 tries to load the public suffix list. I've verified that the background workers still work post removal of the block