### PR TITLE
fix(server): correct OCR rotation precedence and harden connection-abort check

### DIFF
--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -12,7 +12,7 @@ import { cleanupOpenApiDoc } from 'nestjs-zod';
 import { writeFileSync } from 'node:fs';
 import path from 'node:path';
 import picomatch from 'picomatch';
-import parse from 'picomatch/lib/parse';
+import type parse from 'picomatch/lib/parse';
 import { SystemConfig } from 'src/config';
 import { CLIP_MODEL_INFO, endpointTags, serverVersion } from 'src/constants';
 import { extraModels } from 'src/decorators';
@@ -105,10 +105,10 @@ export const isDuplicateDetectionEnabled = (machineLearning: SystemConfig['machi
   isSmartSearchEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
 export const isFaceImportEnabled = (metadata: SystemConfig['metadata']) => metadata.faces.import;
 
-export const isConnectionAborted = (error: Error | any) => error.code === 'ECONNABORTED';
+export const isConnectionAborted = (error: unknown) => (error as { code?: string })?.code === 'ECONNABORTED';
 
 export const handlePromiseError = <T>(promise: Promise<T>, logger: LoggingRepository): void => {
-  promise.catch((error: Error | any) => logger.error(`Promise error: ${error}`, error?.stack));
+  promise.catch((error: unknown) => logger.error(`Promise error: ${error}`, (error as Error)?.stack));
 };
 
 export interface OpenGraphTags {

--- a/server/src/utils/transform.ts
+++ b/server/src/utils/transform.ts
@@ -227,7 +227,7 @@ export const transformOcrBoundingBox = (
   const { points: transformedPoints, currentWidth, currentHeight } = transformPoints(points, edits, imageDimensions);
 
   // Reorder points to maintain semantic ordering (topLeft, topRight, bottomRight, bottomLeft)
-  const netRotation = edits.find((e) => e.action == AssetEditAction.Rotate)?.parameters.angle ?? 0 % 360;
+  const netRotation = (edits.find((e) => e.action === AssetEditAction.Rotate)?.parameters.angle ?? 0) % 360;
   const reorderedPoints = reorderQuadPointsForRotation(transformedPoints, netRotation);
 
   const [p1, p2, p3, p4] = reorderedPoints;


### PR DESCRIPTION
## Description
Fixes operator precedence bug in `transformOcrBoundingBox` (`server/src/utils/transform.ts:230`): `a ?? 0 % 360` was parsed as `a ?? (0%360)` due to `%` binding tighter than `??`. For angles like 450, `netRotation` stayed 450, so `reorderQuadPointsForRotation` fell through to `default` and OCR bounding boxes were misordered. Fixed to `(a ?? 0) % 360` and changed `==` to `===` (eqeqeq).

Also harden `isConnectionAborted` in `server/src/utils/misc.ts:108`: `error.code` without optional chaining threw `TypeError` on `null/undefined` in the `sendFile` catch (`server/src/utils/file.ts:76`), returning an unhandled exception instead of `NotFoundException`. Now `error: unknown` with `(error as {code?:string})?.code`. Change `import parse` to `import type parse` (type-only) and align `handlePromiseError` to `unknown`.

## How Has This Been Tested?
- Fresh checkout + `pnpm install` (2462 packages, Done in 11.3s)
- `pnpm -C server exec tsc --noEmit` – only pre-existing `TS2307: Cannot find module '@immich/plugin-sdk'` errors, no new errors in changed files
- `pnpm -C server exec eslint src/utils/transform.ts src/utils/misc.ts` – exit 0
- `vitest run --config server/test/vitest.config.mjs server/src/utils/transform.spec.ts` – 20 tests passed (23ms); `misc.spec` fails only due to pre-existing `@immich/plugin-sdk` vite resolver error, not patch

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
LLM was used to assist with code review and to identify the precedence/null-safety issues. All changes were manually reviewed, tested locally, and are understood by the author.
