### PR TITLE
chore(mobile): patch Flutter to allow building against iOS simulator

### DIFF
--- a/mobile/ios/scripts/xcode_flutter_patch.sh
+++ b/mobile/ios/scripts/xcode_flutter_patch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Makes Flutter not incorrectly append `-sdk` arguments to simulator builds
+# This breaks macros that must build for the host's platform
+#
+# Flutter was informed of this (https://github.com/flutter/flutter/issues/146122) but has not fixed it in 2 years
+
+set -eu
+sdk="${MISE_TOOL_INSTALL_PATH:-$(mise where aqua:flutter/flutter)}/flutter"
+mac_dart="$sdk/packages/flutter_tools/lib/src/ios/mac.dart"
+
+pattern="buildCommands.addAll(<String>['-sdk', XcodeSdk.IPhoneSimulator.platformName]);"
+
+# Filter out the sdk arg pattern
+if awk -v pat="$pattern" 'index($0, pat) { found=1; next } { print } END { exit !found }' "$mac_dart" > "$mac_dart.tmp"; then
+  # If it was filtered out, apply it
+  mv "$mac_dart.tmp" "$mac_dart"
+
+  # Force flutter itself to rebuild
+  rm -f "$sdk/bin/cache/flutter_tools.snapshot" "$sdk/bin/cache/flutter_tools.stamp"
+
+  echo "flutter postinstall: removed simulator -sdk flag from xcodebuild invocation"
+else
+  rm -f "$mac_dart.tmp"
+fi

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -3,7 +3,7 @@ java = "21.0.2"
 
 [tools."aqua:flutter/flutter"]
 version = "3.44.9"
-postinstall = "bash \"$(git rev-parse --show-toplevel)/mobile/ios/scripts/xcode_flutter_patch.sh\""
+postinstall = "bash ./mobile/ios/scripts/xcode_flutter_patch.sh"
 
 [tools."github:CQLabs/homebrew-dcm"]
 version = "1.37.0"

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -3,7 +3,7 @@ java = "21.0.2"
 
 [tools."aqua:flutter/flutter"]
 version = "3.44.9"
-postinstall = "bash ./mobile/ios/scripts/xcode_flutter_patch.sh"
+postinstall = "bash {{config_root}}/ios/scripts/xcode_flutter_patch.sh"
 
 [tools."github:CQLabs/homebrew-dcm"]
 version = "1.37.0"

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,6 +1,9 @@
 [tools]
-"aqua:flutter/flutter" = "3.44.9"
 java = "21.0.2"
+
+[tools."aqua:flutter/flutter"]
+version = "3.44.9"
+postinstall = "bash \"$(git rev-parse --show-toplevel)/mobile/ios/scripts/xcode_flutter_patch.sh\""
 
 [tools."github:CQLabs/homebrew-dcm"]
 version = "1.37.0"


### PR DESCRIPTION
Immich is not currently buildable for the iOS simulator due to a Flutter build tool internal setting the `-sdk` property indiscriminately, which prevents host running Swift macros from building on the simulator target.

On install, patch Flutter to remove this issue