### PR TITLE
fix(server): recover the Redis subscriber after a silent disconnect

### DIFF
--- a/server/src/middleware/websocket.adapter.spec.ts
+++ b/server/src/middleware/websocket.adapter.spec.ts
@@ -1,0 +1,128 @@
+import { monitorRedisSubscriber } from 'src/middleware/websocket.adapter';
+
+const options = { intervalMs: 30_000, failuresBeforeReconnect: 2 };
+
+const newClient = () => ({
+  status: 'ready',
+  ping: vi.fn().mockResolvedValue('PONG'),
+  disconnect: vi.fn(),
+});
+
+const newLogger = () => ({ warn: vi.fn() });
+
+describe('monitorRedisSubscriber', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should ping on every interval and leave a healthy connection alone', async () => {
+    const client = newClient();
+    const logger = newLogger();
+    const heartbeat = monitorRedisSubscriber(client, logger, options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 3);
+
+    expect(client.ping).toHaveBeenCalledTimes(3);
+    expect(client.disconnect).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    heartbeat.stop();
+  });
+
+  it('should reconnect after consecutive failures', async () => {
+    const client = newClient();
+    const logger = newLogger();
+    client.ping.mockRejectedValue(new Error('Connection is closed.'));
+    const heartbeat = monitorRedisSubscriber(client, logger, options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs);
+    expect(client.disconnect).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('(1/2): Connection is closed.'));
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs);
+    expect(client.disconnect).toHaveBeenCalledExactlyOnceWith(true);
+
+    heartbeat.stop();
+  });
+
+  it('should reconnect when a ping goes unanswered', async () => {
+    const client = newClient();
+    client.ping.mockReturnValue(new Promise(() => {}));
+    const heartbeat = monitorRedisSubscriber(client, newLogger(), options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 3);
+
+    expect(client.disconnect).toHaveBeenCalledExactlyOnceWith(true);
+
+    heartbeat.stop();
+  });
+
+  it('should only keep one ping in flight', async () => {
+    const client = newClient();
+    client.ping.mockReturnValue(new Promise(() => {}));
+    const heartbeat = monitorRedisSubscriber(client, newLogger(), { ...options, failuresBeforeReconnect: 100 });
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 5);
+
+    expect(client.ping).toHaveBeenCalledTimes(1);
+
+    heartbeat.stop();
+  });
+
+  it('should reset the failure count after a successful ping', async () => {
+    const client = newClient();
+    client.ping.mockRejectedValueOnce(new Error('Connection is closed.'));
+    const heartbeat = monitorRedisSubscriber(client, newLogger(), options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 3);
+
+    expect(client.ping).toHaveBeenCalledTimes(3);
+    expect(client.disconnect).not.toHaveBeenCalled();
+
+    heartbeat.stop();
+  });
+
+  it('should skip the ping while the client is not ready', async () => {
+    const client = newClient();
+    client.status = 'reconnecting';
+    const heartbeat = monitorRedisSubscriber(client, newLogger(), options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 3);
+
+    expect(client.ping).not.toHaveBeenCalled();
+    expect(client.disconnect).not.toHaveBeenCalled();
+
+    heartbeat.stop();
+  });
+
+  it('should stop pinging once stopped', async () => {
+    const client = newClient();
+    const heartbeat = monitorRedisSubscriber(client, newLogger(), options);
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs);
+    heartbeat.stop();
+    await vi.advanceTimersByTimeAsync(options.intervalMs * 3);
+
+    expect(client.ping).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not reconnect after being stopped, even with a ping still in flight', async () => {
+    const client = newClient();
+    const logger = newLogger();
+    const { promise, reject } = Promise.withResolvers<string>();
+    client.ping.mockReturnValue(promise);
+    const heartbeat = monitorRedisSubscriber(client, logger, { ...options, failuresBeforeReconnect: 1 });
+
+    await vi.advanceTimersByTimeAsync(options.intervalMs);
+    heartbeat.stop();
+    reject(new Error('Connection is closed.'));
+    await vi.advanceTimersByTimeAsync(options.intervalMs);
+
+    expect(client.disconnect).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/middleware/websocket.adapter.ts
+++ b/server/src/middleware/websocket.adapter.ts
@@ -2,10 +2,109 @@ import { INestApplicationContext } from '@nestjs/common';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { Redis } from 'ioredis';
-import { ServerOptions } from 'socket.io';
+import { Server, ServerOptions } from 'socket.io';
 import { ConfigRepository } from 'src/repositories/config.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+
+// The adapter's subscriber connection only ever receives, so it is idle by
+// design. ioredis reconnects and re-subscribes when it observes the socket
+// close, but a connection severed without a FIN or RST reaching us never
+// produces that event: the client stays `ready` with no subscription behind it,
+// and the worker silently stops receiving every server event until it restarts.
+// A periodic PING turns that into an observable failure. `commandTimeout` alone
+// would not help, because it rejects the command without closing the socket, and
+// neither would `socketTimeout`, whose timer is armed when a command is written
+// while an idle subscriber writes nothing.
+//
+// The thresholds are deliberately slack. A silently severed socket stays severed,
+// so detecting it a few minutes later costs nothing, while reconnecting a healthy
+// subscriber drops whatever is published during the reconnect. Redis has to be
+// unresponsive for three consecutive minutes before this acts, which a fork stall
+// or a slow script will not reach.
+const HEARTBEAT_INTERVAL_MS = 60_000;
+const HEARTBEAT_FAILURES_BEFORE_RECONNECT = 3;
+
+// Structural, so a test can supply a stub and a real ioredis client still fits.
+type HeartbeatClient = {
+  status: string;
+  ping: () => Promise<unknown>;
+  disconnect: (reconnect?: boolean) => void;
+};
+
+type Heartbeat = { stop: () => void };
+
+export const monitorRedisSubscriber = (
+  client: HeartbeatClient,
+  logger: Pick<LoggingRepository, 'warn'>,
+  {
+    intervalMs = HEARTBEAT_INTERVAL_MS,
+    failuresBeforeReconnect = HEARTBEAT_FAILURES_BEFORE_RECONNECT,
+  }: { intervalMs?: number; failuresBeforeReconnect?: number } = {},
+): Heartbeat => {
+  let failures = 0;
+  let waiting = false;
+  let stopped = false;
+
+  const onFailure = (reason: string) => {
+    failures++;
+    logger.warn(`Redis subscriber heartbeat failed (${failures}/${failuresBeforeReconnect}): ${reason}`);
+    if (failures < failuresBeforeReconnect) {
+      return;
+    }
+
+    failures = 0;
+    // The reconnect replaces the connection, so stop waiting on a ping sent over
+    // the old one.
+    waiting = false;
+    logger.warn('Reconnecting the Redis subscriber to restore its subscriptions');
+    // `true` keeps the retry strategy in play, so ioredis reconnects and
+    // restores the channels (`autoResubscribe`, on by default).
+    client.disconnect(true);
+  };
+
+  const beat = () => {
+    if (stopped || client.status !== 'ready') {
+      return;
+    }
+
+    // One ping at a time. An unanswered ping is the signal we are looking for,
+    // and sending more would only pile up commands for ioredis to resend on the
+    // next reconnect.
+    if (waiting) {
+      onFailure('the previous ping went unanswered');
+      return;
+    }
+
+    waiting = true;
+    client
+      .ping()
+      .then(() => {
+        waiting = false;
+        failures = 0;
+      })
+      .catch((error: Error | any) => {
+        waiting = false;
+        if (!stopped) {
+          onFailure(error?.message || error);
+        }
+      });
+  };
+
+  const timer = setInterval(beat, intervalMs);
+  timer.unref();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+};
 
 export class WebSocketAdapter extends IoAdapter {
+  private heartbeats = new Map<Server, Heartbeat>();
+  private logger?: Promise<LoggingRepository>;
+
   constructor(private app: INestApplicationContext) {
     super(app);
   }
@@ -16,6 +115,26 @@ export class WebSocketAdapter extends IoAdapter {
     const pubClient = new Redis(redis);
     const subClient = pubClient.duplicate();
     server.adapter(createAdapter(pubClient, subClient));
+    this.heartbeats.set(server, monitorRedisSubscriber(subClient, this.getLogger()));
     return server;
+  }
+
+  async close(server: Server) {
+    this.heartbeats.get(server)?.stop();
+    this.heartbeats.delete(server);
+    await super.close(server);
+  }
+
+  // LoggingRepository is transient, so it cannot be fetched synchronously here.
+  private getLogger(): Pick<LoggingRepository, 'warn'> {
+    return {
+      warn: (message: string) => {
+        this.logger ??= this.app.resolve(LoggingRepository).then((logger) => {
+          logger.setContext(WebSocketAdapter.name);
+          return logger;
+        });
+        this.logger.then((logger) => logger.warn(message)).catch(() => console.warn(message));
+      },
+    };
   }
 }


### PR DESCRIPTION
## Description

Related to #30988, which has the investigation. That issue was auto-closed as a duplicate one second after filing, because I used `gh issue create` and bypassed the issue form. It needs one correction: the configuration-cache TTL it offers as a mitigation would not have fixed the symptom I hit, because queue concurrency is applied from the `ConfigInit` and `ConfigUpdate` handlers (`queue.service.ts:96`, via `job.repository.ts:147`) rather than read through the cached config at job time.

The Socket.IO Redis adapter's subscriber connection only ever receives, so it is idle by design. ioredis reconnects and re-subscribes when it observes the socket close, but a connection severed without a FIN or RST reaching the client never produces that event. The client stays `ready` with no subscription behind it, and that worker silently stops receiving every server event — `ConfigUpdate`, `AppRestart`, and the `Hls*` session events that hand playback sessions to microservices — until it is restarted. Nothing is logged.

TCP keepalive is not a timely backstop. ioredis calls `setKeepAlive(true, options.keepAlive)` with `keepAlive` defaulting to `0` (`Redis.js:154-165`, `RedisOptions.js:14`), so the socket uses the OS idle default, which is two hours on the host in question. Configuration changes are expected to apply in seconds.

I ran into this with queue concurrency. I raised Thumbnail Generation from 3 to 10, `GET /api/system-config` returned 10, and the microservices worker kept running 3 for about a day. `PUBSUB NUMSUB "socket.io-request#/#"` returned 1 instead of 2, and `CLIENT LIST` showed no subscriber connection from that worker's host, although the same host held 40 other Redis connections and was processing jobs normally. Restarting the worker restored both the subscription and the setting.

That worker runs natively on macOS on a separate host from the Docker stack, through a third-party tool, which is what made a silent severance reachable. I could not lose an update on a stock single-container install: ioredis reconnects over the local bridge in milliseconds, so a publish still lands on a live subscriber. What is not specific to my setup is that once a client is in this state, nothing brings it back.

This adds a heartbeat on the subscriber connection: a `PING` every 60s, and `disconnect(true)` after three consecutive failures, which leaves ioredis's existing retry strategy and `autoResubscribe` to restore the channels. A rejected ping is caught in three minutes, a ping that never returns in four, after which recovery follows ioredis's normal retry schedule.

The thresholds are deliberately slack. A severed socket stays severed, so detecting it minutes later costs nothing, while reconnecting a healthy subscriber drops whatever is published during the reconnect. Redis has to be unresponsive for three consecutive minutes before this acts, which a fork stall during a save, or a slow script, will not reach.

Two alternatives do not work here. `commandTimeout` rejects the command without closing the socket, so the subscription stays dead. `socketTimeout` arms its timer when a command is written, and an idle subscriber writes nothing.

### Scope

This covers the subscriber connection only. It does not replay events published while the subscription was down, since Redis Pub/Sub is not durable. It also leaves `pubClient` alone. The same severance can take out both connections, but the publisher recovers on its own: a hung `publish` is retransmitted by TCP, ioredis notices once the retransmit budget runs out, and the queued commands are resent from `prevCommandQueue`, so outgoing events are delayed rather than lost. The subscriber is the side that never recovers. I am happy to extend the same heartbeat to the publisher if you would rather have one change.

## How Has This Been Tested?

- [x] `mise //server:test`, `//server:lint`, `//server:format`, `//server:check` — the new tests pass and both files are clean. Two pre-existing failures reproduce on a clean tree and come from my local toolchain, not from this change: `media.repository.spec.ts:333` (`mkdtempDisposableSync is not a function` on Node 22.23.2) and `media.repository.ts:190` (`limitInputChannels` not in `SharpOptions`, with `sharp` 0.34.5 installed against the required `^0.35.3`).
- [x] Revert check: commenting out only `client.disconnect(true)` fails exactly the two reconnect tests and leaves the other six passing.
- [x] Behaviour verified outside the test suite against a real Redis with ioredis 5.11.1, the version this repo resolves. A TCP proxy relayed a client to Redis and then closed only its upstream socket, leaving the client socket open and silent:

  | Case | Result |
  | --- | --- |
  | Clean close (`CLIENT KILL`) | Reconnects and restores `sub=3 psub=1` within 3s |
  | Silent severance, no heartbeat | Client logs `connect`, `ready`, `subscribe ok`, then nothing for the 130s I watched. `NUMSUB` drops to 0 and does not return |
  | Silent severance, `PING` with `commandTimeout` | Detected as `Command timed out`, not recovered |
  | Silent severance, `PING` plus `disconnect(true)` | `NUMSUB` returns to 1 and the channels are restored |

  In production the same state persisted for roughly 22 hours, until the worker was restarted.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used throughout: it traced the code paths, wrote the change and the tests, and ran the verification described above. I reviewed the change and the evidence, and directed the investigation.

On the parameters: two consecutive failures rather than one, so a single slow ping during a failover does not force a reconnect; 30s because the window that matters here is measured in hours; only one ping in flight at a time, because ioredis keeps unanswered commands queued and resends them on the next reconnect; and the interval is `unref`'d so it cannot hold the process open at shutdown.

The evidence does not depend on trusting that process. The failure and the recovery were measured against a real Redis with a proxy that is independent of this change, the before and after values are stated above, and reverting only `client.disconnect(true)` fails a named subset of the tests while the rest keep passing.
