### PR TITLE
fix(web): don't reset memory viewer to first asset on delete

### DIFF
--- a/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
+++ b/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
@@ -185,9 +185,6 @@
     if (!current) {
       return;
     }
-
-    // Capture where to land next *before* deleting, since the asset being
-    // removed will no longer resolve via getMemoryAsset() afterwards.
     const nextTarget = current.next?.asset ?? current.previous?.asset;
 
     await memoryManager.deleteAssetFromMemory(current.asset.id);
@@ -195,7 +192,6 @@
     if (nextTarget) {
       await handleNavigate(nextTarget);
     } else {
-      // No assets left to navigate to (memory was fully emptied and removed).
       init(page);
     }
   };

--- a/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
+++ b/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
@@ -186,8 +186,18 @@
       return;
     }
 
+    // Capture where to land next *before* deleting, since the asset being
+    // removed will no longer resolve via getMemoryAsset() afterwards.
+    const nextTarget = current.next?.asset ?? current.previous?.asset;
+
     await memoryManager.deleteAssetFromMemory(current.asset.id);
-    init(page);
+
+    if (nextTarget) {
+      await handleNavigate(nextTarget);
+    } else {
+      // No assets left to navigate to (memory was fully emptied and removed).
+      init(page);
+    }
   };
 
   const handleDeleteMemory = async () => {


### PR DESCRIPTION
## Description
Root cause: in MemoryViewer.svelte, handleDeleteMemoryAsset() calls init(page) after deletion, but the URL still contains the ID of the asset that was just removed. memoryManager.getMemoryAsset() can no longer find it in the asset list and falls back to memoryAssets[0], which is why it resets to the beginning.

Fixes #30531 

capture the next asset (or previous as a fallback) before deleting, then navigate explicitly to it instead of re-reading a stale URL

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Reproduced the bug locally (Docker dev setup) with a memory spanning multiple years
- [x] Verified that after the fix, deleting a photo mid-memory correctly advances to the next asset
- [x] Verified the edge case of deleting the last photo in a memory (correct fallback behavior)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
This PR was created and reviewed manually.
...
