### PR TITLE
chore: lint for unguarded redirect URL reading

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -12,6 +12,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import './lint-env.js';
 
+const ROUTE_CONTINUE = "CallExpression[callee.object.name='Route'][callee.property.name='continue']";
+const NAVIGATION_PARAM_READ = [
+  "CallExpression[callee.property.name='get']",
+  ":matches([arguments.0.value='continue'], [arguments.0.value='previousRoute'],",
+  " [arguments.0.property.name='PREVIOUS_ROUTE'])",
+].join('');
+
 export default typescriptEslint.config(
   ...eslintPluginSvelte.configs.recommended,
   eslintPluginUnicorn.configs.recommended,
@@ -111,6 +118,14 @@ export default typescriptEslint.config(
       ],
 
       curly: 2,
+      // navigation-target query params must be origin-checked at the read site, not at the goto/redirect sink
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: `${NAVIGATION_PARAM_READ}:not(${ROUTE_CONTINUE} > ${NAVIGATION_PARAM_READ})`,
+          message: 'Pass this navigation-target query param through Route.continue() to reject cross-origin values.',
+        },
+      ],
       'unicorn/no-array-reverse': 'off', // toReversed() is not supported in Chrome 109 or Safari 15.4
       'unicorn/no-useless-undefined': 'off',
       'unicorn/prefer-spread': 'off',

--- a/web/src/lib/utils/navigation.ts
+++ b/web/src/lib/utils/navigation.ts
@@ -7,9 +7,6 @@ import { Route } from '$lib/route';
 export type AssetGridRouteSearchParams = {
   at: string | null | undefined;
 };
-export const isExternalUrl = (url: string): boolean => {
-  return new URL(url, location.href).origin !== location.origin;
-};
 
 export const isPhotosRoute = (route?: string | null) => !!route?.startsWith('/(user)/photos/[[assetId=id]]');
 const isSharedLinkSlugRoute = (route?: string | null) => !!route?.startsWith('/(user)/s/[slug]');

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -35,7 +35,6 @@
   import { websocketEvents } from '$lib/stores/websocket';
   import { getPeopleThumbnailUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
-  import { isExternalUrl } from '$lib/utils/navigation';
   import { normalizeSearchString } from '$lib/utils/string-utils';
   import { AssetVisibility, searchPerson, updatePerson, type PersonResponseDto } from '@immich/sdk';
   import {
@@ -92,12 +91,10 @@
 
   onMount(() => {
     const action = $page.url.searchParams.get(QueryParameter.ACTION);
-    const getPreviousRoute = $page.url.searchParams.get(QueryParameter.PREVIOUS_ROUTE);
-    if (getPreviousRoute && !isExternalUrl(getPreviousRoute)) {
-      previousRoute = getPreviousRoute;
-    } else if ($page.params.assetId) {
-      previousRoute = Route.viewPerson(data.person);
-    }
+
+    const fallbackRoute = $page.params.assetId ? Route.viewPerson(data.person) : Route.explore();
+    previousRoute = Route.continue($page.url.searchParams.get(QueryParameter.PREVIOUS_ROUTE), fallbackRoute).toString();
+
     if (action === 'merge') {
       viewMode = PersonPageViewMode.MERGE_PEOPLE;
     }

--- a/web/src/routes/auth/pin-prompt/+page.svelte
+++ b/web/src/routes/auth/pin-prompt/+page.svelte
@@ -30,7 +30,7 @@
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      await goto(Route.continue(data.continueUrl, Route.photos()));
+      await goto(data.continueUrl);
     } catch (error) {
       handleError(error, $t('wrong_pin_code'));
       isBadPinCode = true;

--- a/web/src/routes/auth/pin-prompt/+page.ts
+++ b/web/src/routes/auth/pin-prompt/+page.ts
@@ -16,6 +16,6 @@ export const load = (async ({ url }) => {
       title: $t('pin_verification'),
     },
     hasPinCode: !!pinCode,
-    continueUrl: url.searchParams.get('continue') || Route.locked(),
+    continueUrl: Route.continue(url.searchParams.get('continue'), Route.locked()),
   };
 }) satisfies PageLoad;


### PR DESCRIPTION
## Description

Lint to require explicit handling of redirect URLs in query params.

Either wrap with `Route.continue` or explicitly disable the lint.