### PR TITLE
fix(server): let a second metadata extraction replace stored AV metadata

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -194,10 +194,10 @@ export class AssetRepository {
           .values(audio)
           .onConflict((oc) =>
             oc.column('assetId').doUpdateSet(({ ref }) => ({
-              bitrate: ref('asset_audio.bitrate'),
-              index: ref('asset_audio.index'),
-              profile: ref('asset_audio.profile'),
-              codecName: ref('asset_audio.codecName'),
+              bitrate: ref('excluded.bitrate'),
+              index: ref('excluded.index'),
+              profile: ref('excluded.profile'),
+              codecName: ref('excluded.codecName'),
             })),
           ),
       );
@@ -210,21 +210,22 @@ export class AssetRepository {
           .values(video)
           .onConflict((oc) =>
             oc.column('assetId').doUpdateSet(({ ref }) => ({
-              bitrate: ref('asset_video.bitrate'),
-              timeBase: ref('asset_video.timeBase'),
-              index: ref('asset_video.index'),
-              profile: ref('asset_video.profile'),
-              level: ref('asset_video.level'),
-              colorPrimaries: ref('asset_video.colorPrimaries'),
-              colorTransfer: ref('asset_video.colorTransfer'),
-              colorMatrix: ref('asset_video.colorMatrix'),
-              dvProfile: ref('asset_video.dvProfile'),
-              dvLevel: ref('asset_video.dvLevel'),
-              dvBlSignalCompatibilityId: ref('asset_video.dvBlSignalCompatibilityId'),
-              codecName: ref('asset_video.codecName'),
-              formatName: ref('asset_video.formatName'),
-              formatLongName: ref('asset_video.formatLongName'),
-              pixelFormat: ref('asset_video.pixelFormat'),
+              bitrate: ref('excluded.bitrate'),
+              frameCount: ref('excluded.frameCount'),
+              timeBase: ref('excluded.timeBase'),
+              index: ref('excluded.index'),
+              profile: ref('excluded.profile'),
+              level: ref('excluded.level'),
+              colorPrimaries: ref('excluded.colorPrimaries'),
+              colorTransfer: ref('excluded.colorTransfer'),
+              colorMatrix: ref('excluded.colorMatrix'),
+              dvProfile: ref('excluded.dvProfile'),
+              dvLevel: ref('excluded.dvLevel'),
+              dvBlSignalCompatibilityId: ref('excluded.dvBlSignalCompatibilityId'),
+              codecName: ref('excluded.codecName'),
+              formatName: ref('excluded.formatName'),
+              formatLongName: ref('excluded.formatLongName'),
+              pixelFormat: ref('excluded.pixelFormat'),
             })),
           ),
       );
@@ -237,12 +238,12 @@ export class AssetRepository {
           .values(keyframes)
           .onConflict((oc) =>
             oc.column('assetId').doUpdateSet(({ ref }) => ({
-              pts: ref('asset_keyframe.pts'),
-              accDuration: ref('asset_keyframe.accDuration'),
-              ownDuration: ref('asset_keyframe.ownDuration'),
-              totalDuration: ref('asset_keyframe.totalDuration'),
-              packetCount: ref('asset_keyframe.packetCount'),
-              outputFrames: ref('asset_keyframe.outputFrames'),
+              pts: ref('excluded.pts'),
+              accDuration: ref('excluded.accDuration'),
+              ownDuration: ref('excluded.ownDuration'),
+              totalDuration: ref('excluded.totalDuration'),
+              packetCount: ref('excluded.packetCount'),
+              outputFrames: ref('excluded.outputFrames'),
             })),
           ),
       );

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -23,6 +23,46 @@ beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
 
