### PR TITLE
fix(server): kill pg_dump when a backup fails so it stops holding table locks

### DIFF
--- a/server/src/repositories/process.repository.spec.ts
+++ b/server/src/repositories/process.repository.spec.ts
@@ -83,8 +83,6 @@ describe(ProcessRepository.name, () => {
     });
 
     it('should kill the child process when the stream is destroyed', async () => {
-      // A child left running holds whatever it had open. pg_dump keeps its
-      // transaction alive, which holds AccessShareLock on every table until it exits.
       const process = sut.spawnDuplexStream('bash', ['-c', 'sleep 60']);
       const realProcess = (process as never as { _process: ChildProcessWithoutNullStreams })._process;
 
@@ -98,10 +96,6 @@ describe(ProcessRepository.name, () => {
     });
 
     it('should kill the child when pipeline tears the stream down after a failure', async () => {
-      // pipeline() destroys every stream when one of them fails, so the child has
-      // to go with them rather than outliving the job that spawned it.
-      // `yes` keeps producing output, so the sink is guaranteed to be written to
-      // and can fail the pipeline while the child is still running.
       const process = sut.spawnDuplexStream('yes');
       const realProcess = (process as never as { _process: ChildProcessWithoutNullStreams })._process;
       const failingSink = new Writable({

--- a/server/src/repositories/process.repository.spec.ts
+++ b/server/src/repositories/process.repository.spec.ts
@@ -81,5 +81,40 @@ describe(ProcessRepository.name, () => {
 
       await pipeline(Readable.from(data()), process);
     });
+
+    it('should kill the child process when the stream is destroyed', async () => {
+      // A child left running holds whatever it had open. pg_dump keeps its
+      // transaction alive, which holds AccessShareLock on every table until it exits.
+      const process = sut.spawnDuplexStream('bash', ['-c', 'sleep 60']);
+      const realProcess = (process as never as { _process: ChildProcessWithoutNullStreams })._process;
+
+      expect(realProcess.exitCode).toBeNull();
+
+      const exited = new Promise<void>((resolve) => realProcess.once('exit', () => resolve()));
+      process.destroy();
+      await exited;
+
+      expect(realProcess.killed).toBe(true);
+    });
+
+    it('should kill the child when pipeline tears the stream down after a failure', async () => {
+      // pipeline() destroys every stream when one of them fails, so the child has
+      // to go with them rather than outliving the job that spawned it.
+      // `yes` keeps producing output, so the sink is guaranteed to be written to
+      // and can fail the pipeline while the child is still running.
+      const process = sut.spawnDuplexStream('yes');
+      const realProcess = (process as never as { _process: ChildProcessWithoutNullStreams })._process;
+      const failingSink = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback(new Error('sink exploded'));
+        },
+      });
+
+      const exited = new Promise<void>((resolve) => realProcess.once('exit', () => resolve()));
+      await expect(pipeline(process, failingSink)).rejects.toThrow('sink exploded');
+      await exited;
+
+      expect(realProcess.killed).toBe(true);
+    });
   });
 });

--- a/server/src/repositories/process.repository.ts
+++ b/server/src/repositories/process.repository.ts
@@ -44,10 +44,6 @@ export class ProcessRepository {
       },
 
       destroy(error, callback) {
-        // Destroying the stream has to take the child with it. pipeline() destroys
-        // every stream when one of them fails, and a child left running holds on to
-        // whatever it had open - a pg_dump keeps its transaction alive, which holds
-        // AccessShareLock on every table until the process finally exits.
         if (process.exitCode === null && process.signalCode === null) {
           process.kill();
         }

--- a/server/src/repositories/process.repository.ts
+++ b/server/src/repositories/process.repository.ts
@@ -42,6 +42,17 @@ export class ProcessRepository {
           process.stdin.end(callback);
         }
       },
+
+      destroy(error, callback) {
+        // Destroying the stream has to take the child with it. pipeline() destroys
+        // every stream when one of them fails, and a child left running holds on to
+        // whatever it had open - a pg_dump keeps its transaction alive, which holds
+        // AccessShareLock on every table until the process finally exits.
+        if (process.exitCode === null && process.signalCode === null) {
+          process.kill();
+        }
+        callback(error);
+      },
     });
 
     // stdout -> duplex

