### PR TITLE
feat: backport pull requests to release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,47 @@
+name: Backport
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] no pull request code is checked out or executed
+    types: [closed, labeled]
+
+permissions: {}
+
+jobs:
+  backport:
+    name: Backport pull request
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - id: token
+        uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
+        with:
+          client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.token.outputs.token }}
+          persist-credentials: true
+
+      - name: Create backport pull requests
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          label_pattern: '^backport:(release/.+)$'
+          add_team_reviewers: team
+          auto_merge_enabled: true
+          auto_merge_method: squash
+          comment_style: summary
+          copy_all_reviewers: true
+          copy_labels_pattern: '^changelog:'
+          experimental: |
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }
+          pull_title: '${pull_title}'
+          git_committer_name: 'immich-push-o-matic[bot]'
+          git_committer_email: '179150890+immich-push-o-matic[bot]@users.noreply.github.com'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -54,6 +54,28 @@ jobs:
             echo "rc=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: main
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Setup Mise
+        uses: immich-app/devtools/actions/use-mise@06a9ef925332c91be647d6256642b86b398592c8 # use-mise-action-v3.2.1
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+
+      - name: Install dependencies
+        run: mise //server:install
+
+      - name: Verify the release line does not diverge from main
+        env:
+          MAIN_MIGRATIONS: ${{ github.workspace }}/main/server/src/schema/migrations
+          ORDER: ${{ github.workspace }}/server/src/schema/migrations/ORDER
+        run: mise //server:migrations verify-order --source-folder "${MAIN_MIGRATIONS}" --append-only-from "${ORDER}"
+
       - name: Push tag
         env:
           TAG: ${{ steps.version.outputs.version }}

--- a/.github/workflows/migration-order.yml
+++ b/.github/workflows/migration-order.yml
@@ -21,6 +21,8 @@ jobs:
     env:
       BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       BASELINE: ${{ github.workspace }}/base/server/src/schema/migrations/ORDER
+      MAIN_MIGRATIONS: ${{ github.workspace }}/main/server/src/schema/migrations
+      ORDER: ${{ github.workspace }}/server/src/schema/migrations/ORDER
     steps:
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@1af396ae134e4bc3b63d947e672bc68bf4ff9dc5 # create-workflow-token-action-v3.0.0
@@ -53,3 +55,16 @@ jobs:
 
       - name: Verify migration ORDER
         run: mise //server:migrations verify-order --append-only-from "${BASELINE}"
+
+      - name: Checkout main
+        if: ${{ startsWith(github.base_ref, 'release/') || startsWith(github.ref_name, 'release/') }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: main
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Verify the release line does not diverge from main
+        if: ${{ startsWith(github.base_ref, 'release/') || startsWith(github.ref_name, 'release/') }}
+        run: mise //server:migrations verify-order --source-folder "${MAIN_MIGRATIONS}" --append-only-from "${ORDER}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -64,6 +64,7 @@ jobs:
           client-id: ${{ secrets.PUSH_O_MATIC_APP_CLIENT_ID }}
           private-key: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
           permission-contents: write
+          permission-issues: write
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -101,7 +102,11 @@ jobs:
       - name: Cut the release branch
         if: ${{ github.ref_name == 'main' }}
         env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           VERSION: ${{ steps.output.outputs.version }}
         run: |
           line=$(sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/' <<< "${VERSION}")
           git push origin "HEAD:refs/heads/release/${line}"
+          gh label create "backport:release/${line}" --force \
+            --description "Backport this pull request to release/${line}" \
+            --color 5319e7


### PR DESCRIPTION
A pull request merged to main with a `backport:release/vX.Y` label is cherry-picked
onto that release branch as a new pull request. `prepare-release` creates the label
when it cuts the branch.

Migrations are the one thing that cannot be backported freely: a release must only
ever run a prefix of main's migrations, or upgrading past it replays them out of
order. Pull requests targeting a release branch and `draft-release` both verify
that the branch's `ORDER` is a prefix of main's, so a backport that skips an
earlier migration — or adds one main doesn't have — fails before it can ship.
