### PR TITLE
fix(server): don't select an audio stream ffprobe could not identify

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -272,7 +272,7 @@ export class MediaRepository {
           };
         }),
       audioStreams: results.streams
-        .filter((stream) => stream.codec_type === 'audio')
+        .filter((stream) => stream.codec_type === 'audio' && stream.codec_name !== 'unknown')
         .sort((a, b) => this.compareStreams(a, b))
         .map((stream) => ({
           index: stream.index,


### PR DESCRIPTION
## Description

Fixes #30511

iPhone recordings made with Apple Spatial Audio carry two audio tracks: an AAC track and an APAC track that ffmpeg has no decoder for. Immich selects the APAC track, maps it into the transcode command, and ffmpeg fails before encoding starts:

```
[aist#0:2/none] Decoding requested, but no decoder found for: none
Error opening output file /data/encoded-video/.../....mp4.
Error opening output files: Invalid argument
```

### Where the choice is made

```ts
// server/src/repositories/media.repository.ts:274
audioStreams: results.streams
  .filter((stream) => stream.codec_type === 'audio')
  .sort((a, b) => this.compareStreams(a, b))
  .map(...)

// server/src/repositories/media.repository.ts:512
private compareStreams(a: FfprobeStream, b: FfprobeStream): number {
  const d = (b.disposition?.default ?? 0) - (a.disposition?.default ?? 0);
  if (d !== 0) {
    return d;
  }
  return this.parseInt(b.bit_rate) - this.parseInt(a.bit_rate);
}
```

`metadata.service.ts:1083` then takes `audioStreams[0]`, with no check that the codec can be decoded.

### Why only some files fail

Two recordings from the same library:

| Result | Audio streams | Selected |
| --- | --- | --- |
| Fails | `1 aac bit_rate=156417 default=1`<br>`2 apac bit_rate=414140 default=1` | index 2 |
| Succeeds | `1 aac bit_rate=158431 default=1`<br>`2 apac bit_rate=394864 default=0` | index 1 |

When both tracks carry `default=1`, the disposition comparison ties and the bitrate tiebreaker decides. The APAC track is consistently the higher-bitrate one, so it wins. When only AAC is marked default, AAC wins and the file transcodes normally.

Across a library of 5562 videos, 178 carry an audio stream ffprobe cannot identify, and applying the ordering above by hand shows 4 of them select it. Those 4 are exactly the 4 that failed.

## Changes

Drop audio streams ffprobe reported as `unknown` before the existing ordering runs, per review feedback.

```diff
-        .filter((stream) => stream.codec_type === 'audio')
+        .filter((stream) => stream.codec_type === 'audio' && stream.codec_name !== 'unknown')
```

The video pipeline is unchanged, since the evidence here covers audio selection only.

## How Has This Been Tested?

- [x] Server unit suite on the final change: 95 files, 2201 tests passed. No tests were added — the change is a single predicate on an existing filter, and `media.repository.spec.ts` has no existing seam that drives `probe()`, so covering it would mean introducing the first `ffmpeg.ffprobe` mock in that file for one line of behaviour.
- [x] End to end against a build of this commit, described below.

### End to end

Four iPhone 16 Pro Spatial Audio recordings — the four that fail on the library above — imported into a clean instance built from this commit (`e2e/docker-compose.yml`, machine learning disabled, empty database).

ffprobe in the server image still cannot identify the APAC track:

```
$ ffprobe -select_streams a -show_entries stream=index,codec_name,bit_rate:stream_disposition=default -of csv=p=0 apac-1.MOV
1,aac,156417,1
2,unknown,414140,1
```

(`ffmpeg version 7.1.4-Jellyfin`)

Persisted `asset_audio` after metadata extraction:

| File | index | codecName | bitrate |
| --- | --- | --- | --- |
| apac-1.MOV | 1 | aac | 156417 |
| apac-2.MOV | 1 | aac | 205842 |
| apac-3.MOV | 1 | aac | 158945 |
| apac-4.MOV | 1 | aac | 183742 |

All four transcoded, and every derivative carries audio:

| File | Derivative streams |
| --- | --- |
| apac-1.MOV | `0,h264,video` `1,aac,audio,2ch` |
| apac-2.MOV | `0,h264,video` `1,aac,audio,2ch` |
| apac-3.MOV | `0,h264,video` `1,aac,audio,2ch` |
| apac-4.MOV | `0,h264,video` `1,aac,audio,2ch` |

No `no decoder found` in the server log for any of the four.

The failure is reproducible with the same ffmpeg build by mapping the stream `main` selects instead of the one this change selects:

```
$ ffmpeg -i apac-1.MOV -map 0:0 -map 0:2 -c:v h264 -c:a aac -t 1 out.mp4
[aist#0:2/none] Decoding requested, but no decoder found for: none
Error opening output file out.mp4.
Error opening output files: Invalid argument

$ ffmpeg -i apac-1.MOV -map 0:0 -map 0:1 -c:v h264 -c:a aac -t 1 out.mp4
$ ffprobe -show_entries stream=index,codec_name -of csv=p=0 out.mp4
0,h264
1,aac
```

## Note for existing installs

The selected stream is persisted in `asset_audio`, so this change applies when an asset is probed. Repairing an already-imported asset needs metadata extraction to run again; #30900 is now merged, so a re-extraction replaces the stored value instead of writing it back unchanged.

## Scope

An audio stream ffprobe cannot identify is treated as no audio at all. For the files in this report that is invisible, because the AAC companion track remains and is selected. If an asset's *every* audio track were unidentified, it would now be treated as having no audio, and a derivative produced for it would be video-only rather than the conversion failing. I have no such file to test against, and none appears in the 5555-video library above. The original asset is never modified either way.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used throughout: it traced the code paths, wrote the change, and ran the verification described above. I reviewed the change and the evidence, and directed the investigation.

Nothing here needs that process to be trusted. The reproduction is scripted and independent of the change, and the before and after values are stated.

