### PR TITLE
feat: verify migration ORDER on every PR

### DIFF
--- a/.github/workflows/migration-order.yml
+++ b/.github/workflows/migration-order.yml
@@ -1,0 +1,54 @@
+name: Migration Order
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  migration-order:
+    name: Verify migration ORDER
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      BASELINE: ${{ github.workspace }}/base/server/src/schema/migrations/ORDER
+    steps:
+      - id: token
+        uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
+        with:
+          client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
+          permission-contents: read
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Checkout base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.BASE_SHA }}
+          path: base
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Setup Mise
+        uses: immich-app/devtools/actions/use-mise@06a9ef925332c91be647d6256642b86b398592c8 # use-mise-action-v3.2.1
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+
+      - name: Install dependencies
+        run: mise //server:install
+
+      - name: Verify migration ORDER
+        run: mise //server:migrations verify-order --append-only-from "${BASELINE}"


### PR DESCRIPTION
Verifies the `ORDER` manifest matches the migrations on disk, and only grew relative to the PR's base — catching a manifest that was not synced after moving a migration in, or a sloppy resolution of the conflict the manifest exists to create.

The base state comes from a second `actions/checkout` into `base/`, so a base that cannot be read fails the job rather than silently skipping the append-only assertion.