### PR TITLE
fix(server): store null instead of empty string for user oauthId

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -140,7 +140,7 @@ export type UserAdmin = User & {
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
-  oauthId: string;
+  oauthId: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;
   status: UserStatus;

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -33,7 +33,7 @@ const SyncAuthUserV1Schema = SyncUserV1Schema.merge(
   z.object({
     isAdmin: z.boolean().describe('User is admin'),
     pinCode: z.string().nullable().describe('User pin code'),
-    oauthId: z.string().describe('User OAuth ID'),
+    oauthId: z.string().nullable().describe('User OAuth ID'),
     storageLabel: z.string().nullable().describe('User storage label'),
     quotaSizeInBytes: z.int().nullable().describe('Quota size in bytes'),
     quotaUsageInBytes: z.int().describe('Quota usage in bytes'),

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -127,7 +127,7 @@ const UserAdminResponseSchema = UserResponseSchema.extend({
   createdAt: isoDatetimeToDate.describe('Creation date'),
   deletedAt: isoDatetimeToDate.nullable().describe('Deletion date'),
   updatedAt: isoDatetimeToDate.describe('Last update date'),
-  oauthId: z.string().describe('OAuth ID'),
+  oauthId: z.string().nullable().describe('OAuth ID'),
   quotaSizeInBytes: z.int().min(0).nullable().describe('Storage quota in bytes'),
   quotaUsageInBytes: z.int().min(0).nullable().describe('Storage usage in bytes'),
   status: UserStatusSchema,

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -130,7 +130,7 @@ type UserEvent = {
   isAdmin: boolean;
   shouldChangePassword: boolean;
   avatarColor: UserAvatarColor | null;
-  oauthId: string;
+  oauthId: string | null;
   storageLabel: string | null;
   quotaSizeInBytes: number | null;
   quotaUsageInBytes: number;

--- a/server/src/schema/migrations/1787759834000-ConvertUserOauthIdEmptyStringToNull.ts
+++ b/server/src/schema/migrations/1787759834000-ConvertUserOauthIdEmptyStringToNull.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" DROP NOT NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT NULL;`.execute(db);
+  await sql`UPDATE "user" SET "oauthId" = NULL WHERE "oauthId" = '';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE "user" SET "oauthId" = '' WHERE "oauthId" IS NULL;`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET DEFAULT '';`.execute(db);
+  await sql`ALTER TABLE "user" ALTER COLUMN "oauthId" SET NOT NULL;`.execute(db);
+}

--- a/server/src/schema/migrations/ORDER
+++ b/server/src/schema/migrations/ORDER
@@ -94,3 +94,4 @@
 1786972746372-AssetOcrSyncReset
 1787148183729-ClusterGroups
 1787148183730-DeleteMismatchedMemoryAssets
+1787759834000-ConvertUserOauthIdEmptyStringToNull

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -57,8 +57,8 @@ export class UserTable {
   @DeleteDateColumn()
   deletedAt!: Timestamp | null;
 
-  @Column({ default: '' })
-  oauthId!: Generated<string>;
+  @Column({ nullable: true, default: null })
+  oauthId!: Generated<string | null>;
 
   @UpdateDateColumn()
   updatedAt!: Generated<Timestamp>;

--- a/server/src/services/auth-admin.service.ts
+++ b/server/src/services/auth-admin.service.ts
@@ -5,7 +5,6 @@ import { BaseService } from 'src/services/base.service';
 @Injectable()
 export class AuthAdminService extends BaseService {
   async unlinkAll(_auth: AuthDto) {
-    // TODO replace '' with null
-    await this.userRepository.updateAll({ oauthId: '' });
+    await this.userRepository.updateAll({ oauthId: null });
   }
 }

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -1046,7 +1046,7 @@ describe(AuthService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
         profile: OAuthProfileFactory.create({
-          sub: user.oauthId,
+          sub: 'oauth-id',
           email: user.email,
           picture: 'https://auth.immich.cloud/profiles/1.jpg',
         }),
@@ -1169,7 +1169,7 @@ describe(AuthService.name, () => {
 
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
-        profile: OAuthProfileFactory.create({ sub: user.oauthId, immich_role: 'admin' }),
+        profile: OAuthProfileFactory.create({ sub: 'oauth-id', immich_role: 'admin' }),
       });
       mocks.user.getByOAuthId.mockResolvedValue(user);
       mocks.user.update.mockResolvedValue({ ...user, isAdmin: true });
@@ -1189,7 +1189,7 @@ describe(AuthService.name, () => {
 
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
-        profile: OAuthProfileFactory.create({ sub: user.oauthId, immich_role: ['user'] }),
+        profile: OAuthProfileFactory.create({ sub: 'oauth-id', immich_role: ['user'] }),
       });
       mocks.user.getByOAuthId.mockResolvedValue(user);
       mocks.user.update.mockResolvedValue({ ...user, isAdmin: false });
@@ -1209,7 +1209,7 @@ describe(AuthService.name, () => {
 
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.oauthEnabled);
       mocks.oauth.getProfileAndOAuthSid.mockResolvedValue({
-        profile: OAuthProfileFactory.create({ sub: user.oauthId }),
+        profile: OAuthProfileFactory.create({ sub: 'oauth-id' }),
       });
       mocks.user.getByOAuthId.mockResolvedValue(user);
       mocks.session.create.mockResolvedValue(SessionFactory.create());
@@ -1318,7 +1318,7 @@ describe(AuthService.name, () => {
 
       await sut.unlink(auth);
 
-      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: '' });
+      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: null });
     });
 
     it('should unlink an account and remove the OAuth data from the session', async () => {
@@ -1333,7 +1333,7 @@ describe(AuthService.name, () => {
       await sut.unlink(auth);
 
       expect(mocks.session.update).toHaveBeenCalledWith(session.id, { oauthSid: null, oauthBearerToken: null });
-      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: '' });
+      expect(mocks.user.update).toHaveBeenCalledWith(auth.user.id, { oauthId: null });
     });
   });
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -437,7 +437,7 @@ export class AuthService extends BaseService {
       await this.sessionRepository.update(auth.session.id, { oauthSid: null, oauthBearerToken: null });
     }
 
-    const user = await this.userRepository.update(auth.user.id, { oauthId: '' });
+    const user = await this.userRepository.update(auth.user.id, { oauthId: null });
     return mapUserAdmin(user);
   }
 

--- a/server/test/medium/specs/services/auth-admin.service.spec.ts
+++ b/server/test/medium/specs/services/auth-admin.service.spec.ts
@@ -31,7 +31,7 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
 
@@ -43,7 +43,7 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
 
@@ -56,10 +56,10 @@ describe(AuthAdminService.name, () => {
 
       await expect(sut.unlinkAll(auth)).resolves.toBeUndefined();
       await expect(userRepo.get(user1.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
       await expect(userRepo.get(user2.id, { withDeleted: true })).resolves.toEqual(
-        expect.objectContaining({ oauthId: '' }),
+        expect.objectContaining({ oauthId: null }),
       );
     });
   });


### PR DESCRIPTION
## Description

`user."oauthId"` is declared with `default: ''` and NOT NULL, and every code path that clears an OAuth link writes `''`. Empty string carries no meaning distinct from NULL here (nothing reads `data.cause`-style empty values), and the project's ongoing null-vs-empty-string initiative (#28832 family) prefers NULL.

This change makes the column nullable with a NULL default, converts existing `''` rows to NULL via migration, updates the DTO schemas to `nullable()`, and switches the two unlink code paths (`auth.service.ts`, `auth-admin.service.ts`) to write NULL.

Fixes #30157 (related to the #28832 initiative)

## How Has This Been Tested?

- [x] `server` unit tests for the touched services pass locally
- [x] Type check (`tsc`) passes; DTO schema changes validated by existing spec suites

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI assistant helped draft the migration and description under my direction; I reviewed every changed line, ran the tests myself, and take full responsibility for the change.