### PR TITLE
fix(server): respect public users setting in mobile sync v2

### DIFF
--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -88,6 +88,20 @@ set
 where
   "userId" = $2
 
+-- SessionRepository.requireFullSyncForNonAdmins
+update "session"
+set
+  "isPendingSyncReset" = $1
+where
+  "userId" in (
+    select
+      "user"."id"
+    from
+      "user"
+    where
+      "user"."isAdmin" = $2
+  )
+
 -- SessionRepository.resetSyncProgress
 begin
 update "session"

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -1121,6 +1121,58 @@ where
 order by
   "user"."updateId" asc
 
+-- SyncRepository.user.getRelatedUpserts
+select
+  "id",
+  "name",
+  "email",
+  "avatarColor",
+  "deletedAt",
+  "updateId",
+  "profileImagePath",
+  "profileChangedAt"
+from
+  "user" as "user"
+where
+  "user"."updateId" < $1
+  and "user"."updateId" > $2
+  and (
+    "id" = $3
+    or "id" in (
+      select
+        "partner"."sharedWithId" as "id"
+      from
+        "partner"
+      where
+        "partner"."sharedById" = $4
+    )
+    or "id" in (
+      select
+        "partner"."sharedById" as "id"
+      from
+        "partner"
+      where
+        "partner"."sharedWithId" = $5
+    )
+    or "id" in (
+      select
+        "album_user"."userId" as "id"
+      from
+        "album_user"
+      where
+        "album_user"."albumId" in (
+          select
+            "album_user"."albumId" as "id"
+          from
+            "album_user"
+          where
+            "album_user"."userId" = $6
+        )
+    )
+  )
+order by
+  "user"."updateId" asc
+
 -- SyncRepository.userMetadata.getDeletes
 select
   "id",

--- a/server/src/repositories/session.repository.ts
+++ b/server/src/repositories/session.repository.ts
@@ -137,6 +137,15 @@ export class SessionRepository {
     await this.db.updateTable('session').set({ pinExpiresAt: null }).where('userId', '=', userId).execute();
   }
 
