### PR TITLE
fix(mobile): open memory lane when deep link has no memory id

### DIFF
--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -51,7 +51,7 @@ class DeepLinkService {
     final queryParams = link.uri.queryParameters;
 
     return switch (intent) {
-      "memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
+      "memory" => await _buildMemoryDeepLink(queryParams['id']),
       "asset" => await _buildAssetDeepLink(queryParams['id'] ?? '', ref),
       "album" => await _buildAlbumDeepLink(queryParams['id'] ?? ''),
       "people" => await _buildPeopleDeepLink(queryParams['id'] ?? ''),

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart';
 import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/domain/services/people.service.dart';
@@ -136,5 +138,47 @@ void main() {
     expect(route, isA<AssetViewerRoute>());
     expect((route!.args! as AssetViewerRouteArgs).currentAlbum, isNull);
     verifyNever(() => remoteAlbumService.get(any()));
+  });
+
+  test('memory deep link without an id opens the memory lane', () async {
+    final memory = DriftMemory(
+      id: 'memory-1',
+      createdAt: DateTime(2026, 6, 12),
+      updatedAt: DateTime(2026, 6, 12),
+      ownerId: 'user-1',
+      type: MemoryTypeEnum.onThisDay,
+      data: const MemoryData(year: 2025),
+      isSaved: true,
+      memoryAt: DateTime(2026, 6, 12),
+      assets: [_asset],
+    );
+
+    final user = UserDto(
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User',
+      profileChangedAt: DateTime(2026, 6, 12),
+    );
+
+    final memoryService = MockDriftMemoryService();
+    when(() => memoryService.getMemoryLane('user-1')).thenAnswer((_) async => [memory]);
+
+    final sutWithUser = DeepLinkService(
+      timelineFactory,
+      assetService,
+      remoteAlbumService,
+      memoryService,
+      MockDriftPeopleService(),
+      user,
+    );
+
+    final deepLink = MockPlatformDeepLink();
+    when(() => deepLink.uri).thenReturn(Uri.parse('immich://memory'));
+
+    final route = await sutWithUser.handleScheme(deepLink, ref);
+
+    expect(route, isA<DriftMemoryRoute>());
+    verify(() => memoryService.getMemoryLane('user-1')).called(1);
+    verifyNever(() => memoryService.get(any()));
   });
 }


### PR DESCRIPTION
## Description

Fixes #30634

A `immich://memory` deep link with no `id` query param currently opens the homepage instead of the memory lane.

**Root cause:** `handleScheme` passed `queryParams['id'] ?? ''` to `_buildMemoryDeepLink`, which checks for `null`. An absent id became an empty string, so the service tried to look up memory id `''`, failed, and fell through to the homepage.

**Fix:** Pass the nullable `queryParams['id']` through so a link without an id triggers the memory-lane branch (`getMemoryLane`) instead of a single-memory lookup.

## How Has This Been Tested?

- [x] Added a unit test asserting that a memory deep link without an id calls `getMemoryLane` and never calls `get`.
- [x] Existing deep link tests still pass.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used to write the code. An LLM assistant was used to help fill out this PR description and review the diff.
