### PR TITLE
chore: bump openapi-generator version to v7.25

### DIFF
--- a/open-api/openapitools.json
+++ b/open-api/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.24.0"
+    "version": "7.25.0"
   }
 }


### PR DESCRIPTION
## Description

Bumps `open-api/openapitools.json` to [v7.25.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.25.0).

Regenerated the Dart SDK and diffed against 7.24.0, the change is effectively a no-op for us. All six templates still apply cleanly and remain necessary.

one note-worthy change is that `format: date` fields are no longer converted to UTC before formatting ([#24706](https://github.com/OpenAPITools/openapi-generator/pull/24706)). No behavior change for us since we already use `DateTime.utc` in `mobile/lib/data/server/person.dart`

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
