### PR TITLE
fix(server): hide database password from backup process arguments

### DIFF
--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -209,11 +209,44 @@ describe(DatabaseBackupService.name, () => {
       const args = call[1] as string[];
       expect(args).toMatchInlineSnapshot(`
         [
-          "postgresql://postgres:pwd@host:5432/immich?sslmode=require",
+          "postgresql://postgres@host:5432/immich?sslmode=require",
           "--clean",
           "--if-exists",
         ]
       `);
+    });
+
+    it('should pass the DB_URL password via PGPASSWORD instead of the process arguments', async () => {
+      // the password would otherwise be readable by anyone able to list processes
+      const dbUrl = 'postgresql://postgres:p%40ssword@host:5432/immich';
+      const configMock = {
+        getEnv: () => ({ database: { config: { connectionType: 'url', url: dbUrl }, skipMigrations: false } }),
+        getWorker: () => ImmichWorker.Api,
+        isDev: () => false,
+      } as unknown as any;
+
+      sut = new DatabaseBackupService(
+        mocks.logger as never,
+        mocks.storage as never,
+        configMock as never,
+        mocks.systemMetadata as never,
+        mocks.process,
+        mocks.database as never,
+        mocks.user as never,
+        mocks.cron as never,
+        mocks.job as never,
+        void 0 as never,
+      );
+
+      mocks.database.getPostgresVersion.mockResolvedValue('14.10');
+
+      await sut.handleBackupDatabase();
+
+      expect(mocks.process.spawnDuplexStream).toHaveBeenCalledWith(
+        '/usr/lib/postgresql/14/bin/pg_dump',
+        ['postgresql://postgres@host:5432/immich', '--clean', '--if-exists'],
+        { env: { PATH: process.env.PATH, PGPASSWORD: 'p@ssword' } },
+      );
     });
 
     it('should run a database backup successfully', async () => {
@@ -488,7 +521,7 @@ describe(DatabaseBackupService.name, () => {
         await expect(sut.buildPostgresLaunchArguments('pg_dump')).resolves.toMatchInlineSnapshot(`
           {
             "args": [
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--clean",
               "--if-exists",
             ],
@@ -507,7 +540,7 @@ describe(DatabaseBackupService.name, () => {
           {
             "args": [
               "--dbname",
-              "postgresql://mypg:mypwd@myhost:1234/myimmich?sslmode=require",
+              "postgresql://mypg@myhost:1234/myimmich?sslmode=require",
               "--single-transaction",
               "--set",
               "ON_ERROR_STOP=on",
@@ -517,6 +550,47 @@ describe(DatabaseBackupService.name, () => {
             "bin": "/usr/lib/postgresql/14/bin/psql",
             "databaseMajorVersion": 14,
             "databasePassword": "mypwd",
+            "databaseUsername": "mypg",
+            "databaseVersion": "14.10 (Debian 14.10-1.pgdg120+1)",
+          }
+        `);
+      });
+    });
+
+    describe('using URL with credentials as parameters', () => {
+      beforeEach(() => {
+        const dbUrl = 'postgresql://myhost:1234/myimmich?user=mypg&password=my%2Fpwd';
+        const configMock = {
+          getEnv: () => ({ database: { config: { connectionType: 'url', url: dbUrl }, skipMigrations: false } }),
+          getWorker: () => ImmichWorker.Api,
+          isDev: () => false,
+        } as unknown as any;
+
+        sut = new DatabaseBackupService(
+          mocks.logger as never,
+          mocks.storage as never,
+          configMock as never,
+          mocks.systemMetadata as never,
+          mocks.process,
+          mocks.database as never,
+          mocks.user as never,
+          mocks.cron as never,
+          mocks.job as never,
+          void 0 as never,
+        );
+      });
+
+      it('should remove the password parameter', async () => {
+        await expect(sut.buildPostgresLaunchArguments('pg_dump')).resolves.toMatchInlineSnapshot(`
+          {
+            "args": [
+              "postgresql://myhost:1234/myimmich?user=mypg",
+              "--clean",
+              "--if-exists",
+            ],
+            "bin": "/usr/lib/postgresql/14/bin/pg_dump",
+            "databaseMajorVersion": 14,
+            "databasePassword": "my/pwd",
             "databaseUsername": "mypg",
             "databaseVersion": "14.10 (Debian 14.10-1.pgdg120+1)",
           }

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -129,6 +129,7 @@ export class DatabaseBackupService {
 
     const args: string[] = [];
     let databaseUsername;
+    let databasePassword;
 
     if (isUrlConnection) {
       if (bin !== 'pg_dump') {
@@ -142,16 +143,24 @@ export class DatabaseBackupService {
         parsedUrl.searchParams.delete('uselibpqcompat');
 
         databaseUsername = parsedUrl.username || parsedUrl.searchParams.get('user');
+        databasePassword = decodeUrlComponent(parsedUrl.password) || parsedUrl.searchParams.get('password');
+
+        // the password is handed over via `PGPASSWORD`, so that it is not visible
+        // in the arguments of the spawned process
+        parsedUrl.password = '';
+        parsedUrl.searchParams.delete('password');
 
         url = parsedUrl.href;
       }
 
       // assume typical values if we can't parse URL or not present
       databaseUsername ??= 'postgres';
+      databasePassword ??= '';
 
       args.push(url);
     } else {
       databaseUsername = databaseConfig.username;
+      databasePassword = databaseConfig.password;
 
       args.push(
         '--username',
@@ -214,7 +223,7 @@ export class DatabaseBackupService {
       bin: `/usr/lib/postgresql/${databaseMajorVersion}/bin/${bin}`,
       args,
       databaseUsername,
-      databasePassword: isUrlConnection ? new URL(databaseConfig.url).password : databaseConfig.password,
+      databasePassword,
       databaseVersion,
       databaseMajorVersion,
     };
@@ -458,6 +467,15 @@ export class DatabaseBackupService {
     }
 
     this.logger.log(`Database Restore Success`);
+  }
+}
+
+// `URL` exposes the userinfo section percent-encoded, while `PGPASSWORD` expects the raw value
+function decodeUrlComponent(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
   }
 }
 


### PR DESCRIPTION
## Description

When `DB_URL` is set, the whole connection string was passed to `pg_dump` and `psql` as a plain argument, so the password in it showed up in `ps` for anyone able to list processes. The password was already going through `PGPASSWORD` as well, so the copy in the arguments was not needed.

Now the password is taken out of the URL before it becomes an argument, both the `user:pass` part and a `?password=` query parameter, and only `PGPASSWORD` carries it. `URL` gives the userinfo password back percent-encoded, so it is decoded first because libpq wants the raw value.

Fixes #30333

## How Has This Been Tested?

Two new unit tests in `server/src/services/database-backup.service.spec.ts`. One checks `pg_dump` is spawned with a password-free URL and `PGPASSWORD` set to the decoded password. The other checks the `password` query parameter is stripped. Three existing inline snapshots changed because the URL no longer carries the password. Both new tests fail on `main`.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This code was written alongside AI. The change and its tests were reviewed against the behaviour described in the linked issue before opening, and I am happy to walk through the reasoning or rework any part of it.
