### PR TITLE
feat(mobile): add 360° panorama viewer for equirectangular photos

### DIFF
--- a/mobile/lib/data/db/main/table/remote/exif.dart
+++ b/mobile/lib/data/db/main/table/remote/exif.dart
@@ -84,5 +84,6 @@ extension RemoteExifEntityDataDomainEx on RemoteExifEntityData {
     lens: lens,
     isFlipped: ExifDtoConverter.isOrientationFlipped(orientation),
     exposureSeconds: ExifDtoConverter.exposureTimeToSeconds(exposureTime),
+    projectionType: domain.ProjectionType.fromValue(projectionType),
   );
 }

--- a/mobile/lib/domain/models/exif.model.dart
+++ b/mobile/lib/domain/models/exif.model.dart
@@ -3,6 +3,22 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'exif.model.freezed.dart';
 
+// Aligned with web: https://github.com/immich-app/immich/blob/main/web/src/lib/constants.ts
+enum ProjectionType {
+  equirectangular('EQUIRECTANGULAR'),
+  cubemap('CUBEMAP'),
+  cubestrip('CUBESTRIP'),
+  equirectangularStereo('EQUIRECTANGULAR_STEREO'),
+  cubemapStereo('CUBEMAP_STEREO'),
+  cubestripStereo('CUBESTRIP_STEREO'),
+  cylinder('CYLINDER'),
+  none('NONE');
+
+  const ProjectionType(this.value);
+  final String value;
+  static ProjectionType? fromValue(String? value) => values.where((type) => type.value == value).firstOrNull;
+}
+
 @freezed
 abstract class ExifInfo with _$ExifInfo {
   const ExifInfo._();
@@ -18,6 +34,7 @@ abstract class ExifInfo with _$ExifInfo {
     int? rating,
     int? width,
     int? height,
+    ProjectionType? projectionType,
 
     // GPS
     double? latitude,

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -15,6 +15,7 @@ import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_details.wi
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/ocr_overlay.widget.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/panorama_viewer.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/video_viewer.widget.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
@@ -332,6 +333,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     required PhotoViewHeroAttributes? heroAttributes,
     required bool isCurrent,
     required bool isPlayingMotionVideo,
+    required bool isPanorama,
     required String? localFilePath,
     required Size? remoteThumbnailSize,
   }) {
@@ -354,7 +356,7 @@ class _AssetPageState extends ConsumerState<AssetPage> {
         filterQuality: FilterQuality.high,
         tightMode: true,
         enablePanAlways: true,
-        disableScaleGestures: _showingDetails,
+        disableScaleGestures: _showingDetails || isPanorama,
         scaleStateChangedCallback: _onScaleStateChanged,
         onPageBuild: _onPageBuild,
         onDragStart: _onDragStart,
@@ -461,10 +463,12 @@ class _AssetPageState extends ConsumerState<AssetPage> {
                         : null,
                     isCurrent: isCurrent,
                     isPlayingMotionVideo: isPlayingMotionVideo,
+                    isPanorama: isPanorama(ref, displayAsset),
                     localFilePath: viewIntentFilePath,
                     remoteThumbnailSize: thumbnailSize,
                   ),
                 ),
+                PanoramaButton(asset: displayAsset, controller: _viewController),
                 if (showingOcr && displayAsset.width != null && displayAsset.height != null)
                   Positioned.fill(
                     child: OcrOverlay(

--- a/mobile/lib/presentation/widgets/asset_viewer/panorama_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/panorama_viewer.widget.dart
@@ -1,0 +1,277 @@
+// 360° panoramas, ported from web. Kept in one file on purpose: existing code
+// changes by a few lines, no new dependencies or shared components.
+
+import 'dart:convert';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/exif.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
+import 'package:openapi/api.dart';
+
+// Aligned with web: https://github.com/immich-app/immich/blob/main/web/src/lib/components/asset-viewer/AssetViewer.svelte
+bool isPanorama(WidgetRef ref, BaseAsset asset) =>
+    ref.watch(assetExifProvider(asset).select((s) => s.valueOrNull?.projectionType)) == ProjectionType.equirectangular;
+
+/// Opens [PanoramaViewerPage]; shown only on equirectangular photos.
+class PanoramaButton extends ConsumerWidget {
+  final BaseAsset asset;
+  // Follows the photo while it is dragged
+  final PhotoViewControllerBase? controller;
+
+  const PanoramaButton({super.key, required this.asset, this.controller});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!isPanorama(ref, asset)) {
+      return const SizedBox.shrink();
+    }
+
+    final viewport = MediaQuery.sizeOf(context);
+    final button = Center(
+      child: IconButton.filled(
+        style: IconButton.styleFrom(backgroundColor: Colors.black45, foregroundColor: Colors.white),
+        iconSize: 36,
+        icon: const Icon(Icons.threesixty_rounded),
+        onPressed: () => context.pushRoute(PanoramaViewerRoute(asset: asset)),
+      ),
+    );
+    final controller = this.controller;
+    final following = controller == null
+        ? button
+        : StreamBuilder(
+            stream: controller.outputStateStream,
+            initialData: controller.value,
+            builder: (_, snapshot) => Transform.translate(offset: snapshot.requireData.position, child: button),
+          );
+    // Hidden while the viewer is opening or closing, the button is not part of the hero
+    final transition = ModalRoute.of(context)?.animation;
+    return Positioned(
+      width: viewport.width,
+      height: viewport.height,
+      child: transition == null
+          ? following
+          : AnimatedBuilder(
+              animation: transition,
+              builder: (_, child) => transition.isCompleted ? child! : const SizedBox.shrink(),
+              child: following,
+            ),
+    );
+  }
+}
+
+/// Full-screen viewer for equirectangular (360°) photos: drag to look around, pinch to zoom.
+@RoutePage()
+class PanoramaViewerPage extends StatefulWidget {
+  final BaseAsset asset;
+
+  const PanoramaViewerPage({super.key, required this.asset});
+
+  @override
+  State<PanoramaViewerPage> createState() => _PanoramaViewerPageState();
+}
+
+class _PanoramaViewerPageState extends State<PanoramaViewerPage> {
+  ImageStream? _imageStream;
+  ImageInfo? _imageInfo;
+  // Part of the full sphere the image covers, normalised to [0, 1]
+  Rect _crop = const Rect.fromLTWH(0, 0, 1, 1);
+
+  // View direction and vertical field of view, in degrees
+  double _longitude = 0;
+  double _latitude = 0;
+  double _fov = 90;
+  double _fovAtScaleStart = 90;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_imageStream == null) {
+      _imageStream = getFullImageProvider(
+        widget.asset,
+        size: MediaQuery.sizeOf(context),
+      ).resolve(ImageConfiguration.empty)..addListener(ImageStreamListener(_onImage));
+      _loadCrop().ignore();
+    }
+  }
+
+  // Partial spheres: the server copies the GPano crop into the preview's XMP (same source as web)
+  Future<void> _loadCrop() async {
+    final remoteId = widget.asset.remoteId;
+    if (remoteId == null) {
+      return;
+    }
+    final String xmp;
+    try {
+      final url = getThumbnailUrlForRemoteId(remoteId, type: AssetMediaSize.preview);
+      xmp = latin1.decode((await NetworkRepository.client.get(Uri.parse(url))).bodyBytes);
+    } catch (_) {
+      return; // keep the full sphere
+    }
+    double? tag(String name) => double.tryParse(RegExp('GPano:$name(?:="|>)([0-9.]+)').firstMatch(xmp)?.group(1) ?? '');
+    final fullWidth = tag('FullPanoWidthPixels');
+    final fullHeight = tag('FullPanoHeightPixels');
+    final left = tag('CroppedAreaLeftPixels');
+    final top = tag('CroppedAreaTopPixels');
+    final width = tag('CroppedAreaImageWidthPixels');
+    final height = tag('CroppedAreaImageHeightPixels');
+    if (fullWidth == null || fullHeight == null || left == null || top == null || width == null || height == null) {
+      return;
+    }
+    if (mounted) {
+      setState(() => _crop = Rect.fromLTWH(left / fullWidth, top / fullHeight, width / fullWidth, height / fullHeight));
+    }
+  }
+
+  @override
+  void dispose() {
+    _imageStream?.removeListener(ImageStreamListener(_onImage));
+    _imageInfo?.dispose();
+    super.dispose();
+  }
+
+  // Called for every image the provider yields (thumbnail, preview, original)
+  void _onImage(ImageInfo imageInfo, bool _) {
+    _imageInfo?.dispose();
+    setState(() => _imageInfo = imageInfo);
+  }
+
+  void _onScaleUpdate(ScaleUpdateDetails details) {
+    setState(() {
+      _fov = (_fovAtScaleStart / details.scale).clamp(15.0, 115.0);
+      // Rotate by the angle the dragged distance covers on screen, so the image follows the finger
+      final degreesPerPixel = _fov / context.size!.height;
+      _longitude -= details.focalPointDelta.dx * degreesPerPixel;
+      _latitude = (_latitude + details.focalPointDelta.dy * degreesPerPixel).clamp(-90.0, 90.0);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final image = _imageInfo?.image;
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(backgroundColor: Colors.transparent, foregroundColor: Colors.white, leading: const CloseButton()),
+      body: image == null
+          ? null
+          : GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onScaleStart: (_) => _fovAtScaleStart = _fov,
+              onScaleUpdate: _onScaleUpdate,
+              child: CustomPaint(
+                painter: _SpherePainter(
+                  image: image,
+                  crop: _crop,
+                  longitude: _longitude,
+                  latitude: _latitude,
+                  fov: _fov,
+                ),
+                size: Size.infinite,
+              ),
+            ),
+    );
+  }
+}
+
+/// Paints a sphere textured with an equirectangular image, as seen from its centre.
+class _SpherePainter extends CustomPainter {
+  static const _rows = 32;
+  static const _columns = 64;
+  static const _vertexCount = (_rows + 1) * (_columns + 1);
+
+  // Vertices further than ~80° from the view direction are off screen
+  static const _minDepth = 0.15;
+
+  final ui.Image image;
+  final Rect crop;
+  final double longitude;
+  final double latitude;
+  final double fov;
+
+  const _SpherePainter({
+    required this.image,
+    required this.crop,
+    required this.longitude,
+    required this.latitude,
+    required this.fov,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final yaw = longitude * math.pi / 180;
+    final cosPitch = math.cos(latitude * math.pi / 180);
+    final sinPitch = math.sin(latitude * math.pi / 180);
+    final focalLength = size.height / 2 / math.tan(fov * math.pi / 360);
+    final center = size.center(Offset.zero);
+
+    // Project the vertices of a sphere mesh onto the canvas
+    final positions = Float32List(_vertexCount * 2);
+    final textureCoordinates = Float32List(_vertexCount * 2);
+    final depths = Float32List(_vertexCount);
+    for (var i = 0; i < _vertexCount; i++) {
+      final row = i ~/ (_columns + 1);
+      final column = i % (_columns + 1);
+      final elevation = math.pi / 2 - math.pi * (crop.top + crop.height * row / _rows);
+      final azimuth = 2 * math.pi * (crop.left + crop.width * column / _columns - 0.5) - yaw;
+      final x = math.cos(elevation) * math.sin(azimuth);
+      final y = math.sin(elevation) * cosPitch - math.cos(elevation) * math.cos(azimuth) * sinPitch;
+      final depth = math.sin(elevation) * sinPitch + math.cos(elevation) * math.cos(azimuth) * cosPitch;
+
+      depths[i] = depth;
+      positions[i * 2] = center.dx + focalLength * x / depth;
+      positions[i * 2 + 1] = center.dy - focalLength * y / depth;
+      textureCoordinates[i * 2] = image.width * column / _columns;
+      textureCoordinates[i * 2 + 1] = image.height * row / _rows;
+    }
+
+    // Keep only the triangles in front of the viewer
+    final indices = Uint16List(_rows * _columns * 6);
+    var indexCount = 0;
+    for (var row = 0; row < _rows; row++) {
+      for (var column = 0; column < _columns; column++) {
+        final topLeft = row * (_columns + 1) + column;
+        final corners = [topLeft, topLeft + 1, topLeft + _columns + 1, topLeft + _columns + 2];
+        if (corners.any((corner) => depths[corner] < _minDepth)) {
+          continue;
+        }
+        indices.setAll(indexCount, [corners[0], corners[1], corners[2], corners[1], corners[3], corners[2]]);
+        indexCount += 6;
+      }
+    }
+
+    final paint = Paint()
+      ..shader = ImageShader(
+        image,
+        TileMode.clamp,
+        TileMode.clamp,
+        Matrix4.identity().storage,
+        filterQuality: FilterQuality.medium,
+      );
+    canvas.drawVertices(
+      ui.Vertices.raw(
+        ui.VertexMode.triangles,
+        positions,
+        textureCoordinates: textureCoordinates,
+        indices: Uint16List.sublistView(indices, 0, indexCount),
+      ),
+      BlendMode.srcOver,
+      paint,
+    );
+  }
+
+  // Only rebuilt on gesture or image changes
+  @override
+  bool shouldRepaint(_SpherePainter oldDelegate) => true;
+}

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -71,6 +71,7 @@ import 'package:immich_mobile/presentation/pages/trash.page.dart';
 import 'package:immich_mobile/presentation/pages/user_selection.page.dart';
 import 'package:immich_mobile/presentation/pages/video.page.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/panorama_viewer.widget.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/routing/auth_guard.dart';
 import 'package:immich_mobile/routing/duplicate_guard.dart';
@@ -165,6 +166,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: FavoriteRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: TrashRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: ArchiveRoute.page, guards: [_authGuard, _duplicateGuard]),
+    AutoRoute(page: PanoramaViewerRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: LockedFolderRoute.page, guards: [_authGuard, _lockedGuard, _duplicateGuard]),
     AutoRoute(page: VideoRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: LibraryRoute.page, guards: [_authGuard, _duplicateGuard]),

