### PR TITLE
fix: respect photo orientation when setting person cover photo

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -259,7 +259,21 @@ select
       "asset_file"."assetId" = "asset"."id"
       and "asset_file"."type" = 'preview'
       and "asset_file"."isEdited" = false
-  ) as "previewPath"
+  ) as "previewPath",
+  (
+    select
+      coalesce(json_agg(agg), '[]')
+    from
+      (
+        select
+          "asset_edit"."action",
+          "asset_edit"."parameters"
+        from
+          "asset_edit"
+        where
+          "asset_edit"."assetId" = "asset"."id"
+      ) as agg
+  ) as "edits"
 from
   "person"
   inner join "asset_face" on "asset_face"."id" = "person"."faceAssetId"

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -10,7 +10,7 @@ import { AssetFaceTable } from 'src/schema/tables/asset-face.table';
 import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { PersonGroupTable } from 'src/schema/tables/person-group.table';
 import { PersonTable } from 'src/schema/tables/person.table';
-import { asUuid, dummy, inSharedAlbum, removeUndefinedKeys, withFilePath } from 'src/utils/database';
+import { asUuid, dummy, inSharedAlbum, removeUndefinedKeys, withEdits, withFilePath } from 'src/utils/database';
 import { paginationHelper, PaginationOptions } from 'src/utils/pagination';
 
 export interface PersonSearchOptions {
@@ -378,6 +378,7 @@ export class PersonRepository {
         'asset_exif.orientation as exifOrientation',
       ])
       .select((eb) => withFilePath(eb, AssetFileType.Preview).as('previewPath'))
+      .select(withEdits)
       .where('person.ownerId', '=', ownerId)
       .where('person.personGroupId', '=', personGroupId)
       .where('asset_face.deletedAt', 'is', null)

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1600,6 +1600,46 @@ describe(MediaService.name, () => {
       });
     });
 
