### PR TITLE
feat: split release preparation from drafting

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,123 @@
+name: Draft new release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      rc: ${{ steps.version.outputs.rc }}
+      sha: ${{ steps.version.outputs.sha }}
+    permissions: {}
+    steps:
+      - id: token
+        uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
+        with:
+          client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
+          permission-contents: write
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.token.outputs.token }}
+          persist-credentials: true
+
+      - id: version
+        run: |
+          version="v$(jq -r '.version' package.json)"
+          echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          if [[ "${version}" =~ -rc\.[0-9]+$ ]]; then
+            echo "rc=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rc=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push tag
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+  build_mobile:
+    uses: ./.github/workflows/build-mobile.yml
+    needs: tag
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      PUSH_O_MATIC_APP_CLIENT_ID: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
+      PUSH_O_MATIC_APP_KEY: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
+      KEY_JKS: ${{ secrets.KEY_JKS }}
+      ALIAS: ${{ secrets.ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+      # iOS secrets
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      IOS_CERTIFICATE_P12: ${{ secrets.IOS_CERTIFICATE_P12 }}
+      IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+      FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
+
+    with:
+      ref: ${{ needs.tag.outputs.sha }}
+      environment: production
+
+  draft_release:
+    runs-on: ubuntu-latest
+    needs: [tag, build_mobile]
+    permissions: {}
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
+          permission-contents: write
+          permission-actions: read
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Download APK
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-apk-signed
+          github-token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.tag.outputs.version }}
+          PRERELEASE: ${{ needs.tag.outputs.rc }}
+        run: |
+          gh release create "${TAG}" \
+            --repo "${REPO}" \
+            --draft \
+            --verify-tag \
+            --prerelease="${PRERELEASE}" \
+            --notes-file misc/release/notes.tmpl \
+            --generate-notes \
+            docker/docker-compose.yml \
+            docker/docker-compose.rootless.yml \
+            docker/example.env \
+            docker/hwaccel.ml.yml \
+            docker/hwaccel.transcoding.yml \
+            docker/prometheus.yml \
+            *.apk

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -44,10 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [merge_translations]
     outputs:
-      ref: ${{ steps.push-tag.outputs.commit_long_sha }}
       version: ${{ steps.output.outputs.version }}
-      rc: ${{ steps.output.outputs.rc }}
-    permissions: {} # No job-level permissions are needed because it uses the app-token
+    permissions: {}
     steps:
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
@@ -78,94 +76,14 @@ jobs:
         run: mise //:release --type "${RELEASE_TYPE}"
 
       - id: output
-        run: |
-          echo "version=$IMMICH_VERSION" >> $GITHUB_OUTPUT
-          if [[ "$IMMICH_VERSION" =~ -rc\.[0-9]+$ ]]; then
-            echo "rc=true" >> $GITHUB_OUTPUT
-          else
-            echo "rc=false" >> $GITHUB_OUTPUT
-          fi
+        run: echo "version=$IMMICH_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Commit and tag
-        id: push-tag
-        uses: EndBug/add-and-commit@cc9c08ba6c8df3b93a8f2db63e89b98368ae2ae8 # v11.1.1
-        with:
-          default_author: github_actions
-          message: 'chore: version ${{ steps.output.outputs.version }}'
-          tag: ${{ steps.output.outputs.version }}
-          push: true
-
-  build_mobile:
-    uses: ./.github/workflows/build-mobile.yml
-    needs: bump_version
-    permissions:
-      contents: read
-      pull-requests: write
-    secrets:
-      PUSH_O_MATIC_APP_CLIENT_ID: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
-      PUSH_O_MATIC_APP_KEY: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
-      KEY_JKS: ${{ secrets.KEY_JKS }}
-      ALIAS: ${{ secrets.ALIAS }}
-      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
-      # iOS secrets
-      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
-      IOS_CERTIFICATE_P12: ${{ secrets.IOS_CERTIFICATE_P12 }}
-      IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
-      FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
-
-    with:
-      ref: ${{ needs.bump_version.outputs.ref }}
-      environment: production
-
-  prepare_release:
-    runs-on: ubuntu-latest
-    needs: [build_mobile, bump_version]
-    permissions:
-      actions: read # To download the app artifact
-      # No content permissions are needed because it uses the app-token
-    steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
-          private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
-          permission-contents: write
-          permission-actions: read
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
-
-      - name: Download APK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-apk-signed
-          github-token: ${{ steps.generate-token.outputs.token }}
-
-      - name: Create draft release
+      - name: Commit
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ needs.bump_version.outputs.version }}
-          PRERELEASE: ${{ needs.bump_version.outputs.rc }}
+          VERSION: ${{ steps.output.outputs.version }}
         run: |
-          gh release create "${TAG}" \
-            --repo "${REPO}" \
-            --draft \
-            --verify-tag \
-            --prerelease="${PRERELEASE}" \
-            --notes-file misc/release/notes.tmpl \
-            --generate-notes \
-            docker/docker-compose.yml \
-            docker/docker-compose.rootless.yml \
-            docker/example.env \
-            docker/hwaccel.ml.yml \
-            docker/hwaccel.transcoding.yml \
-            docker/prometheus.yml \
-            *.apk
+          git config user.name 'immich-push-o-matic[bot]'
+          git config user.email '179150890+immich-push-o-matic[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "chore: version ${VERSION}"
+          git push


### PR DESCRIPTION
Splits the release flow into two dispatches: `prepare-release` merges translations and bumps the version, then `draft-release` tags HEAD, builds mobile and creates the draft release. Publishing the draft is unchanged.

`draft-release` takes the version from `package.json` rather than an input, and tags whatever HEAD is when it runs — so anything merged between the two dispatches ships in the release.

Also drops `EndBug/add-and-commit` for plain git (version commits are now authored by push-o-matic rather than github-actions), and installs uv via mise instead of a separate setup action.