### PR TITLE
feat: only move floating docker tags for the newest release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ jobs:
       contents: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      highest-overall: ${{ steps.scope.outputs.highest-overall }}
+      highest-in-line: ${{ steps.scope.outputs.highest-in-line }}
     steps:
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
@@ -49,6 +51,24 @@ jobs:
           force-filters: |
             - '.github/workflows/docker.yml'
           force-events: 'workflow_dispatch,release'
+
+      - name: Determine release scope
+        id: scope
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          overall=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+
+          releases=$(gh api "repos/${REPO}/releases" --paginate --slurp | jq 'flatten | map(select(.draft | not))')
+          in_line=$(jq -r --argjson pre "${PRERELEASE}" '.[] | select(.prerelease == $pre) | .tag_name' <<< "${releases}" \
+            | grep -E "^${TAG%%.*}\." | sort --version-sort | tail -1)
+
+          echo "highest-overall=$([[ "${TAG}" == "${overall}" ]] && echo true || echo false)" | tee -a "$GITHUB_OUTPUT"
+          echo "highest-in-line=$([[ "${TAG}" == "${in_line}" ]] && echo true || echo false)" | tee -a "$GITHUB_OUTPUT"
 
   retag_ml:
     name: Re-Tag ML
@@ -155,9 +175,9 @@ jobs:
         type=ref,event=pr
         type=sha,format=long,prefix=commit-
         type=semver,pattern={{version}},prefix=v
-        type=semver,pattern={{major}},prefix=v
-        type=match,pattern=v(\d+),group=1,prefix=v,suffix=-rc,enable=${{ github.event.release.prerelease == true }}
-        type=raw,value=release,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+        type=semver,pattern={{major}},prefix=v,enable=${{ needs.pre-job.outputs.highest-in-line == 'true' }}
+        type=match,pattern=v(\d+),group=1,prefix=v,suffix=-rc,enable=${{ github.event.release.prerelease == true && needs.pre-job.outputs.highest-in-line == 'true' }}
+        type=raw,value=release,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false && needs.pre-job.outputs.highest-overall == 'true' }}
       build-args: |
         DEVICE=${{ matrix.device }}
 
@@ -180,7 +200,7 @@ jobs:
 
   mirror:
     name: Mirror to Docker Hub
-    needs: [machine-learning, server]
+    needs: [pre-job, machine-learning, server]
     if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
     permissions:
       packages: read


### PR DESCRIPTION
`release` now moves only for the newest release overall, and `v{major}` / `v{major}-rc` only for the newest of that major and stability.