+  @GenerateSql({ params: [] })
+  async requireFullSyncForNonAdmins() {
+    await this.db
+      .updateTable('session')
+      .set({ isPendingSyncReset: true })
+      .where((eb) => eb('userId', 'in', eb.selectFrom('user').select('user.id').where('user.isAdmin', '=', false)))
+      .execute();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   async resetSyncProgress(sessionId: string) {
     await this.db.transaction().execute((tx) => {

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -751,6 +751,42 @@ class UserSync extends BaseSync {
   getUpserts(options: SyncQueryOptions) {
     return this.upsertQuery('user', options).select(columns.syncUser).stream();
   }
+
+  // used when public users are disabled: only self, partners, and album co-members are visible
+  @GenerateSql({ params: [dummyQueryOptions], stream: true })
+  getRelatedUpserts(options: SyncQueryOptions) {
+    const userId = options.userId;
+    return this.upsertQuery('user', options)
+      .select(columns.syncUser)
+      .where((eb) =>
+        eb.or([
+          eb('id', '=', userId),
+          eb(
+            'id',
+            'in',
+            eb.selectFrom('partner').select('partner.sharedWithId as id').where('partner.sharedById', '=', userId),
+          ),
+          eb(
+            'id',
+            'in',
+            eb.selectFrom('partner').select('partner.sharedById as id').where('partner.sharedWithId', '=', userId),
+          ),
+          eb(
+            'id',
+            'in',
+            eb
+              .selectFrom('album_user')
+              .select('album_user.userId as id')
+              .where(
+                'album_user.albumId',
+                'in',
+                eb.selectFrom('album_user').select('album_user.albumId as id').where('album_user.userId', '=', userId),
+              ),
+          ),
+        ]),
+      )
+      .stream();
+  }
 }
 
 class UserMetadataSync extends BaseSync {

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -87,7 +87,7 @@ const throwSessionRequired = () => {
 
 @Injectable()
 export class SyncService extends BaseService {
-  @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.Microservices] })
+  @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.Api] })
   async onConfigUpdate({ newConfig, oldConfig }: ArgOf<'ConfigUpdate'>) {
     if (oldConfig.server.publicUsers && !newConfig.server.publicUsers) {
       await this.sessionRepository.requireFullSyncForNonAdmins();

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -89,7 +89,7 @@ const throwSessionRequired = () => {
 export class SyncService extends BaseService {
   @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.Api] })
   async onConfigUpdate({ newConfig, oldConfig }: ArgOf<'ConfigUpdate'>) {
-    if (oldConfig.server.publicUsers && !newConfig.server.publicUsers) {
+    if (oldConfig.server.publicUsers !== newConfig.server.publicUsers) {
       await this.sessionRepository.requireFullSyncForNonAdmins();
     }
   }

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -166,7 +166,7 @@ export class SyncService extends BaseService {
       [SyncRequestType.AlbumAssetsV1]: () => this.syncAlbumAssetsV1(),
 
       [SyncRequestType.AuthUsersV1]: () => this.syncAuthUsersV1(options, response, checkpointMap),
-      [SyncRequestType.UsersV1]: () => this.syncUsersV1(options, response, checkpointMap),
+      [SyncRequestType.UsersV1]: () => this.syncUsersV1(options, response, checkpointMap, auth),
       [SyncRequestType.PartnersV1]: () => this.syncPartnersV1(options, response, checkpointMap),
       [SyncRequestType.AssetsV2]: () => this.syncAssetsV2(options, response, checkpointMap),
       [SyncRequestType.AssetExifsV1]: () => this.syncAssetExifsV1(options, response, checkpointMap),
@@ -246,7 +246,7 @@ export class SyncService extends BaseService {
     }
   }
 
-  private async syncUsersV1(options: SyncQueryOptions, response: Writable, checkpointMap: CheckpointMap) {
+  private async syncUsersV1(options: SyncQueryOptions, response: Writable, checkpointMap: CheckpointMap, auth: AuthDto) {
     const deleteType = SyncEntityType.UserDeleteV1;
     const deletes = this.syncRepository.user.getDeletes({ ...options, ack: checkpointMap[deleteType] });
     for await (const { id, ...data } of deletes) {
@@ -254,7 +254,11 @@ export class SyncService extends BaseService {
     }
 
     const upsertType = SyncEntityType.UserV1;
-    const upserts = this.syncRepository.user.getUpserts({ ...options, ack: checkpointMap[upsertType] });
+    const { server } = await this.getConfig({ withCache: false });
+    const canViewAllUsers = auth.user.isAdmin || server.publicUsers;
+    const upserts = canViewAllUsers
+      ? this.syncRepository.user.getUpserts({ ...options, ack: checkpointMap[upsertType] })
+      : this.syncRepository.user.getRelatedUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, profileImagePath, ...data } of upserts) {
       send(response, { type: upsertType, ids: [updateId], data: { ...data, hasProfileImage: !!profileImagePath } });
     }

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/com
 import { Insertable } from 'kysely';
 import { DateTime, Duration } from 'luxon';
 import { Writable } from 'node:stream';
-import { OnJob } from 'src/decorators';
+import { OnEvent, OnJob } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import {
   SyncAckDeleteDto,
@@ -12,7 +12,8 @@ import {
   SyncItem,
   SyncStreamDto,
 } from 'src/dtos/sync.dto';
-import { JobName, QueueName, SyncEntityType, SyncRequestType } from 'src/enum';
+import { ImmichWorker, JobName, QueueName, SyncEntityType, SyncRequestType } from 'src/enum';
+import { ArgOf } from 'src/repositories/event.repository';
 import { SyncQueryOptions } from 'src/repositories/sync.repository';
 import { SessionSyncCheckpointTable } from 'src/schema/tables/sync-checkpoint.table';
 import { BaseService } from 'src/services/base.service';
@@ -86,6 +87,13 @@ const throwSessionRequired = () => {
 
 @Injectable()
 export class SyncService extends BaseService {
+  @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.Microservices] })
+  async onConfigUpdate({ newConfig, oldConfig }: ArgOf<'ConfigUpdate'>) {
+    if (oldConfig.server.publicUsers && !newConfig.server.publicUsers) {
+      await this.sessionRepository.requireFullSyncForNonAdmins();
+    }
+  }
+
   getAcks(auth: AuthDto) {
     const sessionId = auth.session?.id;
     if (!sessionId) {

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -332,7 +332,7 @@ export class SyncTestContext extends MediumTestContext<SyncService> {
   constructor(database: Kysely<DB>) {
     super(SyncService, {
       database,
-      real: [SyncRepository, SyncCheckpointRepository, SessionRepository],
+      real: [SyncRepository, SyncCheckpointRepository, SessionRepository, ConfigRepository, SystemMetadataRepository],
       mock: [LoggingRepository],
     });
   }

--- a/server/test/medium/specs/services/sync.service.spec.ts
+++ b/server/test/medium/specs/services/sync.service.spec.ts
@@ -1,9 +1,11 @@
 import { schemaFromCode } from '@immich/sql-tools';
 import { Kysely } from 'kysely';
 import { DateTime } from 'luxon';
+import { SystemConfig } from 'src/config';
 import { AssetMetadataKey, UserMetadataKey } from 'src/enum';
 import { DatabaseRepository } from 'src/repositories/database.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SessionRepository } from 'src/repositories/session.repository';
 import { BaseSync, SyncRepository } from 'src/repositories/sync.repository';
 import { DB } from 'src/schema';
 import { SyncService } from 'src/services/sync.service';
@@ -16,7 +18,7 @@ let defaultDatabase: Kysely<DB>;
 const setup = (db?: Kysely<DB>) => {
   return newMediumService(SyncService, {
     database: db || defaultDatabase,
-    real: [DatabaseRepository, SyncRepository],
+    real: [DatabaseRepository, SyncRepository, SessionRepository],
     mock: [LoggingRepository],
   });
 };
@@ -31,6 +33,17 @@ const assertTableCount = async <T extends keyof DB>(db: Kysely<DB>, t: T, count:
   const { table } = db.dynamic;
   const results = await db.selectFrom(table(t).as(t)).selectAll().execute();
   expect(results).toHaveLength(count);
+};
+
+const withPublicUsers = (publicUsers: boolean) => ({ server: { publicUsers } }) as SystemConfig;
+
+const isPendingSyncReset = async (db: Kysely<DB>, sessionId: string) => {
+  const session = await db
+    .selectFrom('session')
+    .select('isPendingSyncReset')
+    .where('id', '=', sessionId)
+    .executeTakeFirstOrThrow();
+  return session.isPendingSyncReset;
 };
 
 describe(SyncService.name, () => {
@@ -238,6 +251,48 @@ describe(SyncService.name, () => {
       for (const table of auditTables) {
         expect(auditCleanupSpy, `Audit table ${table} was not cleaned up`).toHaveBeenCalledWith(table, 31);
       }
+    });
+  });
+
+  describe('onConfigUpdate', () => {
+    it('should require a full sync for non-admins when public users is disabled', async () => {
+      const { sut, ctx } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser();
+      const { session } = await ctx.newSession({ userId: user.id });
+
+      await sut.onConfigUpdate({ oldConfig: withPublicUsers(true), newConfig: withPublicUsers(false) });
+
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(true);
+    });
+
+    it('should not require a full sync for admins when public users is disabled', async () => {
+      const { sut, ctx } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser({ isAdmin: true });
+      const { session } = await ctx.newSession({ userId: user.id });
+
+      await sut.onConfigUpdate({ oldConfig: withPublicUsers(true), newConfig: withPublicUsers(false) });
+
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
+    });
+
+    it('should not require a full sync when public users is enabled', async () => {
+      const { sut, ctx } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser();
+      const { session } = await ctx.newSession({ userId: user.id });
+
+      await sut.onConfigUpdate({ oldConfig: withPublicUsers(false), newConfig: withPublicUsers(true) });
+
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
+    });
+
+    it('should not require a full sync when public users was already disabled', async () => {
+      const { sut, ctx } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser();
+      const { session } = await ctx.newSession({ userId: user.id });
+
+      await sut.onConfigUpdate({ oldConfig: withPublicUsers(false), newConfig: withPublicUsers(false) });
+
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
     });
   });
 });

--- a/server/test/medium/specs/services/sync.service.spec.ts
+++ b/server/test/medium/specs/services/sync.service.spec.ts
@@ -275,14 +275,14 @@ describe(SyncService.name, () => {
       await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
     });
 
-    it('should not require a full sync when public users is enabled', async () => {
+    it('should require a full sync for non-admins when public users is enabled', async () => {
       const { sut, ctx } = setup(await getKyselyDB());
       const { user } = await ctx.newUser();
       const { session } = await ctx.newSession({ userId: user.id });
 
       await sut.onConfigUpdate({ oldConfig: withPublicUsers(false), newConfig: withPublicUsers(true) });
 
-      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(true);
     });
 
     it('should not require a full sync when public users was already disabled', async () => {
@@ -291,6 +291,16 @@ describe(SyncService.name, () => {
       const { session } = await ctx.newSession({ userId: user.id });
 
       await sut.onConfigUpdate({ oldConfig: withPublicUsers(false), newConfig: withPublicUsers(false) });
+
+      await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
+    });
+
+    it('should not require a full sync when public users was already enabled', async () => {
+      const { sut, ctx } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser();
+      const { session } = await ctx.newSession({ userId: user.id });
+
+      await sut.onConfigUpdate({ oldConfig: withPublicUsers(true), newConfig: withPublicUsers(true) });
 
       await expect(isPendingSyncReset(ctx.database, session.id)).resolves.toBe(false);
     });

--- a/server/test/medium/specs/sync/sync-user.spec.ts
+++ b/server/test/medium/specs/sync/sync-user.spec.ts
@@ -3,6 +3,7 @@ import { SyncEntityType, SyncRequestType } from 'src/enum';
 import { UserRepository } from 'src/repositories/user.repository';
 import { DB } from 'src/schema';
 import { SyncTestContext } from 'test/medium.factory';
+import { factory } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
 
 let defaultDatabase: Kysely<DB>;
@@ -12,6 +13,15 @@ const setup = async (db?: Kysely<DB>) => {
   const { auth, user, session } = await ctx.newSyncAuthUser();
   return { auth, user, session, ctx };
 };
+
+const disablePublicUsers = async (ctx: SyncTestContext) => {
+  const config = await ctx.sut.getConfig({ withCache: false });
+  config.server.publicUsers = false;
+  await ctx.sut.updateConfig(config);
+};
+
+const getSyncedUserIds = (response: Array<{ type: string; data: any }>) =>
+  response.filter((item) => item.type === SyncEntityType.UserV1).map((item) => item.data.id);
 
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
@@ -133,5 +143,69 @@ describe(SyncEntityType.UserV1, () => {
       },
       expect.objectContaining({ type: SyncEntityType.SyncCompleteV1 }),
     ]);
+  });
+
+  describe('public users disabled', () => {
+    it('should only sync the authenticated user when there are no relationships', async () => {
+      const { auth, ctx } = await setup(await getKyselyDB());
+      await disablePublicUsers(ctx);
+
+      const { user: unrelated } = await ctx.newUser();
+
+      const response = await ctx.syncStream(auth, [SyncRequestType.UsersV1]);
+      const ids = getSyncedUserIds(response);
+
+      expect(ids).toEqual([auth.user.id]);
+      expect(ids).not.toContain(unrelated.id);
+    });
+
+    it('should sync partners', async () => {
+      const { auth, ctx } = await setup(await getKyselyDB());
+      await disablePublicUsers(ctx);
+
+      const { user: partner } = await ctx.newUser();
+      await ctx.newPartner({ sharedById: auth.user.id, sharedWithId: partner.id });
+      const { user: unrelated } = await ctx.newUser();
+
+      const response = await ctx.syncStream(auth, [SyncRequestType.UsersV1]);
+      const ids = getSyncedUserIds(response);
+
+      expect(ids).toEqual(expect.arrayContaining([auth.user.id, partner.id]));
+      expect(ids).not.toContain(unrelated.id);
+    });
+
+    it('should sync album co-members', async () => {
+      const { auth, ctx } = await setup(await getKyselyDB());
+      await disablePublicUsers(ctx);
+
+      const { user: coMember } = await ctx.newUser();
+      const { album } = await ctx.newAlbum({ ownerId: auth.user.id });
+      await ctx.newAlbumUser({ albumId: album.id, userId: coMember.id });
+      const { user: unrelated } = await ctx.newUser();
+
+      const response = await ctx.syncStream(auth, [SyncRequestType.UsersV1]);
+      const ids = getSyncedUserIds(response);
+
+      expect(ids).toEqual(expect.arrayContaining([auth.user.id, coMember.id]));
+      expect(ids).not.toContain(unrelated.id);
+    });
+
+    it('should still sync all users for an admin', async () => {
+      const { ctx } = await setup(await getKyselyDB());
+      await disablePublicUsers(ctx);
+
+      const { user: admin } = await ctx.newUser({ isAdmin: true });
+      const { session: adminSession } = await ctx.newSession({ userId: admin.id });
+      const adminAuth = factory.auth({
+        session: adminSession,
+        user: { id: admin.id, name: admin.name, email: admin.email, isAdmin: true },
+      });
+      const { user: unrelated } = await ctx.newUser();
+
+      const response = await ctx.syncStream(adminAuth, [SyncRequestType.UsersV1]);
+      const ids = getSyncedUserIds(response);
+
+      expect(ids).toEqual(expect.arrayContaining([admin.id, unrelated.id]));
+    });
   });
 });


### PR DESCRIPTION
## Description

When "Public Users" is disabled in Server Settings, the web app correctly restricts non-admin users to only seeing themselves in Partner Sharing and Album Sharing. The mobile app however ignores this setting entirely: since Sync v2, the local user list is populated by the `UserV1` sync feed, and `UserSync.getUpserts()` in `sync.repository.ts` streamed every user unconditionally to every client, regardless of the `publicUsers` setting or the requester's admin status. Any authenticated user could see every other user's name and email through Partner/Album sharing on mobile. IMO this is a privacy risk for bigger servers and their users.

This PR:
- Adds `UserSync.getRelatedUpserts()`, used instead of `getUpserts()` when the requester is a non-admin and `publicUsers` is disabled. It scopes the synced user set to thhe user themselves, existing partners (either direction), and existing album co-members. So already established sharing relationships keep displaying correctly, while unrelated users are no longer synced.
- Adds a `ConfigUpdate` handler in `SyncService` that marks all non-admin sessions for a full sync reset whenever the `publicUsers` setting changes (no matter if it is being disabled or enabled). Without this, a device that already fully synced the user list keeps those cached rows indefinitely, since the sync protocol only upserts users and never prunes ones that quietly become invisible. Previously this required a manual logout/login to clear.

## Fixes
- #24528 
- duplicate-closed report: #30250 
- duplicate-closed report: #25252
- Also (probably) applies to a fork and its issue at https://github.com/open-noodle/gallery/issues/890

## How Has This Been Tested?

- [x] Added/updated integration tests against a real Postgres instance covering non-admin with no relationships only syncs self and non-admin with a partner syncs self+partner but not unrelated users. Non-admin with a shared album syncs self+co-member but not unrelated users. Admins always sync every user and the `publicUsers` toggle (both directions) marks non-admin sessions for a full sync reset while admin sessions are left untouched.
- [x] Full existing sync test suite re-run to confirm no regressions.
- [x] Manually verified against a locally built server (this branch) and the existing mobile app. I created an admin and two regular users. I established a partner relationship between the two normal users, confirmed Partner Sharing/Album Sharing correctly restrict to the related user set after disabling Public Users and confirmed it also updates automatically (no logout/login needed, in either toggle direction) after the sync-reset fix.

## API Changes

None (no endpoint signature changes. Behavior of the existing `UserV1` sync stream is scoped for non-admins when `publicUsers` is disabled).

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used Claude Code to draft this PR description for better understandability based on the git history of my commits, as well as the descriptions for the commits itself. Claude Code was also used to analyze the root cause of this issue. The code in this commit was fully handwritten besides the tests. Those were written/assisted by Claude Code and checked against by myself, as well as improved by hand to ensure being on line with the [contributing guidelines](https://github.com/immich-app/immich/pull/30564). ESLint was run against every changed or new file after each edit to catch style and code-quality issues before committing. It flagged a couple of unicorn and consistent-function-scoping violations in the new tests. Helper functions that needed to be moved to module scope, which were fixed before the final commit.

TLDR: Code was handwritten (besides the tests, that were **assisted** by an LLM and **finalized by hand**) and text inside commit messages and the PR was improved by an LLM. LLM was used to find root cause.