### PR TITLE
fix(mobile): allow deep linking to full memory lane

### DIFF
--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -51,7 +51,7 @@ class DeepLinkService {
     final queryParams = link.uri.queryParameters;
 
     return switch (intent) {
-      "memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
+      "memory" => await _buildMemoryDeepLink(queryParams['id']),
       "asset" => await _buildAssetDeepLink(queryParams['id'] ?? '', ref),
       "album" => await _buildAlbumDeepLink(queryParams['id'] ?? ''),
       "people" => await _buildPeopleDeepLink(queryParams['id'] ?? ''),
@@ -82,6 +82,9 @@ class DeepLinkService {
     if (peopleRegex.hasMatch(path)) {
       final peopleId = peopleRegex.firstMatch(path)?.group(1) ?? '';
       return _buildPeopleDeepLink(peopleId);
+    }
+    if (path == '/memory') {
+      return _buildMemoryDeepLink(null);
     }
 
     return null;

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart';
 import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/domain/services/people.service.dart';
@@ -32,16 +34,40 @@ class MockAssetViewerStateNotifier extends Mock implements AssetViewerStateNotif
 
 const _assetId = 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb';
 const _albumId = 'cccccccc-4444-5555-6666-dddddddddddd';
+const _memoryId = 'eeeeeeee-7777-8888-9999-ffffffffffff';
+const _userId = 'user-1';
+
+final _user = UserDto(
+  id: _userId,
+  name: 'Test User',
+  email: 'test@example.com',
+  isAdmin: false,
+  profileChangedAt: DateTime(2026, 6, 12),
+  avatarColor: AvatarColor.primary,
+  memoryEnabled: true,
+);
 
 final _asset = RemoteAsset(
   id: _assetId,
   name: 'photo.jpg',
-  ownerId: 'user-1',
+  ownerId: _userId,
   checksum: 'checksum-1',
   type: AssetType.image,
   createdAt: DateTime(2026, 6, 12),
   updatedAt: DateTime(2026, 6, 12),
   isEdited: false,
+);
+
+final _memory = DriftMemory(
+  id: _memoryId,
+  createdAt: DateTime(2026, 6, 12),
+  updatedAt: DateTime(2026, 6, 12),
+  ownerId: _userId,
+  type: MemoryTypeEnum.onThisDay,
+  data: const MemoryData(year: 2020),
+  isSaved: false,
+  memoryAt: DateTime(2020, 6, 12),
+  assets: [],
 );
 
 final _album = RemoteAlbum(
@@ -62,14 +88,17 @@ void main() {
   late MockTimelineFactory timelineFactory;
   late MockAssetService assetService;
   late MockRemoteAlbumService remoteAlbumService;
+  late MockDriftMemoryService memoryService;
   late MockWidgetRef ref;
   late List<TimelineService> createdTimelineServices;
   late DeepLinkService sut;
+  late DeepLinkService sutWithUser;
 
   setUp(() {
     timelineFactory = MockTimelineFactory();
     assetService = MockAssetService();
     remoteAlbumService = MockRemoteAlbumService();
+    memoryService = MockDriftMemoryService();
     ref = MockWidgetRef();
     createdTimelineServices = [];
 
@@ -90,9 +119,18 @@ void main() {
       timelineFactory,
       assetService,
       remoteAlbumService,
-      MockDriftMemoryService(),
+      memoryService,
       MockDriftPeopleService(),
       null,
+    );
+
+    sutWithUser = DeepLinkService(
+      timelineFactory,
+      assetService,
+      remoteAlbumService,
+      memoryService,
+      MockDriftPeopleService(),
+      _user,
     );
 
     addTearDown(() async {
@@ -102,9 +140,17 @@ void main() {
     });
   });
 
+  /// Creates a mock [PlatformDeepLink] for an https://my.immich.app path.
   PlatformDeepLink link(String path) {
     final deepLink = MockPlatformDeepLink();
     when(() => deepLink.uri).thenReturn(Uri.parse('https://my.immich.app$path'));
+    return deepLink;
+  }
+
+  /// Creates a mock [PlatformDeepLink] for an immich:// scheme URI.
+  PlatformDeepLink schemeLink(String path) {
+    final deepLink = MockPlatformDeepLink();
+    when(() => deepLink.uri).thenReturn(Uri.parse('immich:/$path'));
     return deepLink;
   }
 
@@ -136,5 +182,40 @@ void main() {
     expect(route, isA<AssetViewerRoute>());
     expect((route!.args! as AssetViewerRouteArgs).currentAlbum, isNull);
     verifyNever(() => remoteAlbumService.get(any()));
+  });
+
+  group('memory deep links', () {
+    test('immich://memory opens the full Memory Lane', () async {
+      when(() => memoryService.getMemoryLane(_userId)).thenAnswer((_) async => [_memory]);
+
+      final route = await sutWithUser.handleScheme(schemeLink('/memory'), ref);
+
+      expect(route, isA<DriftMemoryRoute>());
+      final args = route!.args! as DriftMemoryRouteArgs;
+      expect(args.memories, [_memory]);
+      expect(args.memoryIndex, 0);
+    });
+
+    test('immich://memory?id=<uuid> opens that specific memory', () async {
+      when(() => memoryService.get(_memoryId)).thenAnswer((_) async => _memory);
+
+      final route = await sut.handleScheme(schemeLink('/memory?id=$_memoryId'), ref);
+
+      expect(route, isA<DriftMemoryRoute>());
+      final args = route!.args! as DriftMemoryRouteArgs;
+      expect(args.memories, [_memory]);
+      expect(args.memoryIndex, 0);
+    });
+
+    test('https://my.immich.app/memory opens the full Memory Lane', () async {
+      when(() => memoryService.getMemoryLane(_userId)).thenAnswer((_) async => [_memory]);
+
+      final route = await sutWithUser.handleMyImmichApp(link('/memory'), ref);
+
+      expect(route, isA<DriftMemoryRoute>());
+      final args = route!.args! as DriftMemoryRouteArgs;
+      expect(args.memories, [_memory]);
+      expect(args.memoryIndex, 0);
+    });
   });
 }


### PR DESCRIPTION
## Description

`immich://memory` (without an `?id=` parameter) is meant to open the full Memory Lane
screen. Instead, tapping the link navigated to the home screen.

**Root cause:** In `handleScheme()`, the `memory` branch fell back to an empty string
when the `id` query parameter was absent:

```dart
// Before
"memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
```

`_buildMemoryDeepLink` already distinguishes between `null` ("open full lane") and a
non-null string ("open a specific memory"). The `?? ''` coerced a missing parameter into
`''`, causing the service to look up a memory with an empty id, find nothing, and fall
back to the home screen. Removing the null-coalescing operator restores the intended
behaviour.

**Secondary gap:** `https://my.immich.app/memory` is registered in `AndroidManifest.xml`
(`android:path="/memory"`) but `handleMyImmichApp()` had no matching branch, so that URL
was also silently dropped to the home screen. A corresponding `if (path == '/memory')`
block was added.

Fixes #30634

## How Has This Been Tested?

- [x] Unit tests — `flutter test test/services/deep_link_service_test.dart`

Three regression tests were added inside a `group('memory deep links', ...)` block:

| # | Input | Expected result |
|---|---|---|
| 1 | `immich://memory` | `DriftMemoryRoute` - full Memory Lane |
| 2 | `immich://memory?id=<uuid>` | `DriftMemoryRoute` - specific memory |
| 3 | `https://my.immich.app/memory` | `DriftMemoryRoute` - full Memory Lane |

Manual verification (Android):
```sh
adb shell am start -a android.intent.action.VIEW -d "immich://memory"
# Memory Lane opens

adb shell am start -a android.intent.action.VIEW -d "immich://memory?id=<valid-uuid>"
# Specific memory opens
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used to generate this pull request.
