### PR TITLE
chore: align icon and font size of bottom bar actions

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
@@ -86,7 +86,7 @@ class BaseActionButton extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               label,
-              style: const TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400),
+              style: const TextStyle(fontSize: 14.0, fontWeight: FontWeight.w500),
               maxLines: 3,
               textAlign: TextAlign.center,
               softWrap: true,

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -65,7 +65,7 @@ class ViewerBottomBar extends ConsumerWidget {
           ? const SizedBox.shrink()
           : Theme(
               data: context.themeData.copyWith(
-                iconTheme: const IconThemeData(size: 22, color: Colors.white),
+                iconTheme: const IconThemeData(size: ImmichIconSize.md, color: Colors.white),
                 textTheme: context.themeData.textTheme.copyWith(
                   labelLarge: context.themeData.textTheme.labelLarge?.copyWith(color: Colors.white),
                 ),

--- a/mobile/packages/ui/lib/src/components/column_button.dart
+++ b/mobile/packages/ui/lib/src/components/column_button.dart
@@ -78,7 +78,7 @@ class _ImmichColumnButtonState extends State<ImmichColumnButton> {
               maxLines: 2,
               textAlign: .center,
               overflow: .ellipsis,
-              style: const .new(fontSize: ImmichTextSize.label, fontWeight: .w500),
+              style: const .new(fontSize: ImmichTextSize.body, fontWeight: .w500),
             ),
           ],
         ),


### PR DESCRIPTION
This standardises the icon and font size on the bottom sheet to be like the other UI widgets. 

- The bottom bar was using a magic number for it's size (22) which has been updated to `ImmichIconSize.md` (24). 
- All text sizes on the UI library defaults to `ImmichTextSize.body` (14), the column buttons had an incorrect size `ImmichTextSize.label` (12) which has been fixed now

| Before | After |
| :-: | :-: |
| <img width="270" height="600" alt="Screenshot_1787249892" src="https://github.com/user-attachments/assets/002fa7a3-e438-41d8-ab29-98ebed6d10f1" /> | <img width="270" height="600" alt="Screenshot_1787249756" src="https://github.com/user-attachments/assets/aa8b9412-99dd-4e3e-b177-cdbd867a2431" /> |
| <img width="270" height="600" alt="Screenshot_1787249898" src="https://github.com/user-attachments/assets/5fb8d0f5-03e3-468a-90a8-36708d639b04" /> | <img width="270" height="600" alt="Screenshot_1787249761" src="https://github.com/user-attachments/assets/11b60fe7-e409-41d4-9898-3dff47acfb07" /> |