### PR TITLE
fix(server): carry activities over to the keeper when resolving duplicates

### DIFF
--- a/server/src/repositories/activity.repository.ts
+++ b/server/src/repositories/activity.repository.ts
@@ -7,13 +7,18 @@ import { DummyValue, GenerateSql } from 'src/decorators';
 import { AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { ActivityTable } from 'src/schema/tables/activity.table';
-import { asUuid, dummy } from 'src/utils/database';
+import { anyUuid, asUuid, dummy } from 'src/utils/database';
 
 export interface ActivitySearch {
   albumId?: string;
   assetId?: string | null;
   userId?: string;
   isLiked?: boolean;
+}
+
+export interface ActivityAssetMerge {
+  sourceAssetIds: string[];
+  targetAssetId: string;
 }
 
 @Injectable()
@@ -64,6 +69,82 @@ export class ActivityRepository {
   @GenerateSql({ params: [DummyValue.UUID] })
   async delete(id: string) {
     await this.db.deleteFrom('activity').where('id', '=', asUuid(id)).execute();
+  }
+
+  /**
+   * Re-points comments and likes from `sourceAssetIds` onto `targetAssetId` so they survive the
+   * source assets being trashed or deleted (duplicate resolution merges the losers into a keeper).
+   *
+   * Activities are keyed on `(albumId, assetId)` and the table has a composite foreign key onto
+   * `album_asset`, so a row can only move into an album the target is already a member of. Rows in
+   * any other album are left alone rather than being made unreachable by every activity query.
+   *
+   * Every comment moves, textual duplicates included - two separate comments really did exist.
+   * Likes are unique per `(albumId, userId, assetId)`, so at most one like per `(albumId, userId)`
+   * moves, and only when that user has not already liked the target.
+   *
+   * @returns the number of activities that were moved
+   */
+  async mergeAssetActivities({ sourceAssetIds, targetAssetId }: ActivityAssetMerge): Promise<number> {
+    if (sourceAssetIds.length === 0) {
+      return 0;
+    }
+
+    return this.db.transaction().execute(async (tx) => {
+      const comments = await tx
+        .updateTable('activity')
+        .set({ assetId: targetAssetId })
+        .where('activity.assetId', '=', anyUuid(sourceAssetIds))
+        .where('activity.isLiked', '=', false)
+        .where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom('album_asset')
+              .whereRef('album_asset.albumId', '=', 'activity.albumId')
+              .where('album_asset.assetId', '=', asUuid(targetAssetId)),
+          ),
+        )
+        .executeTakeFirst();
+
+      const likes = await tx
+        .with('mergeable_like', (qb) =>
+          qb
+            .selectFrom('activity')
+            .select('activity.id')
+            // the unique like index only allows one like per (albumId, userId) on the target
+            .distinctOn(['activity.albumId', 'activity.userId'])
+            .innerJoin('album_asset', (join) =>
+              join
+                .onRef('album_asset.albumId', '=', 'activity.albumId')
+                .on('album_asset.assetId', '=', asUuid(targetAssetId)),
+            )
+            .where('activity.assetId', '=', anyUuid(sourceAssetIds))
+            .where('activity.isLiked', '=', true)
+            .where((eb) =>
+              eb.not(
+                eb.exists(
+                  eb
+                    .selectFrom('activity as existing')
+                    .whereRef('existing.albumId', '=', 'activity.albumId')
+                    .whereRef('existing.userId', '=', 'activity.userId')
+                    .where('existing.assetId', '=', asUuid(targetAssetId))
+                    .where('existing.isLiked', '=', true),
+                ),
+              ),
+            )
+            // oldest like wins, so the merge is deterministic
+            .orderBy('activity.albumId')
+            .orderBy('activity.userId')
+            .orderBy('activity.createdAt')
+            .orderBy('activity.id'),
+        )
+        .updateTable('activity')
+        .set({ assetId: targetAssetId })
+        .where('activity.id', 'in', (eb) => eb.selectFrom('mergeable_like').select('mergeable_like.id'))
+        .executeTakeFirst();
+
+      return Number(comments.numUpdatedRows) + Number(likes.numUpdatedRows);
+    });
   }
 
   @GenerateSql({ params: [{ albumId: DummyValue.UUID, assetId: DummyValue.UUID }] })

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -321,6 +321,7 @@ describe(DuplicateService.name, () => {
       mocks.access.duplicate.checkOwnerAccess.mockResolvedValue(new Set(['group-1']));
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-2']));
       mocks.access.tag.checkOwnerAccess.mockResolvedValue(new Set(['tag-1', 'tag-2']));
+      mocks.activity.mergeAssetActivities.mockResolvedValue(0);
       mocks.duplicateRepository.get.mockResolvedValue({
         duplicateId: 'group-1',
         assets: [
@@ -367,6 +368,45 @@ describe(DuplicateService.name, () => {
 
       // Verify SidecarWrite was queued (to write tags to sidecar)
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.SidecarWrite, data: { id: asset1.id } }]);
+    });
+
+    it('should merge activities from the trashed assets onto the keeper', async () => {
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+      mocks.access.duplicate.checkOwnerAccess.mockResolvedValue(new Set(['group-1']));
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset2.id]));
+      mocks.duplicateRepository.get.mockResolvedValue({
+        duplicateId: 'group-1',
+        assets: [asset1 as unknown as MapAsset, asset2 as unknown as MapAsset],
+      });
+      mocks.activity.mergeAssetActivities.mockResolvedValue(2);
+
+      const result = await sut.resolve(authStub.admin, {
+        groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id], trashAssetIds: [asset2.id] }],
+      });
+
+      expect(result[0].success).toBe(true);
+      expect(mocks.activity.mergeAssetActivities).toHaveBeenCalledWith({
+        sourceAssetIds: [asset2.id],
+        targetAssetId: asset1.id,
+      });
+    });
+
+    it('should not merge activities when multiple assets are kept', async () => {
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+      mocks.access.duplicate.checkOwnerAccess.mockResolvedValue(new Set(['group-1']));
+      mocks.duplicateRepository.get.mockResolvedValue({
+        duplicateId: 'group-1',
+        assets: [asset1 as unknown as MapAsset, asset2 as unknown as MapAsset],
+      });
+
+      const result = await sut.resolve(authStub.admin, {
+        groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id, asset2.id], trashAssetIds: [] }],
+      });
+
+      expect(result[0].success).toBe(true);
+      expect(mocks.activity.mergeAssetActivities).not.toHaveBeenCalled();
     });
 
     it('should not merge metadata when multiple assets are kept', async () => {

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -200,6 +200,19 @@ export class DuplicateService extends BaseService {
         }
       }
 
+      // Comments and likes on the losers would otherwise cascade away with them. Move them onto the
+      // keeper after album membership has been merged, since an activity can only live in an album
+      // the keeper belongs to. Doing this before the trash means a failure here leaves the losers
+      // untrashed rather than losing the activities.
+      const mergedActivities = await this.activityRepository.mergeAssetActivities({
+        sourceAssetIds: idsToTrash,
+        targetAssetId: idsToKeep[0],
+      });
+
+      if (mergedActivities > 0) {
+        this.logger.debug(`Moved ${mergedActivities} activities onto asset ${idsToKeep[0]}`);
+      }
+
       const hasExifUpdate = Object.keys(exifUpdate).length > 0;
       const hasTagUpdate = mergedTagIds.length > 0;
 

--- a/server/test/medium/specs/services/duplicate.service.spec.ts
+++ b/server/test/medium/specs/services/duplicate.service.spec.ts
@@ -2,6 +2,8 @@ import { Kysely } from 'kysely';
 import { BulkIdErrorReason, BulkIdResponseDto } from 'src/dtos/asset-ids.response.dto';
 import { AssetStatus, AssetVisibility } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
+import { ActivityRepository } from 'src/repositories/activity.repository';
+import { AlbumUserRepository } from 'src/repositories/album-user.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { ConfigRepository } from 'src/repositories/config.repository';
@@ -25,7 +27,9 @@ const setup = (db?: Kysely<DB>) => {
     database: db || defaultDatabase,
     real: [
       AccessRepository,
+      ActivityRepository,
       AlbumRepository,
+      AlbumUserRepository,
       AssetRepository,
       ConfigRepository,
       DuplicateRepository,
@@ -57,6 +61,17 @@ const newDuplicateAsset = async (
 
 const newTag = async (ctx: MediumTestContext, userId: string, value: string) => {
   return ctx.get(TagRepository).create({ userId, value });
+};
+
+const newComment = async (
+  ctx: MediumTestContext,
+  dto: { albumId: string; assetId: string; userId: string; comment: string },
+) => {
+  return ctx.get(ActivityRepository).create({ ...dto, isLiked: false });
+};
+
+const newLike = async (ctx: MediumTestContext, dto: { albumId: string; assetId: string; userId: string }) => {
+  return ctx.get(ActivityRepository).create({ ...dto, isLiked: true });
 };
 
 const expectSuccess = (results: BulkIdResponseDto[], duplicateId: string) => {
@@ -586,6 +601,212 @@ describe(DuplicateService.name, () => {
           isFavorite: false,
           duplicateId: null,
         });
+      });
+    });
+
+    describe('activity merging', () => {
+      it('should move a comment on a trashed duplicate onto the keeper', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [trashed.id]);
+
+        await newComment(ctx, { albumId: album.id, assetId: trashed.id, userId: user.id, comment: 'nice one' });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        // activity search hides activities on trashed assets, so an unmoved comment reads as gone
+        await expect(ctx.get(ActivityRepository).search({ albumId: album.id })).resolves.toEqual([
+          expect.objectContaining({ assetId: keeper.id, comment: 'nice one', isLiked: false }),
+        ]);
+      });
+
+      it('should move a comment left by another album member', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const { user: member } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [trashed.id]);
+        await ctx.newAlbumUser({ albumId: album.id, userId: member.id });
+
+        await newComment(ctx, { albumId: album.id, assetId: trashed.id, userId: member.id, comment: 'from a friend' });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        await expect(ctx.get(ActivityRepository).search({ albumId: album.id })).resolves.toEqual([
+          expect.objectContaining({ assetId: keeper.id, userId: member.id, comment: 'from a friend' }),
+        ]);
+      });
+
+      it('should merge the comments of both copies onto the keeper', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [keeper.id, trashed.id]);
+
+        await newComment(ctx, { albumId: album.id, assetId: keeper.id, userId: user.id, comment: 'on the keeper' });
+        await newComment(ctx, { albumId: album.id, assetId: trashed.id, userId: user.id, comment: 'on the trashed' });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        // the keeper's own comment stays put and the trashed copy's comment joins it
+        const activities = await ctx.get(ActivityRepository).search({ albumId: album.id });
+        expect(activities.every(({ assetId }) => assetId === keeper.id)).toBe(true);
+        expect(activities.map(({ comment }) => comment).sort()).toEqual(['on the keeper', 'on the trashed']);
+      });
+
+      it('should keep both comments when the copies carry the same text', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [keeper.id, trashed.id]);
+
+        await newComment(ctx, { albumId: album.id, assetId: keeper.id, userId: user.id, comment: 'same' });
+        await newComment(ctx, { albumId: album.id, assetId: trashed.id, userId: user.id, comment: 'same' });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        // two separate comments really did exist, so both are kept rather than silently collapsed
+        const activities = await ctx.get(ActivityRepository).search({ albumId: album.id, assetId: keeper.id });
+        expect(activities).toHaveLength(2);
+        expect(activities.map(({ comment }) => comment)).toEqual(['same', 'same']);
+      });
+
+      it('should move a like on a trashed duplicate onto the keeper', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [trashed.id]);
+
+        await newLike(ctx, { albumId: album.id, assetId: trashed.id, userId: user.id });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        await expect(ctx.get(ActivityRepository).search({ albumId: album.id })).resolves.toEqual([
+          expect.objectContaining({ assetId: keeper.id, userId: user.id, isLiked: true }),
+        ]);
+      });
+
+      it('should not violate the like constraint when both copies were liked by the same user', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [keeper.id, trashed.id]);
+
+        await newLike(ctx, { albumId: album.id, assetId: keeper.id, userId: user.id });
+        await newLike(ctx, { albumId: album.id, assetId: trashed.id, userId: user.id });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed.id] }],
+          }),
+          duplicateId,
+        );
+
+        await expect(
+          ctx.get(ActivityRepository).search({ albumId: album.id, assetId: keeper.id, isLiked: true }),
+        ).resolves.toHaveLength(1);
+      });
+
+      it('should move only one like when two trashed copies were liked by the same user', async () => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const duplicateId = factory.uuid();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed1 = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const trashed2 = await newDuplicateAsset(ctx, { ownerId: user.id, duplicateId });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [trashed1.id, trashed2.id]);
+
+        await newLike(ctx, { albumId: album.id, assetId: trashed1.id, userId: user.id });
+        await newLike(ctx, { albumId: album.id, assetId: trashed2.id, userId: user.id });
+
+        const auth = factory.auth({ user: { id: user.id } });
+        expectSuccess(
+          await sut.resolve(auth, {
+            groups: [{ duplicateId, keepAssetIds: [keeper.id], trashAssetIds: [trashed1.id, trashed2.id] }],
+          }),
+          duplicateId,
+        );
+
+        await expect(
+          ctx.get(ActivityRepository).search({ albumId: album.id, assetId: keeper.id, isLiked: true }),
+        ).resolves.toHaveLength(1);
+      });
+
+      it('should leave an activity alone when the keeper is not a member of its album', async () => {
+        const { ctx } = setup();
+        const { user } = await ctx.newUser();
+
+        const keeper = await newDuplicateAsset(ctx, { ownerId: user.id });
+        const loser = await newDuplicateAsset(ctx, { ownerId: user.id });
+        const { album } = await ctx.newAlbum({ ownerId: user.id }, [loser.id]);
+
+        const comment = await newComment(ctx, {
+          albumId: album.id,
+          assetId: loser.id,
+          userId: user.id,
+          comment: 'unreachable if moved',
+        });
+
+        // the (albumId, assetId) foreign key would reject the move, so the row stays put
+        const activityRepo = ctx.get(ActivityRepository);
+        await expect(
+          activityRepo.mergeAssetActivities({ sourceAssetIds: [loser.id], targetAssetId: keeper.id }),
+        ).resolves.toBe(0);
+
+        await expect(activityRepo.search({ albumId: album.id })).resolves.toEqual([
+          expect.objectContaining({ id: comment.id, assetId: loser.id }),
+        ]);
       });
     });
 


