### PR TITLE
fix(web): keep timeline geometry finite when the viewport is hidden

### DIFF
--- a/web/src/lib/managers/timeline-manager/internal/layout-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/layout-support.svelte.ts
@@ -9,7 +9,11 @@ export function updateGeometry(timelineManager: TimelineManager, month: Timeline
   }
   if (!month.isLoaded) {
     const viewportWidth = timelineManager.viewportWidth;
-    if (!month.isHeightActual) {
+    // A hidden timeline has no width, and dividing by it would make the height
+    // infinite. The height setter would then propagate that as an infinite top
+    // to every following month, leaving the whole timeline unpositioned.
+    // updateViewportGeometry recomputes the heights once the viewport is back.
+    if (!month.isHeightActual && viewportWidth > 0) {
       const unwrappedWidth = (3 / 2) * month.assetsCount * timelineManager.rowHeight * (7 / 10);
       const rows = Math.ceil(unwrappedWidth / viewportWidth);
       const height = timelineManager.headerHeight + Math.max(1, rows) * timelineManager.rowHeight;

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -848,4 +848,33 @@ describe('TimelineManager', () => {
       expect(ids).not.toContain(assetC.id);
     });
   });
+
+  describe('geometry when the viewport has no width', () => {
+    let timelineManager: TimelineManager;
+
+    beforeEach(async () => {
+      timelineManager = new TimelineManager();
+      sdkMock.getTimeBuckets.mockResolvedValue([
+        { count: 1, timeBucket: '2024-03-01T00:00:00.000Z' },
+        { count: 3, timeBucket: '2024-01-01T00:00:00.000Z' },
+      ]);
+      // A zero height keeps every month out of the viewport, so none is loaded
+      // and their heights are estimated instead of laid out.
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+    });
+
+    it('keeps the geometry of unloaded months finite', () => {
+      expect(timelineManager.months.every((month) => !month.isLoaded)).toBe(true);
+
+      // The asset viewer covers the timeline, so its width collapses to zero
+      // while its height does not. Estimating heights now divides by zero.
+      timelineManager.viewportWidth = 0;
+      timelineManager.refreshLayout();
+
+      for (const month of timelineManager.months) {
+        expect(Number.isFinite(month.height), `height of ${month.title}`).toBe(true);
+        expect(Number.isFinite(month.top), `top of ${month.title}`).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

While the asset viewer is open the timeline is hidden, so its width is `0`. `updateGeometry()` estimates the height of an unloaded month by dividing by that width, which makes the height `Infinity`. The `height` setter then propagates it as an infinite `top` to every following month, so `translate3d(0,Infinitypx,0)` becomes an invalid CSS value that the browser drops. All the affected months collapse to the same position, and the ones with no thumbnails end up covering the ones that have them and absorbing every click — after closing a photo, no other photo can be opened until the page is reloaded.

`updateViewportGeometry()` already skips geometry updates when the viewport is empty, but the other five callers of `updateGeometry()` do not — including the one that runs when a month finishes loading, which is exactly what happens while the viewer is covering the timeline.

The estimate is skipped while there is no width to estimate against. Nothing is lost by skipping it: `updateViewportGeometry()` recomputes the heights with `invalidateHeight` as soon as the viewport is restored. Laying out months that are already loaded is left untouched, since that path produces finite values either way.

Hardening the `height` setter against non-finite values would also stop the propagation, and I am happy to add it if you would rather have the defence in depth — but on its own it would hide the caller's bug instead of fixing it, so it is not in this PR.

Fixes #30854
Fixes #30744

<sub>#30744 reports the same symptom on the same version through a different entry point (leaving the photo details editor rather than the viewer). Both go through the same code path, so it should be covered too — please reopen it if it survives this change.</sub>

## How Has This Been Tested?

- [x] Added a regression test in `timeline-manager.svelte.spec.ts`: with unloaded months and a viewport width of 0, it asserts that every month's height and top stay finite. It fails on `main` (`height of Mar 2024: expected false to be true`) and passes with this change.
- [x] `pnpm exec vitest run` — 523 passed, 2 skipped.
- [x] `pnpm run lint`, `pnpm run format`, `pnpm run check:svelte` (412 files, 0 errors, 0 warnings), `pnpm run check:typescript`.
- [x] Reproduced the bug on a live v3.1.0 instance with ~44k assets and 158 month buckets: after closing the viewer, 158 of the 172 month blocks had lost their `translate3d` transform and the grid stopped responding to clicks (full measurements in #30854). That instance has not been rebuilt from this branch, so the fix itself is covered by the regression test above rather than by a manual run.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable — the grid still looks completely normal while it is broken. The failure is only visible in the DOM: the month blocks lose their `transform`, which is why the numbers are in #30854 instead of a screenshot.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

<sub>The last two boxes are left unchecked because they only apply to server code; this change is web-only.</sub>

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Heavily. I hit the bug on my own instance and asked Claude (Claude Code) to investigate it. It reproduced the bug in the browser, measured the DOM to find that the month blocks were losing their transform, traced that back to the division by a zero viewport width, wrote the regression test, wrote this fix, and ran the web checklist. I reviewed the result and confirmed the reasoning against the code and against my own instance before opening this. Every claim above is something that was actually run rather than assumed — one line that overstated the manual testing was corrected before this description was submitted.
