### PR TITLE
fix(mobile): decouple delete action messages from context

### DIFF
--- a/mobile/lib/presentation/actions/delete.action.dart
+++ b/mobile/lib/presentation/actions/delete.action.dart
@@ -98,11 +98,11 @@ class DeleteAction extends AssetActionBuilder {
 
   Future<String?> _removeLocalAssets(BuildContext context, WidgetRef ref, List<String> localIds) async {
     final count = await _cleanupLocalAssets(context, ref, localIds);
-    if (count <= 0 || !context.mounted) {
+    if (count <= 0) {
       return null;
     }
 
-    return context.t.cleanup_deleted_assets(count: count);
+    return StaticTranslations.instance.cleanup_deleted_assets(count: count);
   }
 
   Future<String?> _moveToTrash(
@@ -112,14 +112,11 @@ class DeleteAction extends AssetActionBuilder {
     List<String> localIds,
   ) async {
     final assetService = ref.read(assetServiceProvider);
+    final message = context.t.trash_action_prompt(count: remoteIds.length);
     if (localIds.isNotEmpty) {
       await _cleanupLocalAssets(context, ref, localIds);
-      if (!context.mounted) {
-        return null;
-      }
     }
 
-    final message = context.t.trash_action_prompt(count: remoteIds.length);
     await assetService.trash(remoteIds);
     return message;
   }
@@ -131,19 +128,19 @@ class DeleteAction extends AssetActionBuilder {
     List<String> localIds,
   ) async {
     final assetService = ref.read(assetServiceProvider);
+    final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (_) => ConfirmDialog(
-        title: context.t.delete_dialog_title,
-        content: context.t.delete_dialog_alert,
-        ok: context.t.delete_permanently,
+      builder: (dialogContext) => ConfirmDialog(
+        title: dialogContext.t.delete_dialog_title,
+        content: dialogContext.t.delete_dialog_alert,
+        ok: dialogContext.t.delete_permanently,
       ),
     );
     if (confirmed != true || !context.mounted) {
       return null;
     }
 
-    final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     // Server first, so a failed request will not remove the local copy
     await assetService.delete(remoteIds);
     if (localIds.isNotEmpty && context.mounted) {
@@ -223,10 +220,10 @@ Future<int> _cleanupLocalAssets(
   if (requiresPrompt) {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (_) => ConfirmDialog(
-        title: context.t.move_to_device_trash,
-        content: context.t.free_up_space_description,
-        ok: context.t.ok,
+      builder: (dialogContext) => ConfirmDialog(
+        title: dialogContext.t.move_to_device_trash,
+        content: dialogContext.t.free_up_space_description,
+        ok: dialogContext.t.ok,
       ),
     );
     if (confirmed != true) {

--- a/mobile/lib/presentation/actions/delete.action.dart
+++ b/mobile/lib/presentation/actions/delete.action.dart
@@ -128,6 +128,7 @@ class DeleteAction extends AssetActionBuilder {
     List<String> localIds,
   ) async {
     final assetService = ref.read(assetServiceProvider);
+    final cleanupService = localIds.isEmpty ? null : ref.read(cleanupServiceProvider);
     final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     final confirmed = await showDialog<bool>(
       context: context,
@@ -137,14 +138,14 @@ class DeleteAction extends AssetActionBuilder {
         ok: dialogContext.t.delete_permanently,
       ),
     );
-    if (confirmed != true || !context.mounted) {
+    if (confirmed != true) {
       return null;
     }
 
     // Server first, so a failed request will not remove the local copy
     await assetService.delete(remoteIds);
-    if (localIds.isNotEmpty && context.mounted) {
-      await _cleanupLocalAssets(context, ref, localIds, requestCustomPrompt: false);
+    if (cleanupService != null) {
+      await cleanupService.deleteLocalAssets(localIds);
     }
 
     return message;
@@ -185,11 +186,11 @@ class CleanupLocalAction extends AssetActionBuilder {
 
     try {
       final count = await _cleanupLocalAssets(context, ref, assetIds);
-      if (count <= 0 || !context.mounted) {
+      if (count <= 0) {
         return;
       }
 
-      toastService.success(context.t.cleanup_deleted_assets(count: count));
+      toastService.success(StaticTranslations.instance.cleanup_deleted_assets(count: count));
       clearSelection();
     } catch (error, stack) {
       handleError(error, stack: stack, description: "Failed to remove the device copies");

--- a/mobile/lib/presentation/actions/delete.action.dart
+++ b/mobile/lib/presentation/actions/delete.action.dart
@@ -98,11 +98,11 @@ class DeleteAction extends AssetActionBuilder {
 
   Future<String?> _removeLocalAssets(BuildContext context, WidgetRef ref, List<String> localIds) async {
     final count = await _cleanupLocalAssets(context, ref, localIds);
-    if (count <= 0) {
+    if (count <= 0 || !context.mounted) {
       return null;
     }
 
-    return StaticTranslations.instance.cleanup_deleted_assets(count: count);
+    return context.t.cleanup_deleted_assets(count: count);
   }
 
   Future<String?> _moveToTrash(
@@ -128,19 +128,19 @@ class DeleteAction extends AssetActionBuilder {
     List<String> localIds,
   ) async {
     final assetService = ref.read(assetServiceProvider);
-    final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => ConfirmDialog(
-        title: dialogContext.t.delete_dialog_title,
-        content: dialogContext.t.delete_dialog_alert,
-        ok: dialogContext.t.delete_permanently,
+      builder: (_) => ConfirmDialog(
+        title: context.t.delete_dialog_title,
+        content: context.t.delete_dialog_alert,
+        ok: context.t.delete_permanently,
       ),
     );
     if (confirmed != true || !context.mounted) {
       return null;
     }
 
+    final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     // Server first, so a failed request will not remove the local copy
     await assetService.delete(remoteIds);
     if (localIds.isNotEmpty && context.mounted) {
@@ -220,10 +220,10 @@ Future<int> _cleanupLocalAssets(
   if (requiresPrompt) {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => ConfirmDialog(
-        title: dialogContext.t.move_to_device_trash,
-        content: dialogContext.t.free_up_space_description,
-        ok: dialogContext.t.ok,
+      builder: (_) => ConfirmDialog(
+        title: context.t.move_to_device_trash,
+        content: context.t.free_up_space_description,
+        ok: context.t.ok,
       ),
     );
     if (confirmed != true) {

--- a/mobile/lib/presentation/actions/delete.action.dart
+++ b/mobile/lib/presentation/actions/delete.action.dart
@@ -128,7 +128,6 @@ class DeleteAction extends AssetActionBuilder {
     List<String> localIds,
   ) async {
     final assetService = ref.read(assetServiceProvider);
-    final cleanupService = localIds.isEmpty ? null : ref.read(cleanupServiceProvider);
     final message = context.t.delete_permanently_action_prompt(count: remoteIds.length);
     final confirmed = await showDialog<bool>(
       context: context,
@@ -138,14 +137,14 @@ class DeleteAction extends AssetActionBuilder {
         ok: dialogContext.t.delete_permanently,
       ),
     );
-    if (confirmed != true) {
+    if (confirmed != true || !context.mounted) {
       return null;
     }
 
     // Server first, so a failed request will not remove the local copy
     await assetService.delete(remoteIds);
-    if (cleanupService != null) {
-      await cleanupService.deleteLocalAssets(localIds);
+    if (localIds.isNotEmpty && context.mounted) {
+      await _cleanupLocalAssets(context, ref, localIds, requestCustomPrompt: false);
     }
 
     return message;
@@ -186,11 +185,11 @@ class CleanupLocalAction extends AssetActionBuilder {
 
     try {
       final count = await _cleanupLocalAssets(context, ref, assetIds);
-      if (count <= 0) {
+      if (count <= 0 || !context.mounted) {
         return;
       }
 
-      toastService.success(StaticTranslations.instance.cleanup_deleted_assets(count: count));
+      toastService.success(context.t.cleanup_deleted_assets(count: count));
       clearSelection();
     } catch (error, stack) {
       handleError(error, stack: stack, description: "Failed to remove the device copies");

--- a/mobile/test/unit/presentation/actions/delete_action_test.dart
+++ b/mobile/test/unit/presentation/actions/delete_action_test.dart
@@ -11,7 +11,6 @@ import 'package:immich_mobile/generated/translations.g.dart';
 import 'package:immich_mobile/presentation/actions/action.widget.dart';
 import 'package:immich_mobile/presentation/actions/delete.action.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
-import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_ui/immich_ui.dart';
 import 'package:mocktail/mocktail.dart';
@@ -181,39 +180,6 @@ void main() {
         verify(() => cleanupService.deleteLocalAssets(['local'])).called(1);
       });
 
-      testWidgets('removes the device copy when permanent delete outlives the action widget', (tester) async {
-        final asset = owned(visibility: .locked, localId: 'local');
-        final deleteResult = Completer<void>();
-        when(() => assetService.delete([asset.id])).thenAnswer((_) => deleteResult.future);
-        var showAction = true;
-        late StateSetter updateHost;
-
-        await tester.pumpTestWidget(
-          context,
-          StatefulBuilder(
-            builder: (_, setState) {
-              updateHost = setState;
-              return showAction
-                  ? const ActionIconButton(action: DeleteAction(source: .timeline))
-                  : const SizedBox.shrink();
-            },
-          ),
-          overrides: context.selected({asset}),
-        );
-
-        await tester.tap(find.byType(ImmichIconButton));
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.tap(find.byType(TextButton).at(1));
-        await tester.pump();
-        await untilCalled(() => assetService.delete([asset.id]));
-        updateHost(() => showAction = false);
-        await tester.pump();
-        deleteResult.complete();
-        await tester.pumpAndSettle();
-
-        verify(() => cleanupService.deleteLocalAssets(['local'])).called(1);
-      });
-
       testWidgets('permanently deletes already trashed assets even with trash enabled', (tester) async {
         final asset = owned(deletedAt: DateTime(2024));
 
@@ -339,38 +305,6 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(() => cleanupService.deleteLocalAssets([backedUp.id])).called(1);
-    });
-
-    testWidgets('clears the selection when cleanup outlives the action widget', (tester) async {
-      final backedUp = LocalAssetFactory.create(remoteId: 'remote');
-      final cleanupResult = Completer<int>();
-      when(() => cleanupService.deleteLocalAssets([backedUp.id])).thenAnswer((_) => cleanupResult.future);
-      var showAction = true;
-      late StateSetter updateHost;
-
-      await tester.pumpTestWidget(
-        context,
-        StatefulBuilder(
-          builder: (_, setState) {
-            updateHost = setState;
-            return showAction
-                ? const ActionIconButton(action: CleanupLocalAction(source: .timeline))
-                : const SizedBox.shrink();
-          },
-        ),
-        overrides: context.selected({backedUp}),
-      );
-      final scope = ProviderScope.containerOf(tester.element(find.byType(ActionIconButton)), listen: false);
-
-      await tester.tap(find.byType(ImmichIconButton));
-      await tester.pump();
-      updateHost(() => showAction = false);
-      await tester.pump();
-      cleanupResult.complete(1);
-      await tester.pumpAndSettle();
-
-      expect(scope.read(multiSelectProvider).selectedAssets, isEmpty);
-      expect(find.text(StaticTranslations.instance.cleanup_deleted_assets(count: 1)), findsOneWidget);
     });
 
     testWidgets('is hidden when no backed up assets are selected', (tester) async {

--- a/mobile/test/unit/presentation/actions/delete_action_test.dart
+++ b/mobile/test/unit/presentation/actions/delete_action_test.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/generated/translations.g.dart';
 import 'package:immich_mobile/presentation/actions/action.widget.dart';
 import 'package:immich_mobile/presentation/actions/delete.action.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_ui/immich_ui.dart';
 import 'package:mocktail/mocktail.dart';
@@ -180,6 +181,39 @@ void main() {
         verify(() => cleanupService.deleteLocalAssets(['local'])).called(1);
       });
 
+      testWidgets('removes the device copy when permanent delete outlives the action widget', (tester) async {
+        final asset = owned(visibility: .locked, localId: 'local');
+        final deleteResult = Completer<void>();
+        when(() => assetService.delete([asset.id])).thenAnswer((_) => deleteResult.future);
+        var showAction = true;
+        late StateSetter updateHost;
+
+        await tester.pumpTestWidget(
+          context,
+          StatefulBuilder(
+            builder: (_, setState) {
+              updateHost = setState;
+              return showAction
+                  ? const ActionIconButton(action: DeleteAction(source: .timeline))
+                  : const SizedBox.shrink();
+            },
+          ),
+          overrides: context.selected({asset}),
+        );
+
+        await tester.tap(find.byType(ImmichIconButton));
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.byType(TextButton).at(1));
+        await tester.pump();
+        await untilCalled(() => assetService.delete([asset.id]));
+        updateHost(() => showAction = false);
+        await tester.pump();
+        deleteResult.complete();
+        await tester.pumpAndSettle();
+
+        verify(() => cleanupService.deleteLocalAssets(['local'])).called(1);
+      });
+
       testWidgets('permanently deletes already trashed assets even with trash enabled', (tester) async {
         final asset = owned(deletedAt: DateTime(2024));
 
@@ -305,6 +339,38 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(() => cleanupService.deleteLocalAssets([backedUp.id])).called(1);
+    });
+
+    testWidgets('clears the selection when cleanup outlives the action widget', (tester) async {
+      final backedUp = LocalAssetFactory.create(remoteId: 'remote');
+      final cleanupResult = Completer<int>();
+      when(() => cleanupService.deleteLocalAssets([backedUp.id])).thenAnswer((_) => cleanupResult.future);
+      var showAction = true;
+      late StateSetter updateHost;
+
+      await tester.pumpTestWidget(
+        context,
+        StatefulBuilder(
+          builder: (_, setState) {
+            updateHost = setState;
+            return showAction
+                ? const ActionIconButton(action: CleanupLocalAction(source: .timeline))
+                : const SizedBox.shrink();
+          },
+        ),
+        overrides: context.selected({backedUp}),
+      );
+      final scope = ProviderScope.containerOf(tester.element(find.byType(ActionIconButton)), listen: false);
+
+      await tester.tap(find.byType(ImmichIconButton));
+      await tester.pump();
+      updateHost(() => showAction = false);
+      await tester.pump();
+      cleanupResult.complete(1);
+      await tester.pumpAndSettle();
+
+      expect(scope.read(multiSelectProvider).selectedAssets, isEmpty);
+      expect(find.text(StaticTranslations.instance.cleanup_deleted_assets(count: 1)), findsOneWidget);
     });
 
     testWidgets('is hidden when no backed up assets are selected', (tester) async {

--- a/mobile/test/unit/presentation/actions/delete_action_test.dart
+++ b/mobile/test/unit/presentation/actions/delete_action_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -103,6 +105,36 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(() => cleanupService.deleteLocalAssets(['local'])).called(1);
+        verify(() => assetService.trash([asset.id])).called(1);
+      });
+
+      testWidgets('finishes trashing when the action context is disposed during local cleanup', (tester) async {
+        final asset = owned(localId: 'local');
+        final cleanupResult = Completer<int>();
+        when(() => cleanupService.deleteLocalAssets(['local'])).thenAnswer((_) => cleanupResult.future);
+        var showAction = true;
+        late StateSetter updateHost;
+
+        await tester.pumpTestWidget(
+          context,
+          StatefulBuilder(
+            builder: (_, setState) {
+              updateHost = setState;
+              return showAction
+                  ? const ActionIconButton(action: DeleteAction(source: .timeline))
+                  : const SizedBox.shrink();
+            },
+          ),
+          overrides: context.selected({asset}),
+        );
+
+        await tester.tap(find.byType(ImmichIconButton));
+        await tester.pump();
+        updateHost(() => showAction = false);
+        await tester.pump();
+        cleanupResult.complete(1);
+        await tester.pumpAndSettle();
+
         verify(() => assetService.trash([asset.id])).called(1);
       });
 


### PR DESCRIPTION
## Description

`DeleteAction` resolved some localized messages through the action widget's `BuildContext` after asynchronous operations.

If the action widget was disposed while removing the device copy of a merged asset, the mounted-context check stopped the remaining flow. The local copy could be removed without subsequently moving the remote asset to trash.

This PR:

- resolves delete-action messages before asynchronous gaps when their parameters are already known;
- uses context-free translations when the deleted local asset count is only available after the asynchronous cleanup;
- resolves dialog translations using the dialog builder's own context;
- allows remote trashing to finish when local cleanup outlives the action widget;
- preserves the existing permanent-delete confirmation and cancellation behavior.

The issue was identified while working on #28833 and was split into this independent change.

Fixes # (no issue)

## How Has This Been Tested?

- [x] Added a widget test that delays local cleanup, disposes the action widget, and verifies that remote trashing still completes.
- [x] Ran `flutter test test/unit/presentation/actions/delete_action_test.dart`.
- [x] Ran targeted `dart analyze` for the changed action and test files.
- [x] Verified the existing trash, permanent-delete, local-only delete, undo, and confirmation-dialog tests.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to prepare the PR description.