### PR TITLE
fix(mobile): update description display immediately upon editing

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/description.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/description.widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
@@ -27,32 +29,67 @@ class _SheetAssetDescriptionState extends ConsumerState<SheetAssetDescription> {
     super.initState();
 
     _controller = TextEditingController(text: widget.exifInfo?.description ?? '');
+    _descriptionFocus.addListener(_onFocusChange);
   }
 
+  @override
+  void didUpdateWidget(SheetAssetDescription oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.asset.id != widget.asset.id ||
+        (oldWidget.exifInfo?.description != widget.exifInfo?.description && !_descriptionFocus.hasFocus)) {
+      _controller.text = widget.exifInfo?.description ?? '';
+    }
+  }
+
+  @override
+  void dispose() {
+    _descriptionFocus.removeListener(_onFocusChange);
+    _controller.dispose();
+    _descriptionFocus.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (!_descriptionFocus.hasFocus) {
+      unawaited(saveDescription(widget.exifInfo?.description));
+    }
+  }
+
+  bool _isSaving = false;
+
   Future<void> saveDescription(String? previousDescription) async {
+    if (_isSaving) {
+      return;
+    }
+
     final newDescription = _controller.text.trim();
 
-    if (newDescription == previousDescription) {
+    if (newDescription == (previousDescription ?? '')) {
       _descriptionFocus.unfocus();
       return;
     }
 
-    final editAction = await ref.read(actionProvider.notifier).updateDescription(ActionSource.viewer, newDescription);
+    _isSaving = true;
+    try {
+      final editAction = await ref.read(actionProvider.notifier).updateDescription(ActionSource.viewer, newDescription);
 
-    if (!editAction.success) {
-      _controller.text = previousDescription ?? '';
-      if (!mounted) {
-        return;
+      if (!editAction.success) {
+        _controller.text = previousDescription ?? '';
+        if (!mounted) {
+          return;
+        }
+
+        ImmichToast.show(
+          context: context,
+          msg: context.t.exif_bottom_sheet_description_error,
+          toastType: ToastType.error,
+        );
       }
-
-      ImmichToast.show(
-        context: context,
-        msg: context.t.exif_bottom_sheet_description_error,
-        toastType: ToastType.error,
-      );
+    } finally {
+      _isSaving = false;
+      _descriptionFocus.unfocus();
     }
-
-    _descriptionFocus.unfocus();
   }
 
   @override
@@ -60,11 +97,7 @@ class _SheetAssetDescriptionState extends ConsumerState<SheetAssetDescription> {
     final asset = widget.asset;
     final isOwner = ref.watch(currentUserProvider)?.id == (asset is RemoteAsset ? asset.ownerId : null);
 
-    final currentDescription = widget.exifInfo?.description ?? '';
     final hintText = isOwner ? context.t.exif_bottom_sheet_description : context.t.exif_bottom_sheet_no_description;
-    if (_controller.text != currentDescription && !_descriptionFocus.hasFocus) {
-      _controller.text = currentDescription;
-    }
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
@@ -84,7 +117,10 @@ class _SheetAssetDescriptionState extends ConsumerState<SheetAssetDescription> {
             errorBorder: InputBorder.none,
             focusedErrorBorder: InputBorder.none,
           ),
-          onTapOutside: (_) => saveDescription(widget.exifInfo?.description),
+          onTapOutside: (_) {
+            _descriptionFocus.unfocus();
+            unawaited(saveDescription(widget.exifInfo?.description));
+          },
         ),
       ),
     );

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -12,13 +12,17 @@ import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/action.service.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:logging/logging.dart';
 
-final actionProvider = NotifierProvider<ActionNotifier, void>(ActionNotifier.new, dependencies: [multiSelectProvider]);
+final actionProvider = NotifierProvider<ActionNotifier, void>(
+  ActionNotifier.new,
+  dependencies: [multiSelectProvider, actionServiceProvider, foregroundUploadServiceProvider],
+);
 
 class ActionResult {
   final int count;
@@ -156,6 +160,7 @@ class ActionNotifier extends Notifier<void> {
 
     try {
       final isUpdated = await _service.updateDescription(ids.first, description);
+      ref.invalidate(assetExifProvider);
       return ActionResult(count: 1, success: isUpdated);
     } catch (error, stack) {
       _logger.severe('Failed to update description for asset', error, stack);
@@ -172,6 +177,7 @@ class ActionNotifier extends Notifier<void> {
 
     try {
       final isUpdated = await _service.updateRating(ids.first, rating);
+      ref.invalidate(assetExifProvider);
       return ActionResult(count: 1, success: isUpdated);
     } catch (error, stack) {
       _logger.severe('Failed to update rating for asset', error, stack);

--- a/mobile/test/presentation/widgets/asset_viewer/asset_details/description_widget_test.dart
+++ b/mobile/test/presentation/widgets/asset_viewer/asset_details/description_widget_test.dart
@@ -1,0 +1,294 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/exif.model.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_details/description.widget.dart';
+import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
+import 'package:immich_mobile/services/action.service.dart';
+import 'package:immich_mobile/services/foreground_upload.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../unit/factories/remote_asset_factory.dart';
+import '../../../../unit/presentation/presentation_context.dart';
+
+class MockActionService extends Mock implements ActionService {}
+
+void main() {
+  late PresentationContext context;
+  late MockActionService mockActionService;
+  late StreamController<BaseAsset?> assetStreamController;
+
+  setUp(() async {
+    context = await PresentationContext.create();
+    mockActionService = MockActionService();
+    assetStreamController = StreamController<BaseAsset?>.broadcast();
+    when(() => context.service.asset.service.watchAsset(any())).thenAnswer((_) => assetStreamController.stream);
+  });
+
+  tearDown(() async {
+    await assetStreamController.close();
+    await context.dispose();
+  });
+
+  RemoteAsset owned() => RemoteAssetFactory.create(ownerId: context.currentUser.id);
+  RemoteAsset other() => RemoteAssetFactory.create(ownerId: 'other-user');
+
+  Future<void> pumpDescription(
+    WidgetTester tester, {
+    required BaseAsset asset,
+    ExifInfo? exifInfo,
+    List<Override> overrides = const [],
+    Widget? extraChild,
+  }) async {
+    await tester.pumpTestWidget(
+      context,
+      Column(
+        children: [
+          SheetAssetDescription(asset: asset, exifInfo: exifInfo),
+          ?extraChild,
+        ],
+      ),
+      overrides: [
+        actionServiceProvider.overrideWithValue(mockActionService),
+        foregroundUploadServiceProvider.overrideWithValue(context.service.upload),
+        ...overrides,
+      ],
+    );
+  }
+
+  testWidgets('shows existing description in TextField', (tester) async {
+    final asset = owned();
+    await pumpDescription(
+      tester,
+      asset: asset,
+      exifInfo: const ExifInfo(description: 'Initial description'),
+    );
+
+    expect(find.text('Initial description'), findsOneWidget);
+  });
+
+  testWidgets('shows placeholder when description is empty/null', (tester) async {
+    final asset = owned();
+    await pumpDescription(tester, asset: asset, exifInfo: null);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.controller?.text, isEmpty);
+  });
+
+  testWidgets('entering a description and losing focus saves and retains the text', (tester) async {
+    final asset = owned();
+    when(() => mockActionService.updateDescription(asset.id, 'New description')).thenAnswer((_) async => true);
+
+    late WidgetRef testRef;
+
+    await tester.pumpTestWidget(
+      context,
+      Consumer(
+        builder: (widgetContext, ref, _) {
+          testRef = ref;
+          return Column(
+            children: [
+              SheetAssetDescription(
+                asset: asset,
+                exifInfo: const ExifInfo(description: 'Old description'),
+              ),
+              ElevatedButton(key: const Key('other_target'), onPressed: () {}, child: const Text('Other')),
+            ],
+          );
+        },
+      ),
+      overrides: [
+        actionServiceProvider.overrideWithValue(mockActionService),
+        foregroundUploadServiceProvider.overrideWithValue(context.service.upload),
+      ],
+    );
+
+    testRef.read(assetViewerProvider.notifier).setAsset(asset);
+    await tester.pump();
+
+    final textFieldFinder = find.byType(TextField);
+    expect(textFieldFinder, findsOneWidget);
+
+    await tester.tap(textFieldFinder);
+    await tester.pump();
+
+    await tester.enterText(textFieldFinder, 'New description');
+    await tester.pump();
+
+    // Tap outside button to lose focus from textfield
+    await tester.tap(find.byKey(const Key('other_target')));
+    await tester.pumpAndSettle();
+
+    verify(() => mockActionService.updateDescription(asset.id, 'New description')).called(1);
+
+    // Ensure the new description remains displayed and did not revert
+    expect(find.text('New description'), findsOneWidget);
+  });
+
+  testWidgets('does not call updateDescription if text is unchanged', (tester) async {
+    final asset = owned();
+    await pumpDescription(
+      tester,
+      asset: asset,
+      exifInfo: const ExifInfo(description: 'Same description'),
+      extraChild: ElevatedButton(key: const Key('other_target'), onPressed: () {}, child: const Text('Other')),
+    );
+
+    // Tap into text field and then tap away without changing text
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('other_target')));
+    await tester.pumpAndSettle();
+
+    verifyNever(() => mockActionService.updateDescription(any(), any()));
+  });
+
+  testWidgets('reverts text if saving description fails', (tester) async {
+    final asset = owned();
+    when(() => mockActionService.updateDescription(asset.id, 'Failing description')).thenAnswer((_) async => false);
+
+    late WidgetRef testRef;
+
+    await tester.pumpTestWidget(
+      context,
+      Consumer(
+        builder: (widgetContext, ref, _) {
+          testRef = ref;
+          return Column(
+            children: [
+              SheetAssetDescription(
+                asset: asset,
+                exifInfo: const ExifInfo(description: 'Original description'),
+              ),
+              ElevatedButton(key: const Key('other_target'), onPressed: () {}, child: const Text('Other')),
+            ],
+          );
+        },
+      ),
+      overrides: [
+        actionServiceProvider.overrideWithValue(mockActionService),
+        foregroundUploadServiceProvider.overrideWithValue(context.service.upload),
+      ],
+    );
+
+    testRef.read(assetViewerProvider.notifier).setAsset(asset);
+    await tester.pump();
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'Failing description');
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('other_target')));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 4));
+
+    verify(() => mockActionService.updateDescription(asset.id, 'Failing description')).called(1);
+
+    // Should revert back to original description
+    expect(find.text('Original description'), findsOneWidget);
+  });
+
+  testWidgets('updates text when asset changes via didUpdateWidget', (tester) async {
+    final asset1 = owned();
+    final asset2 = other();
+
+    await pumpDescription(
+      tester,
+      asset: asset1,
+      exifInfo: const ExifInfo(description: 'Asset 1 description'),
+    );
+
+    expect(find.text('Asset 1 description'), findsOneWidget);
+
+    await pumpDescription(
+      tester,
+      asset: asset2,
+      exifInfo: const ExifInfo(description: 'Asset 2 description'),
+    );
+
+    expect(find.text('Asset 2 description'), findsOneWidget);
+  });
+
+  test('ActionNotifier.updateDescription invalidates assetExifProvider', () async {
+    final asset = owned();
+    when(() => mockActionService.updateDescription(asset.id, 'Updated description')).thenAnswer((_) async => true);
+
+    int exifProviderCallCount = 0;
+
+    final container = ProviderContainer(
+      overrides: [
+        ...context.overrides,
+        actionServiceProvider.overrideWithValue(mockActionService),
+        foregroundUploadServiceProvider.overrideWithValue(context.service.upload),
+        assetExifProvider.overrideWith((ref, a) {
+          exifProviderCallCount++;
+          return null;
+        }),
+      ],
+    );
+
+    container.read(assetViewerProvider.notifier).setAsset(asset);
+
+    // Read assetExifProvider initially
+    container.read(assetExifProvider(asset));
+    expect(exifProviderCallCount, 1);
+
+    // Trigger updateDescription
+    final result = await container
+        .read(actionProvider.notifier)
+        .updateDescription(ActionSource.viewer, 'Updated description');
+
+    expect(result.success, isTrue);
+
+    // Read assetExifProvider again after invalidation
+    container.read(assetExifProvider(asset));
+    expect(exifProviderCallCount, 2);
+
+    container.dispose();
+  });
+
+  test('ActionNotifier.updateRating invalidates assetExifProvider', () async {
+    final asset = owned();
+    when(() => mockActionService.updateRating(asset.id, 4)).thenAnswer((_) async => true);
+
+    int exifProviderCallCount = 0;
+
+    final container = ProviderContainer(
+      overrides: [
+        ...context.overrides,
+        actionServiceProvider.overrideWithValue(mockActionService),
+        foregroundUploadServiceProvider.overrideWithValue(context.service.upload),
+        assetExifProvider.overrideWith((ref, a) {
+          exifProviderCallCount++;
+          return null;
+        }),
+      ],
+    );
+
+    container.read(assetViewerProvider.notifier).setAsset(asset);
+
+    // Read assetExifProvider initially
+    container.read(assetExifProvider(asset));
+    expect(exifProviderCallCount, 1);
+
+    // Trigger updateRating
+    final result = await container.read(actionProvider.notifier).updateRating(ActionSource.viewer, 4);
+
+    expect(result.success, isTrue);
+
+    // Read assetExifProvider again after invalidation
+    container.read(assetExifProvider(asset));
+    expect(exifProviderCallCount, 2);
+
+    container.dispose();
+  });
+}


### PR DESCRIPTION
## Description

Fixes an issue where editing a photo's description in the mobile app does not update the displayed text immediately upon losing focus (reverting back to the placeholder or previous description until swiping to another asset and back).

- Removed controller mutation from `SheetAssetDescription.build()` which overwrote user input on unfocus before the async update completed.
- Added `didUpdateWidget` and focus listener in `SheetAssetDescription` for clean lifecycle management, asset switches, and external updates.
- Added `dispose()` to clean up `TextEditingController` and `FocusNode`.
- Added `ref.invalidate(assetExifProvider)` in `ActionNotifier.updateDescription` and `updateRating` so the EXIF cache is reactively refreshed.

Fixes #30956

## How Has This Been Tested?

- [x] Ran dedicated unit and widget test suite: `flutter test test/presentation/widgets/asset_viewer/asset_details/description_widget_test.dart`
- [x] Ran full mobile test suite: `flutter test` (1338+ passing tests)
- [x] Verified static analysis: `flutter analyze` (0 issues found)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to assist with debugging the focus lifecycle issue, formatting the PR description, and writing unit/widget test cases for the description widget. All changes and test results were reviewed and validated.