### PR TITLE
fix(web): restore asset viewer keyboard navigation after map focus

### DIFF
--- a/e2e/src/ui/specs/asset-viewer/map-keyboard.e2e-spec.ts
+++ b/e2e/src/ui/specs/asset-viewer/map-keyboard.e2e-spec.ts
@@ -1,0 +1,190 @@
+import { faker } from '@faker-js/faker';
+import { expect, test, type Page } from '@playwright/test';
+import {
+  Changes,
+  createDefaultTimelineConfig,
+  generateTimelineData,
+  TimelineAssetConfig,
+  TimelineData,
+} from 'src/ui/generators/timeline';
+import { setupBaseMockApiRoutes } from 'src/ui/mock-network/base-network';
+import { setupTimelineMockApiRoutes, TimelineTestContext } from 'src/ui/mock-network/timeline-network';
+import { utils } from 'src/utils';
+import { assetViewerUtils } from '../timeline/utils';
+
+const MINIMAL_MAP_STYLE = {
+  version: 8,
+  sources: {},
+  layers: [{ id: 'background', type: 'background', paint: { 'background-color': '#dcdcdc' } }],
+};
+
+const isMapFocused = (page: Page) =>
+  page.evaluate(() => {
+    // eslint-disable-next-line unicorn/no-optional-chaining-on-undeclared-variable
+    return document.activeElement?.classList.contains('maplibregl-canvas') ?? false;
+  });
+
+const isViewerContentFocused = (page: Page) =>
+  page.evaluate(() => {
+    // eslint-disable-next-line unicorn/no-optional-chaining-on-undeclared-variable
+    return document.activeElement?.hasAttribute('data-viewer-content') ?? false;
+  });
+
+const getMapMarkerTransform = (page: Page) =>
+  page.evaluate(() => document.querySelector('.maplibregl-marker')?.getAttribute('style') ?? '');
+
+test.describe('asset viewer map keyboard focus', () => {
+  let adminUserId: string;
+  let timelineRestData: TimelineData;
+  const assets: TimelineAssetConfig[] = [];
+  // Index of the first of two consecutive GPS images, so the info panel map stays
+  // available after navigating to the next asset.
+  let gpsIndex: number;
+  const testContext = new TimelineTestContext();
+  const changes: Changes = {
+    albumAdditions: [],
+    assetDeletions: [],
+    assetArchivals: [],
+    assetFavorites: [],
+  };
+
+  const isGpsImage = (asset: TimelineAssetConfig) =>
+    asset.isImage && asset.latitude !== null && asset.longitude !== null;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    adminUserId = faker.string.uuid();
+    testContext.adminId = adminUserId;
+    timelineRestData = generateTimelineData({ ...createDefaultTimelineConfig(), ownerId: adminUserId });
+    for (const timeBucket of timelineRestData.buckets.values()) {
+      assets.push(...timeBucket);
+    }
+
+    gpsIndex = assets.findIndex((asset, index) => isGpsImage(asset) && isGpsImage(assets[index + 1]));
+    expect(gpsIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  test.beforeEach(async ({ context }) => {
+    await setupBaseMockApiRoutes(context, adminUserId);
+    await setupTimelineMockApiRoutes(context, timelineRestData, changes, testContext);
+    // Keep map interactions hermetic: serve a minimal style and ignore tiles.
+    await context.route('**/tiles.immich.cloud/**', async (route) => {
+      if (route.request().url().includes('/style/')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', json: MINIMAL_MAP_STYLE });
+      } else {
+        await route.abort();
+      }
+    });
+  });
+
+  test.afterEach(() => {
+    testContext.slowBucket = false;
+    changes.albumAdditions = [];
+    changes.assetDeletions = [];
+    changes.assetArchivals = [];
+    changes.assetFavorites = [];
+  });
+
+  const openViewerWithMap = async (page: Page, index: number) => {
+    const asset = assets[index];
+    await page.goto(`/photos/${asset.id}`);
+    await assetViewerUtils.waitForViewerLoad(page, asset);
+    await page.keyboard.press('i');
+    await page.locator('.maplibregl-canvas').waitFor({ state: 'visible', timeout: 15_000 });
+    return asset;
+  };
+
+  test('arrow keys stay with the map while the map is focused', async ({ page }) => {
+    await openViewerWithMap(page, gpsIndex);
+
+    await page.locator('.maplibregl-canvas').click();
+    expect(await isMapFocused(page)).toBe(true);
+
+    const transformBefore = await getMapMarkerTransform(page);
+    await page.keyboard.press('ArrowRight');
+
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[gpsIndex].id}`);
+    expect(await isMapFocused(page)).toBe(true);
+    await expect.poll(() => getMapMarkerTransform(page)).not.toBe(transformBefore);
+  });
+
+  test('clicking the photo restores asset viewer keyboard navigation', async ({ page }) => {
+    await openViewerWithMap(page, gpsIndex);
+
+    await page.locator('.maplibregl-canvas').click();
+    expect(await isMapFocused(page)).toBe(true);
+
+    await page.locator('[data-viewer-content] img[draggable="false"]').first().click();
+    expect(await isViewerContentFocused(page)).toBe(true);
+
+    await page.keyboard.press('ArrowRight');
+
+    await assetViewerUtils.waitForViewerLoad(page, assets[gpsIndex + 1]);
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[gpsIndex + 1].id}`);
+  });
+
+  test('focusing the map again returns keyboard control to the map', async ({ page }) => {
+    await openViewerWithMap(page, gpsIndex);
+
+    await page.locator('.maplibregl-canvas').click();
+    await page.locator('[data-viewer-content] img[draggable="false"]').first().click();
+    expect(await isViewerContentFocused(page)).toBe(true);
+
+    await page.locator('.maplibregl-canvas').click();
+    expect(await isMapFocused(page)).toBe(true);
+
+    const transformBefore = await getMapMarkerTransform(page);
+    await page.keyboard.press('ArrowRight');
+
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[gpsIndex].id}`);
+    expect(await isMapFocused(page)).toBe(true);
+    await expect.poll(() => getMapMarkerTransform(page)).not.toBe(transformBefore);
+  });
+
+  test('tabbing to the map keeps its keyboard accessibility', async ({ page }) => {
+    await openViewerWithMap(page, gpsIndex);
+
+    // Focus something in the viewer first, then tab until the map canvas is reached.
+    await page.locator('[data-viewer-content] img[draggable="false"]').first().click();
+    expect(await isViewerContentFocused(page)).toBe(true);
+
+    for (let i = 0; i < 30; i++) {
+      await page.keyboard.press('Tab');
+      if (await isMapFocused(page)) {
+        break;
+      }
+    }
+    expect(await isMapFocused(page)).toBe(true);
+
+    const transformBefore = await getMapMarkerTransform(page);
+    await page.keyboard.press('ArrowRight');
+
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[gpsIndex].id}`);
+    expect(await isMapFocused(page)).toBe(true);
+    await expect.poll(() => getMapMarkerTransform(page)).not.toBe(transformBefore);
+  });
+
+  test('closing and reopening the info panel leaves no stale focus or listeners', async ({ page }) => {
+    await openViewerWithMap(page, gpsIndex);
+
+    await page.locator('.maplibregl-canvas').click();
+    expect(await isMapFocused(page)).toBe(true);
+
+    await page.locator('#detail-panel [aria-label="Close"]').click();
+    await expect(page.locator('.maplibregl-canvas')).toHaveCount(0);
+
+    await page.keyboard.press('i');
+    await page.locator('.maplibregl-canvas').waitFor({ state: 'visible', timeout: 15_000 });
+
+    await page.locator('.maplibregl-canvas').click();
+    expect(await isMapFocused(page)).toBe(true);
+
+    await page.locator('[data-viewer-content] img[draggable="false"]').first().click();
+    expect(await isViewerContentFocused(page)).toBe(true);
+
+    await page.keyboard.press('ArrowRight');
+
+    await assetViewerUtils.waitForViewerLoad(page, assets[gpsIndex + 1]);
+    await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[gpsIndex + 1].id}`);
+  });
+});

--- a/web/src/lib/actions/__test__/FocusOnPointerDown.spec.ts
+++ b/web/src/lib/actions/__test__/FocusOnPointerDown.spec.ts
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import FocusOnPointerDownTest from './FocusOnPointerDownTest.svelte';
+
+describe('focusOnPointerDown action', () => {
+  it('moves focus to the node on pointer down', async () => {
+    render(FocusOnPointerDownTest);
+    const target = screen.getByTestId('target');
+
+    await fireEvent.pointerDown(target);
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  it('moves focus to the node on wheel', async () => {
+    render(FocusOnPointerDownTest);
+    const target = screen.getByTestId('target');
+
+    await fireEvent.wheel(target);
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  it('moves focus to the node when a non-interactive child is pressed', async () => {
+    render(FocusOnPointerDownTest);
+    const target = screen.getByTestId('target');
+    const span = screen.getByTestId('span');
+
+    await fireEvent.pointerDown(span);
+
+    expect(document.activeElement).toBe(target);
+  });
+
+  it('does not steal focus from interactive controls', async () => {
+    render(FocusOnPointerDownTest);
+    const target = screen.getByTestId('target');
+    const button = screen.getByTestId('button');
+
+    button.focus();
+    await fireEvent.pointerDown(button);
+
+    expect(document.activeElement).not.toBe(target);
+    expect(document.activeElement).toBe(button);
+  });
+});

--- a/web/src/lib/actions/__test__/FocusOnPointerDownTest.svelte
+++ b/web/src/lib/actions/__test__/FocusOnPointerDownTest.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { focusOnPointerDown } from '$lib/actions/focus-on-pointer-down';
+</script>
+
+<div data-testid="target" tabindex="-1" use:focusOnPointerDown>
+  <button type="button" data-testid="button">button</button>
+  <span data-testid="span">span</span>
+</div>

--- a/web/src/lib/actions/focus-on-pointer-down.ts
+++ b/web/src/lib/actions/focus-on-pointer-down.ts
@@ -1,0 +1,30 @@
+import type { ActionReturn } from 'svelte/action';
+import { isInteractiveElement } from '$lib/utils/focus-util';
+
+/**
+ * Moves focus to the node when the user interacts with it via pointer down or wheel,
+ * unless the interaction targets an interactive control that owns its own focus.
+ *
+ * This is used by the asset viewer to reclaim keyboard navigation from other focused
+ * elements (e.g. a map canvas in the info panel), without affecting controls such as
+ * buttons, inputs, or native video players.
+ */
+export const focusOnPointerDown = (node: HTMLElement): ActionReturn => {
+  const onFocus = (event: PointerEvent | WheelEvent) => {
+    if (isInteractiveElement(event.target)) {
+      return;
+    }
+
+    node.focus();
+  };
+
+  node.addEventListener('pointerdown', onFocus);
+  node.addEventListener('wheel', onFocus);
+
+  return {
+    destroy() {
+      node.removeEventListener('pointerdown', onFocus);
+      node.removeEventListener('wheel', onFocus);
+    },
+  };
+};

--- a/web/src/lib/components/asset-viewer/AssetViewer.spec.ts
+++ b/web/src/lib/components/asset-viewer/AssetViewer.spec.ts
@@ -1,4 +1,4 @@
-import { updateAsset } from '@immich/sdk';
+import { AssetTypeEnum, updateAsset } from '@immich/sdk';
 import { fireEvent, waitFor } from '@testing-library/svelte';
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import { getResizeObserverMock } from '$lib/__mocks__/resize-observer.mock';
@@ -75,5 +75,24 @@ describe('AssetViewer', () => {
       expect(updateAsset).toHaveBeenCalledWith({ id: asset.id, updateAssetDto: { isFavorite: true } }),
     );
     await waitFor(() => expect(getByLabelText('unfavorite')).toBeInTheDocument());
+  });
+
+  it('renders the viewer content as a focusable, non-tabbing container', () => {
+    const ownerId = 'owner-id';
+    const user = userAdminFactory.build({ id: ownerId });
+    const asset = assetFactory.build({ ownerId, type: AssetTypeEnum.Image, hasMetadata: false });
+
+    authManager.setUser(user);
+    authManager.setPreferences(preferencesFactory.build({ cast: { gCastEnabled: false } }));
+
+    const { container } = renderWithTooltips(AssetViewer, {
+      cursor: { current: asset },
+      showNavigation: false,
+    });
+
+    const viewerContent = container.querySelector<HTMLElement>('[data-viewer-content]');
+    expect(viewerContent).not.toBeNull();
+    expect(viewerContent?.getAttribute('tabindex')).toBe('-1');
+    expect(viewerContent?.getAttribute('role')).toBe('presentation');
   });
 });

--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -23,6 +23,7 @@
   import { getSharedLink, handlePromiseError } from '$lib/utils';
   import type { OnUndoDelete } from '$lib/utils/actions';
   import { navigateToAsset } from '$lib/utils/asset-utils';
+  import { focusOnPointerDown } from '$lib/actions/focus-on-pointer-down';
   import { handleError } from '$lib/utils/handle-error';
   import { navigate } from '$lib/utils/navigation';
   import { InvocationTracker } from '$lib/utils/invocationTracker';
@@ -541,7 +542,13 @@
   {/if}
 
   <!-- Asset Viewer -->
-  <div data-viewer-content class="relative z-[-1] col-span-4 col-start-1 row-span-full row-start-1">
+  <div
+    data-viewer-content
+    class="relative z-[-1] col-span-4 col-start-1 row-span-full row-start-1 outline-none"
+    role="presentation"
+    tabindex="-1"
+    use:focusOnPointerDown
+  >
     {#if viewerKind === 'StackVideoViewer'}
       <VideoViewer
         asset={previewStackedAsset!}

--- a/web/src/lib/utils/focus-util.spec.ts
+++ b/web/src/lib/utils/focus-util.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { isInteractiveElement } from './focus-util';
+
+describe('isInteractiveElement', () => {
+  const createElement = (tag: string, attrs: Record<string, string> = {}) => {
+    const element = document.createElement(tag);
+    for (const [key, value] of Object.entries(attrs)) {
+      element.setAttribute(key, value);
+    }
+    return element;
+  };
+
+  it('returns true for interactive controls', () => {
+    const cases = [
+      ['button', {}],
+      ['input', {}],
+      ['textarea', {}],
+      ['select', {}],
+      ['summary', {}],
+      ['video', {}],
+      ['audio', {}],
+      ['a', { href: '#' }],
+      ['div', { contenteditable: 'true' }],
+      ['div', { role: 'button' }],
+      ['div', { 'data-overlay-interactive': '' }],
+    ] as const;
+
+    for (const [tag, attrs] of cases) {
+      expect(isInteractiveElement(createElement(tag, attrs)), tag).toBe(true);
+    }
+  });
+
+  it('returns true for descendants of interactive controls', () => {
+    const button = document.createElement('button');
+    const span = document.createElement('span');
+    button.append(span);
+
+    expect(isInteractiveElement(span)).toBe(true);
+  });
+
+  it('returns false for non-interactive elements', () => {
+    const cases = [
+      ['div', {}],
+      ['img', {}],
+      ['span', {}],
+      ['section', {}],
+      ['a', {}],
+      ['canvas', { class: 'maplibregl-canvas', tabindex: '0' }],
+    ] as const;
+
+    for (const [tag, attrs] of cases) {
+      expect(isInteractiveElement(createElement(tag, attrs)), tag).toBe(false);
+    }
+  });
+
+  it('returns false for null and non-element targets', () => {
+    expect(isInteractiveElement(null)).toBe(false);
+    expect(isInteractiveElement(new EventTarget())).toBe(false);
+  });
+});

--- a/web/src/lib/utils/focus-util.ts
+++ b/web/src/lib/utils/focus-util.ts
@@ -52,3 +52,22 @@ export const moveFocus = (
     }
   } while (nextIndex !== currentIndex);
 };
+
+const INTERACTIVE_ELEMENT_SELECTOR = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'summary',
+  'textarea',
+  'video',
+  'audio',
+  '[contenteditable]',
+  '[data-overlay-interactive]',
+  '[role="button"]',
+].join(',');
+
+/** Whether the event target is (or is inside) an interactive control that owns its own keyboard behavior. */
+export const isInteractiveElement = (target: EventTarget | null): boolean => {
+  return target instanceof HTMLElement && target.closest(INTERACTIVE_ELEMENT_SELECTOR) !== null;
+};


### PR DESCRIPTION
## Description

Fixes #29212

**Root cause**

The Info panel map (maplibre-gl, rendered through `Map.svelte` in the detail panel) sets `tabindex="0"` on its canvas. Clicking the map therefore leaves `document.activeElement` on the `maplibregl-canvas`. While the canvas is focused, maplibre's `KeyboardHandler` intercepts `ArrowLeft`/`ArrowRight` in the target phase, calls `preventDefault()` and pans the map. The asset viewer registers its `ArrowLeft`/`ArrowRight` shortcuts on `document` via the `shortcuts` action from `@immich/ui`, which bails early when `event.defaultPrevented` — so photo navigation never fires.

Clicking the photo viewer did not help either, because the viewer content container was not focusable, so focus stayed on the map canvas and it kept swallowing the arrows.

**Fix**

- `web/src/lib/components/asset-viewer/AssetViewer.svelte`: the viewer content container (`data-viewer-content`) is now programmatically focusable (`tabindex="-1"`, `role="presentation"`, `outline-none`) and uses a new `focusOnPointerDown` action.
- `web/src/lib/actions/focus-on-pointer-down.ts` (new): moves focus to the node on `pointerdown`/`wheel` unless the target is an interactive control (`button`, `input`, `textarea`, `select`, `a[href]`, `summary`, `video`, `audio`, `[contenteditable]`, `[role="button"]`, `[data-overlay-interactive]`).
- `web/src/lib/utils/focus-util.ts`: adds `isInteractiveElement()` used by the action.

**Behavior after the change**

- Clicking or tabbing to the map: arrow keys still pan the map and do not change the photo (map keyboard accessibility is preserved).
- Clicking/zooming/panning the photo: focus returns to the viewer content, `ArrowLeft`/`ArrowRight` switch photos again, and the map no longer reacts to those keys.
- Re-focusing the map gives it keyboard control again.
- Closing and reopening the Info panel leaves no stale focus or listeners.
- Buttons, inputs, and other interactive controls are never focus-stolen.

The map's keyboard handling was **not** disabled — the fix only moves focus off the map canvas when the user interacts with the photo viewer.

## How Has This Been Tested?

- [x] Unit tests: `focus-util.spec.ts` (`isInteractiveElement`), `FocusOnPointerDown.spec.ts` (focus transfer + interactive guard), `AssetViewer.spec.ts` (viewer content is focusable, non-tabbing).
- [x] E2E (Playwright `ui` project): new `map-keyboard.e2e-spec.ts` — 5 tests covering map-focused arrows, photo-focused arrows restore navigation, re-focusing the map, Tab access to the map, and Info panel close/reopen.
- [x] `web`: `pnpm run check:svelte`, `pnpm run check:typescript`, `pnpm run lint`, prettier.
- [x] `e2e`: `pnpm run check`, `pnpm run lint`, prettier.

E2E was run locally against the web app served by vite with the existing mock-network setup (`PLAYWRIGHT_DISABLE_WEBSERVER=1`): 5/5 new tests pass. The pre-existing `asset-viewer.e2e-spec.ts` shows the same 4 environment-related failures with and without this change (verified on a clean tree).

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (no new dependencies)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used during the initial investigation and to assist with editing the PR description. I independently reworked and reviewed the final implementation and tests, and verified the reported behavior locally. The final patch does not contain code copied directly from the initial LLM-generated implementation.
