### PR TITLE
fix(mobile): allow deep linking to the full memory lane

### DIFF
--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -51,7 +51,7 @@ class DeepLinkService {
     final queryParams = link.uri.queryParameters;
 
     return switch (intent) {
-      "memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
+      "memory" => await _buildMemoryDeepLink(queryParams['id']),
       "asset" => await _buildAssetDeepLink(queryParams['id'] ?? '', ref),
       "album" => await _buildAlbumDeepLink(queryParams['id'] ?? ''),
       "people" => await _buildPeopleDeepLink(queryParams['id'] ?? ''),
@@ -82,6 +82,9 @@ class DeepLinkService {
     if (peopleRegex.hasMatch(path)) {
       final peopleId = peopleRegex.firstMatch(path)?.group(1) ?? '';
       return _buildPeopleDeepLink(peopleId);
+    }
+    if (path == '/memory') {
+      return _buildMemoryDeepLink(link.uri.queryParameters['id']);
     }
 
     return null;

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart';
 import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/domain/services/people.service.dart';
@@ -32,6 +34,26 @@ class MockAssetViewerStateNotifier extends Mock implements AssetViewerStateNotif
 
 const _assetId = 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb';
 const _albumId = 'cccccccc-4444-5555-6666-dddddddddddd';
+const _memoryId = 'eeeeeeee-8888-9999-aaaa-bbbbbbbbbbbb';
+
+final _user = UserDto(
+  id: 'user-1',
+  email: 'test@immich.app',
+  name: 'Test User',
+  profileChangedAt: DateTime(2026, 6, 12),
+);
+
+DriftMemory memory(String id) => DriftMemory(
+      id: id,
+      createdAt: DateTime(2026, 6, 12),
+      updatedAt: DateTime(2026, 6, 12),
+      ownerId: 'user-1',
+      type: MemoryTypeEnum.onThisDay,
+      data: const MemoryData(year: 2025),
+      isSaved: false,
+      memoryAt: DateTime(2025, 6, 12),
+      assets: const [],
+    );
 
 final _asset = RemoteAsset(
   id: _assetId,
@@ -136,5 +158,49 @@ void main() {
     expect(route, isA<AssetViewerRoute>());
     expect((route!.args! as AssetViewerRouteArgs).currentAlbum, isNull);
     verifyNever(() => remoteAlbumService.get(any()));
+  });
+
+  test('memory scheme link without an id opens the full memory lane', () async {
+    final memoryService = MockDriftMemoryService();
+    when(() => memoryService.getMemoryLane('user-1')).thenAnswer((_) async => [memory(_memoryId)]);
+    sut = DeepLinkService(timelineFactory, assetService, remoteAlbumService, memoryService, MockDriftPeopleService(), _user);
+
+    final deepLink = MockPlatformDeepLink();
+    when(() => deepLink.uri).thenReturn(Uri.parse('immich://memory'));
+
+    final route = await sut.handleScheme(deepLink, ref);
+
+    expect(route, isA<DriftMemoryRoute>());
+    expect((route!.args! as DriftMemoryRouteArgs).memories, [memory(_memoryId)]);
+    verify(() => memoryService.getMemoryLane('user-1')).called(1);
+    verifyNever(() => memoryService.get(any()));
+  });
+
+  test('memory scheme link with an id opens that single memory', () async {
+    final memoryService = MockDriftMemoryService();
+    when(() => memoryService.get(_memoryId)).thenAnswer((_) async => memory(_memoryId));
+    sut = DeepLinkService(timelineFactory, assetService, remoteAlbumService, memoryService, MockDriftPeopleService(), _user);
+
+    final deepLink = MockPlatformDeepLink();
+    when(() => deepLink.uri).thenReturn(Uri.parse('immich://memory?id=$_memoryId'));
+
+    final route = await sut.handleScheme(deepLink, ref);
+
+    expect(route, isA<DriftMemoryRoute>());
+    expect((route!.args! as DriftMemoryRouteArgs).memories, [memory(_memoryId)]);
+    verifyNever(() => memoryService.getMemoryLane(any()));
+    verify(() => memoryService.get(_memoryId)).called(1);
+  });
+
+  test('my.immich.app memory link opens the full memory lane', () async {
+    final memoryService = MockDriftMemoryService();
+    when(() => memoryService.getMemoryLane('user-1')).thenAnswer((_) async => [memory(_memoryId)]);
+    sut = DeepLinkService(timelineFactory, assetService, remoteAlbumService, memoryService, MockDriftPeopleService(), _user);
+
+    final route = await sut.handleMyImmichApp(link('/memory'), ref);
+
+    expect(route, isA<DriftMemoryRoute>());
+    expect((route!.args! as DriftMemoryRouteArgs).memories, [memory(_memoryId)]);
+    verify(() => memoryService.getMemoryLane('user-1')).called(1);
   });
 }


### PR DESCRIPTION
## Description

Fixes #30634

### Root cause

Deep links to the memory lane without an `id` (e.g. `immich://memory`) fell back to the homepage. In `handleScheme`, a missing `id` query param was coerced to `''` via `queryParams['id'] ?? ''`, then passed to `_buildMemoryDeepLink`. Since `'' != null`, it took the single-memory path and called `get('')`, which returns null, so the route was dropped and the user landed on the homepage.

The same gap existed for the `https://my.immich.app/memory` path: it is registered in `AndroidManifest.xml` but `handleMyImmichApp` never handled it.

### Fix

- Pass the raw (nullable) `id` query param for the `memory` intent so `_buildMemoryDeepLink` takes its existing `memoryId == null` branch and loads the full memory lane via `getMemoryLane`.
- Handle the `/memory` path in `handleMyImmichApp`, delegating to `_buildMemoryDeepLink` with the optional `id` query param, matching the web route `/memory?id=`.

## How Has This Been Tested?

Unit tests were added in `mobile/test/services/deep_link_service_test.dart`:

- [x] `immich://memory` (no id) opens the full memory lane
- [x] `immich://memory?id=<id>` opens that single memory
- [x] `https://my.immich.app/memory` opens the full memory lane

Note: I could not execute the Flutter test suite locally (no Flutter SDK available in my environment); the tests are covered by the mobile CI workflow.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was drafted with the assistance of an AI coding assistant (opencode, powered by deepseek-v4-flash-free). I am disclosing this transparently per CONTRIBUTING.md. The change is minimal and localized to `mobile/lib/services/deep_link.service.dart` plus its unit tests.
