### PR TITLE
fix(web): tag faces on videos when realtime transcoding is enabled

### DIFF
--- a/web/src/lib/utils/container-utils.spec.ts
+++ b/web/src/lib/utils/container-utils.spec.ts
@@ -27,6 +27,20 @@ const mockVideo = (props: {
   return element;
 };
 
+// `<hls-video>` extends HTMLElement and proxies the video API, so it is not an HTMLVideoElement
+const mockCustomVideo = (props: {
+  videoWidth: number;
+  videoHeight: number;
+  clientWidth: number;
+  clientHeight: number;
+}): HTMLVideoElement => {
+  const element = Object.create(HTMLElement.prototype);
+  for (const [key, value] of Object.entries(props)) {
+    Object.defineProperty(element, key, { value, writable: true, configurable: true });
+  }
+  return element as HTMLVideoElement;
+};
+
 describe('scaleToFit', () => {
   it('should return full width when image is wider than container', () => {
     expect(scaleToFit({ width: 2000, height: 1000 }, { width: 800, height: 600 })).toEqual({ width: 800, height: 400 });
@@ -86,6 +100,15 @@ describe('getContentMetrics', () => {
     expect(metrics.offsetX).toBe(0);
     expect(metrics.offsetY).toBe(75);
   });
+
+  it('should use clientWidth/clientHeight for custom video elements', () => {
+    const video = mockCustomVideo({ videoWidth: 1920, videoHeight: 1080, clientWidth: 800, clientHeight: 600 });
+    const metrics = getContentMetrics(video);
+    expect(metrics.contentWidth).toBe(800);
+    expect(metrics.contentHeight).toBe(450);
+    expect(metrics.offsetX).toBe(0);
+    expect(metrics.offsetY).toBe(75);
+  });
 });
 
 describe('getNaturalSize', () => {
@@ -96,6 +119,11 @@ describe('getNaturalSize', () => {
 
   it('should return videoWidth/videoHeight for videos', () => {
     const video = mockVideo({ videoWidth: 1920, videoHeight: 1080, clientWidth: 800, clientHeight: 600 });
+    expect(getNaturalSize(video)).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('should return videoWidth/videoHeight for custom video elements', () => {
+    const video = mockCustomVideo({ videoWidth: 1920, videoHeight: 1080, clientWidth: 800, clientHeight: 600 });
     expect(getNaturalSize(video)).toEqual({ width: 1920, height: 1080 });
   });
 });

--- a/web/src/lib/utils/container-utils.ts
+++ b/web/src/lib/utils/container-utils.ts
@@ -49,15 +49,19 @@ export const scaleToFit = (dimensions: Size, container: Size): Size => {
   };
 };
 
+// `<hls-video>` forwards the video API but extends HTMLElement, so `instanceof HTMLVideoElement` is false for it
+const isVideoElement = (element: HTMLImageElement | HTMLVideoElement): element is HTMLVideoElement =>
+  'videoWidth' in element;
+
 const getElementSize = (element: HTMLImageElement | HTMLVideoElement): Size => {
-  if (element instanceof HTMLVideoElement) {
+  if (isVideoElement(element)) {
     return { width: element.clientWidth, height: element.clientHeight };
   }
   return { width: element.width, height: element.height };
 };
 
 export const getNaturalSize = (element: HTMLImageElement | HTMLVideoElement): Size => {
-  if (element instanceof HTMLVideoElement) {
+  if (isVideoElement(element)) {
     return { width: element.videoWidth, height: element.videoHeight };
   }
   return { width: element.naturalWidth, height: element.naturalHeight };


### PR DESCRIPTION
## Description

Tagging a face on a video fails when the `realtimeTranscoding` feature flag is enabled. The request is rejected by the server with:

```
Validation failed: imageWidth: Invalid input: expected number, received undefined
```

The same root cause also misplaces the face/OCR boxes drawn over videos.

**Root cause:** with `realtimeTranscoding` on, `VideoNativeViewer` renders `<hls-video>` instead of `<video>`, and that element is what gets passed to `FaceEditor` as `htmlElement`. `hls-video-element` builds on `CustomVideoElement` from `custom-media-element`, which extends `HTMLElement` — not `HTMLVideoElement` — and forwards the video API to an inner native `<video>` in its shadow root.

The helpers in `web/src/lib/utils/container-utils.ts` branch on `element instanceof HTMLVideoElement`. For `<hls-video>` that check is `false`, so both fall through to the image branch and read `naturalWidth`/`width`, which do not exist on the element. `getNaturalSize()` therefore returns `{ width: undefined, height: undefined }`, and `FaceEditor.getFaceCroppedCoordinates()` passes those straight into `imageWidth`/`imageHeight` on the create-face request.

**Fix:** branch on the presence of the video API rather than the class. `videoWidth` is forwarded onto the custom element's prototype by `custom-media-element`, so `'videoWidth' in element` is true for both a native `<video>` and `<hls-video>`, and this stays correct for any future custom element wrapper.

This only touches the two helpers; the existing `instanceof`-based behaviour for real `<video>` and `<img>` elements is unchanged.

## How Has This Been Tested?

- [x] Added unit tests covering a custom element that forwards the video API without being an `HTMLVideoElement` (one for `getNaturalSize`, one for `getContentMetrics`). Both fail on `main` and pass with the fix; the other 23 tests in the file are unaffected.
- [x] Full web unit suite: 524 passed, 2 skipped.
- [x] `check:svelte` (0 errors, 0 warnings), `check:typescript`, `eslint --max-warnings 0`, and `prettier --check` all clean.
- [x] Reproduced on my own self-hosted instance: with `realtimeTranscoding` enabled, tagging a person on a video produces exactly the validation error quoted above. The root cause was then confirmed by reading the installed `custom-media-element` source (`CustomVideoElement = CustomMediaMixin(globalThis.HTMLElement)`, with `videoWidth` installed on the prototype as a forwarding getter) rather than inferred.
- [x] Running a build of this branch on that instance. I have not yet done a fresh end-to-end click-through on this exact revision, so please treat the manual verification as "reproduced and root-caused" rather than "confirmed fixed in the UI" — the unit tests are the stronger evidence here.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md — **I ticked this originally without having actually read it; see my correction comment below. Having now read it, this PR conflicts with your "no LLM-generated PRs" policy and you should feel free to close it.**
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. I hit this bug on my own instance and used Claude Code to investigate it, write the fix and the tests, and draft this description. The diagnosis was verified against the actual `custom-media-element` source rather than assumed, and I confirmed the new tests fail without the fix and that the fix resolves the bug on my running instance. I have reviewed everything here and take responsibility for it — happy to adjust the approach if you would prefer a different check (e.g. matching on `tagName`, as `VideoNativeViewer.isHlsElement` already does).
