### PR TITLE
fix(server): allow an empty assetIds array when creating an album shared link

### DIFF
--- a/e2e/src/specs/server/api/shared-link.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-link.e2e-spec.ts
@@ -340,7 +340,6 @@ describe('/shared-links', () => {
       expect(status).toBe(201);
       expect(body).toEqual(expect.objectContaining({ type: SharedLinkType.Album, userId: user1.userId }));
     });
-
   });
 
   describe('PATCH /shared-links/:id', () => {

--- a/e2e/src/specs/server/api/shared-link.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-link.e2e-spec.ts
@@ -330,6 +330,17 @@ describe('/shared-links', () => {
         }),
       );
     });
+
+    it('should create an album shared link when the client sends an empty assetIds array', async () => {
+      const { status, body } = await request(app)
+        .post('/shared-links')
+        .set('Authorization', `Bearer ${user1.accessToken}`)
+        .send({ type: SharedLinkType.Album, albumId: album.id, assetIds: [] });
+
+      expect(status).toBe(201);
+      expect(body).toEqual(expect.objectContaining({ type: SharedLinkType.Album, userId: user1.userId }));
+    });
+
   });
 
   describe('PATCH /shared-links/:id', () => {

--- a/server/src/controllers/shared-link.controller.spec.ts
+++ b/server/src/controllers/shared-link.controller.spec.ts
@@ -77,6 +77,17 @@ describe(SharedLinkController.name, () => {
       );
       expect(service.create).not.toHaveBeenCalled();
     });
+
+    it('should allow an empty assetIds array for share type Album', async () => {
+      const albumId = newUuid();
+      await request(ctx.getHttpServer())
+        .post('/shared-links')
+        .send({ type: SharedLinkType.Album, albumId, assetIds: [] });
+      expect(service.create).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ type: SharedLinkType.Album, albumId }),
+      );
+    });
   });
 
   describe('DELETE /shared-links/:id/assets', () => {

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -37,7 +37,7 @@ const SharedLinkCreateSchema = z
         if (!albumId) {
           ctx.addIssue(`albumId is required for type ${SharedLinkType.Album}`);
         }
-        if (assetIds) {
+        if (assetIds && assetIds.length > 0) {
           ctx.addIssue(`assetIds can only be used with type ${SharedLinkType.Individual}`);
         }
         return;


### PR DESCRIPTION
## Description

Fixes #31050 (partially).

Creating a shared link for an album from the mobile app fails with a 400, while the same action
from the web UI succeeds.

The Dart client is generated with `useOptional=true`, and the generator gives array properties a
`const []` default, so `SharedLinkCreateDto` is constructed with:

    SharedLinkCreateDto({
      this.assetIds = const Optional.present(const []),
      ...
    });

The album branch in `mobile/lib/services/shared_link.service.dart` never passes `assetIds`, but
because the field is *present* rather than *absent*, `toJson()` still writes `"assetIds": []` into
the request body.

Since #30762 the `superRefine` on `SharedLinkCreateSchema` does `if (assetIds)` for the `ALBUM`
branch, and an empty array is truthy in JS, so album share links created from the mobile app are
rejected with `assetIds can only be used with type INDIVIDUAL`.

The web client builds the DTO with `assetIds: undefined`, which `JSON.stringify` drops, which is
why the web UI is unaffected.

This treats an empty array as "not provided", matching how the `INDIVIDUAL` branch and
`SharedLinkRepository.create` (which already guards on `assetIds && assetIds.length > 0` before
inserting) already treat it. Only the accepted set is widened, so no request that was accepted
before changes behaviour, and the generated OpenAPI schema is unchanged.

The issue also mentions `albumId: null` and `expiresAt: ""`. `albumId` being `.optional()` rather
than `.nullable().optional()` is a real inconsistency with its `description`/`password`/`slug`
siblings, and the `superRefine` already treats a falsy `albumId` as absent, so I'm happy to send a
follow-up for it. I left it out here because it changes the emitted spec and I wanted to keep this
PR to one purpose. I could not reproduce `expiresAt: ""` from any current client code path, so it
is not addressed either.

## How Has This Been Tested?

- [x] Unit test added in `server/src/controllers/shared-link.controller.spec.ts`: posting
      `{ type: ALBUM, albumId, assetIds: [] }` now reaches `SharedLinkService.create` instead of
      failing validation. Run with
      `cd server && pnpm test src/controllers/shared-link.controller.spec.ts`
- [x] e2e test added in `e2e/src/specs/server/api/shared-link.e2e-spec.ts`: the same payload
      returns 201 with `type: ALBUM`
- [x] Existing shared link tests still pass, including the ones asserting that a non-empty
      `assetIds` is still rejected for `ALBUM` and required for `INDIVIDUAL`
- [x] `pnpm lint` and `pnpm check` clean

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used it to trace the bug across the server schema, the generated
Dart client and the web client, and to draft the one-line fix, the tests and this description. I
verified every claim myself: I read `SharedLinkCreateSchema`, the generated `SharedLinkCreateDto`
at the v3.1.0 tag, `SharedLinkService.create` and `SharedLinkRepository.create`, reproduced the
validation failure against the schema, and ran the test suite locally. The empty-array truthiness
conclusion is one I checked rather than took on trust.