### PR TITLE
fix(server): normalize Windows paths before fast-glob crawl

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -282,7 +282,11 @@ export class StorageRepository {
   watchDir = watch; // Native fs.watch without chokidar overhead
 
   private asGlob(pathToCrawl: string): string {
-    const escapedPath = escapePath(pathToCrawl).replaceAll('"', '["]').replaceAll("'", "[']").replaceAll('`', '[`]');
+    // fast-glob only understands forward-slash paths (backslash is its escape
+    // character), so a Windows path like `Z:\All Back ups` must be normalized
+    // before escaping or it silently matches zero files.
+    const posixPath = pathToCrawl.replaceAll('\\', '/');
+    const escapedPath = escapePath(posixPath).replaceAll('"', '["]').replaceAll("'", "[']").replaceAll('`', '[`]');
     const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
     return `${escapedPath}/**/${extensions}`;
   }


### PR DESCRIPTION
## What
External library scans on Windows silently import 0 assets — no error, the scan just completes instantly.

## Why
`asGlob()` in `storage.repository.ts` builds the `fast-glob` crawl pattern directly from the raw import path. On Windows this path uses backslashes (e.g. `C:\Photos`), but `fast-glob` only understands forward-slash paths — backslash is its own escape character in glob syntax. The resulting pattern silently matches zero files instead of throwing, so a library scan appears to succeed while importing nothing.

## Fix
Normalize backslashes to forward slashes before building the glob pattern in `asGlob()`.

## Testing
Reproduced and verified fixed on a native-Windows Immich server instance: before the fix, scanning an external library at `Z:\<library>` completed in under a second with 0 assets imported; after the fix, the same library correctly imported 700k+ assets.