### PR TITLE
fix(server): never unlink an untracked-file path that an asset now references

### DIFF
--- a/server/src/queries/integrity.repository.sql
+++ b/server/src/queries/integrity.repository.sql
@@ -65,6 +65,28 @@ from
 where
   "person"."thumbnailPath" in $1
 
+-- IntegrityRepository.getTrackedPaths
+select
+  "asset"."originalPath" as "path"
+from
+  "asset"
+where
+  "asset"."originalPath" in $1
+union all
+select
+  "asset_file"."path" as "path"
+from
+  "asset_file"
+where
+  "asset_file"."path" in $2
+union all
+select
+  "person"."thumbnailPath" as "path"
+from
+  "person"
+where
+  "person"."thumbnailPath" in $3
+
 -- IntegrityRepository.getAssetCount
 select
   count(*) as "count"

--- a/server/src/queries/integrity.repository.sql
+++ b/server/src/queries/integrity.repository.sql
@@ -72,14 +72,14 @@ from
   "asset"
 where
   "asset"."originalPath" in $1
-union all
+union
 select
   "asset_file"."path" as "path"
 from
   "asset_file"
 where
   "asset_file"."path" in $2
-union all
+union
 select
   "person"."thumbnailPath" as "path"
 from

--- a/server/src/repositories/integrity.repository.ts
+++ b/server/src/repositories/integrity.repository.ts
@@ -100,10 +100,10 @@ export class IntegrityRepository {
       .selectFrom('asset')
       .select('asset.originalPath as path')
       .where('asset.originalPath', 'in', paths)
-      .unionAll((eb) =>
+      .union((eb) =>
         eb.selectFrom('asset_file').select('asset_file.path as path').where('asset_file.path', 'in', paths),
       )
-      .unionAll((eb) =>
+      .union((eb) =>
         eb
           .selectFrom('person')
           .select((eb) => eb.ref('person.thumbnailPath').$castTo<string>().as('path'))

--- a/server/src/repositories/integrity.repository.ts
+++ b/server/src/repositories/integrity.repository.ts
@@ -94,6 +94,24 @@ export class IntegrityRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.STRING] })
+  getTrackedPaths(paths: string[]) {
+    return this.db
+      .selectFrom('asset')
+      .select('asset.originalPath as path')
+      .where('asset.originalPath', 'in', paths)
+      .unionAll((eb) =>
+        eb.selectFrom('asset_file').select('asset_file.path as path').where('asset_file.path', 'in', paths),
+      )
+      .unionAll((eb) =>
+        eb
+          .selectFrom('person')
+          .select((eb) => eb.ref('person.thumbnailPath').$castTo<string>().as('path'))
+          .where('person.thumbnailPath', 'in', paths),
+      )
+      .execute();
+  }
+
   @GenerateSql({ params: [] })
   getAssetCount() {
     return this.db

--- a/server/src/services/integrity.service.spec.ts
+++ b/server/src/services/integrity.service.spec.ts
@@ -1,3 +1,4 @@
+import { IntegrityReport } from 'src/enum';
 import { IntegrityService } from 'src/services/integrity.service';
 import { newTestService, ServiceMocks } from 'test/utils';
 
@@ -11,6 +12,124 @@ describe(IntegrityService.name, () => {
 
   it('should work', () => {
     expect(sut).toBeDefined();
+  });
+
+  describe('handleUntrackedFiles', () => {
+    beforeEach(() => {
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
+    });
+
+    it('should only report paths that no asset references', async () => {
+      const originalPath = '/data/upload/admin/ab/asset.mov';
+      const encodedVideoPath = '/data/encoded-video/admin/ab/asset.mp4';
+      const untracked = '/data/upload/orphan.mov';
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([{ originalPath, encodedVideoPath }] as never);
+
+      await sut.handleUntrackedFiles({ type: 'asset', paths: [originalPath, encodedVideoPath, untracked] });
+
+      expect(mocks.integrityReport.getAssetFilePathsByPaths).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.create).toHaveBeenCalledWith([
+        { type: IntegrityReport.UntrackedFile, path: untracked },
+      ]);
+    });
+
+    it('should not report a path that is a person thumbnail', async () => {
+      const thumbnailPath = '/data/thumbs/admin/person.jpeg';
+      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([{ thumbnailPath }] as never);
+
+      await sut.handleUntrackedFiles({ type: 'asset_file', paths: [thumbnailPath] });
+
+      expect(mocks.integrityReport.getAssetPathsByPaths).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleUntrackedRefresh', () => {
+    beforeEach(() => {
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
+    });
+
+    it('should delete a report whose path is now referenced by an asset', async () => {
+      const path = '/data/upload/admin/ab/asset.mov';
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
+        { originalPath: path, encodedVideoPath: null },
+      ] as never);
+
+      await sut.handleUntrackedRefresh({ items: [{ reportId: 'report-id', path }] });
+
+      expect(mocks.integrityReport.deleteByIds).toHaveBeenCalledWith(['report-id']);
+      expect(mocks.storage.stat).not.toHaveBeenCalled();
+    });
+
+    it('should keep a report whose path is still untracked and present on disk', async () => {
+      mocks.storage.stat.mockResolvedValue({} as never);
+
+      await sut.handleUntrackedRefresh({ items: [{ reportId: 'report-id', path: '/data/upload/orphan.mov' }] });
+
+      expect(mocks.integrityReport.deleteByIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteIntegrityReport', () => {
+    beforeEach(() => {
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
+    });
+
+    it('should not unlink a path that is now referenced by an asset', async () => {
+      const path = '/data/upload/admin/ab/asset.mov';
+      mocks.integrityReport.getById.mockResolvedValue({ path } as never);
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
+        { originalPath: path, encodedVideoPath: null },
+      ] as never);
+
+      await sut.deleteIntegrityReport('user-id', 'report-id');
+
+      expect(mocks.storage.unlink).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.deleteById).toHaveBeenCalledWith('report-id');
+    });
+
+    it('should unlink a path that is still untracked', async () => {
+      const path = '/data/upload/orphan.mov';
+      mocks.integrityReport.getById.mockResolvedValue({ path } as never);
+
+      await sut.deleteIntegrityReport('user-id', 'report-id');
+
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(path);
+      expect(mocks.integrityReport.deleteById).toHaveBeenCalledWith('report-id');
+    });
+  });
+
+  describe('handleDeleteIntegrityReports', () => {
+    beforeEach(() => {
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
+    });
+
+    it('should skip unlinking paths that are now referenced', async () => {
+      const tracked = '/data/upload/admin/ab/asset.mov';
+      const untracked = '/data/upload/orphan.mov';
+      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
+        { originalPath: tracked, encodedVideoPath: null },
+      ] as never);
+      mocks.storage.unlink.mockResolvedValue(void 0);
+
+      await sut.handleDeleteIntegrityReports({
+        reports: [
+          { id: 'tracked-report', path: tracked },
+          { id: 'untracked-report', path: untracked },
+        ] as never,
+      });
+
+      expect(mocks.storage.unlink).toHaveBeenCalledExactlyOnceWith(untracked);
+      expect(mocks.integrityReport.deleteByIds).toHaveBeenCalledWith(['tracked-report', 'untracked-report']);
+    });
   });
 
   describe('handleDeleteAllIntegrityReports', () => {

--- a/server/src/services/integrity.service.spec.ts
+++ b/server/src/services/integrity.service.spec.ts
@@ -44,6 +44,38 @@ describe(IntegrityService.name, () => {
     });
   });
 
+  describe('deleteIntegrityReport', () => {
+    it('should not unlink a path that is now tracked', async () => {
+      const path = '/data/upload/admin/ab/asset.mov';
+      mocks.integrityReport.getById.mockResolvedValue({ path } as never);
+      mocks.integrityReport.getTrackedPaths.mockResolvedValue([{ path }] as never);
+
+      await sut.deleteIntegrityReport('user-id', 'report-id');
+
+      expect(mocks.storage.unlink).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.deleteById).toHaveBeenCalledWith('report-id');
+    });
+  });
+
+  describe('handleDeleteIntegrityReports', () => {
+    it('should unlink only paths that are still untracked', async () => {
+      const tracked = '/data/upload/admin/ab/asset.mov';
+      const untracked = '/data/upload/orphan.mov';
+      mocks.integrityReport.getTrackedPaths.mockResolvedValue([{ path: tracked }] as never);
+      mocks.storage.unlink.mockResolvedValue();
+
+      await sut.handleDeleteIntegrityReports({
+        reports: [
+          { id: 'tracked-report', path: tracked },
+          { id: 'untracked-report', path: untracked },
+        ] as never,
+      });
+
+      expect(mocks.storage.unlink).toHaveBeenCalledExactlyOnceWith(untracked);
+      expect(mocks.integrityReport.deleteByIds).toHaveBeenCalledWith(['tracked-report', 'untracked-report']);
+    });
+  });
+
   describe('handleDeleteAllIntegrityReports', () => {
     beforeEach(() => {
       mocks.integrityReport.streamIntegrityReportsByProperty.mockReturnValue((function* () {})() as never);

--- a/server/src/services/integrity.service.spec.ts
+++ b/server/src/services/integrity.service.spec.ts
@@ -1,4 +1,3 @@
-import { IntegrityReport } from 'src/enum';
 import { IntegrityService } from 'src/services/integrity.service';
 import { newTestService, ServiceMocks } from 'test/utils';
 
@@ -14,62 +13,19 @@ describe(IntegrityService.name, () => {
     expect(sut).toBeDefined();
   });
 
-  describe('handleUntrackedFiles', () => {
-    beforeEach(() => {
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
-    });
-
-    it('should only report paths that no asset references', async () => {
-      const originalPath = '/data/upload/admin/ab/asset.mov';
-      const encodedVideoPath = '/data/encoded-video/admin/ab/asset.mp4';
-      const untracked = '/data/upload/orphan.mov';
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([{ originalPath, encodedVideoPath }] as never);
-
-      await sut.handleUntrackedFiles({ type: 'asset', paths: [originalPath, encodedVideoPath, untracked] });
-
-      expect(mocks.integrityReport.getAssetFilePathsByPaths).not.toHaveBeenCalled();
-      expect(mocks.integrityReport.create).toHaveBeenCalledWith([
-        { type: IntegrityReport.UntrackedFile, path: untracked },
-      ]);
-    });
-
-    it('should not report a path that is a person thumbnail', async () => {
-      const thumbnailPath = '/data/thumbs/admin/person.jpeg';
-      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([{ thumbnailPath }] as never);
-
-      await sut.handleUntrackedFiles({ type: 'asset_file', paths: [thumbnailPath] });
-
-      expect(mocks.integrityReport.getAssetPathsByPaths).not.toHaveBeenCalled();
-      expect(mocks.integrityReport.create).not.toHaveBeenCalled();
-    });
-  });
-
   describe('handleUntrackedRefresh', () => {
     beforeEach(() => {
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
+      mocks.integrityReport.getTrackedPaths.mockResolvedValue([]);
     });
 
     it('should delete a report whose path is now referenced by an asset', async () => {
       const path = '/data/upload/admin/ab/asset.mov';
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
-        { originalPath: path, encodedVideoPath: null },
-      ] as never);
+      mocks.integrityReport.getTrackedPaths.mockResolvedValue([{ path }] as never);
 
       await sut.handleUntrackedRefresh({ items: [{ reportId: 'report-id', path }] });
 
       expect(mocks.integrityReport.deleteByIds).toHaveBeenCalledWith(['report-id']);
       expect(mocks.storage.stat).not.toHaveBeenCalled();
-    });
-
-    it('should not query for references when the batch is empty', async () => {
-      await sut.handleUntrackedRefresh({ items: [] });
-
-      expect(mocks.integrityReport.getAssetPathsByPaths).not.toHaveBeenCalled();
-      expect(mocks.integrityReport.deleteByIds).not.toHaveBeenCalled();
     });
 
     it('should keep a report whose path is still untracked and present on disk', async () => {
@@ -79,63 +35,12 @@ describe(IntegrityService.name, () => {
 
       expect(mocks.integrityReport.deleteByIds).not.toHaveBeenCalled();
     });
-  });
 
-  describe('deleteIntegrityReport', () => {
-    beforeEach(() => {
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
-    });
+    it('should not query for references when the batch is empty', async () => {
+      await sut.handleUntrackedRefresh({ items: [] });
 
-    it('should not unlink a path that is now referenced by an asset', async () => {
-      const path = '/data/upload/admin/ab/asset.mov';
-      mocks.integrityReport.getById.mockResolvedValue({ path } as never);
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
-        { originalPath: path, encodedVideoPath: null },
-      ] as never);
-
-      await sut.deleteIntegrityReport('user-id', 'report-id');
-
-      expect(mocks.storage.unlink).not.toHaveBeenCalled();
-      expect(mocks.integrityReport.deleteById).toHaveBeenCalledWith('report-id');
-    });
-
-    it('should unlink a path that is still untracked', async () => {
-      const path = '/data/upload/orphan.mov';
-      mocks.integrityReport.getById.mockResolvedValue({ path } as never);
-
-      await sut.deleteIntegrityReport('user-id', 'report-id');
-
-      expect(mocks.storage.unlink).toHaveBeenCalledWith(path);
-      expect(mocks.integrityReport.deleteById).toHaveBeenCalledWith('report-id');
-    });
-  });
-
-  describe('handleDeleteIntegrityReports', () => {
-    beforeEach(() => {
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getAssetFilePathsByPaths.mockResolvedValue([]);
-      mocks.integrityReport.getPersonThumbnailPathsByPaths.mockResolvedValue([]);
-    });
-
-    it('should skip unlinking paths that are now referenced', async () => {
-      const tracked = '/data/upload/admin/ab/asset.mov';
-      const untracked = '/data/upload/orphan.mov';
-      mocks.integrityReport.getAssetPathsByPaths.mockResolvedValue([
-        { originalPath: tracked, encodedVideoPath: null },
-      ] as never);
-      mocks.storage.unlink.mockResolvedValue(void 0);
-
-      await sut.handleDeleteIntegrityReports({
-        reports: [
-          { id: 'tracked-report', path: tracked },
-          { id: 'untracked-report', path: untracked },
-        ] as never,
-      });
-
-      expect(mocks.storage.unlink).toHaveBeenCalledExactlyOnceWith(untracked);
-      expect(mocks.integrityReport.deleteByIds).toHaveBeenCalledWith(['tracked-report', 'untracked-report']);
+      expect(mocks.integrityReport.getTrackedPaths).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.deleteByIds).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/integrity.service.spec.ts
+++ b/server/src/services/integrity.service.spec.ts
@@ -65,6 +65,13 @@ describe(IntegrityService.name, () => {
       expect(mocks.storage.stat).not.toHaveBeenCalled();
     });
 
+    it('should not query for references when the batch is empty', async () => {
+      await sut.handleUntrackedRefresh({ items: [] });
+
+      expect(mocks.integrityReport.getAssetPathsByPaths).not.toHaveBeenCalled();
+      expect(mocks.integrityReport.deleteByIds).not.toHaveBeenCalled();
+    });
+
     it('should keep a report whose path is still untracked and present on disk', async () => {
       mocks.storage.stat.mockResolvedValue({} as never);
 

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -296,6 +296,10 @@ export class IntegrityService extends BaseService {
   private async getTrackedPaths(paths: string[], type?: 'asset' | 'asset_file'): Promise<Set<string>> {
     const trackedPaths = new Set<string>();
 
+    if (paths.length === 0) {
+      return trackedPaths;
+    }
+
     if (type !== 'asset_file') {
       for (const { originalPath, encodedVideoPath } of await this.integrityRepository.getAssetPathsByPaths(paths)) {
         trackedPaths.add(originalPath);

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -314,12 +314,9 @@ export class IntegrityService extends BaseService {
   async handleUntrackedRefresh({ items }: IIntegrityPathWithReportJob): Promise<JobStatus> {
     this.logger.log(`Processing batch of ${items.length} reports to check if they are out of date.`);
 
-    const trackedPaths = new Set<string>();
-    if (items.length > 0) {
-      for (const { path } of await this.integrityRepository.getTrackedPaths(items.map((item) => item.path))) {
-        trackedPaths.add(path);
-      }
-    }
+    const tracked =
+      items.length > 0 ? await this.integrityRepository.getTrackedPaths(items.map(({ path }) => path)) : [];
+    const trackedPaths = new Set(tracked.map(({ path }) => path));
 
     const results = await Promise.all(
       items.map(async ({ reportId, path }) => {

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -190,7 +190,10 @@ export class IntegrityService extends BaseService {
     } else if (fileAssetId) {
       await this.assetRepository.deleteFiles([{ id: fileAssetId }]);
     } else {
-      await this.storageRepository.unlink(path);
+      const trackedPaths = await this.integrityRepository.getTrackedPaths([path]);
+      if (trackedPaths.length === 0) {
+        await this.storageRepository.unlink(path);
+      }
       await this.integrityRepository.deleteById(id);
     }
   }
@@ -709,7 +712,13 @@ export class IntegrityService extends BaseService {
     }
 
     if (byPath.length > 0) {
-      await Promise.all(byPath.map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)));
+      const tracked = await this.integrityRepository.getTrackedPaths(byPath.map(({ path }) => path));
+      const trackedPaths = new Set(tracked.map(({ path }) => path));
+      await Promise.all(
+        byPath
+          .filter(({ path }) => !trackedPaths.has(path))
+          .map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)),
+      );
       await this.integrityRepository.deleteByIds(byPath.map(({ id }) => id));
     }
 

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -190,7 +190,12 @@ export class IntegrityService extends BaseService {
     } else if (fileAssetId) {
       await this.assetRepository.deleteFiles([{ id: fileAssetId }]);
     } else {
-      await this.storageRepository.unlink(path);
+      const trackedPaths = await this.getTrackedPaths([path]);
+
+      if (!trackedPaths.has(path)) {
+        await this.storageRepository.unlink(path);
+      }
+
       await this.integrityRepository.deleteById(id);
     }
   }
@@ -272,27 +277,8 @@ export class IntegrityService extends BaseService {
   async handleUntrackedFiles({ type, paths }: IIntegrityUntrackedFilesJob): Promise<JobStatus> {
     this.logger.log(`Processing batch of ${paths.length} files to check if they are untracked.`);
 
-    const untrackedFiles = new Set<string>(paths);
-    if (type === 'asset') {
-      const assets = await this.integrityRepository.getAssetPathsByPaths(paths);
-      for (const { originalPath, encodedVideoPath } of assets) {
-        untrackedFiles.delete(originalPath);
-
-        if (encodedVideoPath) {
-          untrackedFiles.delete(encodedVideoPath);
-        }
-      }
-    } else {
-      const assets = await this.integrityRepository.getAssetFilePathsByPaths(paths);
-      for (const { path } of assets) {
-        untrackedFiles.delete(path);
-      }
-    }
-
-    const personThumbnailPaths = await this.integrityRepository.getPersonThumbnailPathsByPaths(paths);
-    for (const { thumbnailPath } of personThumbnailPaths) {
-      untrackedFiles.delete(thumbnailPath);
-    }
+    const trackedPaths = await this.getTrackedPaths(paths, type);
+    const untrackedFiles = new Set<string>(paths.filter((path) => !trackedPaths.has(path)));
 
     if (untrackedFiles.size > 0) {
       await this.integrityRepository.create(
@@ -307,12 +293,44 @@ export class IntegrityService extends BaseService {
     return JobStatus.Success;
   }
 
+  private async getTrackedPaths(paths: string[], type?: 'asset' | 'asset_file'): Promise<Set<string>> {
+    const trackedPaths = new Set<string>();
+
+    if (type !== 'asset_file') {
+      for (const { originalPath, encodedVideoPath } of await this.integrityRepository.getAssetPathsByPaths(paths)) {
+        trackedPaths.add(originalPath);
+
+        if (encodedVideoPath) {
+          trackedPaths.add(encodedVideoPath);
+        }
+      }
+    }
+
+    if (type !== 'asset') {
+      for (const { path } of await this.integrityRepository.getAssetFilePathsByPaths(paths)) {
+        trackedPaths.add(path);
+      }
+    }
+
+    for (const { thumbnailPath } of await this.integrityRepository.getPersonThumbnailPathsByPaths(paths)) {
+      trackedPaths.add(thumbnailPath);
+    }
+
+    return trackedPaths;
+  }
+
   @OnJob({ name: JobName.IntegrityUntrackedFilesRefresh, queue: QueueName.IntegrityCheck })
   async handleUntrackedRefresh({ items }: IIntegrityPathWithReportJob): Promise<JobStatus> {
     this.logger.log(`Processing batch of ${items.length} reports to check if they are out of date.`);
 
+    const trackedPaths = await this.getTrackedPaths(items.map(({ path }) => path));
+
     const results = await Promise.all(
       items.map(async ({ reportId, path }) => {
+        if (trackedPaths.has(path)) {
+          return reportId;
+        }
+
         try {
           await this.storageRepository.stat(path);
           return;
@@ -697,7 +715,13 @@ export class IntegrityService extends BaseService {
     }
 
     if (byPath.length > 0) {
-      await Promise.all(byPath.map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)));
+      const trackedPaths = await this.getTrackedPaths(byPath.map(({ path }) => path));
+
+      await Promise.all(
+        byPath
+          .filter(({ path }) => !trackedPaths.has(path))
+          .map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)),
+      );
       await this.integrityRepository.deleteByIds(byPath.map(({ id }) => id));
     }
 

--- a/server/src/services/integrity.service.ts
+++ b/server/src/services/integrity.service.ts
@@ -190,12 +190,7 @@ export class IntegrityService extends BaseService {
     } else if (fileAssetId) {
       await this.assetRepository.deleteFiles([{ id: fileAssetId }]);
     } else {
-      const trackedPaths = await this.getTrackedPaths([path]);
-
-      if (!trackedPaths.has(path)) {
-        await this.storageRepository.unlink(path);
-      }
-
+      await this.storageRepository.unlink(path);
       await this.integrityRepository.deleteById(id);
     }
   }
@@ -277,8 +272,27 @@ export class IntegrityService extends BaseService {
   async handleUntrackedFiles({ type, paths }: IIntegrityUntrackedFilesJob): Promise<JobStatus> {
     this.logger.log(`Processing batch of ${paths.length} files to check if they are untracked.`);
 
-    const trackedPaths = await this.getTrackedPaths(paths, type);
-    const untrackedFiles = new Set<string>(paths.filter((path) => !trackedPaths.has(path)));
+    const untrackedFiles = new Set<string>(paths);
+    if (type === 'asset') {
+      const assets = await this.integrityRepository.getAssetPathsByPaths(paths);
+      for (const { originalPath, encodedVideoPath } of assets) {
+        untrackedFiles.delete(originalPath);
+
+        if (encodedVideoPath) {
+          untrackedFiles.delete(encodedVideoPath);
+        }
+      }
+    } else {
+      const assets = await this.integrityRepository.getAssetFilePathsByPaths(paths);
+      for (const { path } of assets) {
+        untrackedFiles.delete(path);
+      }
+    }
+
+    const personThumbnailPaths = await this.integrityRepository.getPersonThumbnailPathsByPaths(paths);
+    for (const { thumbnailPath } of personThumbnailPaths) {
+      untrackedFiles.delete(thumbnailPath);
+    }
 
     if (untrackedFiles.size > 0) {
       await this.integrityRepository.create(
@@ -293,44 +307,20 @@ export class IntegrityService extends BaseService {
     return JobStatus.Success;
   }
 
-  private async getTrackedPaths(paths: string[], type?: 'asset' | 'asset_file'): Promise<Set<string>> {
-    const trackedPaths = new Set<string>();
-
-    if (paths.length === 0) {
-      return trackedPaths;
-    }
-
-    if (type !== 'asset_file') {
-      for (const { originalPath, encodedVideoPath } of await this.integrityRepository.getAssetPathsByPaths(paths)) {
-        trackedPaths.add(originalPath);
-
-        if (encodedVideoPath) {
-          trackedPaths.add(encodedVideoPath);
-        }
-      }
-    }
-
-    if (type !== 'asset') {
-      for (const { path } of await this.integrityRepository.getAssetFilePathsByPaths(paths)) {
-        trackedPaths.add(path);
-      }
-    }
-
-    for (const { thumbnailPath } of await this.integrityRepository.getPersonThumbnailPathsByPaths(paths)) {
-      trackedPaths.add(thumbnailPath);
-    }
-
-    return trackedPaths;
-  }
-
   @OnJob({ name: JobName.IntegrityUntrackedFilesRefresh, queue: QueueName.IntegrityCheck })
   async handleUntrackedRefresh({ items }: IIntegrityPathWithReportJob): Promise<JobStatus> {
     this.logger.log(`Processing batch of ${items.length} reports to check if they are out of date.`);
 
-    const trackedPaths = await this.getTrackedPaths(items.map(({ path }) => path));
+    const trackedPaths = new Set<string>();
+    if (items.length > 0) {
+      for (const { path } of await this.integrityRepository.getTrackedPaths(items.map((item) => item.path))) {
+        trackedPaths.add(path);
+      }
+    }
 
     const results = await Promise.all(
       items.map(async ({ reportId, path }) => {
+        // The path was untracked when the report was written; an asset may reference it now.
         if (trackedPaths.has(path)) {
           return reportId;
         }
@@ -719,13 +709,7 @@ export class IntegrityService extends BaseService {
     }
 
     if (byPath.length > 0) {
-      const trackedPaths = await this.getTrackedPaths(byPath.map(({ path }) => path));
-
-      await Promise.all(
-        byPath
-          .filter(({ path }) => !trackedPaths.has(path))
-          .map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)),
-      );
+      await Promise.all(byPath.map(({ path }) => this.storageRepository.unlink(path).catch(() => void 0)));
       await this.integrityRepository.deleteByIds(byPath.map(({ id }) => id));
     }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/immich-app/immich/issues/30933

### Problem

An `untracked_file` report stores only a path. If an asset starts referencing that path after the report is created, Refresh previously kept the stale report because it checked only whether the file existed. Deleting the stale report then unlinked the original of a live asset, and the next integrity scan reported that same path as missing.

### Changes

- Add one repository query that finds matching asset originals, asset-file paths, and person thumbnails.
- Drop an untracked report during Refresh when its path is now referenced.
- Revalidate both the single-report and batch-delete paths immediately before unlinking.
- Remove stale reports without unlinking their files when a reference now exists.

The normal untracked scan keeps its existing query shape.

### User impact

Refreshing or deleting a stale untracked report no longer removes a file that Immich currently references. Genuinely untracked files are still deleted as before.

## Verification

- `pnpm --filter immich test src/services/integrity.service.spec.ts --run` — 7/7 passed.
- `pnpm run check` — passed.
- ESLint on both changed service files with `--max-warnings 0` — passed.
- Prettier on both changed service files — passed.
- `git diff --check upstream/main...HEAD` — passed.

The focused regression coverage exercises tracked-path Refresh, single deletion, and mixed batch deletion. The existing medium tests continue to cover unlinking a genuinely untracked path.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with tracing the job and delete paths through the service and with drafting the tests. The diagnosis, final query shape, delete-time guards, and verification were reviewed by the author.