### PR TITLE
fix(mobile): aspect ratio change

### DIFF
--- a/mobile/lib/presentation/pages/edit/editor.provider.dart
+++ b/mobile/lib/presentation/pages/edit/editor.provider.dart
@@ -78,11 +78,16 @@ class EditorProvider extends Notifier<EditorState> {
   }
 
   void setAspectRatio(CropAspectRatio preset) {
+    // Expand the initial selection into a square. We have to keep the longest
+    // side the same as before when the user changes the aspect ratio. Otherwise
+    // the selection might shrink
     Rect startingSquare = Rect.fromCenter(
       center: state.crop.center,
       width: state.crop.longestSide,
       height: state.crop.longestSide,
     );
+    // If one side of the square is outside of the image border after the
+    // expansion, move it towards the center of the required amount
     final dx = _shiftIntoBounds(startingSquare.left, startingSquare.right);
     final dy = _shiftIntoBounds(startingSquare.top, startingSquare.bottom);
     startingSquare = startingSquare.shift(Offset(dx, dy));

--- a/mobile/lib/presentation/pages/edit/editor.provider.dart
+++ b/mobile/lib/presentation/pages/edit/editor.provider.dart
@@ -65,8 +65,28 @@ class EditorProvider extends Notifier<EditorState> {
     state = state.copyWith(crop: crop, hasUnsavedEdits: true);
   }
 
+  /// Returns the required shift that has to be done to fit a segment in a given
+  /// constraint
+  double _shiftIntoBounds(double start, double end, {double min = 0.0, double max = 1.0}) {
+    if (start < min) {
+      return min - start;
+    }
+    if (end > max) {
+      return max - end;
+    }
+    return 0.0;
+  }
+
   void setAspectRatio(CropAspectRatio preset) {
-    state = state.copyWith(aspectRatio: preset, hasUnsavedEdits: true);
+    Rect startingSquare = Rect.fromCenter(
+      center: state.crop.center,
+      width: state.crop.longestSide,
+      height: state.crop.longestSide,
+    );
+    final dx = _shiftIntoBounds(startingSquare.left, startingSquare.right);
+    final dy = _shiftIntoBounds(startingSquare.top, startingSquare.bottom);
+    startingSquare = startingSquare.shift(Offset(dx, dy));
+    state = state.copyWith(aspectRatio: preset, hasUnsavedEdits: true, crop: startingSquare);
   }
 
   void resetEdits() {


### PR DESCRIPTION
## Description

I made the smallest possible change to fix the problem that it is shown in the videos below. Previously when the user changes the aspect ratio, the selected crop area shrinks, now it behaves correctly. 

## Before

https://github.com/user-attachments/assets/32fb67b0-f404-4e73-a9aa-d6689321093d

## After

https://github.com/user-attachments/assets/b00f5b92-e772-4cca-8623-c2697da787b6



## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

All the work was done by me, I just used an LLM to suggest a more elegant implementation.

