### PR TITLE
fix(oauth): send and verify a nonce to tolerate IdP-injected nonces

### DIFF
--- a/e2e/src/specs/server/api/oauth.e2e-spec.ts
+++ b/e2e/src/specs/server/api/oauth.e2e-spec.ts
@@ -36,11 +36,12 @@ const generateCodeChallenge = async (codeVerifier: string): Promise<string> => {
 
 const loginWithOAuth = async (sub: OAuthUser | string, redirectUri?: string) => {
   const state = randomBytes(16).toString('base64url');
+  const nonce = randomBytes(16).toString('base64url');
   const codeVerifier = randomBytes(64).toString('base64url');
   const codeChallenge = await generateCodeChallenge(codeVerifier);
 
   const { url } = await startOAuth({
-    oAuthConfigDto: { redirectUri: redirectUri ?? `${baseUrl}/auth/login`, state, codeChallenge },
+    oAuthConfigDto: { redirectUri: redirectUri ?? `${baseUrl}/auth/login`, state, nonce, codeChallenge },
   });
 
   // login
@@ -67,7 +68,7 @@ const loginWithOAuth = async (sub: OAuthUser | string, redirectUri?: string) => 
   expect(params.get('code')).toBeDefined();
   expect(params.get('state')).toBe(state);
 
-  return { url: redirectUrl, state, codeVerifier };
+  return { url: redirectUrl, state, nonce, codeVerifier };
 };
 
 const setupOAuth = async (token: string, dto: Partial<AdminConfigOAuthDto>) => {
@@ -202,10 +203,14 @@ describe(`/oauth`, () => {
     });
 
     it('should allow passing state and codeVerifier via cookies', async () => {
-      const { url, state, codeVerifier } = await loginWithOAuth('oauth-auto-register');
+      const { url, state, nonce, codeVerifier } = await loginWithOAuth('oauth-auto-register');
       const { status, body } = await request(app)
         .post('/oauth/callback')
-        .set('Cookie', [`immich_oauth_state=${state}`, `immich_oauth_code_verifier=${codeVerifier}`])
+        .set('Cookie', [
+          `immich_oauth_state=${state}`,
+          `immich_oauth_nonce=${nonce}`,
+          `immich_oauth_code_verifier=${codeVerifier}`,
+        ])
         .send({ url });
       expect(status).toBe(201);
       expect(body).toMatchObject({

--- a/mobile/lib/services/oauth.service.dart
+++ b/mobile/lib/services/oauth.service.dart
@@ -11,7 +11,7 @@ class OAuthService {
   final log = Logger('OAuthService');
   OAuthService(this._apiService);
 
-  Future<String?> getOAuthServerUrl(String serverUrl, String state, String codeChallenge) async {
+  Future<String?> getOAuthServerUrl(String serverUrl, String state, String codeChallenge, String nonce) async {
     // Resolve API server endpoint from user provided serverUrl
     await _apiService.resolveAndSetEndpoint(serverUrl);
     final redirectUri = '$callbackUrlScheme:///oauth-callback';
@@ -22,6 +22,7 @@ class OAuthService {
         redirectUri: redirectUri,
         state: Optional.present(state),
         codeChallenge: Optional.present(codeChallenge),
+        nonce: Optional.present(nonce),
       ),
     );
 
@@ -31,7 +32,7 @@ class OAuthService {
     return authUrl;
   }
 
-  Future<LoginResponseDto?> oAuthLogin(String oauthUrl, String state, String codeVerifier) async {
+  Future<LoginResponseDto?> oAuthLogin(String oauthUrl, String state, String codeVerifier, String nonce) async {
     String result = await FlutterWebAuth2.authenticate(url: oauthUrl, callbackUrlScheme: callbackUrlScheme);
 
     log.info('Received OAuth callback: $result');
@@ -41,7 +42,12 @@ class OAuthService {
     }
 
     return await _apiService.oAuthApi.finishOAuth(
-      OAuthCallbackDto(url: result, state: Optional.present(state), codeVerifier: Optional.present(codeVerifier)),
+      OAuthCallbackDto(
+        url: result,
+        state: Optional.present(state),
+        codeVerifier: Optional.present(codeVerifier),
+        nonce: Optional.present(nonce),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -326,6 +326,7 @@ class LoginForm extends HookConsumerWidget {
       String? oAuthServerUrl;
 
       final state = generateRandomString(32);
+      final nonce = generateRandomString(32);
 
       final codeVerifier = randomCodeVerifier();
       final codeChallenge = await generatePKCECodeChallenge(codeVerifier);
@@ -335,6 +336,7 @@ class LoginForm extends HookConsumerWidget {
           normalizeServerUrl(serverEndpointController.text),
           state,
           codeChallenge,
+          nonce,
         );
 
         // Invalidate all api repository provider instance to take into account new access token
@@ -357,7 +359,7 @@ class LoginForm extends HookConsumerWidget {
 
       if (oAuthServerUrl != null) {
         try {
-          final loginResponseDto = await oAuthService.oAuthLogin(oAuthServerUrl, state, codeVerifier);
+          final loginResponseDto = await oAuthService.oAuthLogin(oAuthServerUrl, state, codeVerifier, nonce);
 
           if (loginResponseDto == null || !context.mounted) {
             return;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -22591,6 +22591,10 @@
             "description": "OAuth code verifier (PKCE)",
             "type": "string"
           },
+          "nonce": {
+            "description": "OAuth nonce parameter",
+            "type": "string"
+          },
           "state": {
             "description": "OAuth state parameter",
             "type": "string"
@@ -22610,6 +22614,10 @@
         "properties": {
           "codeChallenge": {
             "description": "OAuth code challenge (PKCE)",
+            "type": "string"
+          },
+          "nonce": {
+            "description": "OAuth nonce parameter",
             "type": "string"
           },
           "redirectUri": {

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -1895,6 +1895,8 @@ export type NotificationUpdateDto = {
 export type OAuthConfigDto = {
     /** OAuth code challenge (PKCE) */
     codeChallenge?: string;
+    /** OAuth nonce parameter */
+    nonce?: string;
     /** OAuth redirect URI */
     redirectUri: string;
     /** OAuth state parameter */
@@ -1911,6 +1913,8 @@ export type OAuthBackchannelLogoutDto = {
 export type OAuthCallbackDto = {
     /** OAuth code verifier (PKCE) */
     codeVerifier?: string;
+    /** OAuth nonce parameter */
+    nonce?: string;
     /** OAuth state parameter */
     state?: string;
     /** OAuth callback URL */

--- a/server/src/controllers/oauth.controller.ts
+++ b/server/src/controllers/oauth.controller.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import {
   AuthDto,
+  CookieResponse,
   LoginResponseDto,
   OAuthAuthorizeResponseDto,
   OAuthBackchannelLogoutDto,
@@ -50,18 +51,14 @@ export class OAuthController {
     @GetLoginDetails() loginDetails: LoginDetails,
   ): Promise<OAuthAuthorizeResponseDto> {
     const { url, state, nonce, codeVerifier } = await this.service.authorize(dto);
-    return respondWithCookie(
-      res,
-      { url },
-      {
-        isSecure: loginDetails.isSecure,
-        values: [
-          { key: ImmichCookie.OAuthState, value: state },
-          { key: ImmichCookie.OAuthNonce, value: nonce },
-          { key: ImmichCookie.OAuthCodeVerifier, value: codeVerifier },
-        ],
-      },
-    );
+    const values: CookieResponse['values'] = [
+      { key: ImmichCookie.OAuthState, value: state },
+      { key: ImmichCookie.OAuthCodeVerifier, value: codeVerifier },
+    ];
+    if (nonce) {
+      values.push({ key: ImmichCookie.OAuthNonce, value: nonce });
+    }
+    return respondWithCookie(res, { url }, { isSecure: loginDetails.isSecure, values });
   }
 
   @Post('callback')

--- a/server/src/controllers/oauth.controller.ts
+++ b/server/src/controllers/oauth.controller.ts
@@ -49,7 +49,7 @@ export class OAuthController {
     @Res({ passthrough: true }) res: Response,
     @GetLoginDetails() loginDetails: LoginDetails,
   ): Promise<OAuthAuthorizeResponseDto> {
-    const { url, state, codeVerifier } = await this.service.authorize(dto);
+    const { url, state, nonce, codeVerifier } = await this.service.authorize(dto);
     return respondWithCookie(
       res,
       { url },
@@ -57,6 +57,7 @@ export class OAuthController {
         isSecure: loginDetails.isSecure,
         values: [
           { key: ImmichCookie.OAuthState, value: state },
+          { key: ImmichCookie.OAuthNonce, value: nonce },
           { key: ImmichCookie.OAuthCodeVerifier, value: codeVerifier },
         ],
       },
@@ -78,6 +79,7 @@ export class OAuthController {
   ): Promise<LoginResponseDto> {
     const body = await this.service.callback(dto, request.headers, loginDetails);
     res.clearCookie(ImmichCookie.OAuthState);
+    res.clearCookie(ImmichCookie.OAuthNonce);
     res.clearCookie(ImmichCookie.OAuthCodeVerifier);
     return respondWithCookie(res, body, {
       isSecure: loginDetails.isSecure,

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -107,6 +107,7 @@ const OAuthCallbackSchema = z
     url: z.string().min(1).describe('OAuth callback URL'),
     state: z.string().optional().describe('OAuth state parameter'),
     codeVerifier: z.string().optional().describe('OAuth code verifier (PKCE)'),
+    nonce: z.string().optional().describe('OAuth nonce parameter'),
   })
   .meta({ id: 'OAuthCallbackDto' });
 
@@ -115,6 +116,7 @@ const OAuthConfigSchema = z
     redirectUri: z.string().describe('OAuth redirect URI'),
     state: z.string().optional().describe('OAuth state parameter'),
     codeChallenge: z.string().optional().describe('OAuth code challenge (PKCE)'),
+    nonce: z.string().optional().describe('OAuth nonce parameter'),
   })
   .meta({ id: 'OAuthConfigDto' });
 

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -14,6 +14,7 @@ export enum ImmichCookie {
   SharedLinkToken = 'immich_shared_link_token',
   OAuthState = 'immich_oauth_state',
   OAuthCodeVerifier = 'immich_oauth_code_verifier',
+  OAuthNonce = 'immich_oauth_nonce',
 }
 
 export enum ImmichHeader {

--- a/server/src/repositories/oauth.repository.ts
+++ b/server/src/repositories/oauth.repository.ts
@@ -10,6 +10,7 @@ import {
   discovery,
   fetchUserInfo,
   None,
+  randomNonce,
   randomPKCECodeVerifier,
   randomState,
   skipSubjectCheck,
@@ -42,9 +43,10 @@ export class OAuthRepository {
     this.logger.setContext(OAuthRepository.name);
   }
 
-  async authorize(config: OAuthConfig, redirectUrl: string, state?: string, codeChallenge?: string) {
+  async authorize(config: OAuthConfig, redirectUrl: string, state?: string, codeChallenge?: string, nonce?: string) {
     const client = await this.getClient(config);
     state ??= randomState();
+    nonce ??= randomNonce();
 
     let codeVerifier: string | null;
     if (codeChallenge) {
@@ -58,6 +60,7 @@ export class OAuthRepository {
       redirect_uri: redirectUrl,
       scope: config.scope,
       state,
+      nonce,
     };
 
     if (config.prompt) {
@@ -71,7 +74,7 @@ export class OAuthRepository {
 
     const url = buildAuthorizationUrl(client, params).href;
 
-    return { url, state, codeVerifier };
+    return { url, state, nonce, codeVerifier };
   }
 
   async getLogoutEndpoint(config: OAuthConfig) {
@@ -84,12 +87,17 @@ export class OAuthRepository {
     url: string,
     expectedState: string,
     codeVerifier: string,
+    expectedNonce?: string,
   ): Promise<{ profile: OAuthProfile; sid?: string; idToken?: string }> {
     const client = await this.getClient(config);
     const pkceCodeVerifier = client.serverMetadata().supportsPKCE() ? codeVerifier : undefined;
 
     try {
-      const tokens = await authorizationCodeGrant(client, new URL(url), { expectedState, pkceCodeVerifier });
+      const tokens = await authorizationCodeGrant(client, new URL(url), {
+        expectedState,
+        pkceCodeVerifier,
+        expectedNonce,
+      });
 
       let profile: OAuthProfile;
       const tokenClaims = tokens.claims();

--- a/server/src/repositories/oauth.repository.ts
+++ b/server/src/repositories/oauth.repository.ts
@@ -45,8 +45,16 @@ export class OAuthRepository {
 
   async authorize(config: OAuthConfig, redirectUrl: string, state?: string, codeChallenge?: string, nonce?: string) {
     const client = await this.getClient(config);
+
+    // Clients that generate their own `state` (e.g. mobile) are also responsible for generating and
+    // round-tripping their own `nonce`. Only auto-generate a nonce for the server-managed, cookie-based
+    // flow (web), so that older mobile clients that never send a nonce continue to work with IdPs that
+    // echo one back on the ID token (see https://github.com/immich-app/immich/issues/29055).
+    const isServerManagedFlow = !state;
     state ??= randomState();
-    nonce ??= randomNonce();
+    if (isServerManagedFlow) {
+      nonce ??= randomNonce();
+    }
 
     let codeVerifier: string | null;
     if (codeChallenge) {
@@ -60,8 +68,11 @@ export class OAuthRepository {
       redirect_uri: redirectUrl,
       scope: config.scope,
       state,
-      nonce,
     };
+
+    if (nonce) {
+      params.nonce = nonce;
+    }
 
     if (config.prompt) {
       params.prompt = config.prompt;

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -38,7 +38,12 @@ describe(AuthService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(AuthService));
 
-    mocks.oauth.authorize.mockResolvedValue({ url: 'http://test', state: 'state', codeVerifier: 'codeVerifier' });
+    mocks.oauth.authorize.mockResolvedValue({
+      url: 'http://test',
+      state: 'state',
+      nonce: 'nonce',
+      codeVerifier: 'codeVerifier',
+    });
     mocks.oauth.getLogoutEndpoint.mockResolvedValue('http://end-session-endpoint');
   });
 
@@ -853,6 +858,7 @@ describe(AuthService.name, () => {
           'http://mobile-redirect?code=abc123',
           'xyz789',
           'foo',
+          undefined,
         );
       });
     }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -279,6 +279,7 @@ export class AuthService extends BaseService {
       this.resolveRedirectUri(oauth, dto.redirectUri),
       dto.state,
       dto.codeChallenge,
+      dto.nonce,
     );
   }
 
@@ -298,12 +299,14 @@ export class AuthService extends BaseService {
       throw new BadRequestException('OAuth code verifier is missing');
     }
 
+    const expectedNonce = dto.nonce ?? this.getCookieOauthNonce(headers) ?? undefined;
+
     const url = this.resolveRedirectUri(oauth, dto.url);
     const {
       profile,
       sid: oauthSid,
       idToken: oauthBearerToken,
-    } = await this.oauthRepository.getProfileAndOAuthSid(oauth, url, expectedState, codeVerifier);
+    } = await this.oauthRepository.getProfileAndOAuthSid(oauth, url, expectedState, codeVerifier, expectedNonce);
     const normalizedEmail = profile.email ? profile.email.trim().toLowerCase() : undefined;
     const { autoRegister, defaultStorageQuota, storageLabelClaim, storageQuotaClaim, roleClaim } = oauth;
     this.logger.debug(`Logging in with OAuth: ${JSON.stringify(profile)}`);
@@ -409,12 +412,14 @@ export class AuthService extends BaseService {
       throw new BadRequestException('OAuth code verifier is missing');
     }
 
+    const expectedNonce = dto.nonce ?? this.getCookieOauthNonce(headers) ?? undefined;
+
     const { oauth } = await this.getConfig({ withCache: false });
     const {
       profile: { sub: oauthId },
       sid,
       idToken,
-    } = await this.oauthRepository.getProfileAndOAuthSid(oauth, dto.url, expectedState, codeVerifier);
+    } = await this.oauthRepository.getProfileAndOAuthSid(oauth, dto.url, expectedState, codeVerifier, expectedNonce);
     const duplicate = await this.userRepository.getByOAuthId(oauthId);
     if (duplicate && duplicate.id !== auth.user.id) {
       this.logger.warn(`OAuth link account failed: sub is already linked to another user (${duplicate.email}).`);
@@ -489,6 +494,11 @@ export class AuthService extends BaseService {
   private getCookieCodeVerifier(headers: IncomingHttpHeaders): string | null {
     const cookies = parse(headers.cookie || '');
     return cookies[ImmichCookie.OAuthCodeVerifier] || null;
+  }
+
+  private getCookieOauthNonce(headers: IncomingHttpHeaders): string | null {
+    const cookies = parse(headers.cookie || '');
+    return cookies[ImmichCookie.OAuthNonce] || null;
   }
 
   async validateSharedLinkKey(key: string | string[]): Promise<AuthDto> {

--- a/server/src/utils/response.ts
+++ b/server/src/utils/response.ts
@@ -17,6 +17,7 @@ export const respondWithCookie = <T>(res: Response, body: T, { isSecure, values 
     [ImmichCookie.AccessToken]: defaults,
     [ImmichCookie.MaintenanceToken]: { ...defaults, maxAge: Duration.fromObject({ days: 1 }).toMillis() },
     [ImmichCookie.OAuthState]: defaults,
+    [ImmichCookie.OAuthNonce]: defaults,
     [ImmichCookie.OAuthCodeVerifier]: defaults,
     // no httpOnly so that the client can know the auth state
     [ImmichCookie.IsAuthenticated]: { ...defaults, httpOnly: false },


### PR DESCRIPTION
## Description

Immich's OAuth flow never sends a `nonce` in the authorization request, so `oauth4webapi` defaults to `expectNoNonce` and **rejects any ID token that carries a `nonce` claim**:

```
OAUTH_JWT_CLAIM_COMPARISON_FAILED: unexpected ID Token "nonce" claim value
```

Several OIDC providers emit a `nonce` whether or not the client asked for one:

- **Slack** returns an empty `nonce: ''` — reported in #29055 (closed as duplicate).
- **AWS Cognito** injects a real `nonce` on federated logins (e.g. Cognito relaying Google). It is a reserved claim that cannot be suppressed, even with a Pre-Token-Generation Lambda.

In both cases every OAuth login fails and there is no configuration option to influence it, because the check lives inside `oauth4webapi` and is only reachable from code.

This PR implements the general fix suggested in #29055: **generate a real `nonce`, round-trip it, and verify it** via `expectedNonce` in `authorizationCodeGrant()`. This restores full, spec-compliant nonce replay protection for providers that require it, while preserving compatibility with providers/clients that don't send a nonce at all.

### How it works

- **Web** is the server-managed, cookie-based flow: the caller doesn't supply its own `state`, so `authorize()` also generates a `nonce` with openid-client's `randomNonce()`, round-trips it through a new httpOnly cookie `immich_oauth_nonce` (same pattern as the existing state/PKCE cookies), and clears it when the flow finishes.
- **Mobile** generates and sends its own `state`/PKCE, so it is also responsible for generating and echoing its own `nonce` through the callback DTO. A mobile client that doesn't send a `nonce` (e.g. an older app version that hasn't picked up this change) is not auto-assigned one either — the server never sends a `nonce` to the IdP in that case, so the resulting ID token has no `nonce` claim and validates against `expectNoNonce` exactly as before. This avoids reproducing the original bug for every mobile user of providers that echo a nonce, instead of only fixing it for web.
- `getProfileAndOAuthSid()` passes whatever nonce is available (or `undefined`) as `expectedNonce` so `oauth4webapi` verifies it per the OIDC spec when present, or enforces its absence when not.

Relates to #29055.

## How Has This Been Tested?

- [x] `server` unit suite: `auth.service.spec.ts` (86/86) and `oauth.controller.spec.ts` (4/4) pass.
- [x] Full `server` unit suite (103 files / 2231 tests) passes locally after rebasing on `main`.
- [x] `tsc --noEmit`, `eslint` (`--max-warnings 0`), and `prettier --check` are all clean on `server` and `e2e`.
- [x] Updated `e2e/src/specs/server/api/oauth.e2e-spec.ts` to thread a `nonce` through the explicit `state`/PKCE flow it exercises (mirroring a nonce-aware client) and to include `immich_oauth_nonce` in the cookie-based callback test.
- [x] Regenerated the OpenAPI spec (`sync-open-api`) and the TypeScript SDK (`oazapfts`) — the only delta is the new optional `nonce` field on `OAuthConfigDto`/`OAuthCallbackDto`, so `generated-api-up-to-date` stays green.
- [x] Root cause confirmed live against **AWS Cognito** (federated Google login): the injected `nonce` reproduces the exact `OAUTH_JWT_CLAIM_COMPARISON_FAILED` rejection on stock Immich.
- [ ] End-to-end browser login through *this exact build* against a live Slack/Cognito provider — **not yet run**; I would appreciate a maintainer or the #29055 reporter validating the round-trip in a real deployment. (Mobile was not compiled locally; the generated Dart client is produced by CI from the updated spec.)

## API Changes

- `OAuthConfigDto` and `OAuthCallbackDto` each gain an **optional** `nonce` string field (non-breaking; passes the oasdiff breaking-change check).
- New httpOnly cookie `immich_oauth_nonce`, used only to round-trip the nonce during the web OAuth flow.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable — no user-facing config or docs change; the nonce is internal to the flow.
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary — none added; `randomNonce` is already exported by the bundled openid-client.
- [x] I have written tests for new code (if applicable) — updated `auth.service.spec.ts` and `oauth.e2e-spec.ts`; the existing OAuth controller/service suites exercise the path.
- [x] I have followed naming conventions/patterns in the surrounding code.
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Full disclosure, per CONTRIBUTING.md: this change was implemented with the assistance of an LLM (Claude). I directed the design (building on the root-cause analysis and the "send a real nonce" approach proposed by the reporter in #29055), reviewed every line, ran the server test suite and typechecks locally, and regenerated the OpenAPI spec and TypeScript SDK myself. I understand the change and its security implications: it strengthens nonce handling by adding genuine, verified replay protection rather than disabling a check, while explicitly keeping the pre-existing (unauthenticated-by-nonce) behavior for callers that never opt in to sending one, so as not to break older mobile clients. I'm flagging this openly and am happy to walk through any part of the implementation or make changes.
