### PR TITLE
fix(server): guard createAll against empty values list

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -448,6 +448,9 @@ export class AssetRepository {
 
   @ChunkedArray({ chunkSize: 4000 })
   async createAll(assets: Insertable<AssetTable>[]) {
+    if (assets.length === 0) {
+      return [];
+    }
     const ids = await this.db.insertInto('asset').values(assets).returning('id').execute();
     return ids.map(({ id }) => id);
   }

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -204,4 +204,11 @@ describe(AssetRepository.name, () => {
       ).resolves.toEqual({ lockedProperties: null });
     });
   });
+
+  describe('createAll', () => {
+    it('should return an empty array when given an empty input', async () => {
+      const { sut } = setup();
+      await expect(sut.createAll([])).resolves.toStrictEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #30827

prevent `AssetRepository.createAll()` from attempting a database insert when given an empty asset array.
when all files in a `LibrarySyncFiles` batch fail during `stat()`, the resulting empty array can reach `createAll()`. Passing an empty array to Kysely's `.values()` generates invalid PostgreSQL SQL and causes the sync job to fail.

this change returns an empty array early for empty input and adds a regression test.

## How Has This Been Tested?

- Added a regression test verifying `createAll([])` returns an empty array without attempting an insert.
- Ran the existing test suite; the new test passes.
- The remaining 5 test failures are pre-existing Windows path-separator issues and are unchanged by this PR.

## Screenshots (if appropriate)

Not applicable.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help investigate the reported issue, review the relevant code paths, and refine the implementation and regression test. The final changes were reviewed and verified against the existing codebase and test suite.