### PR TITLE
feat(mobile): samsung flex window widgets

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -178,6 +178,52 @@
         android:resource="@xml/memory_widget" />
     </receiver>
 
+    <!-- Samsung Flex Window size variants. -->
+    <receiver
+      android:name=".widget.MemoryReceiverFlex2x2"
+      android:exported="true"
+      android:label="@string/memory_widget_flex_2x2_title">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/memory_widget_flex_2x2" />
+      <meta-data
+        android:name="com.samsung.android.appwidget.provider"
+        android:resource="@xml/samsung_appwidget_sub_screen" />
+    </receiver>
+
+    <receiver
+      android:name=".widget.MemoryReceiverFlex4x2"
+      android:exported="true"
+      android:label="@string/memory_widget_flex_4x2_title">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/memory_widget_flex_4x2" />
+      <meta-data
+        android:name="com.samsung.android.appwidget.provider"
+        android:resource="@xml/samsung_appwidget_sub_screen" />
+    </receiver>
+
+    <receiver
+      android:name=".widget.RandomReceiverFlex2x2"
+      android:exported="true"
+      android:label="@string/random_widget_flex_2x2_title">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/random_widget_flex_2x2" />
+      <meta-data
+        android:name="com.samsung.android.appwidget.provider"
+        android:resource="@xml/samsung_appwidget_sub_screen" />
+    </receiver>
+
     <activity android:name=".widget.configure.RandomConfigure"
       android:exported="true"
       android:theme="@style/Theme.Material3.DayNight.NoActionBar">

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -224,6 +224,21 @@
         android:resource="@xml/samsung_appwidget_sub_screen" />
     </receiver>
 
+    <receiver
+      android:name=".widget.RandomReceiverFlex4x2"
+      android:exported="true"
+      android:label="@string/random_widget_flex_4x2_title">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/random_widget_flex_4x2" />
+      <meta-data
+        android:name="com.samsung.android.appwidget.provider"
+        android:resource="@xml/samsung_appwidget_sub_screen" />
+    </receiver>
+
     <activity android:name=".widget.configure.RandomConfigure"
       android:exported="true"
       android:theme="@style/Theme.Material3.DayNight.NoActionBar">

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/FlexWindowReceivers.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/FlexWindowReceivers.kt
@@ -1,0 +1,9 @@
+package app.alextran.immich.widget
+
+// Widget providers for the Samsung Flex Window cover screen.
+
+class MemoryReceiverFlex2x2 : MemoryReceiver()
+
+class MemoryReceiverFlex4x2 : MemoryReceiver()
+
+class RandomReceiverFlex2x2 : RandomReceiver()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/FlexWindowReceivers.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/FlexWindowReceivers.kt
@@ -7,3 +7,5 @@ class MemoryReceiverFlex2x2 : MemoryReceiver()
 class MemoryReceiverFlex4x2 : MemoryReceiver()
 
 class RandomReceiverFlex2x2 : RandomReceiver()