+// Metadata extraction is repeatable: probing improves, files get repaired,
+// and a re-run has to be able to correct what an earlier run stored.
+const audioRow = (assetId: string, n: number) => ({
+  assetId,
+  bitrate: 100_000 + n,
+  index: n,
+  profile: n,
+  codecName: `codec-${n}`,
+});
+
+const videoRow = (assetId: string, n: number) => ({
+  assetId,
+  bitrate: 200_000 + n,
+  frameCount: 300 + n,
+  timeBase: 600 + n,
+  index: n,
+  profile: n,
+  level: n,
+  colorPrimaries: n,
+  colorTransfer: n,
+  colorMatrix: n,
+  dvProfile: n,
+  dvLevel: n,
+  dvBlSignalCompatibilityId: n,
+  codecName: `vcodec-${n}`,
+  formatName: `format-${n}`,
+  formatLongName: `format long ${n}`,
+  pixelFormat: `pixfmt-${n}`,
+});
+
+const keyframeRow = (assetId: string, n: number) => ({
+  assetId,
+  pts: [n],
+  accDuration: [n],
+  ownDuration: [n],
+  totalDuration: 1000 + n,
+  packetCount: 10 + n,
+  outputFrames: 20 + n,
+});
+
 describe(AssetRepository.name, () => {
   describe('getTimeBucket', () => {
     it('should order assets by local day first and fileCreatedAt within each day', async () => {
@@ -80,6 +120,90 @@ describe(AssetRepository.name, () => {
   });
 
   describe('upsertExif', () => {
+    it('should replace stored audio metadata on a second extraction', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'first' },
+        audio: audioRow(asset.id, 2),
+        lockedPropertiesBehavior: 'skip',
+      });
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'second' },
+        audio: audioRow(asset.id, 1),
+        lockedPropertiesBehavior: 'skip',
+      });
+
+      await expect(
+        ctx.database.selectFrom('asset_audio').selectAll().where('assetId', '=', asset.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual(audioRow(asset.id, 1));
+    });
+
+    it('should replace stored video metadata on a second extraction', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'first' },
+        video: videoRow(asset.id, 2),
+        lockedPropertiesBehavior: 'skip',
+      });
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'second' },
+        video: videoRow(asset.id, 1),
+        lockedPropertiesBehavior: 'skip',
+      });
+
+      await expect(
+        ctx.database.selectFrom('asset_video').selectAll().where('assetId', '=', asset.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual(videoRow(asset.id, 1));
+    });
+
+    it('should replace stored keyframe metadata on a second extraction', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'first' },
+        keyframes: keyframeRow(asset.id, 2),
+        lockedPropertiesBehavior: 'skip',
+      });
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'second' },
+        keyframes: keyframeRow(asset.id, 1),
+        lockedPropertiesBehavior: 'skip',
+      });
+
+      await expect(
+        ctx.database.selectFrom('asset_keyframe').selectAll().where('assetId', '=', asset.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual(keyframeRow(asset.id, 1));
+    });
+
+    // A probe that could not read a stream sends no object at all, and that must
+    // not be read as "delete what is already known".
+    it('should leave stored media metadata alone when an extraction omits it', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'first' },
+        audio: audioRow(asset.id, 2),
+        lockedPropertiesBehavior: 'skip',
+      });
+      await sut.upsertExif({
+        exif: { assetId: asset.id, description: 'second' },
+        lockedPropertiesBehavior: 'skip',
+      });
+
+      await expect(
+        ctx.database.selectFrom('asset_audio').selectAll().where('assetId', '=', asset.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual(audioRow(asset.id, 2));
+    });
     it('should append to locked columns', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();


### PR DESCRIPTION
## Description

Related to #30511

`upsertExif` writes derived audio, video and keyframe metadata with an `ON CONFLICT DO UPDATE`. Every column in those three update lists assigns the stored row back to itself:

```ts
// server/src/repositories/asset.repository.ts
oc.column('assetId').doUpdateSet(({ ref }) => ({
  bitrate: ref('asset_audio.bitrate'),
  index: ref('asset_audio.index'),
  profile: ref('asset_audio.profile'),
  codecName: ref('asset_audio.codecName'),
}))
```

`SET bitrate = asset_audio.bitrate` is a self-assignment, so once a row exists nothing can change it. Re-running metadata extraction re-reads the file, builds a fresh snapshot, and then discards it. The same file already uses `excluded` correctly for `asset_exif` and elsewhere, as does `plugin.repository.ts`.

The pattern covers three tables and 25 column references: `asset_audio`, `asset_video` and `asset_keyframe`.

`asset_video.frameCount` has a second problem: it is supplied on insert but missing from the update list, so it would remain stale even after the reference is corrected.

### Why this matters

Metadata extraction is meant to be repeatable. Probing improves between releases, files get repaired or replaced, and a fix to how a stream is selected cannot reach assets that were already imported. An `upsert` that silently degrades to insert-only defeats all of it.

This was found while checking whether #30511 could be repaired by re-extracting metadata. It cannot.

### Why taking the incoming row is safe here

Metadata extraction is the only caller that passes these three objects, and it passes a complete snapshot or nothing:

```ts
// server/src/services/metadata.service.ts
const audioData = format && audio?.codecName ? { /* every column */ } : undefined;
```

`upsertExif` then gates each branch on `if (audio)` / `if (video)` / `if (keyframes)`. A probe that could not read a stream yields `undefined`, and the branch is skipped entirely, so a degraded read cannot write partial values over good ones.

The other three callers (`asset-media.service.ts`, `asset.service.ts`, `tag.service.ts`) pass `exif` only. Every other reference to these tables is a read: joins in `video-stream.repository.ts` and `asset-job.repository.ts`. No API or user action writes them.

## How Has This Been Tested?

Reproduced and verified against a real Postgres through the existing medium-test harness.

**Before the change**, calling `upsertExif` twice with different audio data:

```
first  upsertExif(audio: index 2, codecName 'unknown')  ->  row: index=2 codecName=unknown
second upsertExif(audio: index 1, codecName 'aac')      ->  row: index=2 codecName=unknown
```

**After the change**, the same sequence:

```
first   ->  row: index=2 codecName=unknown
second  ->  row: index=1 codecName=aac
```

- [x] Four medium tests added in `test/medium/specs/repositories/asset.repository.spec.ts`, covering audio, video and keyframe replacement, plus one asserting that an extraction which omits an object leaves the stored row untouched. Each starts from deliberately different stored and incoming values, so a self-assignment cannot pass.
- [x] Reverting only the source change fails exactly the three replacement tests and passes the other seven.
- [x] `asset.repository.spec.ts` medium suite: 10 passed.
- [x] Server unit suite: 95 files passed.
- [x] End to end on a real instance, described below.

### End to end

Two isolated Docker stacks built from this repository, identical except for this commit, both fed the same four iPhone recordings.

An install that already stored the wrong stream was repaired by swapping in the patched image and running metadata extraction with `force`:

```
after image swap        index=2 codecName=unknown     (stored value persists)
after re-extraction     index=1 codecName=aac         (this change)
after video conversion  4 outputs, all h264 + aac, 0 errors
```

Without this change the second step leaves the row unchanged.

### Scope

This changes conflict-update semantics only. It does not claim probe results are accurate, does not delete or null rows when a probe is degraded, does not support partial objects, and makes no schema change.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used throughout: it traced the code paths, wrote the change and the tests, and ran the verification described above. I reviewed the change and the evidence, and directed the investigation.

Nothing here needs that process to be trusted. The reproduction is scripted and independent of the change, the before and after values are stated, and reverting only the source edit fails a named subset of the added tests while the rest keep passing.
