### PR TITLE
fix(web): map

### DIFF
--- a/web/src/lib/components/shared-components/map/Map.svelte
+++ b/web/src/lib/components/shared-components/map/Map.svelte
@@ -216,8 +216,9 @@
     }
 
     return {
-      fileCreatedAfter: dateAfter,
-      fileCreatedBefore: dateBefore,
+      // $mapSettings stores no value as an empty string
+      fileCreatedAfter: dateAfter || undefined,
+      fileCreatedBefore: dateBefore || undefined,
     };
   }
 

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -82,7 +82,11 @@
 
   const timelineOptions = $derived({
     bbox: timelineBoundingBox,
-    visibility: $mapSettings.includeArchived ? undefined : AssetVisibility.Timeline,
+    visibility: $mapSettings.withPartners
+      ? AssetVisibility.Timeline
+      : $mapSettings.includeArchived
+        ? undefined
+        : AssetVisibility.Archive,
     isFavorite: $mapSettings.onlyFavorites || undefined,
     withPartners: $mapSettings.withPartners || undefined,
     assetFilter: selectedClusterIds,


### PR DESCRIPTION
Fixes #29449
Fixes #30603

- Don't send empty strings to the API when start/end dates are not specified
- Don't send archive visibility when `withPartners` is true