--- a/mobile/test/domain/repositories/sync_stream_repository_test.dart
+++ b/mobile/test/domain/repositories/sync_stream_repository_test.dart
@@ -4,9 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/data/db/main/database.dart';
 import 'package:immich_mobile/data/db/main/table/local/album.drift.dart';
 import 'package:immich_mobile/data/db/main/table/remote/album.drift.dart';
+import 'package:immich_mobile/data/db/main/table/remote/exif.dart';
 import 'package:immich_mobile/data/db/main/table/remote/exif.drift.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
+import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/sync_stream.repository.dart';
 import 'package:openapi/api.dart';
 
@@ -85,6 +87,7 @@ SyncAssetExifV1 _createExif({
   required int width,
   required int height,
   required String orientation,
+  String? projectionType,
 }) {
   return SyncAssetExifV1(
     assetId: assetId,
@@ -108,7 +111,7 @@ SyncAssetExifV1 _createExif({
     model: null,
     modifyDate: null,
     profileDescription: null,
-    projectionType: null,
+    projectionType: projectionType,
     rating: null,
     state: null,
     timeZone: null,
@@ -265,6 +268,25 @@ void main() {
       expect(after.linkedRemoteAlbumId, isNull);
       expect(after.name, equals('Camera'));
       expect(after.backupSelection, equals(BackupSelection.none));
+    });
+  });
+
+  group('SyncStreamRepository - projection type', () {
+    test('passes the synced projection type on to the domain model', () async {
+      await sut.updateUsersV1([_createUser()]);
+      for (final (synced, expected) in [('EQUIRECTANGULAR', ProjectionType.equirectangular), (null, null)]) {
+        final assetId = 'asset-$synced';
+        await sut.updateAssetsV1([_createAsset(id: assetId, checksum: assetId, fileName: '$assetId.jpg')]);
+        await sut.updateAssetsExifV1([
+          _createExif(assetId: assetId, width: 8192, height: 4096, orientation: '1', projectionType: synced),
+        ]);
+
+        final query = db.remoteExifEntity.select()..where((tbl) => tbl.assetId.equals(assetId));
+        final result = await query.getSingle();
+
+        expect(result.projectionType, synced);
+        expect(result.toDto().projectionType, expected);
+      }
     });
   });
 


### PR DESCRIPTION
## Description

Draft for reference: #31045 (same branch) was closed by @shenlong-tanwen as a duplicate of the earlier #30192 — "Can you please add your remarks / reviews there as it predates this one". Kept here as a draft, not competing with #30192

360° viewer for equirectangular photos on mobile
Merged panorama PRs: #3412, #6992, #7012 (mine), #3688, #23953, #24193; closed: #28442
No external components; the display logic lives in one local file, `panorama_viewer.widget.dart` (for now)

**Specification:**

1. Server stores exiftool `XMP-GPano:ProjectionType` uppercased ([code](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/server/src/services/metadata.service.ts#L284))
2. Already synced to `remote_exif_entity.projection_type`
3. This PR: `ExifInfo.projectionType == ProjectionType.equirectangular` → 360° button on the flat photo; zoom is disabled there and the button sticks to the photo while it is dragged

**Web vs mobile:**

| | Web | Mobile |
|---|---|---|
| `EQUIRECTANGULAR` photo | inline sphere ([code](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/src/lib/components/asset-viewer/AssetViewer.svelte#L437-L442)) | flat photo (zoom off) + 360° button → full-screen sphere |
| Other projection types | flat ([constants.ts](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/src/lib/constants.ts#L21-L30) declares them, only equirectangular [adapters](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/package.json#L34-L39) installed) | flat |
| Partial sphere (GPano crop) | yes | yes |
| Raw Insta360 `.insp` | sphere by filename (#3688), rendered wrong (#6681) | flat |
| 360° video | yes ([code](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/src/lib/components/asset-viewer/VideoWrapperViewer.svelte#L40)) | flat |
| 360° badge on thumbnails | yes ([code](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/src/lib/components/assets/thumbnail/Thumbnail.svelte#L356)) | no |
| Editor | hidden ([code](https://github.com/immich-app/immich/blob/c04c81a979ae5b0802bce4eda65d11564f2b6350/web/src/lib/services/asset.service.ts#L245)) | as for any photo |

## Changes

```
mobile/
├─ lib/
│  ├─ domain/models/exif.model.dart                           M  +17  ProjectionType enum (web values), projectionType field
│  ├─ data/db/main/table/remote/exif.dart                     M   +1  DB row → model
│  ├─ presentation/widgets/asset_viewer/
│  │  ├─ asset_page.widget.dart                               M   +5  import, PanoramaButton, zoom off on panoramas
│  │  └─ panorama_viewer.widget.dart                          A +277  button, full-screen page, sphere painter, GPano crop
│  └─ routing/router.dart                                     M   +2  import + route
└─ test/domain/repositories/sync_stream_repository_test.dart M  +23  sync → DB → model, with and without projection type

6 files · M modified · A new
```

## How Has This Been Tested?

Android release build:

- [x] Button only on panoramas; flat viewer unchanged
- [x] Sphere: drag, pinch, poles/seam, preview → original, close
- [x] `dart analyze --fatal-infos`, `dart format`, `flutter test`

<details open><summary><h2>Screenshots</h2></summary>

Viewer with 360° button (also with details open) → full-screen sphere

<img src="https://raw.githubusercontent.com/dmitry-brazhenko/immich/panorama-screenshots/01-viewer.jpg" width="200"> <img src="https://raw.githubusercontent.com/dmitry-brazhenko/immich/panorama-screenshots/02-viewer-details.jpg" width="200"> <img src="https://raw.githubusercontent.com/dmitry-brazhenko/immich/panorama-screenshots/03-sphere.jpg" width="200"> <img src="https://raw.githubusercontent.com/dmitry-brazhenko/immich/panorama-screenshots/04-sphere.jpg" width="200">

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

AI generated: `panorama_viewer.widget.dart`, kept in one file to not bring extra components for now. Everything else is single lines propagating `projectionType`
