### PR TITLE
Fall back to sorting by filename for items with the exact same timestamp

### DIFF
--- a/mobile/lib/data/db/main/query/merged_asset.drift
+++ b/mobile/lib/data/db/main/query/merged_asset.drift
@@ -83,7 +83,7 @@ AND NOT EXISTS (
     INNER JOIN local_album_entity la on laa.album_id = la.id
     WHERE laa.asset_id = lae.id AND la.backup_selection = 2 -- excluded
 )
-ORDER BY created_at DESC
+ORDER BY created_at DESC, name DESC
 LIMIT $limit;
 
 mergedBucket(:group_by AS INTEGER):

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -726,6 +726,7 @@ List<OrderingTerm Function($RemoteAssetEntityTable)> _assetDateOrder(GroupAssets
   return [
     if (groupBy != GroupAssetsBy.none) (row) => order(row.effectiveCreatedAt(groupBy)),
     (row) => order(row.createdAt),
+    (row) => order(row.name),
   ];
 }
 

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -67,6 +67,7 @@ const withAssets = (eb: ExpressionBuilder<DB, 'album'>) => {
         .where('asset.deletedAt', 'is', null)
         .$call(withDefaultVisibility)
         .orderBy('asset.fileCreatedAt', 'desc')
+        .orderBy('asset.originalFileName', 'desc')
         .as('asset'),
     )
     .select((eb) => eb.fn.jsonAgg('asset').as('assets'))
@@ -403,6 +404,7 @@ export class AlbumRepository {
         albumThumbnailAssetId: this.updateThumbnailBuilder(eb)
           .select('album_asset.assetId')
           .orderBy('asset.fileCreatedAt', 'desc')
+          .orderBy('asset.originalFileName', 'desc')
           .limit(sql.lit(1)),
       }))
       .where((eb) =>

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -834,6 +834,7 @@ export class AssetRepository {
             'asset.status',
             sql`asset."fileCreatedAt" at time zone 'utc'`.as('fileCreatedAt'),
             sql`asset."createdAt" at time zone 'utc'`.as('createdAt'),
+            'asset.originalFileName',
             eb.fn('encode', ['asset.thumbhash', sql.lit('base64')]).as('thumbhash'),
             'asset_exif.projectionType',
             eb.fn
@@ -940,6 +941,7 @@ export class AssetRepository {
             eb.fn.coalesce(eb.fn('array_agg', ['isTrashed']), sql.lit('{}')).as('isTrashed'),
             eb.fn.coalesce(eb.fn('array_agg', ['livePhotoVideoId']), sql.lit('{}')).as('livePhotoVideoId'),
             eb.fn.coalesce(eb.fn('array_agg', ['fileCreatedAt']), sql.lit('{}')).as('fileCreatedAt'),
+            eb.fn.coalesce(eb.fn('array_agg', ['originalFileName']), sql.lit('{}')).as('originalFileName'),
             eb.fn.coalesce(eb.fn('array_agg', ['localOffsetHours']), sql.lit('{}')).as('localOffsetHours'),
             eb.fn.coalesce(eb.fn('array_agg', ['createdAt']), sql.lit('{}')).as('createdAt'),
             eb.fn.coalesce(eb.fn('array_agg', ['ownerId']), sql.lit('{}')).as('ownerId'),

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -854,6 +854,7 @@ export function withSearchOrder(qb: ReturnType<typeof searchAssetBuilder>, order
         // nulls last: assets without an asset_exif row would otherwise lead descending results
         return nullable ? ordered.nullsLast() : ordered;
       })
+      .orderBy('asset.originalFileName', direction)
       // id tie-break for deterministic pagination
       .orderBy('asset.id', direction)
   );

--- a/web/src/lib/managers/timeline-manager/timeline-day.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-day.svelte.ts
@@ -96,8 +96,17 @@ export class TimelineDay {
   }
 
   sortAssets(sortOrder: AssetOrder = AssetOrder.Desc) {
-    const sortFn = plainDateTimeCompare.bind(undefined, sortOrder === AssetOrder.Asc);
-    this.viewerAssets.sort((a, b) => sortFn(a.asset.fileCreatedAt, b.asset.fileCreatedAt));
+    const isAscending = sortOrder === AssetOrder.Asc;
+    const sortFn = plainDateTimeCompare.bind(undefined, isAscending);
+    this.viewerAssets.sort((a, b) => {
+      const timeCmp = sortFn(a.asset.fileCreatedAt, b.asset.fileCreatedAt);
+      if (timeCmp !== 0) {
+        return timeCmp;
+      }
+      const nameA = a.asset.originalFileName ?? '';
+      const nameB = b.asset.originalFileName ?? '';
+      return isAscending ? nameA.localeCompare(nameB) : nameB.localeCompare(nameA);
+    });
   }
 
   getFirstAsset() {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -441,6 +441,27 @@ describe('TimelineManager', () => {
       timelineManager.upsertAssets([{ ...fixture, isTrashed: true }]);
       expect(timelineManager.assetCount).toEqual(1);
     });
+
+    it('sorts assets by originalFileName when timestamps are identical', () => {
+      const timestamp = fromISODateTimeUTCToObject('2024-01-20T12:00:00.000Z');
+      const assetB = deriveLocalDateTimeFromFileCreatedAt(
+        timelineAssetFactory.build({
+          fileCreatedAt: timestamp,
+          originalFileName: 'photo_B.jpg',
+        }),
+      );
+      const assetA = deriveLocalDateTimeFromFileCreatedAt(
+        timelineAssetFactory.build({
+          fileCreatedAt: timestamp,
+          originalFileName: 'photo_A.jpg',
+        }),
+      );
+
+      timelineManager.upsertAssets([assetB, assetA]);
+      const day = getTimelineMonthByDate(timelineManager, { year: 2024, month: 1 })?.timelineDays[0];
+      const sortedFilenames = day?.getAssets().map((a) => a.originalFileName);
+      expect(sortedFilenames).toEqual(['photo_B.jpg', 'photo_A.jpg']);
+    });
   });
 
   describe('AssetUpdate events', () => {

--- a/web/src/lib/managers/timeline-manager/types.ts
+++ b/web/src/lib/managers/timeline-manager/types.ts
@@ -18,6 +18,7 @@ export type Direction = 'earlier' | 'later';
 export type TimelineAsset = {
   id: string;
   ownerId: string;
+  originalFileName?: string;
   tags?: string[];
   ratio: number;
   thumbhash: string | null;

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -150,6 +150,7 @@ export const toTimelineAsset = (unknownAsset: AssetResponseDto | TimelineAsset):
   return {
     id: assetResponse.id,
     ownerId: assetResponse.ownerId,
+    originalFileName: assetResponse.originalFileName,
     tags: assetResponse.tags?.map((tag) => tag.id),
     ratio,
     thumbhash: assetResponse.thumbhash,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/immich-app/immich/discussions/4170.

When importing untagged data from older cameras, I usually set all of them to the same timestamp (date @ noon) if they have been sorted by day. This breaks the sorting, though, as now this set timestamp is the only thing that Immich considers, so effectively the photos for a day are randomly shuffled. If they stem from a camera, they will have sortable filenames, so this PR introduces this as a standard secondary sorting criterion.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I have generated the code and reviewed it. Will do all further modifications by hand.
