### PR TITLE
fix(server): point the migrations mise task at sql-tools

### DIFF
--- a/server/mise.toml
+++ b/server/mise.toml
@@ -39,8 +39,9 @@ run = "node ./dist/bin/sync-sql.js"
 run = "node ./dist/bin/sync-open-api.js"
 
 [tasks.migrations]
-run = "node ./dist/bin/migrations.js"
-description = "Run database migration commands (create, generate, run, debug, or query)"
+env._.path = "./node_modules/.bin"
+run = "sql-tools -u ${DB_URL:-postgres://postgres:postgres@localhost:5432/immich} migrations"
+description = "Run database migration commands (create, generate, run, sync-order, verify-order, ...)"
 
 [tasks."schema-drop"]
 run = { task = "migrations query 'DROP schema public cascade; CREATE schema public;'" }


### PR DESCRIPTION
`server/src/bin/migrations.ts` was deleted in #26537 when the migration scripts moved to `@immich/sql-tools`, but the mise task still runs its build output — so `mise //server:migrations` fails with module-not-found, as do `schema-drop` and `schema-reset`, which compose on it.

Points the task at `sql-tools` instead, matching what the `migrations:*` scripts in `server/package.json` have done since that migration. Subcommands pass through, so `mise //server:migrations generate <name>` works as the developer docs describe.