### PR TITLE
chore: use import.meta.dirname instead of __dirname

### DIFF
--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -2,12 +2,7 @@ import js from '@eslint/js';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import typescriptEslint from 'typescript-eslint';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export default typescriptEslint.config([
   eslintPluginUnicorn.configs.recommended,
@@ -29,7 +24,7 @@ export default typescriptEslint.config([
 
       parserOptions: {
         project: 'tsconfig.json',
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
 

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -2,12 +2,7 @@ import js from '@eslint/js';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import typescriptEslint from 'typescript-eslint';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export default typescriptEslint.config([
   eslintPluginUnicorn.configs.recommended,
@@ -29,7 +24,7 @@ export default typescriptEslint.config([
 
       parserOptions: {
         project: 'tsconfig.json',
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
 

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -2,12 +2,7 @@ import js from '@eslint/js';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import typescriptEslint from 'typescript-eslint';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export default typescriptEslint.config([
   eslintPluginUnicorn.configs.recommended,
@@ -29,7 +24,7 @@ export default typescriptEslint.config([
 
       parserOptions: {
         project: 'tsconfig.json',
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
 

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -10,10 +10,6 @@ import parser from 'svelte-eslint-parser';
 import typescriptEslint from 'typescript-eslint';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export default typescriptEslint.config(
   ...eslintPluginSvelte.configs.recommended,
@@ -29,7 +25,7 @@ export default typescriptEslint.config(
         'error',
         {
           browserslist: fs
-            .readFileSync(path.join(__dirname, '.browserslistrc'), 'utf8')
+            .readFileSync(path.join(import.meta.dirname, '.browserslistrc'), 'utf8')
             .split('\n')
             .map((line) => line.trim())
             .filter((line) => line && !line.startsWith('#')),
@@ -40,7 +36,7 @@ export default typescriptEslint.config(
       parser,
       parserOptions: {
         project: ['./tsconfig.json'],
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     // ignores: ['**/service-worker/**'],
@@ -96,7 +92,7 @@ export default typescriptEslint.config(
 
       parserOptions: {
         extraFileExtensions: ['.svelte'],
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
         project: ['./tsconfig.json'],
       },
     },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -28,8 +28,8 @@ export default defineConfig({
     alias: {
       'xmlhttprequest-ssl': './node_modules/engine.io-client/lib/xmlhttprequest.js',
       // eslint-disable-next-line unicorn/prefer-module
-      '@test-data': path.resolve(__dirname, './src/test-data'),
-      // '@immich/ui': path.resolve(__dirname, '../../ui/packages/ui'),
+      '@test-data': path.resolve(import.meta.dirname, './src/test-data'),
+      // '@immich/ui': path.resolve(import.meta.dirname, '../../ui/packages/ui'),
     },
   },
   server: {


### PR DESCRIPTION
## Description
Use `import.meta.dirname` instead of `__dirname` and `__filename` where possible. Got a vite warning about a future incompatibility, so I updated the vite config, and a few other usages.

```
immich_web               | (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
immich_web               |   - `__dirname` (vite.config.ts:31:34). Use `import.meta.dirname` instead
immich_web               | Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```