### PR TITLE
fix(mobile): show original folder in asset details

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
@@ -20,6 +20,7 @@ class AssetDetails extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final exifInfo = ref.watch(assetExifProvider(asset)).valueOrNull;
+    final originalPath = ref.watch(assetOriginalPathProvider(asset)).valueOrNull;
 
     return Container(
       constraints: BoxConstraints(minHeight: minHeight),
@@ -44,7 +45,7 @@ class AssetDetails extends ConsumerWidget {
             DateTimeDetails(asset: asset, exifInfo: exifInfo),
             PeopleDetails(asset: asset),
             LocationDetails(asset: asset, exifInfo: exifInfo),
-            TechnicalDetails(asset: asset, exifInfo: exifInfo),
+            TechnicalDetails(asset: asset, exifInfo: exifInfo, originalPath: originalPath),
             RatingDetails(exifInfo: exifInfo),
             AppearsInDetails(asset: asset),
             SizedBox(height: context.padding.bottom + 48),

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
@@ -14,8 +14,9 @@ const _kSeparator = '  •  ';
 class TechnicalDetails extends ConsumerWidget {
   final BaseAsset asset;
   final ExifInfo? exifInfo;
+  final String? originalPath;
 
-  const TechnicalDetails({super.key, required this.asset, this.exifInfo});
+  const TechnicalDetails({super.key, required this.asset, this.exifInfo, this.originalPath});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -30,7 +31,7 @@ class TechnicalDetails extends ConsumerWidget {
           title: context.t.details,
           titleStyle: context.textTheme.labelLarge?.copyWith(color: context.colorScheme.onSurfaceSecondary),
         ),
-        _buildFileInfoTile(context, ref, asset, exifInfo),
+        _buildFileInfoTile(context, ref, asset, exifInfo, originalPath),
         if (cameraTitle != null) ...[
           const SizedBox(height: 16),
           SheetTile(
@@ -62,7 +63,13 @@ class TechnicalDetails extends ConsumerWidget {
     );
   }
 
-  Widget _buildFileInfoTile(BuildContext context, WidgetRef ref, BaseAsset asset, ExifInfo? exifInfo) {
+  Widget _buildFileInfoTile(
+    BuildContext context,
+    WidgetRef ref,
+    BaseAsset asset,
+    ExifInfo? exifInfo,
+    String? originalPath,
+  ) {
     final icon = Icon(
       asset.isImage ? Icons.image_outlined : Icons.videocam_outlined,
       size: 24,
@@ -71,29 +78,39 @@ class TechnicalDetails extends ConsumerWidget {
     final subtitle = _getFileInfo(asset, exifInfo);
     final subtitleStyle = context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary);
 
-    if (asset is LocalAsset) {
-      final assetMediaRepository = ref.read(assetMediaRepositoryProvider);
-      return FutureBuilder<String?>(
-        future: assetMediaRepository.getOriginalFilename(asset.id),
-        builder: (context, snapshot) {
-          return SheetTile(
-            title: snapshot.data ?? asset.name,
+    Widget buildFileInfo(String title) {
+      return Column(
+        children: [
+          SheetTile(
+            title: title,
             titleStyle: context.textTheme.labelLarge,
             leading: icon,
             subtitle: subtitle,
             subtitleStyle: subtitleStyle,
-          );
-        },
+          ),
+          if (originalPath != null && originalPath.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            SheetTile(
+              title: context.t.folder,
+              titleStyle: context.textTheme.labelLarge,
+              leading: Icon(Icons.folder_outlined, size: 24, color: context.textTheme.labelLarge?.color),
+              subtitle: originalPath,
+              subtitleStyle: subtitleStyle,
+            ),
+          ],
+        ],
       );
     }
 
-    return SheetTile(
-      title: asset.name,
-      titleStyle: context.textTheme.labelLarge,
-      leading: icon,
-      subtitle: subtitle,
-      subtitleStyle: subtitleStyle,
-    );
+    if (asset is LocalAsset) {
+      final assetMediaRepository = ref.read(assetMediaRepositoryProvider);
+      return FutureBuilder<String?>(
+        future: assetMediaRepository.getOriginalFilename(asset.id),
+        builder: (context, snapshot) => buildFileInfo(snapshot.data ?? asset.name),
+      );
+    }
+
+    return buildFileInfo(asset.name);
   }
 
   static String _getFileInfo(BaseAsset asset, ExifInfo? exifInfo) {

--- a/mobile/lib/providers/infrastructure/asset_viewer/asset.provider.dart
+++ b/mobile/lib/providers/infrastructure/asset_viewer/asset.provider.dart
@@ -2,7 +2,17 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/repositories/asset_api.repository.dart';
 
 final assetExifProvider = FutureProvider.autoDispose.family<ExifInfo?, BaseAsset>((ref, asset) {
   return ref.watch(assetServiceProvider).getExif(asset);
+});
+
+final assetOriginalPathProvider = FutureProvider.autoDispose.family<String?, BaseAsset>((ref, asset) async {
+  final assetId = asset.remoteId;
+  if (assetId == null) {
+    return null;
+  }
+
+  return ref.watch(assetApiRepositoryProvider).getOriginalPath(assetId);
 });

--- a/mobile/lib/repositories/asset_api.repository.dart
+++ b/mobile/lib/repositories/asset_api.repository.dart
@@ -76,6 +76,11 @@ class AssetApiRepository extends ApiRepository {
     return response.originalMimeType.orElse(null);
   }
 
+  Future<String?> getOriginalPath(String assetId) async {
+    final response = await _api.getAssetInfo(assetId);
+    return response?.originalPath;
+  }
+
   Future<void> updateDescription(String assetId, String description) {
     return _api.updateAsset(assetId, UpdateAssetDto(description: Optional.present(description)));
   }

--- a/mobile/test/presentation/widgets/asset_viewer/technical_details_widget_test.dart
+++ b/mobile/test/presentation/widgets/asset_viewer/technical_details_widget_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart';
+
+import '../../../test_utils.dart';
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  testWidgets('shows the original asset path in technical details', (tester) async {
+    const originalPath = '/data/library/2025/holiday/photo.jpg';
+    final asset = TestUtils.createRemoteAsset(id: 'asset-1');
+
+    await tester.pumpConsumerWidget(TechnicalDetails(asset: asset, originalPath: originalPath));
+    await tester.pumpAndSettle();
+
+    expect(find.text(originalPath), findsOneWidget);
+  });
+}

--- a/mobile/test/providers/asset_viewer/asset_original_path_provider_test.dart
+++ b/mobile/test/providers/asset_viewer/asset_original_path_provider_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
+import 'package:immich_mobile/repositories/asset_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils.dart';
+
+class _MockAssetApiRepository extends Mock implements AssetApiRepository {}
+
+void main() {
+  test('loads the original path for a remote asset', () async {
+    final apiRepository = _MockAssetApiRepository();
+    when(() => apiRepository.getOriginalPath('asset-1')).thenAnswer((_) async => '/data/library/photo.jpg');
+    final container = ProviderContainer(overrides: [assetApiRepositoryProvider.overrideWithValue(apiRepository)]);
+    addTearDown(container.dispose);
+
+    final asset = TestUtils.createRemoteAsset(id: 'asset-1');
+
+    expect(await container.read(assetOriginalPathProvider(asset).future), '/data/library/photo.jpg');
+    verify(() => apiRepository.getOriginalPath('asset-1')).called(1);
+  });
+}


### PR DESCRIPTION
## Description

The mobile asset-info panel did not show the server-side folder/path even though the API response already includes `originalPath` and the web asset viewer displays it.

This change:

- fetches `originalPath` on demand for remote assets when details are shown;
- renders a localized `Folder` row beneath the filename;
- leaves the cached mobile asset and Drift schemas unchanged;
- keeps local-only assets unchanged.

Fixes # (no existing upstream issue found for this mobile parity gap)

## How Has This Been Tested?

- [x] `/tmp/flutter-3.44.9/flutter/bin/flutter test` — 1,328 tests passed, 1 skipped
- [x] Asset-viewer and new folder-path tests passed
- [x] Dart code generation completed with no tracked generated-file changes
- [x] `dart format --set-exit-if-changed` passed
- [x] `dart analyze --fatal-infos` passed on changed files

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (no user-facing documentation change is needed)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (No new dependencies.)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] Server `src/services/` repository-usage checklist item is not applicable to this mobile-only change
- [x] Server `src/repositories/` simplicity checklist item is not applicable to this mobile-only change

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was implemented with substantial LLM assistance. I reviewed the implementation, ported it onto the current official `main`, resolved the upstream-base conflict, and verified it with the full mobile test suite, code generation, formatting, and analysis. No `good-first-issue` was used.