### PR TITLE
chore: tune map icon size

### DIFF
--- a/web/src/lib/components/shared-components/map/Map.svelte
+++ b/web/src/lib/components/shared-components/map/Map.svelte
@@ -400,7 +400,7 @@
             <Control position="top-left">
               <ControlGroup>
                 <ControlButton onclick={() => (viewportGridActive ? onViewportClose?.() : handleViewportSelect())}>
-                  <Icon title={$t('show_photos_in_area')} icon={mdiImageMultiple} size="100%" class="text-black/80" />
+                  <Icon title={$t('show_photos_in_area')} icon={mdiImageMultiple} size="70%" class="text-black/80" />
                 </ControlButton>
               </ControlGroup>
             </Control>
@@ -414,7 +414,7 @@
         <Control>
           <ControlGroup>
             <ControlButton onclick={handleSettingsClick}>
-              <Icon icon={mdiCog} size="100%" class="text-black/80" />
+              <Icon icon={mdiCog} size="70%" class="text-black/80" />
             </ControlButton>
           </ControlGroup>
         </Control>


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="265" height="602" alt="image" src="https://github.com/user-attachments/assets/322bfb65-01bf-49ae-9047-48be5099380b" /> | <img width="290" height="552" alt="image" src="https://github.com/user-attachments/assets/1e886498-753d-4a15-9bcd-44f2c30864ed" /> |
