### PR TITLE
fix(web): clear the hovered asset when the pointer leaves a thumbnail

### DIFF
--- a/web/src/lib/components/assets/thumbnail/__test__/Thumbnail.spec.ts
+++ b/web/src/lib/components/assets/thumbnail/__test__/Thumbnail.spec.ts
@@ -1,8 +1,8 @@
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import Thumbnail from '$lib/components/assets/thumbnail/Thumbnail.svelte';
 import { getTabbable } from '$lib/utils/focus-util';
-import { assetFactory } from '@test-data/factories/asset-factory';
+import { assetFactory, timelineAssetFactory } from '@test-data/factories/asset-factory';
 
 vi.mock('$lib/utils/navigation', () => ({
   currentUrlReplaceAssetId: vi.fn(),
@@ -47,6 +47,19 @@ describe('Thumbnail component', () => {
     // Guarding against inserting extra tabbable elements in future in <Thumbnail/>
     const tabbables = getTabbable(container!);
     expect(tabbables.length).toBe(0);
+  });
+
+  it('reports whether the pointer is over the thumbnail', async () => {
+    const asset = timelineAssetFactory.build();
+    const onMouseEvent = vi.fn();
+    const { baseElement } = render(Thumbnail, { asset, onMouseEvent });
+
+    const container = baseElement.querySelector('[data-thumbnail-focus-container]')!;
+    await fireEvent.mouseEnter(container);
+    await fireEvent.mouseLeave(container);
+
+    expect(onMouseEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({ isMouseOver: true }));
+    expect(onMouseEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({ isMouseOver: false }));
   });
 
   it('shows thumbhash while image is loading', () => {

--- a/web/src/lib/components/assets/thumbnail/__test__/Thumbnail.spec.ts
+++ b/web/src/lib/components/assets/thumbnail/__test__/Thumbnail.spec.ts
@@ -1,8 +1,8 @@
-import { fireEvent, render } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import Thumbnail from '$lib/components/assets/thumbnail/Thumbnail.svelte';
 import { getTabbable } from '$lib/utils/focus-util';
-import { assetFactory, timelineAssetFactory } from '@test-data/factories/asset-factory';
+import { assetFactory } from '@test-data/factories/asset-factory';
 
 vi.mock('$lib/utils/navigation', () => ({
   currentUrlReplaceAssetId: vi.fn(),
@@ -47,19 +47,6 @@ describe('Thumbnail component', () => {
     // Guarding against inserting extra tabbable elements in future in <Thumbnail/>
     const tabbables = getTabbable(container!);
     expect(tabbables.length).toBe(0);
-  });
-
-  it('reports whether the pointer is over the thumbnail', async () => {
-    const asset = timelineAssetFactory.build();
-    const onMouseEvent = vi.fn();
-    const { baseElement } = render(Thumbnail, { asset, onMouseEvent });
-
-    const container = baseElement.querySelector('[data-thumbnail-focus-container]')!;
-    await fireEvent.mouseEnter(container);
-    await fireEvent.mouseLeave(container);
-
-    expect(onMouseEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({ isMouseOver: true }));
-    expect(onMouseEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({ isMouseOver: false }));
   });
 
   it('shows thumbhash while image is loading', () => {

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -361,7 +361,7 @@
             }}
             onSelect={() => handleSelectAssets(currentAsset)}
             onPreview={assetInteraction.selectionActive ? () => void navigateToAsset(asset) : undefined}
-            onMouseEvent={() => assetMouseEventHandler(currentAsset)}
+            onMouseEvent={({ isMouseOver }) => assetMouseEventHandler(isMouseOver ? currentAsset : null)}
             {showArchiveIcon}
             asset={currentAsset}
             selected={assetInteraction.hasSelectedAsset(currentAsset.id)}

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -685,7 +685,7 @@
                   }
                   void onSelectAssets(asset);
                 }}
-                onMouseEvent={() => handleSelectAssetCandidates(asset)}
+                onMouseEvent={({ isMouseOver }) => handleSelectAssetCandidates(isMouseOver ? asset : null)}
                 onPreview={isSelectionMode || assetInteraction.selectionActive
                   ? (asset) => void navigate({ targetRoute: 'current', assetId: asset.id })
                   : undefined}


### PR DESCRIPTION
## Description

Fixes [#31095 — Holding Shift while typing in the album dialog activates timeline selection](https://github.com/immich-app/immich/issues/31095).

### Problem

`Thumbnail` reports both pointer enter and leave through `isMouseOver`, but the timeline and gallery grids discarded that value and always stored the asset. Their nullable hover state therefore never returned to `null`, so Shift could resolve a selection range against the last thumbnail after the pointer had left, including behind an open dialog.

### Fix

Forward the existing `isMouseOver` payload in both grids and pass `null` on leave. This restores the candidate-clearing path already present in both components and matches the existing `AssetViewer` handling.

### Deliberately not done

No test-only parent-component harness was added. The earlier child payload test passed on the buggy base and exercised neither changed call site, so it was removed rather than kept as misleading regression coverage.

### User impact

Typing capital letters in the add-to-album dialog no longer paints a stale Shift-selection range on the timeline behind it.

## Verification

- `corepack pnpm --filter immich-web test src/lib/components/assets/thumbnail/__test__/Thumbnail.spec.ts --run` — 2/2 existing thumbnail tests passed after the non-regression case was removed.
- GitHub Web tests, lint, and web end-to-end tests passed on the implementation commit; the test-removal follow-up triggered a fresh run.
- `git diff --check` — passed.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assisted with tracing the existing event flow, reviewing the final two-line change, and running verification commands. The root cause, final code, and observed results were reviewed and confirmed by me.