### PR TITLE
fix(e2e): wait out the duplicate #asset-grid during navigation

### DIFF
--- a/e2e/src/ui/specs/timeline/utils.ts
+++ b/e2e/src/ui/specs/timeline/utils.ts
@@ -132,6 +132,7 @@ export const timelineUtils = {
     return page.locator('#asset-grid');
   },
   async waitForTimelineLoad(page: Page) {
+    await expect(timelineUtils.locator(page)).toHaveCount(1);
     await expect(timelineUtils.locator(page)).toBeInViewport();
     await expect.poll(() => thumbnailUtils.locator(page).count()).toBeGreaterThan(0);
   },


### PR DESCRIPTION
While a client-side navigation settles, both the outgoing and incoming page render a timeline, so `#asset-grid` briefly resolves to two elements and the assertion fails with a strict mode violation.

Second most common e2e-ui flake.