### PR TITLE
fix(web): prevent folders asset race on trash

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -485,12 +485,12 @@ export const delay = async (ms: number) => {
 };
 
 export const getNextAsset = (assets: AssetResponseDto[], currentAsset: AssetResponseDto | undefined) => {
-  const index = currentAsset ? assets.findIndex((a) => a.id === currentAsset.id) : -1;
+  const index = currentAsset ? assets.findIndex((a) => a?.id === currentAsset.id) : -1;
   return index >= 0 ? assets[index + 1] : undefined;
 };
 
 export const getPreviousAsset = (assets: AssetResponseDto[], currentAsset: AssetResponseDto | undefined) => {
-  const index = currentAsset ? assets.findIndex((a) => a.id === currentAsset.id) : -1;
+  const index = currentAsset ? assets.findIndex((a) => a?.id === currentAsset.id) : -1;
   return index >= 0 ? assets[index - 1] : undefined;
 };
 

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { afterNavigate, goto, invalidateAll } from '$app/navigation';
   import ActionMenuItem from '$lib/components/ActionMenuItem.svelte';
-  import OnEvents from '$lib/components/OnEvents.svelte';
   import UserPageLayout, { headerId } from '$lib/components/layouts/UserPageLayout.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import GalleryViewer from '$lib/components/shared-components/gallery-viewer/GalleryViewer.svelte';
@@ -92,8 +91,6 @@
       </section>
     </Sidebar>
   {/snippet}
-
-  <OnEvents onAssetsDelete={invalidateAll} />
 
   <Breadcrumbs node={data.tree} icon={mdiFolderHome} title={$t('folders')} getLink={getLinkForPath} />
 


### PR DESCRIPTION
## Description

Fixes #30548
Fixes the navigation error when trashing an asset from an external library in the folder view.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x ] Tested locally
- [ x] Lint
- [ x] Typecheck
- [ x] Build

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ x] I have carefully read CONTRIBUTING.md
- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
This PR was created and reviewed manually.
...