+    it('should transform the face crop after a manual rotation', async () => {
+      const person = PersonFactory.create();
+      const data = {
+        ...personThumbnailStub.newThumbnailMiddle,
+        edits: [{ action: AssetEditAction.Rotate, parameters: { angle: 90 } }],
+      };
+      const decodedImage = Buffer.from('decoded');
+      const editedImage = Buffer.from('edited');
+      const decodedInfo = { width: 400, height: 500 } as OutputInfo;
+      const editedInfo = { width: 500, height: 400 } as OutputInfo;
+      mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue(data);
+      mocks.media.decodeImage.mockResolvedValueOnce({ data: decodedImage, info: decodedInfo });
+      mocks.media.decodeImage.mockResolvedValueOnce({ data: editedImage, info: editedInfo });
+      mocks.media.generateThumbnail.mockResolvedValue();
+
+      await expect(
+        sut.handleGeneratePersonThumbnail({ ownerId: person.ownerId, personGroupId: person.personGroupId }),
+      ).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.media.decodeImage).toHaveBeenNthCalledWith(2, decodedImage, {
+        colorspace: Colorspace.P3,
+        processInvalidImages: false,
+        raw: decodedInfo,
+        edits: data.edits,
+      });
+      expect(mocks.media.generateThumbnail).toHaveBeenCalledWith(
+        editedImage,
+        expect.objectContaining({
+          raw: editedInfo,
+          edits: [
+            {
+              action: 'crop',
+              parameters: expect.objectContaining({ x: 295, y: 95, width: 110, height: 110 }),
+            },
+          ],
+        }),
+        expect.any(String),
+      );
+    });
+
     it('should use preview path if video', async () => {
       const person = PersonFactory.create();
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -43,7 +43,7 @@ import { checkFaceVisibility, checkOcrVisibility } from 'src/utils/editor';
 import { BaseConfig, ThumbnailConfig } from 'src/utils/media';
 import { mimeTypes } from 'src/utils/mime-types';
 import { batched, clamp } from 'src/utils/misc';
-import { getOutputDimensions } from 'src/utils/transform';
+import { getOutputDimensions, transformFaceBoundingBox } from 'src/utils/transform';
 
 interface UpsertFileOptions {
   assetId: string;
@@ -401,7 +401,7 @@ export class MediaService extends BaseService {
       return JobStatus.Failed;
     }
 
-    const { x1, y1, x2, y2, oldWidth, oldHeight, exifOrientation, previewPath, originalPath } = data;
+    const { x1, y1, x2, y2, oldWidth, oldHeight, exifOrientation, previewPath, originalPath, edits } = data;
     let inputImage: string | Buffer;
     if (data.type === AssetType.Video) {
       if (!previewPath) {
@@ -423,13 +423,34 @@ export class MediaService extends BaseService {
       orientation: Buffer.isBuffer(inputImage) && exifOrientation ? Number(exifOrientation) : undefined,
     });
 
+    // Face coordinates are stored relative to the unedited, auto-oriented preview. Apply the same edits to both the
+    // image and the coordinates before extracting the face, so manual rotations do not shift the crop.
+    const face = transformFaceBoundingBox(
+      {
+        boundingBoxX1: x1,
+        boundingBoxY1: y1,
+        boundingBoxX2: x2,
+        boundingBoxY2: y2,
+        imageWidth: oldWidth,
+        imageHeight: oldHeight,
+      },
+      edits,
+      { width: info.width, height: info.height },
+    );
+    const decoded = edits.length > 0 ? await this.mediaRepository.decodeImage(decodedImage, {
+      colorspace: image.colorspace,
+      processInvalidImages: false,
+      raw: info,
+      edits,
+    }) : { data: decodedImage, info };
+
     const thumbnailPath = StorageCore.getPersonThumbnailPath({ ownerId, personGroupId });
     this.storageCore.ensureFolders(thumbnailPath);
 
     const thumbnailOptions: GenerateThumbnailOptions = {
       colorspace: image.colorspace,
       format: ImageFormat.Jpeg,
-      raw: info,
+      raw: decoded.info,
       quality: image.thumbnail.quality,
       progressive: false,
       processInvalidImages: false,
@@ -438,14 +459,22 @@ export class MediaService extends BaseService {
         {
           action: AssetEditAction.Crop,
           parameters: this.getCrop(
-            { old: { width: oldWidth, height: oldHeight }, new: { width: info.width, height: info.height } },
-            { x1, y1, x2, y2 },
+            {
+              old: { width: face.imageWidth, height: face.imageHeight },
+              new: { width: decoded.info.width, height: decoded.info.height },
+            },
+            {
+              x1: face.boundingBoxX1,
+              y1: face.boundingBoxY1,
+              x2: face.boundingBoxX2,
+              y2: face.boundingBoxY2,
+            },
           ),
         },
       ],
     };
 
-    await this.mediaRepository.generateThumbnail(decodedImage, thumbnailOptions, thumbnailPath);
+    await this.mediaRepository.generateThumbnail(decoded.data, thumbnailOptions, thumbnailPath);
     await this.personRepository.update({ ownerId, personGroupId, thumbnailPath });
 
     return JobStatus.Success;

--- a/server/test/fixtures/person.stub.ts
+++ b/server/test/fixtures/person.stub.ts
@@ -14,6 +14,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.jpg',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   newThumbnailMiddle: Object.freeze({
@@ -27,6 +28,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.jpg',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   newThumbnailEnd: Object.freeze({
@@ -40,6 +42,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.jpg',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   rawEmbeddedThumbnail: Object.freeze({
@@ -53,6 +56,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.dng',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   negativeCoordinate: Object.freeze({
@@ -66,6 +70,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.jpg',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   overflowingCoordinate: Object.freeze({
@@ -79,6 +84,7 @@ export const personThumbnailStub = {
     type: AssetType.Image,
     originalPath: '/original/path.jpg',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
   videoThumbnail: Object.freeze({
@@ -92,6 +98,7 @@ export const personThumbnailStub = {
     type: AssetType.Video,
     originalPath: '/original/path.mp4',
     exifOrientation: '1',
+    edits: [],
     previewPath: AssetFileFactory.create({ type: AssetFileType.Preview }).path,
   }),
 };


### PR DESCRIPTION
## Description

When selecting a rotated photo as a Person's featured/cover photo, Immich was cropping the face using the original (unrotated) image orientation. This caused the face crop to be misaligned or show the wrong area of the image.

This PR fixes the face crop logic so that photo rotation/EXIF orientation is correctly applied before extracting the face region for person cover photos.

Fixes #31106

## How Has This Been Tested?

- [x] Manually verified on Web: selected a rotated photo as a Person cover photo and confirmed the face is cropped using the correct orientation
- [x] Verified non-rotated photos still generate correct face crops (no regression)
- [x] Tested with 90°, 180°, and 270° rotated images
- [x] Ran relevant unit/lint checks locally

<details>
<summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Drag and drop before/after screenshots below this line if you have them -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used an LLM (Codex) to help locate the relevant crop/orientation logic and implement the fix. I reviewed and tested the changes myself.
