### PR TITLE
fix: _safeRun is finally safe

### DIFF
--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -93,13 +93,13 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     await _ref.read(galleryPermissionNotifier.notifier).getGalleryPermissionStatus();
   }
 
-  Future<void> _safeRun(Future<void> action, String debugName) async {
+  Future<void> _safeRun(Future<void> Function() action, String debugName) async {
     if (!_shouldContinueOperation()) {
       return;
     }
 
     try {
-      await action;
+      await action();
     } catch (e, stackTrace) {
       _log.warning("Error during $debugName operation", e, stackTrace);
     }
@@ -117,13 +117,15 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     try {
       bool syncSuccess = false;
       await Future.wait([
-        _safeRun(backgroundManager.syncLocal(full: CurrentPlatform.isAndroid ? true : false), "syncLocal"),
-        _safeRun(backgroundManager.syncRemote().then((success) => syncSuccess = success), "syncRemote"),
+        _safeRun(() => backgroundManager.syncLocal(full: CurrentPlatform.isAndroid), "syncLocal"),
+        _safeRun(() async {
+          syncSuccess = await backgroundManager.syncRemote();
+        }, "syncRemote"),
       ]);
       _ref.invalidate(driftMemoryFutureProvider);
       if (syncSuccess) {
         await Future.wait([
-          _safeRun(backgroundManager.hashAssets(), "hashAssets").then((_) {
+          _safeRun(backgroundManager.hashAssets, "hashAssets").then((_) {
             unawaited(_resumeBackup());
           }),
           _resumeBackup(),
@@ -131,11 +133,11 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
           // _safeRun(backgroundManager.syncCloudIds(), "syncCloudIds"),
         ]);
       } else {
-        await _safeRun(backgroundManager.hashAssets(), "hashAssets");
+        await _safeRun(backgroundManager.hashAssets, "hashAssets");
       }
 
       if (isAlbumLinkedSyncEnable) {
-        await _safeRun(backgroundManager.syncLinkedAlbum(), "syncLinkedAlbum");
+        await _safeRun(backgroundManager.syncLinkedAlbum, "syncLinkedAlbum");
       }
     } catch (e, stackTrace) {
       _log.severe("Error during background sync", e, stackTrace);
@@ -149,7 +151,7 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
       final currentUser = Store.tryGet(StoreKey.currentUser);
       if (currentUser != null) {
         await _safeRun(
-          _ref.read(driftBackupProvider.notifier).startForegroundBackup(currentUser.id),
+          () => _ref.read(driftBackupProvider.notifier).startForegroundBackup(currentUser.id),
           "handleBackupResume",
         );
       }


### PR DESCRIPTION
The previous implementation skipped awaiting an already started future based off of the life cycle. It never prevented it from starting