### PR TITLE
fix(web): partner sharing timeline

### DIFF
--- a/web/src/lib/managers/timeline-manager/internal/websocket-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/websocket-support.svelte.ts
@@ -13,10 +13,10 @@ export class WebsocketSupport {
   #processPendingChanges = throttle(() => {
     const { add, update, remove } = this.#getPendingChangeBatches();
     if (add.length > 0) {
-      this.#timelineManager.upsertAssets(add);
+      this.#timelineManager.upsertAssetsFromLiveEvent(add);
     }
     if (update.length > 0) {
-      this.#timelineManager.upsertAssets(update);
+      this.#timelineManager.upsertAssetsFromLiveEvent(update);
     }
     if (remove.length > 0) {
       this.#timelineManager.removeAssets(remove);

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -485,6 +485,61 @@ describe('TimelineManager', () => {
     });
   });
 
+  describe('live event asset insertion', () => {
+    let timelineManager: TimelineManager;
+
+    beforeEach(async () => {
+      timelineManager = new TimelineManager();
+      sdkMock.getTimeBuckets.mockResolvedValue([]);
+
+      await timelineManager.updateViewport({ width: 1588, height: 1000 });
+    });
+
+    afterEach(() => {
+      timelineManager.destroy();
+    });
+
+    it('does not insert live event assets with a different owner into a user-scoped timeline', async () => {
+      await timelineManager.updateOptions({ userId: 'partner-id', visibility: AssetVisibility.Timeline });
+
+      const asset = deriveLocalDateTimeFromFileCreatedAt(
+        timelineAssetFactory.build({
+          ownerId: 'current-user-id',
+          visibility: AssetVisibility.Timeline,
+        }),
+      );
+
+      timelineManager.upsertAssetsFromLiveEvent([asset]);
+
+      expect(timelineManager.assetCount).toEqual(0);
+    });
+
+    it('inserts live event assets for the matching owner into a user-scoped timeline', async () => {
+      await timelineManager.updateOptions({ userId: 'partner-id', visibility: AssetVisibility.Timeline });
+
+      const asset = deriveLocalDateTimeFromFileCreatedAt(
+        timelineAssetFactory.build({
+          ownerId: 'partner-id',
+          visibility: AssetVisibility.Timeline,
+        }),
+      );
+
+      timelineManager.upsertAssetsFromLiveEvent([asset]);
+
+      expect(timelineManager.assetCount).toEqual(1);
+    });
+
+    it('does not insert unknown live event assets into album timelines', async () => {
+      await timelineManager.updateOptions({ albumId: 'album-id' });
+
+      const asset = deriveLocalDateTimeFromFileCreatedAt(timelineAssetFactory.build());
+
+      timelineManager.upsertAssetsFromLiveEvent([asset]);
+
+      expect(timelineManager.assetCount).toEqual(0);
+    });
+  });
+
   describe('removeAssets', () => {
     let timelineManager: TimelineManager;
 

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -538,6 +538,30 @@ describe('TimelineManager', () => {
 
       expect(timelineManager.assetCount).toEqual(0);
     });
+
+    it('updates existing live event assets in scoped timelines', async () => {
+      await timelineManager.updateOptions({ albumId: 'album-id' });
+
+      const asset = deriveLocalDateTimeFromFileCreatedAt(
+        timelineAssetFactory.build({
+          isFavorite: false,
+        }),
+      );
+
+      timelineManager.upsertAssets([asset]);
+      expect(timelineManager.assetCount).toEqual(1);
+      expect(timelineManager.months[0].getFirstAsset().isFavorite).toEqual(false);
+
+      timelineManager.upsertAssetsFromLiveEvent([
+        {
+          ...asset,
+          isFavorite: true,
+        },
+      ]);
+
+      expect(timelineManager.assetCount).toEqual(1);
+      expect(timelineManager.months[0].getFirstAsset().isFavorite).toEqual(true);
+    });
   });
 
   describe('removeAssets', () => {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -381,6 +381,12 @@ export class TimelineManager extends VirtualScrollManager {
     this.addAssetsUpsertSegments([...notExcluded]);
   }
 
+  upsertAssetsFromLiveEvent(assets: TimelineAsset[]) {
+    const notUpdated = this.#updateAssets(assets);
+    const insertable = notUpdated.filter((asset) => this.canInsertAssetFromLiveEvent(asset));
+    this.addAssetsUpsertSegments(insertable);
+  }
+
   async findTimelineMonthForAsset(asset: AssetDescriptor | AssetResponseDto) {
     if (!this.isInitialized) {
       await this.initTask.waitUntilExecution();
@@ -618,6 +624,19 @@ export class TimelineManager extends VirtualScrollManager {
       (this.#options.tagId && asset.tags && !asset.tags.includes(this.#options.tagId)) ||
       (this.#options.assetFilter !== undefined && !this.#options.assetFilter.has(asset.id))
     );
+  }
+
+  canInsertAssetFromLiveEvent(asset: TimelineAsset) {
+    if (this.isExcluded(asset)) {
+      return false;
+    }
+    if (this.#options.albumId || this.#options.personId || this.#options.timelineAlbumId) {
+      return false;
+    }
+    if (this.#options.userId && !this.#options.withPartners && asset.ownerId !== this.#options.userId) {
+      return false;
+    }
+    return true;
   }
 
   getAssetOrder() {


### PR DESCRIPTION
## Description
Problem:
when a user was viewing another user's Partner Sharing timeline, newly uploaded assets belonging to the current user suddenly also appear inside the partner library as if the uploaded picture are theirs. After the user refresh the page, it display the right photos of partner library.
This behavior only occures on partner feature and not on shared library. 

Changes made:
I separate the function to asset handling that happen through websocket from regular timeline upserts. From this separation, the new function that i created only focus on handling websocket event on inserting new assets when it compatibles with the current timeline scope. the old function still be used on handling regular app-level insertions.

After changes:
The issue seems to be fix, since manual test on web app cannot reproduce the issue. (Also checked on shared library) 

Fixes #21656 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Added 4 unit tests focused on the timeline manager to test the functionality and behavior of live event insertion and updates. (All Passed)
- [x] I manually test the reproduces steps to see if the bug still there or is there any other side effects. (Passed)
- [x] Ran automated Tests (Lint, Format, check-svelte, check-typescript, unit test) -> passed

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used LLM to help me understand the issue and locate relevant parts of the codebase. The changes and tests are written by me. I then only ask LLM for other side effects of the issues or the code.

...
