### PR TITLE
chore: cleanup translation dependency on i18n

### DIFF
--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -58,13 +58,7 @@ depends = ["//:open-api-dart"]
 [tasks."codegen:translation"]
 alias = "translation"
 description = "Generate translations from i18n JSONs"
-run = [
-  { task = "//:i18n:format-fix" },
-  { tasks = [
-    "i18n:loader",
-    "i18n:keys",
-  ] },
-]
+depends = ["//:i18n:format-fix", "i18n:loader", "i18n:keys"]
 
 [tasks."codegen:app-icon"]
 description = "Generate app icons"
@@ -127,6 +121,7 @@ run = [
   "dart format lib/generated/codegen_loader.g.dart",
 ]
 depends = ["//:open-api-dart"]
+wait_for = ["//:i18n:format-fix"]
 
 [tasks."i18n:keys"]
 description = "Generate i18n keys"
@@ -135,6 +130,7 @@ run = [
   "dart run bin/generate_keys.dart",
   "dart format lib/generated/translations.g.dart",
 ]
+wait_for = ["//:i18n:format-fix"]
 
 [tasks."analyze:dart"]
 description = "Run Dart analysis"


### PR DESCRIPTION
`codegen:translation` mise task had the dependencies in a `run` block rather than `depends` like the other tasks do. That kicked-off another open-api dart codegen task again. This removes the redundant generation as well as brings the task in line with the other tasks