### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ Read more about translations [here](https://docs.immich.app/developer/translatio
 
 ## Star history
 
-<a href="https://star-history.com/#immich-app/immich&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#immich-app/immich&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_ar_JO.md
+++ b/readme_i18n/README_ar_JO.md
@@ -117,10 +117,10 @@ password: demo
 
 ## Star History
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>

--- a/readme_i18n/README_bg_BG.md
+++ b/readme_i18n/README_bg_BG.md
@@ -116,11 +116,11 @@
 
 ## История на звездите
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_de_DE.md
+++ b/readme_i18n/README_de_DE.md
@@ -119,11 +119,11 @@ Mehr zum Thema Übersetzungen kannst du [hier](https://docs.immich.app/developer
 
 ## Github Sterne
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_es_ES.md
+++ b/readme_i18n/README_es_ES.md
@@ -111,11 +111,11 @@ Lea mas acerca de las traducciones [acá](https://docs.immich.app/developer/tran
 
 ## Historial de Estrellas
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_fr_FR.md
+++ b/readme_i18n/README_fr_FR.md
@@ -113,10 +113,10 @@ mot de passe: demo
 
 ## Historique des favoris
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>

--- a/readme_i18n/README_it_IT.md
+++ b/readme_i18n/README_it_IT.md
@@ -118,11 +118,11 @@ Scopri di più sulle traduzioni [qui](https://docs.immich.app/developer/translat
 
 ## Cronologia delle stelle
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Grafico storico delle stelle" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Grafico storico delle stelle" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_ko_KR.md
+++ b/readme_i18n/README_ko_KR.md
@@ -116,11 +116,11 @@
 
 ## 스타 기록
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="스타 기록 차트" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="스타 기록 차트" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_ml_IN.md
+++ b/readme_i18n/README_ml_IN.md
@@ -118,11 +118,11 @@
 
 ## സ്റ്റാർ ചരിത്രം
 
-<a href="https://star-history.com/#immich-app/immich&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#immich-app/immich&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=date" width="100%" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=date" width="100%" />
   </picture>
 </a>
 

--- a/readme_i18n/README_nl_NL.md
+++ b/readme_i18n/README_nl_NL.md
@@ -110,11 +110,11 @@ Je kunt [hier](https://docs.immich.app/developer/translations) meer over vertali
 
 ## Ster geschiedenis
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_pt_BR.md
+++ b/readme_i18n/README_pt_BR.md
@@ -123,11 +123,11 @@ Leia mais sobre as traduções
 
 ## Histórico de estrelas
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Gráfico de histórico de estrelas" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Gráfico de histórico de estrelas" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_ru_RU.md
+++ b/readme_i18n/README_ru_RU.md
@@ -118,11 +118,11 @@
 
 ## История звёзд
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_sv_SE.md
+++ b/readme_i18n/README_sv_SE.md
@@ -115,10 +115,10 @@ lösenord: demo
 
 ## Stjärn-Historik
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>

--- a/readme_i18n/README_th_TH.md
+++ b/readme_i18n/README_th_TH.md
@@ -120,11 +120,11 @@
 
 ## ประวัติการให้ดาว
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="แผนภูมิประวัติการให้ดาว" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="แผนภูมิประวัติการให้ดาว" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_uk_UA.md
+++ b/readme_i18n/README_uk_UA.md
@@ -118,11 +118,11 @@
 
 ## Історія зірок
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_vi_VN.md
+++ b/readme_i18n/README_vi_VN.md
@@ -118,11 +118,11 @@ Truy cập bản demo [tại đây](https://demo.immich.app). Đối với ứng
 
 ## Lịch sử Đánh dấu sao
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Biểu đồ Lịch sử Đánh dấu" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Biểu đồ Lịch sử Đánh dấu" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_zh_CN.md
+++ b/readme_i18n/README_zh_CN.md
@@ -122,11 +122,11 @@
 
 ## Star增长曲线
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 

--- a/readme_i18n/README_zh_TW.md
+++ b/readme_i18n/README_zh_TW.md
@@ -119,11 +119,11 @@
 
 ## Star 數量歷史紀錄
 
-<a href="https://star-history.com/#immich-app/immich&Date">
+<a href="https://star-history.dera.page/#immich-app/immich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
-   <img alt="Star 歷史紀錄圖表" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" />
+   <img alt="Star 歷史紀錄圖表" src="https://star-history.dera.page/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the project READMEs has stopped rendering. It is an important piece of the project's landing page, and it currently appears broken to anyone visiting the repository, so a fix is necessary.

This PR updates the chart URLs in README.md and all localized READMEs to use a working mirror of the same service. All existing parameters are preserved, including the dark/light theme variants and the wrapped interactive link.