### PR TITLE
fix: zIndexes in image viewer causing layout issue on mobile web

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -627,7 +627,7 @@
       transition:fly={{ duration: 150 }}
       id="detail-panel"
       class={[
-        'row-span-4 row-start-1 overflow-y-auto bg-light transition-all dark:border-l dark:border-s-immich-dark-gray z-1',
+        'z-1 row-span-4 row-start-1 overflow-y-auto bg-light transition-all dark:border-l dark:border-s-immich-dark-gray',
         showDetailPanel ? 'w-90' : 'w-100',
       ]}
       translate="yes"
@@ -642,7 +642,7 @@
 
   {#if stack && withStacked && !assetViewerManager.isShowEditor && $slideshowState === SlideshowState.None}
     {@const stackedAssets = stack.assets}
-    <div id="stack-slideshow" class="absolute bottom-0 col-span-4 col-start-1 w-fit max-w-full z-[-1]">
+    <div id="stack-slideshow" class="absolute bottom-0 z-[-1] col-span-4 col-start-1 w-fit max-w-full">
       <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div

--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -627,7 +627,7 @@
       transition:fly={{ duration: 150 }}
       id="detail-panel"
       class={[
-        'row-span-4 row-start-1 overflow-y-auto bg-light transition-all dark:border-l dark:border-s-immich-dark-gray',
+        'row-span-4 row-start-1 overflow-y-auto bg-light transition-all dark:border-l dark:border-s-immich-dark-gray z-1',
         showDetailPanel ? 'w-90' : 'w-100',
       ]}
       translate="yes"
@@ -642,7 +642,7 @@
 
   {#if stack && withStacked && !assetViewerManager.isShowEditor && $slideshowState === SlideshowState.None}
     {@const stackedAssets = stack.assets}
-    <div id="stack-slideshow" class="absolute bottom-0 col-span-4 col-start-1 w-fit max-w-full">
+    <div id="stack-slideshow" class="absolute bottom-0 col-span-4 col-start-1 w-fit max-w-full z-[-1]">
       <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div

--- a/web/src/lib/components/shared-components/search-bar/SearchFilters.svelte
+++ b/web/src/lib/components/shared-components/search-bar/SearchFilters.svelte
@@ -185,8 +185,8 @@
   }
 
   const margin = 8;
-  let windowInnerHeight: number = $state(0),
-    mainView: HTMLDivElement | undefined = $state();
+  let windowInnerHeight: number = $state(0);
+  let mainView: HTMLDivElement | undefined = $state();
 
   const maxHeight = $derived.by(() => {
     if (!mainView) {

--- a/web/src/lib/components/shared-components/search-bar/SearchFilters.svelte
+++ b/web/src/lib/components/shared-components/search-bar/SearchFilters.svelte
@@ -183,89 +183,108 @@
       searchHistory.selectActiveOption();
     }
   }
+
+  const margin = 8;
+  let windowInnerHeight: number = $state(0),
+    mainView: HTMLDivElement | undefined = $state();
+
+  const maxHeight = $derived.by(() => {
+    if (!mainView) {
+      return 0;
+    }
+    const rect = mainView.parentElement!.getBoundingClientRect();
+    return windowInnerHeight - rect.y - margin;
+  });
 </script>
+
+<svelte:window bind:innerHeight={windowInnerHeight} />
 
 <div role="listbox" {id}>
   {#if isOpen}
     <div
       transition:fly={{ y: 25, duration: 250 }}
-      class="absolute z-1 w-full rounded-b-3xl bg-white shadow-[0_8px_20px_rgba(0,0,0,0.12)] transition-all dark:bg-immich-dark-gray dark:text-gray-300"
+      bind:this={mainView}
+      class="absolute z-1 w-full overflow-hidden rounded-b-3xl bg-white shadow-[0_8px_20px_rgba(0,0,0,0.12)] transition-all dark:bg-immich-dark-gray dark:text-gray-300"
     >
-      <SearchHistorySection
-        bind:this={searchHistory}
-        {onSelectSearchTerm}
-        {onClearSearchTerm}
-        {onClearAllSearchTerms}
-        {onActiveSelectionChange}
-      />
-      <div class="px-5">
-        <Text class="py-5" fontWeight="medium" aria-hidden={true}>{$t('filter_by')}</Text>
-        <div class="flex flex-wrap gap-2">
-          {#each filters as item (item.name)}
-            <SearchButton
-              active={activeFilter === item.name || Boolean(item.activeTitle())}
-              leadingIcon={item.icon}
-              class={activeFilter === item.name ? 'border-2' : undefined}
-              onclick={() => (activeFilter = item.name)}
-            >
-              {item.activeTitle() ?? item.title}
-            </SearchButton>
-          {/each}
-        </div>
-      </div>
-      {#if activeFilter}
-        <div class="px-5 pt-5">
-          {#if activeFilter === 'type'}
-            <SearchTextSection />
-          {:else if activeFilter === 'people'}
-            <SearchPeopleSection bind:title={peopleTitle} parentPromise={peoplePromise} />
-          {:else if activeFilter === 'date'}
-            <SearchDateSection />
-          {:else if activeFilter === 'places'}
-            <SearchLocationSection />
-          {:else if activeFilter === 'tags'}
-            <SearchTagsSection bind:title={tagsTitle} parentPromise={tagsPromise} />
-          {:else if activeFilter === 'media'}
-            <SearchMediaSection />
-          {/if}
-        </div>
-      {/if}
-      <div
-        class="grid transition-[grid-template-rows] duration-200 ease-in-out {showAdvanced
-          ? 'grid-rows-[1fr]'
-          : 'grid-rows-[0fr]'}"
-        inert={!showAdvanced}
-      >
-        <div class="overflow-hidden">
-          <div class="my-5 h-px w-full bg-light-200 dark:bg-dark-600"></div>
-          <div class="px-5">
-            <SearchCameraSection />
-            {#if authManager.authenticated && authManager.preferences.ratings.enabled}
-              <SearchRatingsSection />
-            {/if}
-            <SearchDisplaySection />
+      <div class="immich-scrollbar overflow-auto" style:max-height={`${maxHeight}px`}>
+        <SearchHistorySection
+          bind:this={searchHistory}
+          {onSelectSearchTerm}
+          {onClearSearchTerm}
+          {onClearAllSearchTerms}
+          {onActiveSelectionChange}
+        />
+        <div class="px-5">
+          <Text class="py-5" fontWeight="medium" aria-hidden={true}>{$t('filter_by')}</Text>
+          <div class="flex flex-wrap gap-2">
+            {#each filters as item (item.name)}
+              <SearchButton
+                active={activeFilter === item.name || Boolean(item.activeTitle())}
+                leadingIcon={item.icon}
+                class={activeFilter === item.name ? 'border-2' : undefined}
+                onclick={() => (activeFilter = item.name)}
+              >
+                {item.activeTitle() ?? item.title}
+              </SearchButton>
+            {/each}
           </div>
         </div>
-      </div>
-      <div class="my-5 h-px w-full bg-light-200 dark:bg-dark-600"></div>
-      <div class="flex gap-2 px-5 pb-5">
-        <Button
-          size="small"
-          variant={advancedFiltersSet ? 'outline' : 'ghost'}
-          leadingIcon={mdiTune}
-          trailingIcon={showAdvanced ? mdiChevronUp : mdiChevronDown}
-          onclick={() => (showAdvanced = !showAdvanced)}>{$t('advanced_filters')}</Button
+        {#if activeFilter}
+          <div class="px-5 pt-5">
+            {#if activeFilter === 'type'}
+              <SearchTextSection />
+            {:else if activeFilter === 'people'}
+              <SearchPeopleSection bind:title={peopleTitle} parentPromise={peoplePromise} />
+            {:else if activeFilter === 'date'}
+              <SearchDateSection />
+            {:else if activeFilter === 'places'}
+              <SearchLocationSection />
+            {:else if activeFilter === 'tags'}
+              <SearchTagsSection bind:title={tagsTitle} parentPromise={tagsPromise} />
+            {:else if activeFilter === 'media'}
+              <SearchMediaSection />
+            {/if}
+          </div>
+        {/if}
+        <div
+          class="grid transition-[grid-template-rows] duration-200 ease-in-out {showAdvanced
+            ? 'grid-rows-[1fr]'
+            : 'grid-rows-[0fr]'}"
+          inert={!showAdvanced}
         >
-        <div class="flex-1"></div>
-        <Button
-          size="small"
-          shape="round"
-          variant="outline"
-          color="secondary"
-          class="bg-transparent"
-          onclick={() => clear()}>{$t('clear_all')}</Button
-        >
-        <Button size="small" shape="round" onclick={() => onSearch()}>{$t('search')}</Button>
+          <div class="overflow-hidden">
+            <div class="my-5 h-px w-full bg-light-200 dark:bg-dark-600"></div>
+            <div class="px-5">
+              <SearchCameraSection />
+              {#if authManager.authenticated && authManager.preferences.ratings.enabled}
+                <SearchRatingsSection />
+              {/if}
+              <SearchDisplaySection />
+            </div>
+          </div>
+        </div>
+        <div class="my-5 h-px w-full bg-light-200 dark:bg-dark-600"></div>
+        <div class="flex gap-2 px-5 pb-5">
+          <Button
+            size="small"
+            variant={advancedFiltersSet ? 'outline' : 'ghost'}
+            leadingIcon={mdiTune}
+            trailingIcon={showAdvanced ? mdiChevronUp : mdiChevronDown}
+            onclick={() => (showAdvanced = !showAdvanced)}
+          >
+            <div class="hidden sm:block">{$t('advanced_filters')}</div>
+          </Button>
+          <div class="flex-1"></div>
+          <Button
+            size="small"
+            shape="round"
+            variant="outline"
+            color="secondary"
+            class="bg-transparent"
+            onclick={() => clear()}>{$t('clear_all')}</Button
+          >
+          <Button size="small" shape="round" onclick={() => onSearch()}>{$t('search')}</Button>
+        </div>
       </div>
     </div>
   {/if}


### PR DESCRIPTION
## Description
Fix for two minor layout issues in the image viewer on small screens in web client, also added a scrollbar to the advanced search panel when too tall for screen.

It took me longer than I'd like to admit to figure out how the custom classes work. But then I finally realized this project is using Tailwind and found their docs in 2 seconds lol.

## How Has This Been Tested?
Using fone and Chrome Dev Tools

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before / After:\
<img width=250 src="https://github.com/user-attachments/assets/b1ee3fd7-f21b-4407-8c8f-47a55c701037" /> <img width=250 src="https://github.com/user-attachments/assets/423d405f-68eb-4ed7-852c-dc9c1b83eec6" />

Before / After:\
<img width=250 src="https://github.com/user-attachments/assets/d88e1fd9-3050-4347-9a33-205e515627ea" /> <img width=250 src="https://github.com/user-attachments/assets/c3e7e597-0505-473b-a692-620625c1f78d" />

Scrollable Filter Panel:\
<img width=600 src="https://github.com/user-attachments/assets/e7095644-ff87-4e33-a2e5-41c437a1cb6a" />
</details>

## Checklist:
- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
AI can't see what we see- Mainly because it doesn't have A-eyes