+
+class RandomReceiverFlex4x2 : RandomReceiver()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/MemoryReceiver.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/MemoryReceiver.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class MemoryReceiver : GlanceAppWidgetReceiver() {
+open class MemoryReceiver : GlanceAppWidgetReceiver() {
   override val glanceAppWidget = PhotoWidget()
 
   override fun onUpdate(
@@ -28,7 +28,7 @@ class MemoryReceiver : GlanceAppWidgetReceiver() {
 
   override fun onReceive(context: Context, intent: Intent) {
     val fromMainApp = intent.getBooleanExtra(HomeWidgetPlugin.TRIGGERED_FROM_HOME_WIDGET, false)
-    val provider = ComponentName(context, MemoryReceiver::class.java)
+    val provider = ComponentName(context, javaClass)
     val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
 
     // Launch coroutine to setup a single shot if the app requested the update

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/RandomReceiver.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/RandomReceiver.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class RandomReceiver : GlanceAppWidgetReceiver() {
+open class RandomReceiver : GlanceAppWidgetReceiver() {
   override val glanceAppWidget = PhotoWidget()
 
   override fun onUpdate(
@@ -28,7 +28,7 @@ class RandomReceiver : GlanceAppWidgetReceiver() {
 
   override fun onReceive(context: Context, intent: Intent) {
     val fromMainApp = intent.getBooleanExtra(HomeWidgetPlugin.TRIGGERED_FROM_HOME_WIDGET, false)
-    val provider = ComponentName(context, RandomReceiver::class.java)
+    val provider = ComponentName(context, javaClass)
     val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
 
     // Launch coroutine to setup a single shot if the app requested the update

--- a/mobile/android/app/src/main/res/values/attrs_samsung_widget.xml
+++ b/mobile/android/app/src/main/res/values/attrs_samsung_widget.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Samsung cover screen widget attributes. The names are imposed by the Samsung host.
+     targetHost = 4 (cover screen), widgetSize = columns * 4 (2 columns = 8, 4 columns = 16).
+     The host only offers 2x2 and 4x2 tiles, taller ones are clamped back to 2 rows.
+-->
+<resources>
+  <attr name="targetHost" format="integer" />
+  <attr name="widgetSize" format="integer" />
+</resources>

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
 <resources>
   <string name="memory_widget_title">Memories</string>
   <string name="random_widget_title">Random</string>
+  <!-- Samsung Flex Window size variants. -->
+  <string name="memory_widget_flex_2x2_title">Memories (2x2)</string>
+  <string name="memory_widget_flex_4x2_title">Memories (4x2)</string>
+  <string name="random_widget_flex_2x2_title">Random (2x2)</string>
 
   <string name="memory_widget_description">See memories from Immich.</string>
   <string name="random_widget_description">View a random image from your library or a specific album.</string>

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
   <string name="memory_widget_flex_2x2_title">Memories (2x2)</string>
   <string name="memory_widget_flex_4x2_title">Memories (4x2)</string>
   <string name="random_widget_flex_2x2_title">Random (2x2)</string>
+  <string name="random_widget_flex_4x2_title">Random (4x2)</string>
 
   <string name="memory_widget_description">See memories from Immich.</string>
   <string name="random_widget_description">View a random image from your library or a specific album.</string>

--- a/mobile/android/app/src/main/res/xml/memory_widget_flex_2x2.xml
+++ b/mobile/android/app/src/main/res/xml/memory_widget_flex_2x2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Memories widget for the Samsung Flex Window cover screen, smallest tile of its 4x2 grid. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:initialLayout="@layout/glance_default_loading_layout"
+  android:minWidth="150dp"
+  android:minHeight="133dp"
+  android:targetCellWidth="2"
+  android:targetCellHeight="2"
+  android:resizeMode="none"
+  android:widgetCategory="keyguard"
+  android:updatePeriodMillis="1200000"
+  app:targetHost="4"
+  app:widgetSize="8"
+  tools:targetApi="31"
+  android:description="@string/memory_widget_description"
+  android:previewImage="@drawable/memory_preview"
+  />

--- a/mobile/android/app/src/main/res/xml/memory_widget_flex_4x2.xml
+++ b/mobile/android/app/src/main/res/xml/memory_widget_flex_4x2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Memories widget for the Samsung Flex Window cover screen, full width of its 4x2 grid. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:initialLayout="@layout/glance_default_loading_layout"
+  android:minWidth="304dp"
+  android:minHeight="128dp"
+  android:targetCellWidth="4"
+  android:targetCellHeight="2"
+  android:resizeMode="none"
+  android:widgetCategory="keyguard"
+  android:updatePeriodMillis="1200000"
+  app:targetHost="4"
+  app:widgetSize="16"
+  tools:targetApi="31"
+  android:description="@string/memory_widget_description"
+  android:previewImage="@drawable/memory_preview"
+  />

--- a/mobile/android/app/src/main/res/xml/random_widget_flex_2x2.xml
+++ b/mobile/android/app/src/main/res/xml/random_widget_flex_2x2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Random widget for the Samsung Flex Window cover screen, smallest tile of its 4x2 grid. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:initialLayout="@layout/glance_default_loading_layout"
+  android:minWidth="150dp"
+  android:minHeight="133dp"
+  android:targetCellWidth="2"
+  android:targetCellHeight="2"
+  android:resizeMode="none"
+  android:widgetCategory="keyguard"
+  android:updatePeriodMillis="1200000"
+  android:configure="app.alextran.immich.widget.configure.RandomConfigure"
+  android:widgetFeatures="reconfigurable|configuration_optional"
+  app:targetHost="4"
+  app:widgetSize="8"
+  tools:targetApi="31"
+  android:description="@string/random_widget_description"
+  android:previewImage="@drawable/random_preview"
+  />

--- a/mobile/android/app/src/main/res/xml/random_widget_flex_4x2.xml
+++ b/mobile/android/app/src/main/res/xml/random_widget_flex_4x2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Random widget for the Samsung Flex Window cover screen, full width of its 4x2 grid. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:initialLayout="@layout/glance_default_loading_layout"
+  android:minWidth="304dp"
+  android:minHeight="128dp"
+  android:targetCellWidth="4"
+  android:targetCellHeight="2"
+  android:resizeMode="none"
+  android:widgetCategory="keyguard"
+  android:updatePeriodMillis="1200000"
+  android:configure="app.alextran.immich.widget.configure.RandomConfigure"
+  android:widgetFeatures="reconfigurable|configuration_optional"
+  app:targetHost="4"
+  app:widgetSize="16"
+  tools:targetApi="31"
+  android:description="@string/random_widget_description"
+  android:previewImage="@drawable/random_preview"
+  />

--- a/mobile/android/app/src/main/res/xml/samsung_appwidget_sub_screen.xml
+++ b/mobile/android/app/src/main/res/xml/samsung_appwidget_sub_screen.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Allow Immich to be used as a sub-screen widget on Samsung devices -->
+<samsung-appwidget-provider display="sub_screen" />

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -44,6 +44,7 @@ const List<(String, String)> kWidgetNames = [
   ('com.immich.widget.memory', 'app.alextran.immich.widget.MemoryReceiverFlex2x2'),
   ('com.immich.widget.memory', 'app.alextran.immich.widget.MemoryReceiverFlex4x2'),
   ('com.immich.widget.random', 'app.alextran.immich.widget.RandomReceiverFlex2x2'),
+  ('com.immich.widget.random', 'app.alextran.immich.widget.RandomReceiverFlex4x2'),
 ];
 
 const int kMinMonthsToEnableScrubberSnap = 12;

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -37,9 +37,13 @@ const String kWidgetCustomHeaders = "widget_custom_headers";
 // add widget identifiers here for new widgets
 // these are used to force a widget refresh
 // (iOSName, androidFQDN)
+// Android-only providers reuse the iOS name of their counterpart, updateWidget rejects a null one.
 const List<(String, String)> kWidgetNames = [
   ('com.immich.widget.random', 'app.alextran.immich.widget.RandomReceiver'),
   ('com.immich.widget.memory', 'app.alextran.immich.widget.MemoryReceiver'),
+  ('com.immich.widget.memory', 'app.alextran.immich.widget.MemoryReceiverFlex2x2'),
+  ('com.immich.widget.memory', 'app.alextran.immich.widget.MemoryReceiverFlex4x2'),
+  ('com.immich.widget.random', 'app.alextran.immich.widget.RandomReceiverFlex2x2'),
 ];
 
 const int kMinMonthsToEnableScrubberSnap = 12;


### PR DESCRIPTION
## Description

Add three widget providers sized for the Samsung Flex Window (the cover screen on Galaxy Flip devices): Memories 2x2, Memories 4x2 and Random 2x2.

The existing Memories and Random widgets only target the home screen, so the cover screen widget picker does not offer them. Declaring a provider for that host requires a `com.samsung.android.appwidget.provider` meta-data pointing at a `<samsung-appwidget-provider display="sub_screen" />` resource, plus sizes that match the cover screen grid.

The new providers subclass `MemoryReceiver` and `RandomReceiver`, so the image download and refresh logic is unchanged. Those two receivers now resolve their `ComponentName` from `javaClass` instead of a hardcoded class literal, so each subclass only targets its own widget ids. The new providers are also added to `kWidgetNames`, so they get refreshed on login and logout like the existing ones.

Android-only, no iOS counterpart. No new dependencies.


## How Has This Been Tested?

Tested on a Galaxy Z Flip 8 (SM-F776B), One UI 9.

- [x] The three widgets appear in the cover screen widget picker and render photos from the server
- [x] The Random variant opens its album configuration screen when clicked
- [ ] Tapping a widget deep links into the app
      **Not verified: One UI does not allow launching an app from the cover screen without a [Good Lock](https://galaxystore.samsung.com/detail/com.samsung.android.goodlock) workaround. This path is not reachable in a default configuration.**
- [x] Widgets are cleared after logging out of the app
- [x] The existing home screen widgets are unaffected

Declared sizes were checked against the stock One UI cover widgets with `adb shell dumpsys appwidget`:

| Provider | Declared min | Matches |
| --- | --- | --- |
| `MemoryReceiverFlex2x2` | 150 x 133 dp | `AlarmMultiCoverWidgetProvider2X2`, `TimerWidget2X2Provider` |
| `RandomReceiverFlex2x2` | 150 x 133 dp | same |
| `MemoryReceiverFlex4x2` | 304 x 128 dp | `CoverWidgetMasterProviderB54X2` |

None of the 58 cover screen providers on the device declares a tile taller than two rows, and a provider declaring four rows is clamped back to two by the host.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<table>
<tr>
<td><img width="250" src="https://github.com/user-attachments/assets/5ddbc85c-c1a4-42b9-8be0-1889f87843eb" /></td>
<td><img width="400" src="https://github.com/user-attachments/assets/5e0e2971-a6a4-4282-bb29-39d73eea220e" /></td>
</tr>
</table>


</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable) **- not applicable, this is Android manifest and resource declarations**
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. **- not applicable**
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) **- not applicable**

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I wrote the implementation myself. I used an LLM to review it before opening the PR, which caught a missing entry in `kWidgetNames` and some misspelling in my comments.