### PR TITLE
feat: full path multi word search improvements

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -470,11 +470,7 @@ export function searchAssetBuilderLegacy(kysely: Kysely<DB>, options: AssetSearc
     .$if(!!options.originalPath, (qb) =>
       tokenizeForSearch(options.originalPath!).reduce(
         (query, token) =>
-          query.where(
-            sql`f_unaccent(asset."originalPath")`,
-            'ilike',
-            sql`'%' || f_unaccent(${token}) || '%'`,
-          ),
+          query.where(sql`f_unaccent(asset."originalPath")`, 'ilike', sql`'%' || f_unaccent(${token}) || '%'`),
         qb,
       ),
     )

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -468,7 +468,15 @@ export function searchAssetBuilderLegacy(kysely: Kysely<DB>, options: AssetSearc
         .where('asset_file.path', '=', options.encodedVideoPath!),
     )
     .$if(!!options.originalPath, (qb) =>
-      qb.where(sql`f_unaccent(asset."originalPath")`, 'ilike', sql`'%' || f_unaccent(${options.originalPath}) || '%'`),
+  tokenizeForSearch(options.originalPath!).reduce(
+    (query, token) =>
+      query.where(
+        sql`f_unaccent(asset."originalPath")`,
+        'ilike',
+          sql`'%' || f_unaccent(${token}) || '%'`,
+          ),
+        qb,
+      ),
     )
     .$if(!!options.originalFileName, (qb) =>
       qb.where(

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -468,12 +468,12 @@ export function searchAssetBuilderLegacy(kysely: Kysely<DB>, options: AssetSearc
         .where('asset_file.path', '=', options.encodedVideoPath!),
     )
     .$if(!!options.originalPath, (qb) =>
-  tokenizeForSearch(options.originalPath!).reduce(
-    (query, token) =>
-      query.where(
-        sql`f_unaccent(asset."originalPath")`,
-        'ilike',
-          sql`'%' || f_unaccent(${token}) || '%'`,
+      tokenizeForSearch(options.originalPath!).reduce(
+        (query, token) =>
+          query.where(
+            sql`f_unaccent(asset."originalPath")`,
+            'ilike',
+            sql`'%' || f_unaccent(${token}) || '%'`,
           ),
         qb,
       ),


### PR DESCRIPTION
## Description

Improves the `Full path or folder` search added in #26758 by tokenizing multi-word `originalPath` queries.

Currently, the full search string is used as one `ILIKE` substring. This means a path containing `italy france 2026` matches `france 2026`, but not `italy 2026` or `france italy`.

This change reuses the existing `tokenizeForSearch()` helper and applies one `ILIKE` condition per token. All tokens must match somewhere in the original path, while their order and adjacency no longer matter.

Example for a folder/path containing `italy france 2026`:

- `italy` -> match
- `france 2026` -> match
- `italy 2026` -> match
- `france italy` -> match
- `2026 italy` -> match

No schema changes or new dependencies are introduced.

Fixes # (issue)

## How Has This Been Tested?

- [x] Built a custom Immich server image based on v3.1.0
- [x] Tested against a real external-library Docker deployment
- [x] Verified single-word full-path searches continue to work
- [x] Verified multi-word searches match when terms are non-adjacent
- [x] Verified term order no longer affects matching

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable. This change only affects server-side search matching behavior.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

ChatGPT was used as aid while search for the existing path-search-implementation. The change was manually applied, built, and live-tested by my team on our own Immich v3.1.0 installation (Docker on Synology) before submission.