### PR TITLE
fix(server): remove extra closing brace in library watcher log messages

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -110,7 +110,7 @@ export class LibraryService extends BaseService {
 
     const handler = async (event: string, path: string) => {
       if (matcher(path)) {
-        this.logger.debug(`File ${event} event received for ${path} in library ${library.id}}`);
+        this.logger.debug(`File ${event} event received for ${path} in library ${library.id}`);
         await this.jobRepository.queue({
           name: JobName.LibrarySyncFiles,
           data: { libraryId: library.id, paths: [path] },
@@ -121,7 +121,7 @@ export class LibraryService extends BaseService {
     };
 
     const deletionHandler = async (path: string) => {
-      this.logger.debug(`File unlink event received for ${path} in library ${library.id}}`);
+      this.logger.debug(`File unlink event received for ${path} in library ${library.id}`);
       await this.jobRepository.queue({
         name: JobName.LibraryRemoveAsset,
         data: { libraryId: library.id, paths: [path] },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
fix a typo in two language in library.service.ts that printed an extra }

Fixes #30727 

## How Has This Been Tested?



## Checklist:

- [ x] I have carefully read CONTRIBUTING.md
- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ x] I have written tests for new code (if applicable)
- [x ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used.
