### PR TITLE
feat(ml): add DirectML execution provider support

### DIFF
--- a/machine-learning/immich_ml/config.py
+++ b/machine-learning/immich_ml/config.py
@@ -5,13 +5,21 @@ import sys
 from pathlib import Path
 from socket import socket
 
-from gunicorn.arbiter import Arbiter
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from rich.console import Console
 from rich.logging import RichHandler
 from uvicorn import Server
-from uvicorn.workers import UvicornWorker
+
+try:
+    # gunicorn (and its Arbiter/UvicornWorker integration) depends on fcntl, which is
+    # Unix-only. It is only needed when launched via `python -m immich_ml`; running
+    # uvicorn directly (e.g. natively on Windows) never touches these.
+    from gunicorn.arbiter import Arbiter
+    from uvicorn.workers import UvicornWorker
+except ImportError:
+    Arbiter = None  # type: ignore[assignment,misc]
+    UvicornWorker = None  # type: ignore[assignment,misc]
 
 from .schemas import ModelPrecision
 
@@ -150,11 +158,13 @@ class CustomUvicornServer(Server):
         await super().shutdown()
 
 
-class CustomUvicornWorker(UvicornWorker):
-    async def _serve(self) -> None:
-        self.config.app = self.wsgi
-        server = CustomUvicornServer(config=self.config)
-        self._install_sigquit_handler()
-        await server.serve(sockets=self.sockets)
-        if not server.started:
-            sys.exit(Arbiter.WORKER_BOOT_ERROR)
+if UvicornWorker is not None:
+
+    class CustomUvicornWorker(UvicornWorker):  # type: ignore[misc]
+        async def _serve(self) -> None:
+            self.config.app = self.wsgi
+            server = CustomUvicornServer(config=self.config)
+            self._install_sigquit_handler()
+            await server.serve(sockets=self.sockets)
+            if not server.started:
+                sys.exit(Arbiter.WORKER_BOOT_ERROR)

--- a/machine-learning/immich_ml/models/constants.py
+++ b/machine-learning/immich_ml/models/constants.py
@@ -93,6 +93,7 @@ SUPPORTED_PROVIDERS = [
     "MIGraphXExecutionProvider",
     "OpenVINOExecutionProvider",
     "CoreMLExecutionProvider",
+    "DmlExecutionProvider",
     "CPUExecutionProvider",
 ]
 

--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -53,6 +53,7 @@ openvino = ["onnxruntime-openvino>=1.24.1,<2"]
 armnn = ["onnxruntime>=1.23.2,<2"]
 rknn = ["onnxruntime>=1.23.2,<2", "rknn-toolkit-lite2>=2.3.0,<3"]
 rocm = ["onnxruntime-migraphx>=1.23.2,<2"]
+directml = ["onnxruntime-directml>=1.23.2,<2"]
 
 [tool.uv]
 compile-bytecode = true

