### PR TITLE
fix(server): enforce strict equality (===)

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -838,7 +838,7 @@ export class AssetRepository {
           )
           .$if(!!options.withCoordinates, (qb) => qb.select(['asset_exif.latitude', 'asset_exif.longitude']))
           .where('asset.deletedAt', options.isTrashed ? 'is not' : 'is', null)
-          .$if(options.visibility == undefined, withDefaultVisibility)
+          .$if(options.visibility === undefined, withDefaultVisibility)
           .$if(!!options.visibility, (qb) => qb.where('asset.visibility', '=', options.visibility!))
           .$if(!!options.bbox, (qb) => {
             const bbox = options.bbox!;

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -402,8 +402,8 @@ export class StorageTemplateService extends BaseService {
     const substitutions: Record<string, string> = {
       filename,
       ext: extension,
-      filetype: asset.type == AssetType.Image ? 'IMG' : 'VID',
-      filetypefull: asset.type == AssetType.Image ? 'IMAGE' : 'VIDEO',
+      filetype: asset.type === AssetType.Image ? 'IMG' : 'VID',
+      filetypefull: asset.type === AssetType.Image ? 'IMAGE' : 'VIDEO',
       assetId: asset.id,
       assetIdShort: asset.id.slice(-12),
       //just throw into the root if it doesn't belong to an album

--- a/server/src/utils/bytes.ts
+++ b/server/src/utils/bytes.ts
@@ -20,7 +20,7 @@ export function asHumanReadable(bytes: number, precision = 1): string {
     }
   }
 
-  return `${remainder.toFixed(magnitude == 0 ? 0 : precision)} ${units[magnitude]}`;
+  return `${remainder.toFixed(magnitude === 0 ? 0 : precision)} ${units[magnitude]}`;
 }
 
 // if an asset is jsonified in the DB before being returned, its buffer fields will be hex-encoded strings


### PR DESCRIPTION
## Description
Fixes inconsistent loose equality checks:
- `server/src/repositories/asset.repository.ts:841` – `options.visibility == undefined` → `=== undefined` (consistent with lines 709/766)
- `server/src/utils/bytes.ts:23` – `magnitude == 0` → `=== 0` (number comparison)
- `server/src/services/storage-template.service.ts:405-406` – `asset.type == AssetType.Image` → `===`

Loose `==` allows implicit coercion and is inconsistent with the rest of the codebase (eqeqeq). No functional change for current types, but stricter and lint-clean.

## How Has This Been Tested?
- `pnpm install` fresh, `pnpm -C server exec tsc --noEmit` – only pre-existing `@immich/plugin-sdk` TS2307
- `pnpm -C server exec eslint src/repositories/asset.repository.ts src/utils/bytes.ts src/services/storage-template.service.ts` – exit 0
- No functional change, existing tests pass (transform.spec 20/20)

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
LLM assisted in locating loose equality instances; fix was manually reviewed and verified.
