### PR TITLE
fix(web): keep json response validation when overriding fetch

### DIFF
--- a/web/src/lib/utils/server.ts
+++ b/web/src/lib/utils/server.ts
@@ -1,4 +1,4 @@
-import { defaults } from '@immich/sdk';
+import { setFetch } from '@immich/sdk';
 import { memoize } from 'lodash-es';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
@@ -11,7 +11,7 @@ async function _init(fetch: Fetch) {
   // set event.fetch on the fetch-client used by @immich/sdk
   // https://kit.svelte.dev/docs/load#making-fetch-requests
   // https://github.com/oazapfts/oazapfts/blob/main/README.md#fetch-options
-  defaults.fetch = fetch;
+  setFetch(fetch);
   await initLanguage();
   await serverConfigManager.init();
   await authManager.load();


### PR DESCRIPTION
`defaults.fetch = fetch` replaces the transport wholesale, dropping the validation added in #31006. `setFetch` composes instead, so SvelteKit's `event.fetch` still issues the request.
