### PR TITLE
fix: asset stack stacked over asset details

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_stack.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_stack.widget.dart
@@ -22,6 +22,11 @@ class AssetStackRow extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    final showingDetails = ref.watch(assetViewerProvider.select((s) => s.showingDetails));
+    if (showingDetails) {
+      return const SizedBox.shrink();
+    }
+
     final showingControls = ref.watch(assetViewerProvider.select((s) => s.showingControls));
     final double opacity =
         ref.watch(assetViewerProvider.select((s) => s.backgroundOpacity)) * (showingControls ? 1 : 0);


### PR DESCRIPTION
Hides the asset stack row when the asset details page is up