### PR TITLE
fix(web): restore timeline keyboard focus after closing the asset viewer

### DIFF
--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -149,6 +149,30 @@ test.describe('Timeline', () => {
     });
   });
   test.describe('keyboard', () => {
+    test('PageDown still scrolls after closing the asset viewer with the back button', async ({ page }) => {
+      await pageUtils.openPhotosPage(page);
+      await thumbnailUtils.clickAssetId(page, assets[0].id);
+      await assetViewerUtils.waitForViewerLoad(page, assets[0]);
+      await page.getByLabel('Go back').click();
+      await page.waitForURL('**/photos?at=*');
+      await expect(assetViewerUtils.locator(page)).toHaveCount(0);
+
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const grid = document.querySelector('#asset-grid');
+            return grid === document.activeElement || !!grid?.contains(document.activeElement);
+          }),
+        )
+        .toBe(true);
+
+      const scrollTopBefore = await page.evaluate(() => document.querySelector('#asset-grid')?.scrollTop ?? 0);
+      await page.keyboard.press('PageDown');
+      await expect
+        .poll(() => page.evaluate(() => document.querySelector('#asset-grid')?.scrollTop ?? 0))
+        .toBeGreaterThan(scrollTopBefore);
+    });
+
     /**
      * This text tests keyboard nativation, and also ensures that the scroll-to-asset behavior
      * scrolls the minimum amount. That is, if you are navigating using right arrow (auto scrolling

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -21,6 +21,7 @@
   import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
   import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
+  import { restoreFocusTo } from '$lib/utils/focus-util';
   import { isAssetViewerRoute, navigate } from '$lib/utils/navigation';
   import { getTimes, type ScrubberListener } from '$lib/utils/timeline-util';
   import { type AlbumResponseDto, type PersonResponseDto, type UserResponseDto } from '@immich/sdk';
@@ -213,11 +214,19 @@
     if (!scrolled) {
       // if the asset is not found, scroll to the top
       timelineManager.scrollTo(0);
-    } else if (scrollTarget) {
+    }
+
+    // Unhide before focusing. Hidden elements cannot receive focus.
+    invisible = false;
+
+    if (scrolled && scrollTarget) {
       await tick();
       focusAsset(scrollTarget);
     }
-    invisible = false;
+
+    if (!isAssetViewerRoute(page)) {
+      restoreFocusTo(scrollableElement);
+    }
   };
 
   // note: only modified once in afterNavigate()

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -224,7 +224,7 @@
       focusAsset(scrollTarget);
     }
 
-    if (!isAssetViewerRoute(page)) {
+    if (hasNavigatedToOrFromAssetViewer && !isAssetViewerRoute(page)) {
       restoreFocusTo(scrollableElement);
     }
   };

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -216,7 +216,7 @@
       timelineManager.scrollTo(0);
     }
 
-    // Unhide before focusing. Hidden elements cannot receive focus.
+    // have to unhide first, otherwise focus() does nothing
     invisible = false;
 
     if (scrolled && scrollTarget) {

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -99,7 +99,7 @@
   const handleClose = async (assetId: string) => {
     invisible = true;
     assetViewerManager.gridScrollTarget = { at: assetId };
-    // keepFocus: SvelteKit would otherwise reset focus to body after this navigation.
+    // without this, sveltekit dumps focus on body when the viewer closes
     await navigate(
       {
         targetRoute: 'current',

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -99,11 +99,15 @@
   const handleClose = async (assetId: string) => {
     invisible = true;
     assetViewerManager.gridScrollTarget = { at: assetId };
-    await navigate({
-      targetRoute: 'current',
-      assetId: null,
-      assetGridRouteSearchParams: assetViewerManager.gridScrollTarget,
-    });
+    // keepFocus: SvelteKit would otherwise reset focus to body after this navigation.
+    await navigate(
+      {
+        targetRoute: 'current',
+        assetId: null,
+        assetGridRouteSearchParams: assetViewerManager.gridScrollTarget,
+      },
+      { keepFocus: true },
+    );
   };
 
   const handleRemoveFromAlbum = async (assetIds: string[]) => {

--- a/web/src/lib/utils/focus-util.spec.ts
+++ b/web/src/lib/utils/focus-util.spec.ts
@@ -1,0 +1,40 @@
+import { restoreFocusTo } from '$lib/utils/focus-util';
+
+describe('restoreFocusTo', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    element.tabIndex = -1;
+    document.body.append(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('focuses the element when focus is on body', () => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+
+    restoreFocusTo(element);
+
+    expect(document.activeElement).toBe(element);
+  });
+
+  it('does not steal focus from a descendant', () => {
+    const child = document.createElement('div');
+    child.tabIndex = 0;
+    element.append(child);
+    child.focus();
+
+    restoreFocusTo(element);
+
+    expect(document.activeElement).toBe(child);
+  });
+
+  it('does nothing when the element is missing', () => {
+    expect(() => restoreFocusTo(undefined)).not.toThrow();
+    expect(() => restoreFocusTo(null)).not.toThrow();
+  });
+});

--- a/web/src/lib/utils/focus-util.ts
+++ b/web/src/lib/utils/focus-util.ts
@@ -12,6 +12,19 @@ export const setDefaultTabbleOptions = (options: TabbableOpts) => {
 export const getTabbable = (container: Element, includeContainer: boolean = false) =>
   tabbable(container, { ...defaultOpts, includeContainer });
 
+export const restoreFocusTo = (element: HTMLElement | undefined | null) => {
+  if (!element) {
+    return;
+  }
+
+  const active = document.activeElement;
+  if (active === element || (active && element.contains(active))) {
+    return;
+  }
+
+  element.focus({ preventScroll: true });
+};
+
 export const moveFocus = (
   selector: (element: HTMLElement | SVGElement) => boolean,
   direction: 'previous' | 'next',


### PR DESCRIPTION
## Description

Fixes #30911

`#asset-grid` is the timeline scroll container (`overflow-y-auto`, `tabindex="-1"`). PageUp / PageDown / Home / End only work while that node, or something inside it, is focused. On first load we already call `focus({ preventScroll: true })` in `onMount`.

Clicking the viewer's back button focuses that button. The viewer then unmounts, the focused node is gone, and the browser leaves `document.body` focused. The timeline itself never remounts, so the keys stop working until you click the grid (or focus it from the console). Esc does not move focus onto the back button, which is why that path is unaffected.

This change:

- navigates back with `keepFocus: true` so SvelteKit does not also reset focus to `body`
- restores focus to `#asset-grid` after returning to the timeline, unless a thumbnail already has it
- unhides the timeline before focusing, since hidden elements cannot receive focus

## How Has This Been Tested?

- [x] Unit tests for `restoreFocusTo` (`web/src/lib/utils/focus-util.spec.ts`)
- [x] Added an e2e case that opens an asset, clicks `Go back`, then asserts focus is back in `#asset-grid` and PageDown scrolls

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used an LLM while tracing the timeline/viewer focus path and drafting the patch. I reviewed the root cause and the diff.