--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -253,9 +253,6 @@ describe(DatabaseBackupService.name, () => {
     });
 
     it('should destroy the spawned processes if the write stream fails', async () => {
-      // createWriteStream throws after pg_dump is already running (ENOENT when the
-      // backup volume is unmounted). Without tearing the children down, pg_dump sits
-      // idle in transaction holding AccessShareLock on every table.
       const spawned: Duplex[] = [];
       mocks.process.spawnDuplexStream.mockImplementation(() => {
         const duplex = mockDuplex()('command', 0, 'data', '');

--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { DateTime } from 'luxon';
-import { PassThrough, Readable } from 'node:stream';
+import { Duplex, PassThrough, Readable } from 'node:stream';
 import { StorageCore } from 'src/cores/storage.core';
 import { defaults, SystemConfig } from 'src/dtos/config.dto';
 import { ImmichWorker, JobStatus, StorageFolder } from 'src/enum';
@@ -250,6 +250,28 @@ describe(DatabaseBackupService.name, () => {
         throw new Error('error');
       });
       await expect(sut.handleBackupDatabase()).rejects.toThrow('error');
+    });
+
+    it('should destroy the spawned processes if the write stream fails', async () => {
+      // createWriteStream throws after pg_dump is already running (ENOENT when the
+      // backup volume is unmounted). Without tearing the children down, pg_dump sits
+      // idle in transaction holding AccessShareLock on every table.
+      const spawned: Duplex[] = [];
+      mocks.process.spawnDuplexStream.mockImplementation(() => {
+        const duplex = mockDuplex()('command', 0, 'data', '');
+        spawned.push(duplex);
+        return duplex;
+      });
+      mocks.storage.createWriteStream.mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+
+      await expect(sut.handleBackupDatabase()).rejects.toThrow('ENOENT');
+
+      expect(spawned).toHaveLength(2);
+      for (const stream of spawned) {
+        expect(stream.destroyed).toBe(true);
+      }
     });
 
     it('should fail if rename fails', async () => {

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, Optional } from '@nestjs/common';
 import { debounce } from 'lodash';
 import { DateTime } from 'luxon';
 import path, { basename } from 'node:path';
-import { PassThrough, Readable, Writable } from 'node:stream';
+import { Duplex, PassThrough, Readable, Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import semver from 'semver';
 import { serverVersion } from 'src/constants';
@@ -236,21 +236,30 @@ export class DatabaseBackupService {
     const backupFilePath = path.join(StorageCore.getBaseFolder(StorageFolder.Backups), filename);
     const temporaryFilePath = `${backupFilePath}.tmp`;
 
+    // Declared outside the try so the catch can still reach them. Anything that
+    // throws between spawning and pipeline() taking ownership - createWriteStream
+    // hitting ENOENT on an unmounted backup volume, for instance - would otherwise
+    // leave the children running with nothing holding a reference to them.
+    let pgdump: Duplex | undefined;
+    let gzip: Duplex | undefined;
+
     try {
-      const pgdump = this.processRepository.spawnDuplexStream(bin, args, {
+      pgdump = this.processRepository.spawnDuplexStream(bin, args, {
         env: {
           PATH: process.env.PATH,
           PGPASSWORD: databasePassword,
         },
       });
 
-      const gzip = this.processRepository.spawnDuplexStream('gzip', ['--rsyncable']);
+      gzip = this.processRepository.spawnDuplexStream('gzip', ['--rsyncable']);
       const fileStream = this.storageRepository.createWriteStream(temporaryFilePath);
 
       await pipeline(pgdump, gzip, fileStream);
       await this.storageRepository.rename(temporaryFilePath, backupFilePath);
     } catch (error) {
       this.logger.error(`Database Backup Failure: ${error}`);
+      pgdump?.destroy();
+      gzip?.destroy();
       await this.storageRepository
         .unlink(temporaryFilePath)
 

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -236,10 +236,6 @@ export class DatabaseBackupService {
     const backupFilePath = path.join(StorageCore.getBaseFolder(StorageFolder.Backups), filename);
     const temporaryFilePath = `${backupFilePath}.tmp`;
 
-    // Declared outside the try so the catch can still reach them. Anything that
-    // throws between spawning and pipeline() taking ownership - createWriteStream
-    // hitting ENOENT on an unmounted backup volume, for instance - would otherwise
-    // leave the children running with nothing holding a reference to them.
     let pgdump: Duplex | undefined;
     let gzip: Duplex | undefined;
 


### PR DESCRIPTION
## Description

Fixes #30824

A failed backup left `pg_dump` running. `DatabaseBackupService` spawns it, then opens the output stream, and if that open throws the error path never terminates the child. The orphaned connection sits `idle in transaction` holding `AccessShareLock` on every table until someone kills it by hand. In the report it survived five days and blocked DDL from another application sharing the same Postgres.

Two things were wrong.

`spawnDuplexStream` never killed the child when the returned stream was destroyed. `_destroy` was not overridden, so destroying the duplex left the process running. That is broader than the reported case: `pipeline()` destroys every stream when one of them fails, so any mid-pipeline failure leaked too. Destroying the duplex now kills the child, guarded on `exitCode`/`signalCode` so an already-exited process is left alone.

`createDatabaseBackup` declared `pgdump` and `gzip` inside the `try`, so the `catch` could not reach them. That is exactly the reported path: `createWriteStream` throws `ENOENT` when the backup volume is unmounted, which happens after both children are spawned but before `pipeline()` takes ownership, leaving nothing holding a reference to them. They are now declared outside the `try` and destroyed on failure.

## How Has This Been Tested?

- [x] `should kill the child process when the stream is destroyed`: spawns a long-running child, destroys the stream, waits for exit
- [x] `should kill the child when pipeline tears the stream down after a failure`: a sink that errors mid-pipeline, asserting the child still exits
- [x] `should destroy the spawned processes if the write stream fails`: the reported case, `createWriteStream` throwing after the children are spawned

All three fail on `main` (the first two time out waiting for an exit that never comes) and pass with the change.

Full server suite goes from 2173 to 2176 passing, 94 files, no failures before or after. `prettier --check`, `eslint --max-warnings 0` and `tsc --noEmit` are all clean. Run on Node 24.15.0 to match `.nvmrc`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Server-side only, no UI changes.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The change and its tests were drafted with Claude Code. I reviewed the diff, and ran the tests, the full server suite, lint, format and typecheck locally before opening this.
