### PR TITLE
fix(web): keep people timeline visible after closing asset viewer

### DIFF
--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -148,6 +148,47 @@ test.describe('Timeline', () => {
       await thumbnailUtils.expectTopIsTimelineTop(page, assets.at(-1 - 15)!.id);
     });
   });
+  test.describe('/people/:id', () => {
+    const personId = faker.string.uuid();
+
+    test.beforeEach(async ({ context }) => {
+      await context.route(new RegExp(`/api/people/${personId}/statistics$`), (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          json: { assets: assets.length },
+        }),
+      );
+      await context.route(new RegExp(`/api/people/${personId}$`), (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          json: {
+            id: personId,
+            name: 'Test Person',
+            birthDate: null,
+            isHidden: false,
+            thumbnailPath: '',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        }),
+      );
+    });
+
+    test('Open person asset, close viewer, restore visible timeline', async ({ page }) => {
+      const asset = assets[0];
+      await page.goto(`/people/${personId}`);
+      await timelineUtils.waitForTimelineLoad(page);
+      await thumbnailUtils.clickAssetId(page, asset.id);
+      await assetViewerUtils.waitForViewerLoad(page, asset);
+
+      await page.getByLabel('Go back').click();
+      await page.waitForURL(`**/people/${personId}?at=${asset.id}`);
+
+      await expect(page.locator('#virtual-timeline')).not.toHaveClass(/invisible/);
+      await thumbnailUtils.expectInViewport(page, asset.id);
+    });
+  });
   test.describe('keyboard', () => {
     /**
      * This text tests keyboard nativation, and also ensures that the scroll-to-asset behavior

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -209,6 +209,13 @@
       }
     }
     const scrollTarget = assetViewerManager.gridScrollTarget?.at;
+
+    // Do not keep the grid hidden while the scroll target is loaded. Route-specific
+    // timelines can be reinitialized during navigation, so resolving the target may
+    // take longer than the navigation itself (or be canceled by another update).
+    // The grid must remain usable even if restoring its exact position is delayed.
+    invisible = false;
+
     const scrolled = scrollTarget ? await scrollAndLoadAsset(scrollTarget) : false;
     if (!scrolled) {
       // if the asset is not found, scroll to the top
@@ -217,7 +224,6 @@
       await tick();
       focusAsset(scrollTarget);
     }
-    invisible = false;
   };
 
   // note: only modified once in afterNavigate()


### PR DESCRIPTION
## Description

Closing an asset viewer from a People timeline sets the timeline to invisible while its scroll target is restored. In Chrome, route-specific timeline reinitialization can delay or cancel that asynchronous restoration, leaving an otherwise initialized grid hidden indefinitely.

Make the grid visible before awaiting scroll restoration. Scrolling and focus restoration remain best-effort, and a regression test covers closing a person asset and restoring the visible timeline at the selected asset.

Fixes #30126

## How Has This Been Tested?

- [x] Reproduced on the v3.1.0 demo in Chrome using the URL from #30126: the route returned to `/people/:id?at=:assetId`, but `#virtual-timeline` remained `invisible`.
- [x] Ran the patched v3.1.0 web app in Chrome against the demo backend: the same in-app Back action restored a visible People grid with the selected asset in view.
- [x] `pnpm --filter immich-web check:typescript`
- [x] `pnpm --filter immich-e2e check`
- [x] Targeted Prettier checks and E2E ESLint

The local Playwright browser run was blocked by the host's macOS browser sandbox. Local `check:svelte` is also blocked on current `main` by an unrelated `hls.js` version mismatch in `VideoNativeViewer.svelte`; it reports no diagnostics in the changed timeline file.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not included; this is a visibility and navigation-state change covered by the reproduction above.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (not applicable; no service changes)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) (not applicable; no repository changes)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Codex was used extensively to reproduce the issue in Chrome, inspect the timeline state, identify the visibility/restoration coupling, implement the fix and regression test, run the checks listed above, and draft this pull request. The LLM involvement is disclosed in full in accordance with CONTRIBUTING.md.
