### PR TITLE
chore(mobile): update flutter-maplibre-gl to 0.27.0

### DIFF
--- a/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "84a79bc375a301169390ac110c868f06c857b83f",
-        "version" : "6.27.0"
+        "revision" : "5ee345ca5d65238a6fce29bba87816204be7df20",
+        "version" : "6.28.0"
       }
     },
     {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1072,26 +1072,26 @@ packages:
     dependency: "direct main"
     description:
       name: maplibre_gl
-      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
+      sha256: "8b24dce6a050ba44779154c550e0318654ee12c572fa5fd1ad0c12e90d061356"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.2"
+    version: "0.27.0"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
+      sha256: "8a1952b77ce841162fcd2601dc857f5b3f8eea46d34025b901ef803bb15d2adc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.2"
+    version: "0.27.0"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
+      sha256: c9c7bb1183cc9c6baafcef0b5b741420db869ca45e474ca80edf732168a286ee
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.2"
+    version: "0.27.0"
   matcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   intl: ^0.20.2
   local_auth: ^2.3.0
   logging: ^1.3.0
-  maplibre_gl: ^0.26.0
+  maplibre_gl: ^0.27.0
   native_video_player:
     git:
       url: https://github.com/immich-app/native_video_player


### PR DESCRIPTION
Fixes #24278

No expected breaking changes. `flutter-maplibre-gl` has a very strange license file structure so Flutter's license parser still doesn't do a great job, but the projects are properly attributed.

Checked a number of interactions, map disposals/recreations, etc. with no obvious regressions.