### PR TITLE
feat: iOS dynamic background ids

### DIFF
--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -22,8 +22,9 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     print("BackgroundWorkerApiImpl:disableUploadWorker Disabled background workers")
   }
   
-  private static let refreshTaskID = "app.alextran.immich.background.refreshUpload"
-  private static let processingTaskID = "app.alextran.immich.background.processingUpload"
+  private static let taskIDs = Bundle.main.object(forInfoDictionaryKey: "BGTaskSchedulerPermittedIdentifiers") as! [String]
+  private static let refreshTaskID = taskIDs.first { $0.hasSuffix(".refreshUpload") }!
+  private static let processingTaskID = taskIDs.first { $0.hasSuffix(".processingUpload") }!
   private static let taskSemaphore = DispatchSemaphore(value: 1)
 
   public static func registerBackgroundWorkers() {


### PR DESCRIPTION
## Description

Background identifiers are hardcoded.

Solves the theoretical issue of changing ids in the future and forgetting to update everywhere. I think getting them dynamically is better.

Fixes # (issue)

## How Has This Been Tested?

See screenshot below.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1058" height="392" alt="Screenshot 2026-08-05 at 18 03 28" src="https://github.com/user-attachments/assets/7328200a-03ea-45e3-aeb9-767c6a5e8bad" />
<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
NA