### PR TITLE
fix(server): avoid GROUP BY on full person row in getAllForUser

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -28,38 +28,44 @@ select
   "person".*
 from
   "person"
-  inner join "asset_face" on "asset_face"."personId" = "person"."id"
-  inner join "asset" on "asset_face"."assetId" = "asset"."id"
-  and "asset"."visibility" = 'timeline'
-  and "asset"."deletedAt" is null
+  inner join (
+    select
+      "asset_face"."personId" as "personId",
+      count("asset_face"."assetId") as "faceCount"
+    from
+      "asset_face"
+      inner join "asset" on "asset_face"."assetId" = "asset"."id"
+      and "asset"."visibility" = 'timeline'
+      and "asset"."deletedAt" is null
+    where
+      "asset_face"."deletedAt" is null
+      and "asset_face"."isVisible" is true
+    group by
+      "asset_face"."personId"
+  ) as "face_counts" on "face_counts"."personId" = "person"."id"
 where
   "person"."ownerId" = $1
-  and "asset_face"."deletedAt" is null
-  and "asset_face"."isVisible" is true
-  and "person"."isHidden" = $2
-group by
-  "person"."id"
-having
-  (
-    "person"."name" != $3
-    or count("asset_face"."assetId") >= COALESCE(
+  and (
+    "person"."name" != $2
+    or "face_counts"."faceCount" >= COALESCE(
       (
         SELECT
           value -> 'people' ->> 'minimumFaces'
         FROM
           user_metadata
         WHERE
-          "userId" = $4
+          "userId" = $3
           AND key = 'preferences'
       ),
       '3'
     )::int
   )
+  and "person"."isHidden" = $4
 order by
   "person"."isHidden" asc,
   "person"."isFavorite" desc,
   NULLIF(person.name, '') is null asc,
-  count("asset_face"."assetId") desc,
+  "face_counts"."faceCount" desc,
   NULLIF(person.name, '') asc nulls last,
   "person"."createdAt"
 limit

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -149,26 +149,29 @@ export class PersonRepository {
 
   @GenerateSql({ params: [{ take: 1, skip: 0 }, DummyValue.UUID] })
   async getAllForUser(pagination: PaginationOptions, userId: string, options?: PersonSearchOptions) {
-    const items = await this.db
-      .selectFrom('person')
-      .selectAll('person')
-      .innerJoin('asset_face', 'asset_face.personId', 'person.id')
+    const faceCounts = this.db
+      .selectFrom('asset_face')
       .innerJoin('asset', (join) =>
         join
           .onRef('asset_face.assetId', '=', 'asset.id')
           .on('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
           .on('asset.deletedAt', 'is', null),
       )
-      .where('person.ownerId', '=', userId)
+      .select(['asset_face.personId as personId', (eb) => eb.fn.count('asset_face.assetId').as('faceCount')])
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
-      .orderBy('person.isHidden', 'asc')
-      .orderBy('person.isFavorite', 'desc')
-      .having((eb) =>
+      .groupBy('asset_face.personId');
+
+    const items = await this.db
+      .selectFrom('person')
+      .selectAll('person')
+      .innerJoin(faceCounts.as('face_counts'), 'face_counts.personId', 'person.id')
+      .where('person.ownerId', '=', userId)
+      .where((eb) =>
         eb.or([
           eb('person.name', '!=', ''),
           eb(
-            (innerEb) => innerEb.fn.count('asset_face.assetId'),
+            'face_counts.faceCount',
             '>=',
             sql<number>`COALESCE(
               (SELECT value -> 'people' ->> 'minimumFaces'
@@ -180,7 +183,8 @@ export class PersonRepository {
           ),
         ]),
       )
-      .groupBy('person.id')
+      .orderBy('person.isHidden', 'asc')
+      .orderBy('person.isFavorite', 'desc')
       .$if(!!options?.closestFaceAssetId, (qb) =>
         qb.orderBy((eb) =>
           eb(
@@ -201,7 +205,7 @@ export class PersonRepository {
       .$if(!options?.closestFaceAssetId, (qb) =>
         qb
           .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
-          .orderBy((eb) => eb.fn.count('asset_face.assetId'), 'desc')
+          .orderBy('face_counts.faceCount', 'desc')
           .orderBy(sql`NULLIF(person.name, '')`, (om) => om.asc().nullsLast())
           .orderBy('person.createdAt'),
       )


### PR DESCRIPTION
## Description

The Explore page can fail with a Postgres 42803 error ("column must appear in the GROUP BY clause or be used in an aggregate function") when fetching people, because `PersonRepository.getAllForUser` grouped the query by `person.id` while ordering by `person.createdAt`, which isn't part of the GROUP BY or an aggregate.

A previous attempt (#30563) fixed this by grouping on the full `person` row, but that was rejected as inefficient since it forces Postgres to group on every selected column of `person` instead of just its primary key.

This PR removes the `GROUP BY` on `person` entirely. Visible face counts are now pre-aggregated in a narrow subquery grouped only by `asset_face.personId`, which is then joined back onto `person`. Since the outer query no longer groups `person`, `person.createdAt` (and any other `person.*` column) can be freely selected/ordered on without triggering 42803, and the `HAVING` clause becomes a plain `WHERE` since `face_counts.faceCount` is already aggregated upstream.

Fixes #30562

## How Has This Been Tested?

- [x] `pnpm --dir server run check` (tsc --noEmit, no errors)
- [x] `pnpm --dir server exec eslint src/repositories/person.repository.ts --max-warnings 0` (no errors)
- [x] `pnpm --dir server exec vitest run --config test/vitest.config.mjs src/services/person.service.spec.ts` (73 passed)
- [x] Regenerated `server/src/queries/person.repository.sql` via `mise //:sql` against a local Postgres instance and confirmed the `getAllForUser` fixture reflects the new query shape (subquery join instead of `group by "person"."id"`)

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM helped investigate the root cause, evaluate the trade-off raised on the prior closed PR, and draft the local patch. I reviewed the diff, ran the checks above, and validated the regenerated SQL fixture before submitting.