### PR TITLE
fix(web): do not play memory video if the `MemoryVideoViewer` element is not visible

### DIFF
--- a/web/src/routes/(user)/memories/[id]/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
+++ b/web/src/routes/(user)/memories/[id]/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
@@ -172,7 +172,8 @@
     galleryInView = false;
     // only call play after the first page load. When page first loads the gallery will not be visible
     // and calling play here will result in duplicate invocation.
-    if (!galleryFirstLoad) {
+    // also check if the element is visible to avoid playback in the background
+    if (!galleryFirstLoad && videoPlayer?.checkVisibility()) {
       handlePromiseError(handleAction('galleryOutOfView', 'play'));
     }
     galleryFirstLoad = false;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clicking on a gallery video while having a memory video open can start a double playback in certain situations.
This happens because the code responsible for auto playing/pausing the memory video doesn't check if the element is visible.

To fix it, I used the [`Element.checkVisibility()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) method. This Web API is currently "Newly available", however, I couldn't find a FAQ entry or contributing guideline regarding the usage of newly added Web APIs.

I don't think it would be an issue considering that it is [supported by 93.39% of browser installations according to caniuse](https://caniuse.com/?search=checkVisibility), but wanted to disclose it anyway.

<img width="1377" height="817" alt="image" src="https://github.com/user-attachments/assets/3d60e7a8-03dd-42d8-8b4d-250acf60191f" />


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Open a memory containing a video (memory video starts playing)
2. Scroll down to the gallery (memory video stops playing)
3. Click on a video in the gallery (with my patch the memory video doesn't start automatically, without it, it does)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
This code is 100% hand-made.

