### PR TITLE
fix(server): mark nullable fields in OpenAPI spec

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -19647,6 +19647,7 @@
           },
           "profileImagePath": {
             "description": "Profile image path",
+            "nullable": true,
             "type": "string"
           },
           "shouldChangePassword": {
@@ -20829,10 +20830,12 @@
           "profileChangedAt": {
             "description": "Profile change date",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "profileImagePath": {
             "description": "Profile image path",
+            "nullable": true,
             "type": "string"
           }
         },
@@ -25054,6 +25057,7 @@
           },
           "oauthId": {
             "description": "User OAuth ID",
+            "nullable": true,
             "type": "string"
           },
           "pinCode": {
@@ -25065,6 +25069,7 @@
             "description": "User profile changed at",
             "example": "2024-01-01T00:00:00.000Z",
             "format": "date-time",
+            "nullable": true,
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "type": "string"
           },
@@ -25079,6 +25084,7 @@
             "description": "Quota usage in bytes",
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
+            "nullable": true,
             "type": "integer"
           },
           "storageLabel": {
@@ -25668,6 +25674,7 @@
             "description": "User profile changed at",
             "example": "2024-01-01T00:00:00.000Z",
             "format": "date-time",
+            "nullable": true,
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
             "type": "string"
           }
@@ -27232,6 +27239,7 @@
           "albumThumbnailAssetId": {
             "description": "Album thumbnail asset ID",
             "format": "uuid",
+            "nullable": true,
             "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
@@ -27544,15 +27552,18 @@
           },
           "oauthId": {
             "description": "OAuth ID",
+            "nullable": true,
             "type": "string"
           },
           "profileChangedAt": {
             "description": "Profile change date",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "profileImagePath": {
             "description": "Profile image path",
+            "nullable": true,
             "type": "string"
           },
           "quotaSizeInBytes": {
@@ -27838,10 +27849,12 @@
           "profileChangedAt": {
             "description": "Profile change date",
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "profileImagePath": {
             "description": "Profile image path",
+            "nullable": true,
             "type": "string"
           }
         },

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -23,9 +23,9 @@ export type UserResponseDto = {
     /** User name */
     name: string;
     /** Profile change date */
-    profileChangedAt: string;
+    profileChangedAt: string | null;
     /** Profile image path */
-    profileImagePath: string;
+    profileImagePath: string | null;
 };
 export type ActivityResponseDto = {
     /** Asset ID (if activity is for an asset) */
@@ -216,11 +216,11 @@ export type UserAdminResponseDto = {
     /** User name */
     name: string;
     /** OAuth ID */
-    oauthId: string;
+    oauthId: string | null;
     /** Profile change date */
-    profileChangedAt: string;
+    profileChangedAt: string | null;
     /** Profile image path */
-    profileImagePath: string;
+    profileImagePath: string | null;
     /** Storage quota in bytes */
     quotaSizeInBytes: number | null;
     /** Storage usage in bytes */
@@ -565,7 +565,7 @@ export type UpdateAlbumDto = {
     /** Album name */
     albumName?: string;
     /** Album thumbnail asset ID */
-    albumThumbnailAssetId?: string;
+    albumThumbnailAssetId?: string | null;
     /** Album description */
     description?: string | null;
     /** Enable activity feed */
@@ -1059,7 +1059,7 @@ export type LoginResponseDto = {
     /** User name */
     name: string;
     /** Profile image path */
-    profileImagePath: string;
+    profileImagePath: string | null;
     /** Should change password */
     shouldChangePassword: boolean;
     /** User email */
@@ -1437,9 +1437,9 @@ export type PartnerResponseDto = {
     /** User name */
     name: string;
     /** Profile change date */
-    profileChangedAt: string;
+    profileChangedAt: string | null;
     /** Profile image path */
-    profileImagePath: string;
+    profileImagePath: string | null;
 };
 export type PartnerCreateDto = {
     /** User ID to share with */
@@ -3221,15 +3221,15 @@ export type SyncAuthUserV1 = {
     /** User name */
     name: string;
     /** User OAuth ID */
-    oauthId: string;
+    oauthId: string | null;
     /** User pin code */
     pinCode: string | null;
     /** User profile changed at */
-    profileChangedAt: string;
+    profileChangedAt: string | null;
     /** Quota size in bytes */
     quotaSizeInBytes: number | null;
     /** Quota usage in bytes */
-    quotaUsageInBytes: number;
+    quotaUsageInBytes: number | null;
     /** User storage label */
     storageLabel: string | null;
 };
@@ -3365,7 +3365,7 @@ export type SyncUserV1 = {
     /** User name */
     name: string;
     /** User profile changed at */
-    profileChangedAt: string;
+    profileChangedAt: string | null;
 };
 /**
  * List all activities

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -88,7 +88,7 @@ const UpdateAlbumSchema = z
           )
           .getExtensions(),
       }),
-    albumThumbnailAssetId: z.uuidv4().optional().describe('Album thumbnail asset ID'),
+    albumThumbnailAssetId: z.uuidv4().nullable().optional().describe('Album thumbnail asset ID'),
     isActivityEnabled: z.boolean().optional().describe('Enable activity feed'),
     order: AssetOrderSchema.optional(),
   })

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -32,7 +32,7 @@ const LoginResponseSchema = z
     userId: z.uuidv4().describe('User ID'),
     userEmail: toEmail.describe('User email'),
     name: z.string().describe('User name'),
-    profileImagePath: z.string().describe('Profile image path'),
+    profileImagePath: z.string().nullable().describe('Profile image path'),
     isAdmin: z.boolean().describe('Is admin user'),
     shouldChangePassword: z.boolean().describe('Should change password'),
     isOnboarded: z.boolean().describe('Is onboarded'),

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -25,7 +25,7 @@ const SyncUserV1Schema = z
     avatarColor: UserAvatarColorSchema.nullish(),
     deletedAt: isoDatetimeToDate.nullable().describe('User deleted at'),
     hasProfileImage: z.boolean().describe('User has profile image'),
-    profileChangedAt: isoDatetimeToDate.describe('User profile changed at'),
+    profileChangedAt: isoDatetimeToDate.nullable().describe('User profile changed at'),
   })
   .meta({ id: 'SyncUserV1' });
 
@@ -33,10 +33,10 @@ const SyncAuthUserV1Schema = SyncUserV1Schema.merge(
   z.object({
     isAdmin: z.boolean().describe('User is admin'),
     pinCode: z.string().nullable().describe('User pin code'),
-    oauthId: z.string().describe('User OAuth ID'),
+    oauthId: z.string().nullable().describe('User OAuth ID'),
     storageLabel: z.string().nullable().describe('User storage label'),
     quotaSizeInBytes: z.int().nullable().describe('Quota size in bytes'),
-    quotaUsageInBytes: z.int().describe('Quota usage in bytes'),
+    quotaUsageInBytes: z.int().nullable().describe('Quota usage in bytes'),
   }),
 ).meta({ id: 'SyncAuthUserV1' });
 

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -27,10 +27,10 @@ export const UserResponseSchema = z
     id: z.uuidv4().describe('User ID'),
     name: z.string().describe('User name'),
     email: toEmail.describe('User email'),
-    profileImagePath: z.string().describe('Profile image path'),
+    profileImagePath: z.string().nullable().describe('Profile image path'),
     avatarColor: UserAvatarColorSchema,
     // TODO: use `isoDatetimeToDate` when using `ZodSerializerDto` on the controllers.
-    profileChangedAt: z.string().meta({ format: 'date-time' }).describe('Profile change date'),
+    profileChangedAt: z.string().meta({ format: 'date-time' }).nullable().describe('Profile change date'),
   })
   .meta({ id: 'UserResponseDto' });
 
@@ -122,7 +122,7 @@ const UserAdminResponseSchema = UserResponseSchema.extend({
   createdAt: isoDatetimeToDate.describe('Creation date'),
   deletedAt: isoDatetimeToDate.nullable().describe('Deletion date'),
   updatedAt: isoDatetimeToDate.describe('Last update date'),
-  oauthId: z.string().describe('OAuth ID'),
+  oauthId: z.string().nullable().describe('OAuth ID'),
   quotaSizeInBytes: z.int().min(0).nullable().describe('Storage quota in bytes'),
   quotaUsageInBytes: z.int().min(0).nullable().describe('Storage usage in bytes'),
   status: UserStatusSchema,


### PR DESCRIPTION
## Description

Fixes #30823

Some fields in the OpenAPI spec were marked as non-nullable, but the server can return `null` for them. This can cause strictly typed SDKs to fail when deserializing API responses.

I updated the affected DTO schemas to correctly mark these fields as nullable.

### Changes

- Added `.nullable()` to 8 fields across the user, auth, sync, and album DTOs.
- Regenerated `open-api/immich-openapi-specs.json`.
- Regenerated the `@immich/sdk` TypeScript client to match the updated OpenAPI spec.
- Verified that the generated spec only contains the expected nullable changes.
- Left fields that are already correctly nullable or are guaranteed to be non-null unchanged.

## How Has This Been Tested?

- Checked each affected field against the mapper and Zod schema to confirm that `null` can be returned.
- Verified that `UpdateAlbumDto.albumThumbnailAssetId: null` is supported for clearing an album thumbnail.
- Regenerated the OpenAPI spec and checked the diff for unrelated changes.
- Ran the relevant tests.
- The full server build currently has a pre-existing `WorkflowTrigger.AssetTagged` TypeScript error related to an out-of-sync `@immich/plugin-sdk`. This error is unrelated to these changes.

## Screenshots (if appropriate)

Not applicable.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to help investigate the issue, review the relevant code, and check the changes. The affected fields and final diff were manually verified.

...
