### PR TITLE
fix(mobile): render maps into a TextureView

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:immich_mobile/wm_executor.dart';
 import 'package:immich_ui/immich_ui.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:logging/logging.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:timezone/data/latest.dart';
 
 void main() async {
@@ -73,6 +74,12 @@ Future<void> initApp() async {
     } catch (e) {
       dPrint(() => "Error setting high refresh rate: $e");
     }
+
+    // Render maps into a TextureView. The default SurfaceView cannot be hosted by
+    // Flutter's texture-layer composition, so Flutter falls back to allocating a
+    // VirtualDisplay per map, whose overlay layers Android does not reliably free
+    // (#31087). Must be set before the first MapLibreMap is built.
+    MapLibreMap.useHybridComposition = true;
   }
 
   await DynamicTheme.fetchSystemPalette();


### PR DESCRIPTION
## Description

MapLibre renders into a `SurfaceView` by default. Flutter's texture-layer composition cannot host one, so it falls back to allocating a `VirtualDisplay` per map — once per photo with coordinates opened, because of the map thumbnail in the asset detail panel. Android does not reliably free those displays' overlay layers, and they accumulate until unrelated apps start hanging.

Setting `useHybridComposition` puts the map in a `TextureView`, which keeps it on the texture-layer path and creates no virtual display at all. It is a static setting, so it has to be assigned before the first map is built.

Fixes #31087

## How Has This Been Tested?

On a Pixel 8 Pro (Android 17), before and after the change, opening photos with coordinates:

- `Creating virtual display: flutter-vd#N` in logcat: 17 occurrences before, 0 after
- overlay layers (`adb shell dumpsys SurfaceFlinger --list | grep -c Overlays`): 4 → 32 → 12 before, unchanged after
- the map still renders — same surface, same size, now via a `SurfaceTexture`

`dart analyze --fatal-infos` and `flutter test` (1330 passed, 1 skipped) are clean.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to analyse the problem and to work on the fix, and to draft this description. The code and the bug itself were verified by me: the bug was reproduced on a real device and measured before and after the change, so these results are not hallucinations.
