### PR TITLE
fix(server): skip audio streams without codecs

### DIFF
--- a/server/src/repositories/media.repository.spec.ts
+++ b/server/src/repositories/media.repository.spec.ts
@@ -1,9 +1,10 @@
+import ffmpeg, { type FfprobeData } from 'fluent-ffmpeg';
 import { mkdtempDisposableSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import sharp from 'sharp';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
-import { Colorspace, ImageFormat } from 'src/enum';
+import { AacProfile, Colorspace, ImageFormat } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { MediaRepository } from 'src/repositories/media.repository';
 import { automock } from 'test/utils';
@@ -66,6 +67,38 @@ describe(MediaRepository.name, () => {
   beforeEach(() => {
     // eslint-disable-next-line no-sparse-arrays
     sut = new MediaRepository(automock(LoggingRepository, { args: [, { getEnv: () => ({}) }], strict: false }));
+  });
+
+  describe('probe', () => {
+    it('should ignore audio streams without a resolved codec', async () => {
+      vi.spyOn(ffmpeg, 'ffprobe').mockImplementationOnce((...args) => {
+        const callback = args.at(-1) as (error: Error | null, data: FfprobeData) => void;
+        callback(null, {
+          streams: [
+            {
+              index: 1,
+              codec_type: 'audio',
+              codec_name: 'aac',
+              profile: 'LC',
+              bit_rate: '151550',
+              disposition: { default: 1 },
+            },
+            {
+              index: 2,
+              codec_type: 'audio',
+              codec_tag_string: 'apac',
+              bit_rate: '398950',
+              disposition: { default: 1 },
+            },
+          ],
+          format: {},
+        } as FfprobeData);
+      });
+
+      const result = await sut.probe('spatial-audio.mov');
+
+      expect(result.audioStreams).toEqual([{ index: 1, codecName: 'aac', profile: AacProfile.Lc, bitrate: 151_550 }]);
+    });
   });
 
   describe('applyEdits (single actions)', () => {

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -273,7 +273,7 @@ export class MediaRepository {
           };
         }),
       audioStreams: results.streams
-        .filter((stream) => stream.codec_type === 'audio')
+        .filter((stream) => stream.codec_type === 'audio' && stream.codec_name)
         .sort((a, b) => this.compareStreams(a, b))
         .map((stream) => ({
           index: stream.index,


### PR DESCRIPTION
## Description

Metadata extraction sorted every audio stream before choosing the first one. When an iPhone spatial-audio video contains both AAC and a codec-less APAC stream, the APAC stream can win solely because it has a higher bitrate. Immich then stores that stream index, and every transcoding attempt maps the same undecodable audio stream.

This filters out audio streams without a resolved codec before sorting them. The regression test models the reported two-default-stream case and verifies that the valid AAC fallback is retained even though its bitrate is lower.

Fixes #31170

## How Has This Been Tested?

- [x] Added a repository regression test for AAC plus codec-less APAC stream selection
- [x] Ran the full server unit suite: 2,264 tests passed
- [x] Ran server formatting, lint, and TypeScript checks

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable; this is a server-side metadata extraction fix.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Codex was used to inspect the issue and repository, implement the code and regression test, run the checks listed above, and draft this description. The change was kept to the reported stream-selection path and verified against the full server unit suite.
