### PR TITLE
fix(server): tokenize full path search terms

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -468,7 +468,15 @@ export function searchAssetBuilderLegacy(kysely: Kysely<DB>, options: AssetSearc
         .where('asset_file.path', '=', options.encodedVideoPath!),
     )
     .$if(!!options.originalPath, (qb) =>
-      qb.where(sql`f_unaccent(asset."originalPath")`, 'ilike', sql`'%' || f_unaccent(${options.originalPath}) || '%'`),
+  tokenizeForSearch(options.originalPath!).reduce(
+    (query, token) =>
+      query.where(
+        sql`f_unaccent(asset."originalPath")`,
+        'ilike',
+          sql`'%' || f_unaccent(${token}) || '%'`,
+          ),
+        qb,
+      ),
     )
     .$if(!!options.originalFileName, (qb) =>
       qb.where(

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -468,12 +468,12 @@ export function searchAssetBuilderLegacy(kysely: Kysely<DB>, options: AssetSearc
         .where('asset_file.path', '=', options.encodedVideoPath!),
     )
     .$if(!!options.originalPath, (qb) =>
-  tokenizeForSearch(options.originalPath!).reduce(
-    (query, token) =>
-      query.where(
-        sql`f_unaccent(asset."originalPath")`,
-        'ilike',
-          sql`'%' || f_unaccent(${token}) || '%'`,
+      tokenizeForSearch(options.originalPath!).reduce(
+        (query, token) =>
+          query.where(
+            sql`f_unaccent(asset."originalPath")`,
+            'ilike',
+            sql`'%' || f_unaccent(${token}) || '%'`,
           ),
         qb,
       ),


### PR DESCRIPTION
## Description

Improves the `Full path or folder` search added in #26758 by tokenizing multi-word `originalPath` queries.

Currently, the full search string is used as one `ILIKE` substring. This means a path containing `italien frankreich 2026` matches `frankreich 2026`, but not `italien 2026` or `frankreich italien`.

This change reuses the existing `tokenizeForSearch()` helper and applies one `ILIKE` condition per token. All tokens must match somewhere in the original path, while their order and adjacency no longer matter.

Example for a folder/path containing `italy france 2026`:

- `italy` -> match
- `france2026` -> match
- `italy 2026` -> match
- `france italy` -> match
- `2026 italy` -> match

No schema changes or new dependencies are introduced.

## How Has This Been Tested?

- [x] Built a custom Immich server image based on v3.1.0
- [x] Tested against a real external-library Docker deployment
- [x] Verified single-word full-path searches continue to work
- [x] Verified multi-word searches match when terms are non-adjacent
- [x] Verified term order no longer affects matching

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that no new dependencies are required
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] I have written automated tests for this change

## LLM usage

AI was used as a development aid to inspect the existing search implementation, suggest the small query change, and help prepare this pull request. The change was manually built and tested on an Immich v3.1.0 Docker installation before submission.