### PR TITLE
fix(server): repoint the person feature photo when its face is deleted

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1309,6 +1309,61 @@ describe(PersonService.name, () => {
     });
   });
 
+  describe('deleteFace', () => {
+    it('should pick a new feature photo when the deleted face was the featured one', async () => {
+      const auth = AuthFactory.create();
+      const faceId = newUuid();
+      const face = AssetFaceFactory.from({ id: faceId }).person({ faceAssetId: faceId }).build();
+      const remainingFace = AssetFaceFactory.create({ personGroupId: face.personGroupId });
+
+      mocks.access.person.checkFaceOwnerAccess.mockResolvedValue(new Set([faceId]));
+      mocks.person.getFaceById.mockResolvedValue(getForAssetFace(face));
+      mocks.person.getRandomFace.mockResolvedValue(remainingFace);
+
+      await expect(sut.deleteFace(auth, faceId, { force: false })).resolves.toBeUndefined();
+
+      expect(mocks.person.softDeleteAssetFaces).toHaveBeenCalledWith(faceId);
+      expect(mocks.person.update).toHaveBeenCalledWith({
+        ownerId: face.person!.ownerId,
+        personGroupId: face.person!.personGroupId,
+        faceAssetId: remainingFace.id,
+      });
+    });
+
+    it('should clear the feature photo when no face is left to promote', async () => {
+      const auth = AuthFactory.create();
+      const faceId = newUuid();
+      const face = AssetFaceFactory.from({ id: faceId }).person({ faceAssetId: faceId }).build();
+
+      mocks.access.person.checkFaceOwnerAccess.mockResolvedValue(new Set([faceId]));
+      mocks.person.getFaceById.mockResolvedValue(getForAssetFace(face));
+      mocks.person.getRandomFace.mockResolvedValue(void 0);
+
+      await expect(sut.deleteFace(auth, faceId, { force: true })).resolves.toBeUndefined();
+
+      expect(mocks.person.deleteAssetFace).toHaveBeenCalledWith(faceId);
+      expect(mocks.person.update).toHaveBeenCalledWith({
+        ownerId: face.person!.ownerId,
+        personGroupId: face.person!.personGroupId,
+        faceAssetId: null,
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
+    });
+
+    it('should leave the feature photo alone when another face is deleted', async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from().person({ faceAssetId: newUuid() }).build();
+
+      mocks.access.person.checkFaceOwnerAccess.mockResolvedValue(new Set([face.id]));
+      mocks.person.getFaceById.mockResolvedValue(getForAssetFace(face));
+
+      await expect(sut.deleteFace(auth, face.id, { force: false })).resolves.toBeUndefined();
+
+      expect(mocks.person.softDeleteAssetFaces).toHaveBeenCalledWith(face.id);
+      expect(mocks.person.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('mapFace', () => {
     it('should map a face', () => {
       const user = UserFactory.create();

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -148,8 +148,9 @@ export class PersonService extends BaseService {
     for (const { ownerId, personGroupId } of changeFeaturePhoto) {
       const assetFace = await this.personRepository.getRandomFace(personGroupId);
 
+      await this.personRepository.update({ ownerId, personGroupId, faceAssetId: assetFace?.id ?? null });
+
       if (assetFace) {
-        await this.personRepository.update({ ownerId, personGroupId, faceAssetId: assetFace.id });
         jobs.push({ name: JobName.PersonGenerateThumbnail, data: { ownerId, personGroupId } });
       }
     }
@@ -737,6 +738,12 @@ export class PersonService extends BaseService {
   async deleteFace(auth: AuthDto, id: string, dto: AssetFaceDeleteDto): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.FaceDelete, ids: [id] });
 
-    return dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id);
+    const face = await this.personRepository.getFaceById(id, { viewingUserId: auth.user.id });
+
+    await (dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id));
+
+    if (face.person?.faceAssetId === id) {
+      await this.createNewFeaturePhoto([face.person]);
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixes #30952

Deleting the face a person is featured by leaves `person.faceAssetId` pointing at it. `deleteFace` soft-deletes the `asset_face` row without touching the person, so the reference survives the delete, and `getDataForThumbnailGenerationJob` — which joins `asset_face` on `deletedAt IS NULL` — then matches nothing. Thumbnail generation logs `Could not generate person thumbnail for <id>: missing data` and never recovers, because nothing repoints `faceAssetId` afterwards. `force: true` has the same end state via the `ON DELETE SET NULL` foreign key: the reference is cleared but no replacement is chosen.

`deleteFace` now promotes another face through `createNewFeaturePhoto`, the same helper `reassignFaces`, `reassignFacesById` and `createFace` already use for this situation.

`createNewFeaturePhoto` additionally clears `faceAssetId` when `getRandomFace` finds nothing to promote. Without that, the reported flow — a person with a single face, deleted and re-cropped — still ends up stuck: the delete leaves the stale id in place, and `createFace`'s `if (!person.faceAssetId)` check then sees a truthy value and skips the new face. Leaving a reference to a row that is deleted or belongs to someone else is not a state any caller wants, so the fix belongs in the shared helper rather than at each call site.

## How Has This Been Tested?

- [x] `deleteFace` promotes a remaining face when the deleted one was featured
- [x] `deleteFace` clears `faceAssetId` when no face is left to promote
- [x] `deleteFace` leaves `faceAssetId` alone when a different face is deleted
- [x] The first two fail on `main` and pass with the change
- [x] `person.service.spec.ts`: 70 tests pass
- [x] `tsc --noEmit`, `eslint --max-warnings 0` and `prettier --check` on the changed files are clean

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with tracing the call paths and drafting the tests. The root cause, the decision to fix it in `createNewFeaturePhoto` rather than at each call site, and the final code were mine, and I verified every claim above by running the tests locally.