### PR TITLE
docs: fix identity provider examples in oauth guide

### DIFF
--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -154,9 +154,10 @@ identity_providers:
       - client_id: 'immich'
         client_name: 'Immich'
         # https://www.authelia.com/integration/openid-connect/frequently-asked-questions/#how-do-i-generate-a-client-identifier-or-client-secret
-        client_secret: $pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'
         public: false
-        require_pkce: false
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://example.immich.app/auth/login'
           - 'https://example.immich.app/user-settings'
@@ -180,7 +181,7 @@ Configuration of OAuth in Immich System Settings
 
 | Setting                            | Value                                                               |
 | ---------------------------------- | ------------------------------------------------------------------- |
-| Issuer URL                         | `https://example.immich.app/.well-known/openid-configuration`       |
+| Issuer URL                         | `https://auth.example.com`                                          |
 | Client ID                          | immich                                                              |
 | Client Secret                      | 0v89FXkQOWO\***\*\*\*\*\***\*\*\***\*\*\*\*\***mprbvXD549HH6s1iw... |
 | Token Endpoint Auth Method         | client_secret_post                                                  |
@@ -212,21 +213,21 @@ Configuration of Authorised redirect URIs (Authentik OAuth2/OpenID Provider)
 
 Configuration of OAuth in Immich System Settings
 
-| Setting                      | Value                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------- |
-| Issuer URL                   | `https://example.immich.app/application/o/immich/.well-known/openid-configuration` |
-| Client ID                    | AFCj2rM1f4rps**\*\*\*\***\***\*\*\*\***lCLEum6hH9...                               |
-| Client Secret                | 0v89FXkQOWO\***\*\*\*\*\***\*\*\***\*\*\*\*\***mprbvXD549HH6s1iw...                |
-| Scope                        | openid email profile                                                               |
-| Signing Algorithm            | RS256                                                                              |
-| Storage Label Claim          | preferred_username                                                                 |
-| Storage Quota Claim          | immich_quota                                                                       |
-| Default Storage Quota (GiB)  | 0 (empty for unlimited quota)                                                      |
-| Button Text                  | Sign in with Authentik (optional)                                                  |
-| Auto Register                | Enabled (optional)                                                                 |
-| Auto Launch                  | Enabled (optional)                                                                 |
-| Mobile Redirect URI Override | Disable                                                                            |
-| Mobile Redirect URI          |                                                                                    |
+| Setting                      | Value                                                               |
+| ---------------------------- | ------------------------------------------------------------------- |
+| Issuer URL                   | `https://authentik.example.com/application/o/immich/`               |
+| Client ID                    | AFCj2rM1f4rps**\*\*\*\***\***\*\*\*\***lCLEum6hH9...                |
+| Client Secret                | 0v89FXkQOWO\***\*\*\*\*\***\*\*\***\*\*\*\*\***mprbvXD549HH6s1iw... |
+| Scope                        | openid email profile                                                |
+| Signing Algorithm            | RS256                                                               |
+| Storage Label Claim          | preferred_username                                                  |
+| Storage Quota Claim          | immich_quota                                                        |
+| Default Storage Quota (GiB)  | 0 (empty for unlimited quota)                                       |
+| Button Text                  | Sign in with Authentik (optional)                                   |
+| Auto Register                | Enabled (optional)                                                  |
+| Auto Launch                  | Enabled (optional)                                                  |
+| Mobile Redirect URI Override | Disable                                                             |
+| Mobile Redirect URI          |                                                                     |
 
 </details>
 


### PR DESCRIPTION
## Description

- enable PKCE in the authelia client example
- remove the `.well-known` suffix from authelia and authentik examples (similar to the google and keycloak examples)
- fix the authelia and authentik issuer URLs to point at the identity provider host instead of the immich host

## How Has This Been Tested?

Tested with Authelia v4.39.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I wanted to update the PKCE change and remove the `.well-known` suffix and :robot: pointed out the typos in the issuer URLs.
