### PR TITLE
Fix grouped person queries

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -38,7 +38,7 @@ where
   and "asset_face"."isVisible" is true
   and "person"."isHidden" = $2
 group by
-  "person"."id"
+  "person".*
 having
   (
     "person"."name" != $3
@@ -77,7 +77,7 @@ where
   "asset_face"."deletedAt" is null
   and "asset_face"."isVisible" is true
 group by
-  "person"."id"
+  "person".*
 having
   count("asset_face"."assetId") = $1
 

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -180,7 +180,7 @@ export class PersonRepository {
           ),
         ]),
       )
-      .groupBy('person.id')
+      .groupBy(sql`"person".*`)
       .$if(!!options?.closestFaceAssetId, (qb) =>
         qb.orderBy((eb) =>
           eb(
@@ -222,7 +222,7 @@ export class PersonRepository {
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
       .having((eb) => eb.fn.count('asset_face.assetId'), '=', 0)
-      .groupBy('person.id')
+      .groupBy(sql`"person".*`)
       .execute();
   }
 


### PR DESCRIPTION
## Description

Fixes #30562

The Explore page can fail with a Postgres `42803` error when fetching people because `PersonRepository.getAllForUser` selects `person.*`, aggregates face counts, groups only by `person.id`, and then orders by `person.createdAt`.

This updates the grouped person queries to group by the selected `person` row, matching the selected columns and keeping the existing ordering/result behavior intact. The generated SQL snapshot was updated accordingly.

## How Has This Been Tested?

- [x] `pnpm --dir server run check`
- [x] `pnpm --dir server exec eslint src/repositories/person.repository.ts --max-warnings 0`
- [x] `pnpm --dir server exec vitest run --config test/vitest.config.mjs src/services/person.service.spec.ts`

Note: an accidental broader server unit run also executed; `person.service.spec.ts` passed there, but unrelated `asset.controller.spec.ts` tests timed out.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

yep, LLM helped investigate the issue and prepare the local patch. I reviewed the change and validation results before submission.