### PR TITLE
chore: pump flutter_lints to 6.0

### DIFF
--- a/mobile/lib/pages/common/large_leading_tile.dart
+++ b/mobile/lib/pages/common/large_leading_tile.dart
@@ -54,7 +54,7 @@ class LargeLeadingTile extends StatelessWidget {
                 ],
               ),
             ),
-            if (trailing != null) trailing!,
+            ?trailing,
           ],
         ),
       ),

--- a/mobile/lib/pages/search/map/map_location_picker.page.dart
+++ b/mobile/lib/pages/search/map/map_location_picker.page.dart
@@ -140,7 +140,7 @@ class _BottomBar extends StatelessWidget {
                 const SizedBox(width: 15),
                 ValueListenableBuilder(
                   valueListenable: selectedLatLng,
-                  builder: (_, value, __) =>
+                  builder: (_, value, _) =>
                       Text("${value.latitude.toStringAsFixed(4)}, ${value.longitude.toStringAsFixed(4)}"),
                 ),
               ],

--- a/mobile/lib/presentation/pages/dev/media_stat.page.dart
+++ b/mobile/lib/presentation/pages/dev/media_stat.page.dart
@@ -58,7 +58,7 @@ class LocalMediaSummaryPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(context.t.local_media_summary)),
       body: Consumer(
-        builder: (ctx, ref, __) {
+        builder: (ctx, ref, _) {
           final db = ref.watch(driftProvider);
           final albumsFuture = ref.watch(localAlbumRepository).getAll();
 
@@ -138,7 +138,7 @@ class RemoteMediaSummaryPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(context.t.remote_media_summary)),
       body: Consumer(
-        builder: (ctx, ref, __) {
+        builder: (ctx, ref, _) {
           final db = ref.watch(driftProvider);
           final albumsFuture = ref.watch(remoteAlbumRepository).getAll();
 

--- a/mobile/lib/presentation/pages/drift_place.page.dart
+++ b/mobile/lib/presentation/pages/drift_place.page.dart
@@ -94,7 +94,7 @@ class _Map extends StatelessWidget {
                 height: 200,
                 width: context.width,
                 child: MapThumbnail(
-                  onTap: (_, __) => context.pushRoute(DriftMapRoute(initialLocation: currentLocation)),
+                  onTap: (_, _) => context.pushRoute(DriftMapRoute(initialLocation: currentLocation)),
                   zoom: 8,
                   centre: currentLocation ?? const LatLng(21.44950, -157.91959),
                   showAttribution: false,

--- a/mobile/lib/presentation/pages/feature_message/whats_new.page.dart
+++ b/mobile/lib/presentation/pages/feature_message/whats_new.page.dart
@@ -17,7 +17,7 @@ class WhatsNewPage extends StatelessWidget {
       body: ListView.separated(
         padding: const EdgeInsets.only(top: 16, bottom: 64),
         itemCount: highlights.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 24),
+        separatorBuilder: (_, _) => const SizedBox(height: 24),
         itemBuilder: (_, index) => _HighlightCard(highlight: highlights[index]),
       ),
     );
@@ -53,7 +53,7 @@ class _HighlightCard extends StatelessWidget {
                     : Image.asset(
                         highlight.image!,
                         fit: BoxFit.contain,
-                        errorBuilder: (context, _, __) => const FeatureMessagePlaceholder(),
+                        errorBuilder: (context, _, _) => const FeatureMessagePlaceholder(),
                       ),
               ),
             ),

--- a/mobile/lib/presentation/widgets/album/pending_uploads_banner.widget.dart
+++ b/mobile/lib/presentation/widgets/album/pending_uploads_banner.widget.dart
@@ -214,7 +214,7 @@ class _PendingUploadsSheet extends ConsumerWidget {
               child: ListView.separated(
                 scrollDirection: Axis.horizontal,
                 itemCount: pending.length,
-                separatorBuilder: (_, __) => const SizedBox(width: 8),
+                separatorBuilder: (_, _) => const SizedBox(width: 8),
                 itemBuilder: (_, index) => _PendingUploadTile(entry: pending[index]),
               ),
             ),

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
@@ -77,7 +77,7 @@ class AppearsInDetails extends ConsumerWidget {
         );
       },
       loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -363,7 +363,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
         onDragCancel: _onDragCancel,
         onTapUp: _onTapUp,
         onLongPressStart: asset.isMotionPhoto ? _onLongPress : null,
-        errorBuilder: (_, __, ___) => SizedBox(
+        errorBuilder: (_, _, _) => SizedBox(
           width: size.width,
           height: size.height,
           child: Thumbnail.fromAsset(asset: asset, fit: BoxFit.contain),

--- a/mobile/lib/presentation/widgets/asset_viewer/ocr_overlay.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/ocr_overlay.widget.dart
@@ -110,7 +110,7 @@ class _OcrOverlayState extends ConsumerState<OcrOverlay> {
         );
       },
       loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/feature_message/feature_message_dialog.widget.dart
+++ b/mobile/lib/presentation/widgets/feature_message/feature_message_dialog.widget.dart
@@ -17,8 +17,8 @@ Future<void> showFeatureMessageDialog(BuildContext context) {
     barrierLabel: context.t.whats_new,
     barrierColor: Colors.black.withValues(alpha: 0.55),
     transitionDuration: const Duration(milliseconds: 280),
-    pageBuilder: (_, __, ___) => const _FeatureMessageDialog(),
-    transitionBuilder: (_, animation, __, child) {
+    pageBuilder: (_, _, _) => const _FeatureMessageDialog(),
+    transitionBuilder: (_, animation, _, child) {
       final curved = CurvedAnimation(parent: animation, curve: Curves.easeOutCubic, reverseCurve: Curves.easeInCubic);
       return FadeTransition(
         opacity: animation,
@@ -249,7 +249,7 @@ class _FeaturePage extends StatelessWidget {
                       : Image.asset(
                           highlight.image!,
                           fit: BoxFit.contain,
-                          errorBuilder: (context, _, __) => const FeatureMessagePlaceholder(),
+                          errorBuilder: (context, _, _) => const FeatureMessagePlaceholder(),
                         ),
                 ),
               ),

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -408,7 +408,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
 
     return PopScope(
       canPop: !isMultiSelectEnabled,
-      onPopInvokedWithResult: (_, __) {
+      onPopInvokedWithResult: (_, _) {
         if (isMultiSelectEnabled) {
           ref.read(multiSelectProvider.notifier).reset();
         }

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -157,7 +157,7 @@ class AppRouter extends RootStackRouter {
         customRouteBuilder: <T>(context, child, page) => PageRouteBuilder<T>(
           fullscreenDialog: page.fullscreenDialog,
           settings: page,
-          pageBuilder: (_, __, ___) => child,
+          pageBuilder: (_, _, _) => child,
           opaque: false,
           transitionsBuilder: TransitionsBuilders.fadeIn,
         ),

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -378,7 +378,7 @@ class BackgroundUploadService {
       'fileModifiedAt': modifiedAt.toUtc().toIso8601String(),
       'isFavorite': isFavorite?.toString() ?? 'false',
       'duration': '0',
-      if (fields != null) ...fields,
+      ...?fields,
       if (CurrentPlatform.isIOS && cloudId != null)
         'metadata': jsonEncode([
           RemoteAssetMetadataItem(

--- a/mobile/lib/utils/hooks/app_settings_update_hook.dart
+++ b/mobile/lib/utils/hooks/app_settings_update_hook.dart
@@ -9,7 +9,7 @@ ValueNotifier<T> useAppSettingsState<T>(AppSettingsEnum<T> key) {
   final notifier = useState<T>(Store.get(key.storeKey, key.defaultValue));
 
   // Listen to changes to the notifier and update app settings
-  useValueChanged(notifier.value, (_, __) => unawaited(Store.put(key.storeKey, notifier.value)));
+  useValueChanged(notifier.value, (_, _) => unawaited(Store.put(key.storeKey, notifier.value)));
 
   return notifier;
 }

--- a/mobile/lib/widgets/asset_viewer/video_controls.dart
+++ b/mobile/lib/widgets/asset_viewer/video_controls.dart
@@ -97,7 +97,7 @@ class _VideoControlsState extends ConsumerState<VideoControls> {
         _hideTimer.reset();
       }
     });
-    ref.listen(_provider.select((v) => v.status), (_, __) => _hideTimer.reset());
+    ref.listen(_provider.select((v) => v.status), (_, _) => _hideTimer.reset());
 
     final notifier = ref.watch(_provider.notifier);
     final isLoaded = duration != Duration.zero;

--- a/mobile/lib/widgets/common/immich_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/immich_sliver_app_bar.dart
@@ -73,7 +73,7 @@ class ImmichSliverAppBar extends ConsumerWidget {
                 onPressed: () => showDialog(context: context, builder: (context) => const CastDialog()),
                 icon: Icon(isCasting ? Icons.cast_connected_rounded : Icons.cast_rounded),
               ),
-            if (actions != null) ...actions!,
+            ...?actions,
             if (showUploadButton && !isReadonlyModeEnabled) const _BackupIndicator(),
             const _ProfileIndicator(),
             const SizedBox(width: 8),

--- a/mobile/lib/widgets/map/map_settings/map_theme_picker.dart
+++ b/mobile/lib/widgets/map/map_settings/map_theme_picker.dart
@@ -79,7 +79,7 @@ class _BorderedMapThumbnail extends StatelessWidget {
           child: MapThumbnail(
             zoom: 2,
             centre: const LatLng(47, 5),
-            onTap: (_, __) => onThemeChange(mode),
+            onTap: (_, _) => onThemeChange(mode),
             themeMode: mode,
             showAttribution: false,
           ),

--- a/mobile/lib/widgets/map/map_theme_override.dart
+++ b/mobile/lib/widgets/map/map_theme_override.dart
@@ -69,7 +69,7 @@ class _MapThemeOverrideState extends ConsumerState<MapThemeOverride> with Widget
     final appTheme = ref.watch(immichThemeProvider);
     final locale = ref.watch(localeProvider);
 
-    useValueChanged<ThemeMode, void>(_theme, (_, __) {
+    useValueChanged<ThemeMode, void>(_theme, (_, _) {
       if (_theme == ThemeMode.system) {
         WidgetsBinding.instance.addObserver(this);
       } else {

--- a/mobile/lib/widgets/photo_view/src/utils/ignorable_change_notifier.dart
+++ b/mobile/lib/widgets/photo_view/src/utils/ignorable_change_notifier.dart
@@ -28,12 +28,12 @@ class IgnorableChangeNotifier extends ChangeNotifier {
     return super.hasListeners || (_ignorableListeners?.isNotEmpty ?? false);
   }
 
-  void addIgnorableListener(listener) {
+  void addIgnorableListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
     _ignorableListeners!.add(listener);
   }
 
-  void removeIgnorableListener(listener) {
+  void removeIgnorableListener(VoidCallback listener) {
     assert(_debugAssertNotDisposed());
     _ignorableListeners!.remove(listener);
   }

--- a/mobile/lib/widgets/settings/advanced_settings.dart
+++ b/mobile/lib/widgets/settings/advanced_settings.dart
@@ -36,7 +36,7 @@ class AdvancedSettings extends HookConsumerWidget {
     final preferRemote = useState(ref.watch(appConfigProvider).image.preferRemote);
     useValueChanged(
       preferRemote.value,
-      (_, __) => unawaited(ref.read(settingsProvider).write(.imagePreferRemote, preferRemote.value)),
+      (_, _) => unawaited(ref.read(settingsProvider).write(.imagePreferRemote, preferRemote.value)),
     );
     final readonlyModeEnabled = useAppSettingsState(AppSettingsEnum.readonlyModeEnabled);
 
@@ -44,7 +44,7 @@ class AdvancedSettings extends HookConsumerWidget {
 
     useValueChanged(
       levelId.value,
-      (_, __) => unawaited(LogService.I.setLogLevel(Level.LEVELS[levelId.value].toLogLevel())),
+      (_, _) => unawaited(LogService.I.setLogLevel(Level.LEVELS[levelId.value].toLogLevel())),
     );
 
     Future<bool> checkAndroidVersion() async {

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_layout_settings.dart
@@ -15,7 +15,7 @@ class LayoutSettings extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tilesPerRow = useState(ref.watch(appConfigProvider.select((s) => s.timeline.tilesPerRow)));
-    useValueChanged<int, void>(tilesPerRow.value, (_, __) {
+    useValueChanged<int, void>(tilesPerRow.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.timelineTilesPerRow, tilesPerRow.value));
     });
 

--- a/mobile/lib/widgets/settings/asset_viewer_settings/image_viewer_quality_setting.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/image_viewer_quality_setting.dart
@@ -15,7 +15,7 @@ class ImageViewerQualitySetting extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isOriginal = useState(ref.watch(appConfigProvider).image.loadOriginal);
-    useValueChanged<bool, void>(isOriginal.value, (_, __) {
+    useValueChanged<bool, void>(isOriginal.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.imageLoadOriginal, isOriginal.value));
     });
 

--- a/mobile/lib/widgets/settings/asset_viewer_settings/image_viewer_tap_to_navigate_setting.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/image_viewer_tap_to_navigate_setting.dart
@@ -14,7 +14,7 @@ class ImageViewerTapToNavigateSetting extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tapToNavigate = useState(ref.watch(appConfigProvider).viewer.tapToNavigate);
-    useValueChanged<bool, void>(tapToNavigate.value, (_, __) {
+    useValueChanged<bool, void>(tapToNavigate.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.viewerTapToNavigate, tapToNavigate.value));
     });
 

--- a/mobile/lib/widgets/settings/asset_viewer_settings/slideshow_settings.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/slideshow_settings.dart
@@ -23,16 +23,16 @@ class SlideshowSettings extends HookConsumerWidget {
     final useLook = useState(slideshow.look);
     final useDirection = useState(slideshow.direction);
 
-    useValueChanged<bool, void>(useRepeat.value, (_, __) {
+    useValueChanged<bool, void>(useRepeat.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.slideshowRepeat, useRepeat.value));
     });
-    useValueChanged<int, void>(useDuration.value, (_, __) {
+    useValueChanged<int, void>(useDuration.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.slideshowDuration, useDuration.value));
     });
-    useValueChanged<SlideshowLook, void>(useLook.value, (_, __) {
+    useValueChanged<SlideshowLook, void>(useLook.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.slideshowLook, useLook.value));
     });
-    useValueChanged<SlideshowDirection, void>(useDirection.value, (_, __) {
+    useValueChanged<SlideshowDirection, void>(useDirection.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.slideshowDirection, useDirection.value));
     });
 

--- a/mobile/lib/widgets/settings/asset_viewer_settings/video_viewer_settings.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/video_viewer_settings.dart
@@ -18,13 +18,13 @@ class VideoViewerSettings extends HookConsumerWidget {
     final useLoopVideo = useState(viewer.loopVideo);
     final useOriginalVideo = useState(viewer.loadOriginalVideo);
 
-    useValueChanged<bool, void>(useAutoPlayVideo.value, (_, __) {
+    useValueChanged<bool, void>(useAutoPlayVideo.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.viewerAutoPlayVideo, useAutoPlayVideo.value));
     });
-    useValueChanged<bool, void>(useLoopVideo.value, (_, __) {
+    useValueChanged<bool, void>(useLoopVideo.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.viewerLoopVideo, useLoopVideo.value));
     });
-    useValueChanged<bool, void>(useOriginalVideo.value, (_, __) {
+    useValueChanged<bool, void>(useOriginalVideo.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.viewerLoadOriginalVideo, useOriginalVideo.value));
     });
 

--- a/mobile/lib/widgets/settings/free_up_space_settings.dart
+++ b/mobile/lib/widgets/settings/free_up_space_settings.dart
@@ -407,7 +407,7 @@ class _FreeUpSpaceSettingsState extends ConsumerState<FreeUpSpaceSettings> {
                   setState(() => _currentStep = CleanupStep.values[step]);
                 }
               },
-              controlsBuilder: (_, __) => const SizedBox.shrink(),
+              controlsBuilder: (_, _) => const SizedBox.shrink(),
               steps: [
                 // Step 1: Select Cutoff Date
                 Step(

--- a/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
+++ b/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
@@ -21,7 +21,7 @@ class NetworkingSettings extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentEndpoint = getServerUrl();
     final featureEnabled = useState(ref.watch(appConfigProvider).network.autoEndpointSwitching);
-    useValueChanged<bool, void>(featureEnabled.value, (_, __) {
+    useValueChanged<bool, void>(featureEnabled.value, (_, _) {
       unawaited(ref.read(settingsProvider).write(.networkAutoEndpointSwitching, featureEnabled.value));
     });
 

--- a/mobile/lib/widgets/settings/settings_button_list_tile.dart
+++ b/mobile/lib/widgets/settings/settings_button_list_tile.dart
@@ -41,7 +41,7 @@ class SettingsButtonListTile extends StatelessWidget {
               subtileText!,
               style: context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary),
             ),
-          if (subtitle != null) subtitle!,
+          ?subtitle,
           const SizedBox(height: 6),
           child ?? ElevatedButton(onPressed: onButtonTap, child: Text(buttonText)),
         ],

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -512,10 +512,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -1016,10 +1016,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.1.0"
   local_auth:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -101,7 +101,7 @@ dev_dependencies:
   fake_async: ^1.3.3
   file: ^7.0.1 # for MemoryFileSystem
   flutter_launcher_icons: ^0.14.4
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   flutter_native_splash: ^2.4.7
   flutter_test:
     sdk: flutter

--- a/mobile/test/infrastructure/repositories/sync_api_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/sync_api_repository_test.dart
@@ -189,7 +189,7 @@ void main() {
     final Completer<void> firstBatchReceived = Completer<void>();
     final Completer<void> secondBatchReceived = Completer<void>();
 
-    Future<void> onDataCallback(List<SyncEvent> events, Function() _, Function() __) async {
+    Future<void> onDataCallback(List<SyncEvent> events, Function() _, Function() _) async {
       onDataCallCount++;
       if (onDataCallCount == 1) {
         receivedEventsBatch1 = events;
@@ -244,7 +244,7 @@ void main() {
     final streamError = Exception("Network Error");
     int onDataCallCount = 0;
 
-    Future<void> onDataCallback(List<SyncEvent> _, Function() _, Function() __) async {
+    Future<void> onDataCallback(List<SyncEvent> _, Function() _, Function() _) async {
       onDataCallCount++;
     }
 
@@ -270,7 +270,7 @@ void main() {
     when(() => mockStreamedResponse.stream).thenAnswer((_) => http.ByteStream(errorBodyController.stream));
 
     int onDataCallCount = 0;
-    Future<void> onDataCallback(List<SyncEvent> _, Function() _, Function() __) async {
+    Future<void> onDataCallback(List<SyncEvent> _, Function() _, Function() _) async {
       onDataCallCount++;
     }
 

--- a/mobile/test/presentation/widgets/asset_viewer/asset_page_zoom_reset_test.dart
+++ b/mobile/test/presentation/widgets/asset_viewer/asset_page_zoom_reset_test.dart
@@ -20,7 +20,7 @@ class _SwappableTimelineService extends TimelineService {
   BaseAsset asset;
   _SwappableTimelineService(this.asset)
     : super((
-        assetSource: (_, __) async => [],
+        assetSource: (_, _) async => [],
         bucketSource: () => Stream.value(const [Bucket(assetCount: 1)]),
         origin: TimelineOrigin.main,
       ));

--- a/mobile/test/presentation/widgets/images/cache_aware_listener_tracker_mixin_test.dart
+++ b/mobile/test/presentation/widgets/images/cache_aware_listener_tracker_mixin_test.dart
@@ -29,7 +29,7 @@ void main() {
   setUp(() {
     // Create a fresh, real Flutter ImageCache for every test
     cache = ImageCache();
-    uiListener = ImageStreamListener((_, __) {});
+    uiListener = ImageStreamListener((_, _) {});
   });
 
   group('CacheAwareListenerTrackerMixin with Real ImageCache', () {
@@ -130,7 +130,7 @@ void main() {
 
       final stream = cache.putIfAbsent(key, () => completer)!;
 
-      final uiListener2 = ImageStreamListener((_, __) {});
+      final uiListener2 = ImageStreamListener((_, _) {});
       stream.addListener(uiListener);
       stream.addListener(uiListener2);
 
@@ -157,7 +157,7 @@ void main() {
       expect(completer.wasCancelled, isFalse);
 
       // A second UI listener attaches — must NOT be treated as cache
-      final uiListener2 = ImageStreamListener((_, __) {});
+      final uiListener2 = ImageStreamListener((_, _) {});
       stream.addListener(uiListener2);
 
       // Remove first UI listener; second UI still active → no cancel

--- a/mobile/test/presentation/widgets/timeline/timeline_args_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_args_test.dart
@@ -64,7 +64,7 @@ void main() {
 
     TimelineArgs? probed;
     final probe = Consumer(
-      builder: (_, ref, __) {
+      builder: (_, ref, _) {
         probed = ref.watch(timelineArgsProvider);
         return const SizedBox.shrink();
       },
@@ -103,7 +103,7 @@ void main() {
     TimelineArgs? probed;
     final probe = SliverToBoxAdapter(
       child: Consumer(
-        builder: (_, ref, __) {
+        builder: (_, ref, _) {
           probed = ref.watch(timelineArgsProvider);
           return const SizedBox.shrink();
         },
@@ -148,7 +148,7 @@ void main() {
 
     TimelineArgs? probed;
     final probe = Consumer(
-      builder: (_, ref, __) {
+      builder: (_, ref, _) {
         probed = ref.watch(timelineArgsProvider);
         return const SizedBox.shrink();
       },

--- a/mobile/test/presentation/widgets/timeline/timeline_scroll_to_top_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_scroll_to_top_test.dart
@@ -51,7 +51,7 @@ void main() {
           page: PageInfo('Overlay', builder: (_) => const Scaffold(body: SizedBox.shrink())),
           type: RouteType.custom(
             customRouteBuilder: <T>(_, child, page) =>
-                PageRouteBuilder<T>(settings: page, opaque: false, pageBuilder: (_, __, ___) => child),
+                PageRouteBuilder<T>(settings: page, opaque: false, pageBuilder: (_, _, _) => child),
           ),
         ),
       ],

--- a/mobile/test/providers/infrastructure/memory_provider_test.dart
+++ b/mobile/test/providers/infrastructure/memory_provider_test.dart
@@ -48,7 +48,7 @@ void main() {
     test('re-queries after local midnight', () {
       fakeAsync((async) {
         final container = makeContainer();
-        container.listen(driftMemoryFutureProvider, (_, __) {});
+        container.listen(driftMemoryFutureProvider, (_, _) {});
         async.flushMicrotasks();
 
         verify(() => memoryService.getMemoryLane('user-1')).called(1);
@@ -66,7 +66,7 @@ void main() {
     test('cancels the midnight timer when disposed', () {
       fakeAsync((async) {
         final container = makeContainer();
-        final subscription = container.listen(driftMemoryFutureProvider, (_, __) {});
+        final subscription = container.listen(driftMemoryFutureProvider, (_, _) {});
         async.flushMicrotasks();
         verify(() => memoryService.getMemoryLane('user-1')).called(1);
 
@@ -83,7 +83,7 @@ void main() {
 
       fakeAsync((async) {
         final container = makeContainer();
-        container.listen(driftMemoryFutureProvider, (_, __) {});
+        container.listen(driftMemoryFutureProvider, (_, _) {});
         async.flushMicrotasks();
 
         async.elapse(const Duration(hours: 25));


### PR DESCRIPTION
Pumps `flutter_lints` to 6.0, which brought in few lints automatically
- `unnecessary_underscores`
- `use_null_aware_elements`