### PR TITLE
fix(server): preserve metadata when sidecar writes fail

### DIFF
--- a/server/src/repositories/metadata.repository.spec.ts
+++ b/server/src/repositories/metadata.repository.spec.ts
@@ -1,0 +1,19 @@
+import { ExifTool } from 'exiftool-vendored';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { MetadataRepository } from 'src/repositories/metadata.repository';
+import { automock } from 'test/utils';
+
+describe(MetadataRepository.name, () => {
+  it('should propagate sidecar write errors', async () => {
+    const error = new Error('read-only file system');
+    const logger = automock(LoggingRepository, { strict: false });
+    const sut = new MetadataRepository(logger);
+    const write = vitest.fn().mockRejectedValue(error);
+    sut['exiftool'] = { write } as unknown as ExifTool;
+
+    await expect(sut.writeTags('/read-only/asset.jpg.xmp', { Description: 'description' })).rejects.toBe(error);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Error writing exif data (/read-only/asset.jpg.xmp): Error: read-only file system',
+    );
+  });
+});

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -132,6 +132,7 @@ export class MetadataRepository {
       await this.exiftool.write(path, tagsToWrite);
     } catch (error) {
       this.logger.warn(`Error writing exif data (${path}): ${error}`);
+      throw error;
     }
   }
 }

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -2019,6 +2019,25 @@ describe(MetadataService.name, () => {
       ]);
     });
 
+    it('should retain locked properties when writing tags fails', async () => {
+      const asset = AssetFactory.from()
+        .file({ type: AssetFileType.Sidecar })
+        .exif({ description: 'database description' })
+        .build();
+      const error = new Error('read-only file system');
+
+      mocks.assetJob.getLockedPropertiesForMetadataExtraction.mockResolvedValue(['description']);
+      mocks.assetJob.getForSidecarWriteJob.mockResolvedValue(getForSidecarWrite(asset));
+      mocks.metadata.writeTags.mockRejectedValue(error);
+
+      await expect(sut.handleSidecarWrite({ id: asset.id })).rejects.toBe(error);
+      expect(mocks.metadata.writeTags).toHaveBeenCalledWith(asset.files[0].path, {
+        Description: 'database description',
+        ImageDescription: 'database description',
+      });
+      expect(mocks.asset.unlockProperties).not.toHaveBeenCalled();
+    });
+
     it('should write rating', async () => {
       const asset = AssetFactory.from().file({ type: AssetFileType.Sidecar }).exif().build();
       asset.exifInfo.rating = 4;


### PR DESCRIPTION
## Description

`MetadataRepository.writeTags` currently logs ExifTool write failures and then
returns successfully. `MetadataService.handleSidecarWrite` consequently
unlocks the manually edited properties and reports a successful job even when
the XMP sidecar was not updated. A later metadata extraction can then replace
the database edit with the unchanged sidecar value.

This is reproducible for external libraries mounted read-only, but applies to
any sidecar write failure. This change rethrows the error after logging it so
the sidecar job fails before the properties are unlocked. Successful writes
retain the existing behavior.

The patch does not redirect or copy sidecars and does not change the source
library's permissions. It only makes the existing write failure visible to the
job boundary and preserves the database values and their metadata locks.

## How Has This Been Tested?

- [x] `pnpm --dir server test --run src/repositories/metadata.repository.spec.ts src/services/metadata.service.spec.ts` (118 tests passed)
- [x] `pnpm --dir server format`
- [x] `pnpm --dir server lint`
- [x] `pnpm --dir server check`
- [x] `pnpm --dir server test --run` (full server unit suite passed)
- [x] The same behavior has been exercised in a production deployment with an external library mounted read-only: failed sidecar writes retain the edited database description and its lock.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich-specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The implementation and tests were authored and reviewed by the contributor.
An LLM was used for repository navigation, rebasing the existing patch onto
current `main`, executing the validation commands, and helping draft this PR
description. The contributor reviewed and owns the behavior, code, tests, and
claims in this PR.
