### PR TITLE
fix(web): stream large album archives instead of buffering blobs

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -28,6 +28,11 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { downloadBlob, downloadRequest, withError } from '$lib/utils';
+import {
+  downloadPostStream,
+  shouldPreferStreamingDownload,
+  supportsFileSystemAccessDownload,
+} from '$lib/utils/download-stream';
 import { getByteUnitString } from '$lib/utils/byte-units';
 import { getFormatter } from '$lib/utils/i18n';
 import { navigate } from '$lib/utils/navigation';
@@ -104,13 +109,31 @@ export const downloadArchive = async (fileName: string, options: Omit<DownloadIn
     downloadManager.add(downloadKey, archive.size, abort);
 
     try {
+      const archiveUrl = getBaseUrl() + '/download/archive' + (queryParams ? `?${queryParams}` : '');
+      const archiveBody = { assetIds: archive.assetIds, edited: true };
+      const onProgress = (loaded: number) => downloadManager.update(downloadKey, loaded);
+
+      const useStreaming =
+        supportsFileSystemAccessDownload() && shouldPreferStreamingDownload(archive.size);
+
+      if (useStreaming) {
+        const result = await downloadPostStream(archiveUrl, archiveBody, archiveName, {
+          signal: abort.signal,
+          onProgress,
+        });
+
+        if (result === 'streamed') {
+          continue;
+        }
+      }
+
       // TODO use sdk once it supports progress events
       const { data } = await downloadRequest({
         method: 'POST',
-        url: getBaseUrl() + '/download/archive' + (queryParams ? `?${queryParams}` : ''),
-        data: { assetIds: archive.assetIds, edited: true },
+        url: archiveUrl,
+        data: archiveBody,
         signal: abort.signal,
-        onDownloadProgress: (event) => downloadManager.update(downloadKey, event.loaded),
+        onDownloadProgress: (event) => onProgress(event.loaded),
       });
 
       downloadBlob(data, archiveName);

--- a/web/src/lib/utils/download-stream.spec.ts
+++ b/web/src/lib/utils/download-stream.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isSafariBrowser,
+  shouldPreferStreamingDownload,
+  supportsFileSystemAccessDownload,
+} from './download-stream';
+
+describe('download-stream helpers', () => {
+  it('shouldPreferStreamingDownload on Safari user agents', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    });
+    expect(isSafariBrowser()).toBe(true);
+    expect(shouldPreferStreamingDownload(1024)).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('shouldPreferStreamingDownload for large archives on non-Safari', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    expect(isSafariBrowser()).toBe(false);
+    expect(shouldPreferStreamingDownload(500 * 1024 * 1024)).toBe(true);
+    expect(shouldPreferStreamingDownload(100 * 1024 * 1024)).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('supportsFileSystemAccessDownload reflects showSaveFilePicker', () => {
+    vi.stubGlobal('window', { showSaveFilePicker: vi.fn() });
+    expect(supportsFileSystemAccessDownload()).toBe(true);
+    vi.stubGlobal('window', {});
+    expect(supportsFileSystemAccessDownload()).toBe(false);
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/src/lib/utils/download-stream.ts
+++ b/web/src/lib/utils/download-stream.ts
@@ -1,0 +1,84 @@
+/** Safari detection — same heuristic as asset-utils MIME support. */
+export function isSafariBrowser(): boolean {
+  return typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+}
+
+export function supportsFileSystemAccessDownload(): boolean {
+  return typeof window !== 'undefined' && 'showSaveFilePicker' in window;
+}
+
+export type StreamDownloadResult = 'streamed' | 'fallback';
+
+const LARGE_ARCHIVE_BYTES = 400 * 1024 * 1024;
+
+/** Prefer streaming when Safari would OOM on in-memory blobs, or for very large archives. */
+export function shouldPreferStreamingDownload(archiveSizeBytes: number): boolean {
+  return isSafariBrowser() || archiveSizeBytes > LARGE_ARCHIVE_BYTES;
+}
+
+function createProgressTransform(onProgress?: (loaded: number) => void): TransformStream<Uint8Array, Uint8Array> {
+  let loaded = 0;
+  return new TransformStream({
+    transform(chunk, controller) {
+      loaded += chunk.byteLength;
+      onProgress?.(loaded);
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+/**
+ * Stream a POST response directly to disk via the File System Access API.
+ * Avoids materializing the full archive as a Blob (Safari hangs above ~500MB).
+ */
+export async function downloadPostStream(
+  url: string,
+  body: unknown,
+  filename: string,
+  options: { signal?: AbortSignal; onProgress?: (loaded: number) => void } = {},
+): Promise<StreamDownloadResult> {
+  if (!supportsFileSystemAccessDownload()) {
+    return 'fallback';
+  }
+
+  let fileHandle: FileSystemFileHandle;
+  try {
+    fileHandle = await window.showSaveFilePicker({
+      suggestedName: filename,
+      types: [{ description: 'ZIP archive', accept: { 'application/zip': ['.zip'] } }],
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+    return 'fallback';
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: options.signal,
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.status} ${response.statusText}`);
+  }
+
+  if (!response.body) {
+    return 'fallback';
+  }
+
+  const writable = await fileHandle.createWritable();
+  try {
+    await response.body.pipeThrough(createProgressTransform(options.onProgress)).pipeTo(writable, {
+      signal: options.signal,
+    });
+  } catch (error) {
+    await writable.abort(error);
+    throw error;
+  }
+
+  return 'streamed';
+}


### PR DESCRIPTION
## Summary

Safari keeps large XHR `Blob` responses in memory (Chrome/Firefox spill to disk). Album downloads over ~500MB hang the tab around 30% progress.

The server already streams ZIP archives. This change streams the POST body to disk via the File System Access API (`showSaveFilePicker` + `pipeTo`) so the archive is never materialized as a Blob.

- Used on Safari always, and on other browsers for archives over 400MB
- Falls back to the existing XHR + `createObjectURL` path when the picker is unavailable, the user cancels, or the stream cannot be opened
- Cookie auth is preserved with `credentials: include`

Fixes #28316

## Test plan

- [ ] macOS Safari: download a >500MB album (demo City / Blue Cars) — tab stays responsive, zip completes
- [ ] Chrome/Firefox: same album still downloads
- [ ] Cancel mid-download via the download panel
- [ ] Multi-part archives still download sequentially
- [ ] Shared-link album download still works