### PR TITLE
feat: cut releases from release branches

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -38,13 +38,16 @@ on:
         required: true
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}
+
+env:
+  DEPLOY: ${{ inputs.environment == 'production' || github.ref == 'refs/heads/main' }}
 
 jobs:
   pre-job:
@@ -143,10 +146,9 @@ jobs:
           ALIAS: ${{ secrets.ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
-          IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ $IS_MAIN == 'true' ]]; then
+          if [[ $DEPLOY == 'true' ]]; then
             flutter build apk --release
             flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
           else
@@ -229,7 +231,7 @@ jobs:
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+          bundler-cache: true # zizmor: ignore[cache-poisoning] release branches cannot read caches written by pull requests
           working-directory: ./mobile/ios
 
       - name: Install dependencies
@@ -288,21 +290,16 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           ENVIRONMENT: ${{ inputs.environment || 'development' }}
-          GITHUB_REF: ${{ github.ref }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 6
         working-directory: ./mobile/ios
         run: |
-          # Only upload to TestFlight on main branch
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
-            if [[ "$ENVIRONMENT" == "development" ]]; then
-              bundle exec fastlane gha_testflight_dev
-            else
-              bundle exec fastlane gha_release_prod
-            fi
-          else
-            # Build only, no TestFlight upload for non-main branches
+          if [[ "$DEPLOY" != 'true' ]]; then
             bundle exec fastlane gha_build_only
+          elif [[ "$ENVIRONMENT" == "development" ]]; then
+            bundle exec fastlane gha_testflight_dev
+          else
+            bundle exec fastlane gha_release_prod
           fi
 
       - name: Clean up keychain

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,7 +1,7 @@
 name: CLI Build
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
     paths:
       - 'packages/cli/**'
       - '.github/workflows/cli.yml'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,7 +1,7 @@
 name: Docs build
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -18,6 +18,18 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
     permissions: {}
     steps:
+      - name: Check this is a release branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          case "${BRANCH}" in
+            release/*) ;;
+            *)
+              echo "::error::releases are drafted from a release branch, not ${BRANCH}"
+              exit 1
+              ;;
+          esac
+
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
         with:

--- a/.github/workflows/migration-order.yml
+++ b/.github/workflows/migration-order.yml
@@ -3,7 +3,7 @@ name: Migration Order
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   migration-order:
     name: Verify migration ORDER
+    if: ${{ !github.event.created }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,15 +6,12 @@ on:
       releaseType:
         description: 'Release type'
         required: true
-        default: 'false'
+        default: 'preminor'
         type: choice
         options:
-          - 'false'
-          - minor
-          - patch
           - premajor
           - preminor
-          - prepatch
+          - patch
           - prerelease
           - release
       skipTranslations:
@@ -32,7 +29,7 @@ jobs:
   merge_translations:
     uses: ./.github/workflows/merge-translations.yml
     with:
-      skip: ${{ inputs.skipTranslations }}
+      skip: ${{ inputs.skipTranslations || github.ref_name != 'main' }}
     permissions:
       pull-requests: write
     secrets:
@@ -47,6 +44,20 @@ jobs:
       version: ${{ steps.output.outputs.version }}
     permissions: {}
     steps:
+      - name: Check the release type suits this branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RELEASE_TYPE: ${{ inputs.releaseType }}
+        run: |
+          case "${BRANCH}:${RELEASE_TYPE}" in
+            main:premajor | main:preminor) ;;
+            release/*:patch | release/*:prerelease | release/*:release) ;;
+            *)
+              echo "::error::${RELEASE_TYPE} cannot be released from ${BRANCH}"
+              exit 1
+              ;;
+          esac
+
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
         with:
@@ -59,7 +70,6 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
           persist-credentials: true
-          ref: main
 
       - name: Setup Mise
         uses: immich-app/devtools/actions/use-mise@06a9ef925332c91be647d6256642b86b398592c8 # use-mise-action-v3.2.1
@@ -87,3 +97,11 @@ jobs:
           git add -A
           git commit -m "chore: version ${VERSION}"
           git push
+
+      - name: Cut the release branch
+        if: ${{ github.ref_name == 'main' }}
+        env:
+          VERSION: ${{ steps.output.outputs.version }}
+        run: |
+          line=$(sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/' <<< "${VERSION}")
+          git push origin "HEAD:refs/heads/release/${line}"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/packages/scripts/src/commands/release.spec.ts
+++ b/packages/scripts/src/commands/release.spec.ts
@@ -33,6 +33,13 @@ describe(getNewVersion.name, () => {
         ],
       },
       {
+        name: 'cutting the next line while on a prerelease',
+        items: [
+          ['preminor', '3.3.0-rc.0', '3.4.0-rc.0'],
+          ['premajor', '3.3.0-rc.0', '4.0.0-rc.0'],
+        ],
+      },
+      {
         name: 'premajor',
         items: [
           ['premajor', '2.7.5', '3.0.0-rc.0'],
@@ -58,8 +65,6 @@ describe(getNewVersion.name, () => {
         ['patch', 'v3.0.0-rc.0'],
         ['prepatch', 'v3.0.0-rc.0'],
         ['minor', 'v3.0.0-rc.0'],
-        ['preminor', 'v3.0.0-rc.0'],
-        ['premajor', 'v3.0.0-rc.0'],
         ['prerelease', 'v3.0.0'],
         ['release', 'v3.0.0'],
       ])('should not allow a $0 on $1', (type, version) => {

--- a/packages/scripts/src/commands/release.ts
+++ b/packages/scripts/src/commands/release.ts
@@ -123,12 +123,17 @@ export const getNewVersion = (versionRaw: string, type: string) => {
   switch (type) {
     case 'patch':
     case 'prepatch':
-    case 'minor':
-    case 'preminor':
-    case 'premajor': {
+    case 'minor': {
       newVersionRaw = inc(version, type);
       // can only use while not in a prerelease
       valid = !isPrerelease(version);
+      break;
+    }
+
+    case 'preminor':
+    case 'premajor': {
+      // cutting the next release line is allowed while main sits on a prerelease
+      newVersionRaw = inc(version, type);
       break;
     }
 


### PR DESCRIPTION
Cutting a release now happens on a `release/vX.Y` branch instead of on main, so a
patch release no longer freezes main.

`prepare-release` takes `premajor`/`preminor` on main — bumping main to the next
`-rc.0` and pushing the new `release/vX.Y` — and `patch`/`prerelease`/`release` on
a release branch. Any other combination is refused, and `draft-release` only runs
on a release branch.

Mobile store uploads and the per-ABI APKs were gated on being on main, which
silently goes false once a release is drafted from a release branch. They now key
off the `production` environment that `draft-release` already passes.

CI that ran on pushes to main now also runs on pushes to `release/*`.

Depends on immich-app/core-infra-tf#50, which protects the branches this starts
creating.