### PR TITLE
fix(web): flag metadata fields missing from only some duplicates

### DIFF
--- a/web/src/lib/utils/duplicate-utils.spec.ts
+++ b/web/src/lib/utils/duplicate-utils.spec.ts
@@ -1,0 +1,89 @@
+import type { AssetResponseDto, ExifResponseDto } from '@immich/sdk';
+import { computeDifferingMetadataFields, countDifferingMetadataItems } from '$lib/utils/duplicate-utils';
+import { assetFactory } from '@test-data/factories/asset-factory';
+
+// Derives both assets from a single base so that everything except `exifInfo` is identical,
+// leaving the field under test as the only possible difference.
+const buildPair = (first: ExifResponseDto, second: ExifResponseDto): AssetResponseDto[] => {
+  const base = assetFactory.build();
+  return [
+    { ...base, id: 'first-asset', exifInfo: first },
+    { ...base, id: 'second-asset', exifInfo: second },
+  ];
+};
+
+describe('computeDifferingMetadataFields', () => {
+  it('flags coordinates when only one asset has them', () => {
+    const assets = buildPair({ latitude: 48.8583, longitude: 2.2944 }, {});
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.latitude).toBe(true);
+    expect(diffs.longitude).toBe(true);
+  });
+
+  it('does not flag coordinates when neither asset has them', () => {
+    const assets = buildPair({}, {});
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.latitude).toBe(false);
+    expect(diffs.longitude).toBe(false);
+  });
+
+  it('does not flag coordinates when both assets share them', () => {
+    const coordinates = { latitude: 48.8583, longitude: 2.2944 };
+    const assets = buildPair(coordinates, { ...coordinates });
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.latitude).toBe(false);
+    expect(diffs.longitude).toBe(false);
+  });
+
+  it('flags coordinates when the assets disagree', () => {
+    const assets = buildPair({ latitude: 48.8583, longitude: 2.2944 }, { latitude: 41.8902, longitude: 12.4922 });
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.latitude).toBe(true);
+    expect(diffs.longitude).toBe(true);
+  });
+
+  it('treats an explicit null the same as an absent field', () => {
+    const assets = buildPair({ description: null }, {});
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.description).toBe(false);
+  });
+
+  it('treats an empty string the same as an absent field', () => {
+    const assets = buildPair({ description: '' }, { description: null });
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.description).toBe(false);
+  });
+
+  it('flags other nullable fields present on only one asset', () => {
+    const assets = buildPair({ rating: 4, lensModel: 'EF24-70mm f/2.8L II USM', make: 'Canon' }, {});
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    expect(diffs.rating).toBe(true);
+    expect(diffs.lensModel).toBe(true);
+    expect(diffs.make).toBe(true);
+  });
+});
+
+describe('countDifferingMetadataItems', () => {
+  it('counts a field that only one asset has', () => {
+    const assets = buildPair({ latitude: 48.8583, longitude: 2.2944 }, {});
+
+    const diffs = computeDifferingMetadataFields(assets);
+
+    // latitude and longitude belong to the single "gps" field
+    expect(countDifferingMetadataItems(diffs)).toBe(1);
+  });
+});

--- a/web/src/lib/utils/duplicate-utils.ts
+++ b/web/src/lib/utils/duplicate-utils.ts
@@ -27,6 +27,11 @@ import type { MessageFormatter } from 'svelte-i18n';
 import { getAssetResolution, getFileSize } from '$lib/utils/asset-utils';
 import { fromISODateTime, fromISODateTimeUTC } from '$lib/utils/timeline-util';
 
+// Stands in for a value that is absent, so that "present on one asset, absent on another" counts as a difference.
+// Every value below collapses to it, since the metadata renderers fall back to "unknown" for each of them.
+const MISSING = Symbol('missing');
+const MISSING_VALUES = new Set<unknown>([undefined, null, '']);
+
 const truncateMiddle = (path: string, maxLength = 50): string => {
   if (path.length <= maxLength) {
     return path;
@@ -289,9 +294,7 @@ export const computeDifferingMetadataFields = (assets: AssetResponseDto[]): Diff
 
     for (const asset of assets) {
       const value = getValueForAsset(asset, key);
-      if (value !== undefined && value !== null) {
-        uniqueValues.add(normalizeForComparison(key, value));
-      }
+      uniqueValues.add(MISSING_VALUES.has(value) ? MISSING : normalizeForComparison(key, value));
     }
 
     diffs[key] = uniqueValues.size > 1;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the Duplicate Detection utility, a metadata field was only listed as differing when two or more assets each had a *present* value that disagreed. `computeDifferingMetadataFields` skipped `null`/`undefined` values before building its set of unique values, so a field present on one asset and absent on another collapsed to a set of size 1 and was never flagged. Since `DuplicateAsset.svelte` only renders fields marked as differing, the row disappeared entirely.

The practical consequence is the one described in the issue: when the same photo was uploaded twice — once with GPS metadata and once without — the comparison table gave no indication that only one copy had location data, making it easy to keep the stripped copy and trash the original.

This affected every nullable field, not just coordinates (`description`, `rating`, `lensModel`, `make`, `model`, `city`/`state`/`country`, …), so the fix is applied at the comparison level rather than special-casing GPS.

Absent values now map to a sentinel that takes part in the comparison, so "present on one asset, absent on another" counts as a difference. Two values collapse into that sentinel alongside `undefined`:

- `null`, because `getValueForAsset` returns `undefined` when `exifInfo` lacks a key but `null` when the key exists holding null — without collapsing them, two assets that both simply lack a field would be reported as differing.
- `''`, because the field renderers fall back to `$t('unknown')` via `||`, and Immich stores `description: ''` for assets without a description. Without collapsing it, `''` vs `null` would produce a row displaying "Unknown" against "Unknown".

Fixes #30491 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] New unit tests in `web/src/lib/utils/duplicate-utils.spec.ts` (8 cases): coordinates on only one asset are flagged; not flagged when neither or both have them; still flagged when both have differing values; `null` vs absent and `''` vs `null` are not flagged; other nullable fields present on only one asset are flagged; `countDifferingMetadataItems` picks up the newly flagged field.
- [x] Confirmed the tests fail against the unpatched `computeDifferingMetadataFields` (3 of 8) and pass with the fix, while the false-positive guards pass either way.
- [x] Full web unit suite: 530 passed, 2 skipped. `prettier --check`, `eslint --max-warnings 0` and `tsc --noEmit` all clean.
- [x] Reproduced manually on the dev stack (`docker-compose.dev.yml`): uploaded two assets, set `latitude`/`longitude` on one via `PUT /assets/:id`, grouped both with a shared `duplicateId` via `PUT /assets`. `GET /duplicates` confirmed the response carried coordinates and a reverse-geocoded city for one asset and `null` for the other. Before the change the comparison showed only File name and Path; after it, the Location and GPS rows appear with the value on one side and "Unknown" on the other.
- [x] Checked for false positives: a second group where neither asset has coordinates shows no Location or GPS row.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

**Before** - one asset has GPS (48.8583, 2.2944 / Paris), the other has none, but no GPS or Location row is shown:
<img width="1500" height="1200" alt="before" src="https://github.com/user-attachments/assets/316a7bc9-d436-43bd-a3c5-2edc11cad607" />

**After** - Location and GPS rows appear, with "Unknown" on the asset that lacks them:
<img width="1500" height="1200" alt="after" src="https://github.com/user-attachments/assets/251f75b7-23ff-4c51-b8be-97c4a09c5a63" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable - N/A
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. - N/A, web-only change
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) - N/A, web-only change 

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used for the writing of this pull request.