### PR TITLE
fix: Build SDK in dev container

### DIFF
--- a/server/bin/immich-dev
+++ b/server/bin/immich-dev
@@ -6,4 +6,5 @@ if [[ "$IMMICH_ENV" == "production" ]]; then
 fi
 
 cd /usr/src/app || exit
+pnpm --filter @immich/plugin-sdk build
 pnpm --filter immich exec nest start --debug "0.0.0.0:9230" --watch -- "$@"


### PR DESCRIPTION
## Description
IDK how #28620 managed to fix that bug for some people, but it isn't working for me when using the supplied docker dev file. The fix works, the problem is that the launch command for docker calls `immich-dev` instead, but the PR only updated `.devcontainer/server/container-start-frontend.sh`, which the docker does not use.

## How Has This Been Tested?
Fresh install starting dev container with default configuration, only modification made to docker file was to edit the volume mounts at the bottom- otherwise, these cache mounts will get reused by docker so it wouldn't be a true "from scratch" test.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
</details>

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
AI? More like A-why