--- a/machine-learning/uv.lock
+++ b/machine-learning/uv.lock
@@ -804,6 +804,9 @@ cpu = [
 cuda = [
     { name = "onnxruntime-gpu" },
 ]
+directml = [
+    { name = "onnxruntime-directml" },
+]
 openvino = [
     { name = "onnxruntime-openvino" },
 ]
@@ -866,6 +869,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'armnn'", specifier = ">=1.23.2,<2" },
     { name = "onnxruntime", marker = "extra == 'cpu'", specifier = ">=1.23.2,<2" },
     { name = "onnxruntime", marker = "extra == 'rknn'", specifier = ">=1.23.2,<2" },
+    { name = "onnxruntime-directml", marker = "extra == 'directml'", specifier = ">=1.23.2,<2" },
     { name = "onnxruntime-gpu", marker = "extra == 'cuda'", specifier = ">=1.23.2,<2" },
     { name = "onnxruntime-migraphx", marker = "extra == 'rocm'", specifier = ">=1.23.2,<2" },
     { name = "onnxruntime-openvino", marker = "extra == 'openvino'", specifier = ">=1.24.1,<2" },
@@ -881,7 +885,7 @@ requires-dist = [
     { name = "tokenizers", specifier = ">=0.15.0,<1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.22.0,<1.0" },
 ]
-provides-extras = ["cpu", "cuda", "openvino", "armnn", "rknn", "rocm"]
+provides-extras = ["cpu", "cuda", "openvino", "armnn", "rknn", "rocm", "directml"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1424,6 +1428,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
     { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
     { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
+name = "onnxruntime-directml"
+version = "1.24.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/90/99566dc6398028e7691a5b12720fd85f757a0901818b84599d28abb3f085/onnxruntime_directml-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:96642a787e5a6f33bf043521c0f06eb1eb663f6b830e5862a2026d03f9c90543", size = 25106000, upload-time = "2026-03-17T21:47:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ea/33814eb0ec96775eda4c1d30b0d86e91d7d2cd0d84c66d3915aef0e06fa3/onnxruntime_directml-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:f2ecb68b7b7b259d2ef3112ae760149f9b5a1e7c0fbb73d539da6250a648a614", size = 25111930, upload-time = "2026-03-17T21:47:18.419Z" },
+    { url = "https://files.pythonhosted.org/packages/60/53/2bd2696fac19cf8ca55496a0bcfe431f3aff9579eabbb0e231dc238acf6f/onnxruntime_directml-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:2f1031cb2281e5b27cca9efe0b9399317c7286e4d226f7a79d4ab79bbd94d19e", size = 25112253, upload-time = "2026-03-17T21:47:22.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/04/816932a3ade867a687e406716ca76e0774c6b921545b45818e3ebfcc54ce/onnxruntime_directml-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:51d86bb949488e572b00422f344990a4a81d982416d73b6c0e4ced2bcd423d19", size = 25571098, upload-time = "2026-03-17T21:47:25.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Adds `DmlExecutionProvider` support so the ML service can run ONNX inference on any DirectX 12 GPU on Windows — AMD, Intel, and NVIDIA all support DirectML.

## Why
ROCm has no viable path on many Windows setups (e.g. AMD RDNA2 cards under a WSL2-backed Docker Desktop have no `/dev/kfd` passthrough), and CUDA obviously doesn't help non-NVIDIA users. DirectML is a DX12 compute layer that works across vendors and is the natural fit for running the ML service natively on Windows.

## Changes
- `machine-learning/immich_ml/models/constants.py`: add `DmlExecutionProvider` to `SUPPORTED_PROVIDERS`, mirroring the existing CUDA/ROCm/OpenVINO/CoreML entries.
- `machine-learning/pyproject.toml` + `uv.lock`: add a `directml` optional-dependency extra (`onnxruntime-directml`), mirroring the existing `cuda`/`rocm` extras.
- `machine-learning/immich_ml/config.py`: guard the `gunicorn`/`UvicornWorker` imports behind try/except. `gunicorn` depends on `fcntl`, which is Unix-only, so importing `config.py` fails outright on Windows even though gunicorn is only actually needed when launched through its own Arbiter. This only matters if the service is launched via `uvicorn` directly (as is necessary on Windows, since gunicorn itself doesn't run there) — zero behavior change when gunicorn is available and used normally.

No changes to `_provider_options_default`/`_sess_options_default` in `ort.py` were needed — the existing `case _: options = {}` fallback already handles DirectML correctly.

## Testing
Verified on a native-Windows ML service instance (AMD RX 6800 XT): startup logs correctly list `DmlExecutionProvider` ahead of `CPUExecutionProvider`, and Task Manager's GPU **Compute** graph (not the default 3D/Copy graph) spikes during Smart Search / Face Detection jobs while CPU stays well below saturation — confirming inference is actually running on the GPU, not silently falling back to CPU.

Note: `MACHINE_LEARNING_REQUEST_THREADS` should be set to `1` when using DirectML — DML sessions are not safe for concurrent `Run()` calls. This is an existing env var, no code change needed, just worth calling out for anyone trying this.