### PR TITLE
fix: save user_version in migration transaction

### DIFF
--- a/mobile/lib/data/db/main/database.dart
+++ b/mobile/lib/data/db/main/database.dart
@@ -170,9 +170,15 @@ class Drift extends $Drift {
       await customStatement('PRAGMA foreign_keys = OFF');
 
       try {
-        await transaction(
-          () => m.runMigrationSteps(
-            from: from,
+        await transaction(() async {
+          // Re-read the current version inside the transaction to avoid race between different connections.
+          final current = (await customSelect('PRAGMA user_version').getSingle()).read<int>('user_version');
+          if (current >= to) {
+            return;
+          }
+
+          await m.runMigrationSteps(
+            from: current,
             to: to,
             steps: migrationSteps(
               from1To2: (m, v2) async {
@@ -360,8 +366,13 @@ class Drift extends $Drift {
                 await m.createIndex(v31.idxRemoteAssetUploaded);
               },
             ),
-          ),
-        );
+          );
+
+          // This prevents a drift between the current connection and other connections in the pool,
+          // which is waiting for the transaction to finish. Drift updates this outside of the transaction,
+          // so doing it inside the transaction ensures that all connections are in sync.
+          await customStatement('PRAGMA user_version = $to');
+        });
 
         if (kDebugMode) {
           // Fail if the migration broke foreign keys

--- a/mobile/test/drift/main/concurrent_migration_test.dart
+++ b/mobile/test/drift/main/concurrent_migration_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/data/db/main/database.dart';
+
+import 'generated/schema_v22.dart' as v22;
+
+void main() {
+  driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+
+  late Directory dir;
+  late File file;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('immich_migration_test');
+    file = File('${dir.path}/db.sqlite');
+
+    final old = v22.DatabaseAtV22(NativeDatabase(file));
+    await old.customStatement('PRAGMA journal_mode = WAL');
+    await old.localAssetEntity.insertOne(
+      v22.LocalAssetEntityCompanion.insert(id: 'asset', name: 'asset.mp4', type: 0, durationInSeconds: const .new(5)),
+    );
+    await old.close();
+  });
+
+  tearDown(() async => await dir.delete(recursive: true));
+
+  Drift open() =>
+      Drift(NativeDatabase.createInBackground(file, setup: (db) => db.execute('PRAGMA busy_timeout = 30000;')));
+
+  test('two isolates migrating the same database concurrently both succeed', () async {
+    final first = open();
+    final second = open();
+    addTearDown(() async {
+      await first.close();
+      await second.close();
+    });
+
+    // Migrations are executed lazily; The below forces both instances to run the migration concurrently
+    await Future.wait([first.customSelect('SELECT 1').get(), second.customSelect('SELECT 1').get()]);
+
+    for (final db in [first, second]) {
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.read<int>('user_version'), db.schemaVersion);
+    }
+  });
+}


### PR DESCRIPTION
Updates the migration to also persist the `user_version` within the same transaction. Drift writes it again after the [transaction is committed](https://github.com/simolus3/drift/blob/9e4ccdc58a94914fccac6ee8570f89f16e746d3e/drift/lib/src/runtime/executor/helpers/engines.dart#L556-L563) but is harmless as it is the same version
