### PR TITLE
fix(server): include videoCodec and container in exifInfo for search/sync APIs

### DIFF
--- a/server/src/dtos/exif.dto.ts
+++ b/server/src/dtos/exif.dto.ts
@@ -30,6 +30,9 @@ export const ExifResponseSchema = z
     description: z.string().nullish().default(null).describe('Image description'),
     projectionType: z.string().nullish().default(null).describe('Projection type'),
     rating: z.int().min(1).max(5).nullish().default(null).describe('Rating'),
+    fps: z.number().nullish().default(null).describe('Video frames per second'),
+    videoCodec: z.string().nullish().default(null).describe('Video codec'),
+    container: z.string().nullish().default(null).describe('Video container format'),
   })
   .describe('EXIF response')
   .meta({ id: 'ExifResponseDto' });
@@ -60,5 +63,8 @@ export function mapExif(entity: MaybeDehydrated<Exif>): ExifResponseDto {
     description: entity.description,
     projectionType: entity.projectionType,
     rating: entity.rating,
+    fps: entity.fps,
+    videoCodec: entity.videoCodec,
+    container: entity.container,
   };
 }

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -109,8 +109,7 @@ export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'asset', O>)
 }
 
 const selectExifInfo = (eb: AssetExpressionBuilder) =>
-  eb.fn
-    .toJson(eb.table('asset_exif'))
+  sql`CASE WHEN asset_exif."assetId" IS NOT NULL THEN to_jsonb(asset_exif) || COALESCE((SELECT jsonb_build_object('videoCodec', "codecName", 'container', "formatName") FROM asset_video WHERE "assetId" = asset_exif."assetId" LIMIT 1), '{}'::jsonb) ELSE NULL END`
     .$castTo<ShallowDehydrateObject<Selectable<AssetExifTable>> | null>()
     .as('exifInfo');
 
@@ -122,7 +121,9 @@ export function withExif<O>(qb: SelectQueryBuilder<DB, 'asset', O>) {
 export function withExifInner<O>(qb: SelectQueryBuilder<DB, 'asset', O>) {
   return qb
     .innerJoin('asset_exif', 'asset.id', 'asset_exif.assetId')
-    .select((eb) => eb.fn.toJson(eb.table('asset_exif')).as('exifInfo'))
+    .select((eb) =>
+      sql`CASE WHEN asset_exif."assetId" IS NOT NULL THEN to_jsonb(asset_exif) || COALESCE((SELECT jsonb_build_object('videoCodec', "codecName", 'container', "formatName") FROM asset_video WHERE "assetId" = asset_exif."assetId" LIMIT 1), '{}'::jsonb) ELSE NULL END`.as('exifInfo'),
+    )
     .$narrowType<{ exifInfo: NotNull }>();
 }
 


### PR DESCRIPTION
## Description

The `exifInfo` object returned by search and sync APIs is missing `videoCodec`, `container`, and `fps` fields for video assets. These fields are present in the asset detail API response but not in the list/search/sync endpoints, causing inconsistent behavior for clients that rely on these fields to determine playback strategy.

### Changes

**`server/src/dtos/exif.dto.ts`**
- Added `fps`, `videoCodec`, and `container` fields to `ExifResponseSchema`
- Added corresponding mappings in `mapExif()`

**`server/src/utils/database.ts`**
- Modified `selectExifInfo()` to merge `videoCodec` (from `asset_video.codecName`) and `container` (from `asset_video.formatName`) into the exifInfo JSON via a correlated subquery
- Applied the same change to `withExifInner()` for consistency

### How it works

The existing `selectExifInfo` converts the entire `asset_exif` row to JSON using `to_jsonb(asset_exif)`. The fix merges this with a small JSON object built from `asset_video`:

```sql
to_jsonb(asset_exif) || COALESCE(
  (SELECT jsonb_build_object('videoCodec', codecName, 'container', formatName)
   FROM asset_video WHERE assetId = asset_exif.assetId LIMIT 1),
  '{}'::jsonb
)
```

This approach:
- Uses a correlated subquery (no additional JOIN needed, avoids potential duplicate join issues)
- Returns `null` for image assets (no `asset_video` row)
- Is indexed on `asset_video.assetId` for performance

The `fps` field already exists in `asset_exif` and was already included in the JSON — it just wasn't exposed in the schema or `mapExif`.

## Testing

- Verified that search API (`/api/search/metadata`) now returns non-null `videoCodec` and `container` for video assets
- Verified that asset detail API (`/api/assets/:id`) still returns the same values
- Verified that image assets still return `null` for these fields
- No regression in existing search/sync functionality
