### PR TITLE
fix(mobile):Disable smart dashes and quotes in password input

### DIFF
--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -506,6 +506,10 @@ class LoginForm extends HookConsumerWidget {
                         ImmichPasswordInput(
                           controller: passwordController,
                           focusNode: passwordFocusNode,
+                          smartDashesType: SmartDashesType.disabled,
+                          smartQuotesType: SmartQuotesType.disabled,
+                          autocorrect: false,
+                          enableSuggestions: false,
                           label: context.t.password,
                           hintText: context.t.login_form_password_hint,
                           keyboardAction: TextInputAction.go,

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -76,6 +76,8 @@ class LoginForm extends HookConsumerWidget {
     final warningMessage = useState<String?>(null);
     final loginFormKey = GlobalKey<FormState>();
     final ValueNotifier<String?> serverEndpoint = useState<String?>(null);
+    final SmartDashesType smartDashesType;
+    final SmartQuotesType smartQuotesType;
 
     Future<void> checkVersionMismatch() async {
       try {
@@ -508,8 +510,6 @@ class LoginForm extends HookConsumerWidget {
                           focusNode: passwordFocusNode,
                           smartDashesType: SmartDashesType.disabled,
                           smartQuotesType: SmartQuotesType.disabled,
-                          autocorrect: false,
-                          enableSuggestions: false,
                           label: context.t.password,
                           hintText: context.t.login_form_password_hint,
                           keyboardAction: TextInputAction.go,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #30752 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
I haven't tested this as I don't own any iOS devices. My Android devices don't do smart dashes.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM, just documentation online.
...
