### PR TITLE
fix(server): attach error handler to accepted sockets to prevent crash on connection reset

### DIFF
--- a/server/src/app.common.ts
+++ b/server/src/app.common.ts
@@ -91,5 +91,15 @@ export async function configureExpress(
   const server = await (host ? app.listen(port, host) : app.listen(port));
   server.requestTimeout = 24 * 60 * 60 * 1000;
 
+  // A socket with no 'error' listener throws on error instead of emitting it,
+  // crashing the process - this hits idle keep-alive sockets and sockets handed
+  // off to the websocket upgrade handler when a peer resets the connection.
+  // Attach one at accept time so every socket has one for its whole lifetime.
+  server.on('connection', (socket) => {
+    socket.on('error', (error) => {
+      logger.debug(`Socket error: ${error.message}`);
+    });
+  });
+
   logger.log(`${IMMICH_SERVER_START} on ${await app.getUrl()} [v${serverVersion}] [${environment}] `);
 }


### PR DESCRIPTION
fix(server): attach error handler to accepted sockets to prevent crash on connection reset

## Description

Immich's HTTP server never attaches an `'error'` listener to sockets it accepts. Node throws instead of emitting when a socket's `'error'` event has zero listeners, which crashes the whole process this hits an idle keep-alive socket, or one handed off to the websocket upgrade handler, when the peer resets the connection (e.g. the mobile app closing). The process exits with code 1 and the container restarts, even though every prior request succeeded.

Verified in `server/src/app.common.ts`: `configureExpress()` calls `app.listen()` and only sets `server.requestTimeout` on the result nothing else touches the returned server or its sockets. There's no `clientError` handler, no `uncaughtException` `unhandledRejection` handler, and no `'connection'` listener anywhere in `server/src`.

Fix: attach a listener to each socket at accept time (`server.on('connection', ...)`), so it has an `'error'` listener for its entire lifetime regardless of what happens to it afterward (idle keep-alive, or handed off during a websocket upgrade). A `clientError` handler wouldn't cover this that only fires during HTTP request/header parsing, and this crash happens after a request has already completed.

Fixes #30931 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Isolated the exact `server.on('connection', ...)` / `socket.on('error', ...)` snippet against real `@types/node` and ran `tsc --noEmit --strict` (matching this repo's own `tsconfig.json`) compiles clean.
- [ ] Could not run the full test suite or reproduce the crash locally reproducing needs a live server + mobile client connection teardown, and I wasn't able to get a full monorepo install running in my environment (unrelated `pnpm` Corepack issue on my machine, not a repo problem).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
