### PR TITLE
fix(cli): report upload-time duplicates in json output

### DIFF
--- a/packages/cli/src/commands/asset.spec.ts
+++ b/packages/cli/src/commands/asset.spec.ts
@@ -72,12 +72,34 @@ describe('uploadFiles', () => {
       };
     });
 
-    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual([
-      {
-        filepath: testFilePath,
-        id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
-      },
-    ]);
+    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual({
+      newAssets: [
+        {
+          filepath: testFilePath,
+          id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
+        },
+      ],
+      duplicateAssets: [],
+    });
+  });
+
+  it('returns duplicate assets when the server rejects the upload as a duplicate', async () => {
+    fetchMocker.doMockIf(new RegExp(`${baseUrl}/assets$`), function () {
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 'fc5621b1-86f6-44a1-9905-403e607df9f5', status: 'duplicate' }),
+      };
+    });
+
+    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual({
+      newAssets: [],
+      duplicateAssets: [
+        {
+          filepath: testFilePath,
+          id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
+        },
+      ],
+    });
   });
 
   it('returns new assets when upload file retry is successful', async () => {
@@ -94,12 +116,15 @@ describe('uploadFiles', () => {
       };
     });
 
-    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual([
-      {
-        filepath: testFilePath,
-        id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
-      },
-    ]);
+    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual({
+      newAssets: [
+        {
+          filepath: testFilePath,
+          id: 'fc5621b1-86f6-44a1-9905-403e607df9f5',
+        },
+      ],
+      duplicateAssets: [],
+    });
   });
 
   it('returns new assets when upload file retry is failed', async () => {
@@ -107,7 +132,10 @@ describe('uploadFiles', () => {
       throw new Error('Network error');
     });
 
-    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual([]);
+    await expect(uploadFiles([testFilePath], { concurrency: 1 })).resolves.toEqual({
+      newAssets: [],
+      duplicateAssets: [],
+    });
   });
 
   it('uploads assets with the specified visibility', async () => {

--- a/packages/cli/src/commands/asset.ts
+++ b/packages/cli/src/commands/asset.ts
@@ -67,8 +67,10 @@ class UploadFile extends File {
 }
 
 const uploadBatch = async (files: string[], options: UploadOptionsDto) => {
-  const { newFiles, duplicates } = await checkForDuplicates(files, options);
-  const newAssets = await uploadFiles(newFiles, options);
+  const { newFiles, duplicates: existingDuplicates } = await checkForDuplicates(files, options);
+  const { newAssets, duplicateAssets } = await uploadFiles(newFiles, options);
+  // the server can still reject an upload as a duplicate, e.g. when the same file is present twice in the batch
+  const duplicates = [...existingDuplicates, ...duplicateAssets];
   if (options.jsonOutput) {
     console.log(JSON.stringify({ newFiles, duplicates, newAssets }, undefined, 4));
   }
@@ -309,11 +311,14 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
   return { newFiles, duplicates };
 };
 
-export const uploadFiles = async (files: string[], options: UploadOptionsDto): Promise<Asset[]> => {
+export const uploadFiles = async (
+  files: string[],
+  options: UploadOptionsDto,
+): Promise<{ newAssets: Asset[]; duplicateAssets: Asset[] }> => {
   const { dryRun, concurrency, progress } = options;
   if (files.length === 0) {
     console.log('All assets were already uploaded, nothing to do.');
-    return [];
+    return { newAssets: [], duplicateAssets: [] };
   }
 
   // Compute total size first
@@ -327,7 +332,7 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
 
   if (dryRun) {
     console.log(`Would have uploaded ${files.length} asset${s(files.length)} (${byteSize(totalSize)})`);
-    return files.map((filepath) => ({ id: '', filepath }));
+    return { newAssets: files.map((filepath) => ({ id: '', filepath })), duplicateAssets: [] };
   }
 
   let uploadProgress: SingleBar | undefined;
@@ -351,6 +356,7 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
   let successSize = 0;
 
   const newAssets: Asset[] = [];
+  const duplicateAssets: Asset[] = [];
 
   const queue = new Queue<string, AssetMediaResponseDto>(
     async (filepath: string) => {
@@ -360,11 +366,12 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
       }
 
       const response = await uploadFile(filepath, stats, options);
-      newAssets.push({ id: response.id, filepath });
       if (response.status === AssetMediaStatus.Duplicate) {
+        duplicateAssets.push({ id: response.id, filepath });
         duplicateCount++;
         duplicateSize += stats.size ?? 0;
       } else {
+        newAssets.push({ id: response.id, filepath });
         successCount++;
         successSize += stats.size ?? 0;
       }
@@ -398,7 +405,7 @@ export const uploadFiles = async (files: string[], options: UploadOptionsDto): P
     }
   }
 
-  return newAssets;
+  return { newAssets, duplicateAssets };
 };
 
 const uploadFile = async (


### PR DESCRIPTION
## Description

With `--json-output`, the `duplicates` array was only filled from `checkForDuplicates`, which asks the server about the checksums of the whole batch in one call. That check cannot see files that are duplicated inside the batch itself, so they get passed on to `uploadFiles` and the server rejects them with `AssetMediaStatus.Duplicate`. `uploadFiles` counted those for the "Skipped N duplicate assets" log line but returned them as new assets, so they never made it into the json.

`uploadFiles` now returns `{ newAssets, duplicateAssets }` and `uploadBatch` merges the second one into `duplicates`. The return type of the exported `uploadFiles` changed, which is why the existing tests were updated too.

Fixes #24291

## How Has This Been Tested?

Added a case to the `uploadFiles` tests in `packages/cli/src/commands/asset.spec.ts` that mocks `POST /assets` returning status `duplicate` and checks the file lands in `duplicateAssets` instead of `newAssets`. The three existing `uploadFiles` assertions moved to the new return shape. The new assertion fails on `main` and passes here.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This code was written alongside AI. The change and its tests were reviewed against the behaviour described in the linked issue before opening, and I am happy to walk through the reasoning or rework any part of it.