### PR DESCRIPTION
## Description

Resolving a duplicate group merges album membership, description, tags, rating,
favourite and visibility onto the keeper — but comments and likes on the losing
assets are silently lost. There is no warning in the UI and no way to recover
them afterwards.

This matters for anyone who has commented on assets before deduplicating: the
commented-on copy is often a derivative, while the keeper heuristic picks the
full-resolution original.

**Reproduction (v3.1.0)**

1. Two copies of one photo in a duplicate group, both in an album.
2. `POST /api/activities` with `{albumId, assetId, type: "comment", comment: "..."}`
   against one copy, and set a description on it via `PUT /api/assets/{id}`.
3. Resolve the duplicate, keeping the other copy.
4. `exifInfo.description` — carried over. `GET /api/activities?albumId=…&assetId=<keeper>`
   — **empty**, and the comment is unreachable on the trashed copy too.

**Why they disappear.** `activity` cascades from `asset`, so the rows die at hard
delete. But they are already invisible before that: since #19113,
`ActivityRepository.search` and `getStatistics` filter on `asset.deletedAt is null`,
so a comment vanishes the moment its asset is trashed.

**The fix.** Re-point the losing assets' activities onto the keeper during
resolution, in `DuplicateService.resolveGroup`, next to the existing merge logic.

