### PR TITLE
fix(mobile): clear album description sends null instead of empty string

### DIFF
--- a/mobile/lib/domain/services/remote_album.service.dart
+++ b/mobile/lib/domain/services/remote_album.service.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
 import 'package:immich_mobile/repositories/album_api_repository.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:logging/logging.dart';
 
 /// Categorizes a heterogeneous asset selection into the candidates that can
@@ -135,7 +136,7 @@ class RemoteAlbumService {
   Future<RemoteAlbum> updateAlbum(
     String albumId, {
     String? name,
-    String? description,
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,

--- a/mobile/lib/presentation/pages/remote_album.page.dart
+++ b/mobile/lib/presentation/pages/remote_album.page.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dar
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/remote_album_sliver_app_bar.dart';
 
@@ -265,10 +266,13 @@ class _EditAlbumDialogState extends ConsumerState<_EditAlbumDialog> {
     try {
       final newTitle = titleController.text.trim();
       final newDescription = descriptionController.text.trim();
+      final description = newDescription.isEmpty
+          ? const Option<String?>.some(null)
+          : Option<String?>.some(newDescription);
 
       await ref
           .read(remoteAlbumProvider.notifier)
-          .updateAlbum(widget.album.id, name: newTitle, description: newDescription);
+          .updateAlbum(widget.album.id, name: newTitle, description: description);
       if (!mounted) {
         return;
       }

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -15,6 +15,7 @@ import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.da
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
+import 'package:immich_mobile/utils/option.dart';
 import 'package:logging/logging.dart';
 
 part 'remote_album.provider.freezed.dart';
@@ -142,7 +143,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
   Future<RemoteAlbum?> updateAlbum(
     String albumId, {
     String? name,
-    String? description,
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,

--- a/mobile/lib/repositories/album_api_repository.dart
+++ b/mobile/lib/repositories/album_api_repository.dart
@@ -3,6 +3,7 @@ import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/repositories/api.repository.dart';
+import 'package:immich_mobile/utils/option.dart';
 // ignore: import_rule_openapi
 import 'package:openapi/api.dart' hide AlbumUserRole;
 
@@ -73,7 +74,7 @@ class AlbumApiRepository extends ApiRepository {
     String albumId,
     UserDto owner, {
     String? name,
-    String? description,
+    Option<String?> description = const Option.none(),
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     AlbumAssetOrder? order,
@@ -88,9 +89,7 @@ class AlbumApiRepository extends ApiRepository {
         albumId,
         UpdateAlbumDto(
           albumName: name == null ? const Optional.absent() : Optional.present(name),
-          description: description == null
-              ? const Optional.absent()
-              : Optional.present(description.isEmpty ? null : description),
+          description: description.toOptional(),
           albumThumbnailAssetId: thumbnailAssetId == null
               ? const Optional.absent()
               : Optional.present(thumbnailAssetId),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This reverts commit c9adffbe734cfe2084300f86b4d4369f25ac3f7e (#28956) re-applying #28817.

The original change was reverted because the server rejected null for album.description. Since #30123 the column is nullable and the API accepts null, so the mobile client can send an explicit null again when clearing the description.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude to re-apply the changes made in the original PR after the mobile code refactor