### PR TITLE
fix(ml): read CLIP model configs as UTF-8

### DIFF
--- a/machine-learning/immich_ml/models/clip/textual.py
+++ b/machine-learning/immich_ml/models/clip/textual.py
@@ -58,7 +58,7 @@ class BaseCLIPTextualEncoder(InferenceModel):
     @cached_property
     def model_cfg(self) -> dict[str, Any]:
         log.debug(f"Loading model config for CLIP model '{self.model_name}'")
-        model_cfg: dict[str, Any] = json.load(self.model_cfg_path.open())
+        model_cfg: dict[str, Any] = json.load(self.model_cfg_path.open(encoding="utf-8"))
         log.debug(f"Loaded model config for CLIP model '{self.model_name}'")
         return model_cfg
 
@@ -70,14 +70,14 @@ class BaseCLIPTextualEncoder(InferenceModel):
     @cached_property
     def tokenizer_file(self) -> dict[str, Any]:
         log.debug(f"Loading tokenizer file for CLIP model '{self.model_name}'")
-        tokenizer_file: dict[str, Any] = json.load(self.tokenizer_file_path.open())
+        tokenizer_file: dict[str, Any] = json.load(self.tokenizer_file_path.open(encoding="utf-8"))
         log.debug(f"Loaded tokenizer file for CLIP model '{self.model_name}'")
         return tokenizer_file
 
     @cached_property
     def tokenizer_cfg(self) -> dict[str, Any]:
         log.debug(f"Loading tokenizer config for CLIP model '{self.model_name}'")
-        tokenizer_cfg: dict[str, Any] = json.load(self.tokenizer_cfg_path.open())
+        tokenizer_cfg: dict[str, Any] = json.load(self.tokenizer_cfg_path.open(encoding="utf-8"))
         log.debug(f"Loaded tokenizer config for CLIP model '{self.model_name}'")
         return tokenizer_cfg
 

--- a/machine-learning/immich_ml/models/clip/visual.py
+++ b/machine-learning/immich_ml/models/clip/visual.py
@@ -46,14 +46,14 @@ class BaseCLIPVisualEncoder(InferenceModel):
     @cached_property
     def model_cfg(self) -> dict[str, Any]:
         log.debug(f"Loading model config for CLIP model '{self.model_name}'")
-        model_cfg: dict[str, Any] = json.load(self.model_cfg_path.open())
+        model_cfg: dict[str, Any] = json.load(self.model_cfg_path.open(encoding="utf-8"))
         log.debug(f"Loaded model config for CLIP model '{self.model_name}'")
         return model_cfg
 
     @cached_property
     def preprocess_cfg(self) -> dict[str, Any]:
         log.debug(f"Loading visual preprocessing config for CLIP model '{self.model_name}'")
-        preprocess_cfg: dict[str, Any] = json.load(self.preprocess_cfg_path.open())
+        preprocess_cfg: dict[str, Any] = json.load(self.preprocess_cfg_path.open(encoding="utf-8"))
         log.debug(f"Loaded visual preprocessing config for CLIP model '{self.model_name}'")
         return preprocess_cfg
 

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -617,6 +617,38 @@ class TestCLIP:
         assert len(embedding) == clip_model_cfg["embed_dim"]
         mocked.run.assert_called_once()
 
+    def test_reads_model_configs_as_utf8(self, mocker: MockerFixture, tmp_path: Path) -> None:
+        original_open = Path.open
+
+        def locale_default_is_ascii(self: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+            if "b" not in mode and kwargs.get("encoding") is None:
+                kwargs["encoding"] = "ascii"
+            return original_open(self, mode, *args, **kwargs)
+
+        mocker.patch.object(OpenClipTextualEncoder, "download")
+        mocker.patch.object(OpenClipVisualEncoder, "download")
+
+        textual = OpenClipTextualEncoder("ViT-B-32__openai", cache_dir=tmp_path)
+        visual = OpenClipVisualEncoder("ViT-B-32__openai", cache_dir=tmp_path)
+        paths = [
+            textual.model_cfg_path,
+            textual.tokenizer_file_path,
+            textual.tokenizer_cfg_path,
+            visual.model_cfg_path,
+            visual.preprocess_cfg_path,
+        ]
+        for path in paths:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(orjson.dumps({"eos_token": "<|café|>"}).decode(), encoding="utf-8")
+
+        mocker.patch.object(Path, "open", locale_default_is_ascii)
+
+        assert textual.model_cfg["eos_token"] == "<|café|>"
+        assert textual.tokenizer_file["eos_token"] == "<|café|>"
+        assert textual.tokenizer_cfg["eos_token"] == "<|café|>"
+        assert visual.model_cfg["eos_token"] == "<|café|>"
+        assert visual.preprocess_cfg["eos_token"] == "<|café|>"
+
     def test_openclip_tokenizer(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
## Description

Fixes #30914

The CLIP encoders load their JSON configs with `Path.open()` and no encoding, so the text codec comes from `locale.getpreferredencoding()`. A container started without a locale resolves that to ASCII, and any non-ASCII byte in the config raises `UnicodeDecodeError`.

`ViT-SO400M-16-SigLIP2-384__webli` hits this through `tokenizer_config.json`. The failure is quiet: only the textual encoder loads those files, so visual embedding keeps working, `/ping` stays healthy and the container stays `Ready` while every smart-search request returns 500.

The issue names the three reads in `clip/textual.py`. `clip/visual.py` loads `config.json` and `preprocess_cfg.json` the same way from the same model directories, so all five now pass `encoding="utf-8"`. Nothing else in the config-loading path changes — these files are UTF-8 JSON as published.

I left `sessions/rknn/rknnpool.py` alone: it reads `/proc/device-tree/compatible`, which is not a model config and has its own error handling.

## How Has This Been Tested?

- [x] New `TestCLIP::test_reads_model_configs_as_utf8` writes non-ASCII configs for both encoders and reads them with `Path.open` defaulting to ASCII, standing in for the unset-locale container
- [x] It fails on `main` with `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3` and passes with the change
- [x] `pytest test_main.py`: 102 passed, 3 skipped
- [x] `ruff check` and `ruff format --check` clean

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with locating the sibling reads in the visual encoder and drafting the test. The decision on scope and the final code were mine, and I ran the suite and the linters locally.