### PR TITLE
fix(web): face editor coordinates on a not-yet-loaded video

### DIFF
--- a/web/src/lib/components/asset-viewer/VideoNativeViewer.svelte
+++ b/web/src/lib/components/asset-viewer/VideoNativeViewer.svelte
@@ -76,6 +76,7 @@
 
   let videoPlayer: HTMLVideoElement | undefined = $state();
   let isLoading = $state(true);
+  let hasLoadedMetadata = $state(false);
   let assetFileUrl = $derived.by(() => {
     if (featureFlagsManager.value.realtimeTranscoding) {
       return getAssetHlsUrl(assetId);
@@ -241,6 +242,7 @@
 
   $effect(() => {
     // reactive on `assetFileUrl` changes
+    hasLoadedMetadata = false;
     if (videoPlayer && assetFileUrl) {
       hasFocused = false;
       rebuildCount = 0;
@@ -385,6 +387,7 @@
             {...useSwipe(onSwipe)}
             class="h-full object-contain"
             oncanplay={(e: Event) => handleCanPlay(e.currentTarget as HTMLVideoElement)}
+            onloadedmetadata={() => (hasLoadedMetadata = true)}
             onended={onVideoEnded}
             onseeking={onSeeking}
             onplaying={(e: Event) => {
@@ -410,6 +413,7 @@
             {...useSwipe(onSwipe)}
             class="h-full object-contain"
             oncanplay={(e) => handleCanPlay(e.currentTarget)}
+            onloadedmetadata={() => (hasLoadedMetadata = true)}
             onended={onVideoEnded}
             onseeking={onSeeking}
             onplaying={(e) => {
@@ -489,7 +493,7 @@
         </div>
       {/if}
 
-      {#if assetViewerManager.isFaceEditMode && videoPlayer}
+      {#if assetViewerManager.isFaceEditMode && videoPlayer && hasLoadedMetadata}
         <FaceEditor htmlElement={videoPlayer} {containerWidth} {containerHeight} {assetId} />
       {/if}
     {/if}

--- a/web/src/lib/utils/container-utils.ts
+++ b/web/src/lib/utils/container-utils.ts
@@ -29,7 +29,12 @@ export type ContentMetrics = {
   offsetY: number;
 };
 
+const isMeasurable = (dimensions: Size) => dimensions.width > 0 && dimensions.height > 0;
+
 export const scaleToCover = (dimensions: Size, container: Size): Size => {
+  if (!isMeasurable(dimensions)) {
+    return { width: 0, height: 0 };
+  }
   const scaleX = container.width / dimensions.width;
   const scaleY = container.height / dimensions.height;
   const scale = Math.max(scaleX, scaleY);
@@ -40,6 +45,9 @@ export const scaleToCover = (dimensions: Size, container: Size): Size => {
 };
 
 export const scaleToFit = (dimensions: Size, container: Size): Size => {
+  if (!isMeasurable(dimensions)) {
+    return { width: 0, height: 0 };
+  }
   const scaleX = container.width / dimensions.width;
   const scaleY = container.height / dimensions.height;
   const scale = Math.min(scaleX, scaleY);

--- a/web/src/lib/utils/layout-utils.spec.ts
+++ b/web/src/lib/utils/layout-utils.spec.ts
@@ -1,4 +1,4 @@
-import { scaleToFit } from '$lib/utils/container-utils';
+import { scaleToCover, scaleToFit } from '$lib/utils/container-utils';
 
 describe('scaleToFit', () => {
   const tests = [
@@ -49,6 +49,19 @@ describe('scaleToFit', () => {
   for (const { name, dimensions, container, expected } of tests) {
     it(`should handle ${name}`, () => {
       expect(scaleToFit(dimensions, container)).toEqual(expected);
+    });
+  }
+
+  const unmeasurable = [
+    { name: 'zero width and height', dimensions: { width: 0, height: 0 } },
+    { name: 'zero width', dimensions: { width: 0, height: 1000 } },
+    { name: 'zero height', dimensions: { width: 1000, height: 0 } },
+  ];
+
+  for (const { name, dimensions } of unmeasurable) {
+    it(`should return an empty size for ${name}`, () => {
+      expect(scaleToFit(dimensions, { width: 500, height: 500 })).toEqual({ width: 0, height: 0 });
+      expect(scaleToCover(dimensions, { width: 500, height: 500 })).toEqual({ width: 0, height: 0 });
     });
   }
 });


### PR DESCRIPTION
The face editor was mounted as soon as the `<video>` element existed, not once it had dimensions. Before `loadedmetadata`, `videoWidth`/`videoHeight` are 0, so `scaleToFit` divides by zero and every face coordinate comes out NaN. It never recovers, since the natural size isn't read reactively.

Should fix the bulk of the e2e-ui test flakes.