### PR TITLE
fix(web): natural (numeric-aware) sort for tag/folder tree children

### DIFF
--- a/web/src/lib/utils/tree-utils.spec.ts
+++ b/web/src/lib/utils/tree-utils.spec.ts
@@ -1,0 +1,36 @@
+import type { TagResponseDto } from '@immich/sdk';
+import { TreeNode } from '$lib/utils/tree-utils';
+
+const makeTag = (value: string, id = value): TagResponseDto =>
+  ({
+    id,
+    value,
+    color: undefined,
+    createdAt: '',
+    updatedAt: '',
+    parentId: undefined,
+  }) as unknown as TagResponseDto;
+
+describe('TreeNode.children', () => {
+  it('sorts sibling nodes using natural (numeric-aware) order', () => {
+    // Insertion order is intentionally not sorted to prove the getter sorts.
+    const tags = ['10) item', '2) item', '1) item', '20) item', '3) item'].map((value) => makeTag(`parent/${value}`));
+
+    const root = TreeNode.fromTags(tags);
+    const [parent] = root.children;
+
+    expect(parent.children.map((c) => c.value)).toEqual(['1) item', '2) item', '3) item', '10) item', '20) item']);
+  });
+
+  it('sorts alphabetically when there are no numbers', () => {
+    const tags = ['banana', 'apple', 'cherry'].map((v) => makeTag(v));
+    const root = TreeNode.fromTags(tags);
+    expect(root.children.map((c) => c.value)).toEqual(['apple', 'banana', 'cherry']);
+  });
+
+  it('is case-insensitive at the base sensitivity level', () => {
+    const tags = ['Banana', 'apple', 'Cherry'].map((v) => makeTag(v));
+    const root = TreeNode.fromTags(tags);
+    expect(root.children.map((c) => c.value)).toEqual(['apple', 'Banana', 'Cherry']);
+  });
+});

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -3,6 +3,9 @@
 /* eslint-disable unicorn/prefer-at */
 import type { TagResponseDto } from '@immich/sdk';
 
+// Natural (numeric-aware) collator so e.g. "2) Foo" sorts before "10) Foo".
+const naturalCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
 export class TreeNode extends Map<string, TreeNode> {
   value: string;
   path: string;
@@ -106,7 +109,7 @@ export class TreeNode extends Map<string, TreeNode> {
   }
 
   get children(): TreeNode[] {
-    return (this._children ??= Array.from(this.values()));
+    return (this._children ??= Array.from(this.values()).sort((a, b) => naturalCollator.compare(a.value, b.value)));
   }
 }
 


### PR DESCRIPTION
## Description

Tag and folder trees in the web UI are rendered from `TreeNode.children`, which returned siblings in `Map` insertion order. Since the server returns tags in Postgres' default lexicographic order (`ORDER BY value`), entries with numeric prefixes end up in the wrong visual order, e.g.:

```
1) foo
10) foo   ← should be near the end
11) foo
2) foo    ← should be second
20) foo
3) foo
```

Sort children with `Intl.Collator(..., { numeric: true, sensitivity: 'base' })` so numbered prefixes and mixed alphanumeric values order intuitively. This is a purely client-side fix in a single getter and does not require any server, DB, or API changes.

Fixes # (no matching issue found; happy to link one if maintainers know of a duplicate)

## How Has This Been Tested?

- [x] New unit tests in `web/src/lib/utils/tree-utils.spec.ts` covering numeric-aware sort, plain alphabetical sort, and case-insensitivity.
- [x] `pnpm exec vitest run src/lib/utils/tree-utils.spec.ts` — 3/3 pass.
- [x] `pnpm exec eslint src/lib/utils/tree-utils.ts src/lib/utils/tree-utils.spec.ts` — clean.
- [x] `pnpm exec prettier --check` on changed files — clean.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (none needed)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (No new dependencies.)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (N/A — web-only change)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (N/A — web-only change)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM assistant (GitHub Copilot) was used to help draft the fix, tests, and this PR description. All code was reviewed line-by-line by the author before committing; tests were run locally and pass.