Two constraints shape the implementation:

- **Activities are keyed on `(albumId, assetId)`.** `ActivityTable` has a composite
  foreign key onto `album_asset`, so a row can only move into an album the keeper
  already belongs to. The merge therefore runs *after* album membership has
  transferred, and leaves rows in any other album where they are rather than
  creating an activity no query can reach.
- **Likes are unique per `(albumId, userId, assetId)`** (`activity_like_idx`,
  partial on `isLiked = true`). A naive `UPDATE … SET assetId = keeper` violates it
  when both copies were liked by the same user, so at most one like per
  `(albumId, userId)` moves, and only when that user has not already liked the
  keeper.

Comments are not deduplicated: two separate comments really did exist, so both are
kept even when the text matches. Likes are a boolean fact about a user, so they
collapse. The merge runs before the trash, so a failure leaves the losers untrashed
rather than losing activities.

No API changes — no endpoint, DTO, or schema change, and no migration.

## How Has This Been Tested?

New unit tests in `src/services/duplicate.service.spec.ts` and new medium tests in
`test/medium/specs/services/duplicate.service.spec.ts` covering: a comment on a
trashed duplicate surviving on the keeper; comments on both copies merging, with
identical text kept as two rows; a comment by another album member moved with its
author intact; a like moving onto the keeper; the same user liking both copies not
violating `activity_like_idx`; two trashed copies liked by one user yielding exactly
one like; an activity left alone when the keeper is not in its album; and the merge
being skipped when more than one asset is kept.

- [x] `mise //server:lint`
- [x] `mise //server:format`
- [x] `mise //server:check`
- [x] `mise //server:test` — full unit suite
- [x] `mise //server:test-medium` — `duplicate.service`, `activity.service`, `album.service`
- [x] Manually against a live server: comment on the derivative, resolve keeping the
      original, confirm the comment is returned for the keeper

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A — no user-visible UI change; comments that used to vanish now remain on the keeper.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. Claude Code (Opus 5) was used to investigate the cause, write the
implementation and the tests, and draft this description. I directed the work,
reviewed the diff, and verified the behaviour and the full test run myself,
including against a live server.