### PR TITLE
chore: device state local sync from sync status page

### DIFF
--- a/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
@@ -14,6 +14,7 @@ import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/trash_sync.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/sync_status.provider.dart';
@@ -144,7 +145,11 @@ class SyncStatusAndActions extends HookConsumerWidget {
           subtitle: "tap_to_run_job".t(context: context),
           leading: const Icon(Icons.sync),
           trailing: _SyncStatusIcon(status: ref.watch(syncStatusProvider).localSyncStatus),
-          onTap: () {
+          onTap: () async {
+            await ref.read(localSyncServiceProvider).resetFullSync();
+            if (!context.mounted) {
+              return;
+            }
             unawaited(ref.read(backgroundSyncProvider).syncLocal(full: true));
           },
         ),


### PR DESCRIPTION
The sync local button in the sync status page is used for troubleshooting an issue with the local sync. It being the same flow as the regular full sync doesn't help much. This PR changes it to reset the status of it before the local sync so it pulls fresh metadata off the device for all assets 