### PR TITLE
fix(mobile): photo_manager rejects whole batch as soon as one id can't be resolved in MediaStore

### DIFF
--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -55,7 +55,7 @@ class AssetMediaRepository {
 
     final useTrash = trash && CurrentPlatform.isAndroid && await _androidSupportsTrash();
     try {
-      return await _deleteAll(ids, useTrash);
+      return await _runDelete(ids, useTrash);
     } on PlatformException catch (error, stack) {
       // photo_manager rejects whole batch as soon as one id can't be resolved in MediaStore, see #30133
       final existingIds = await _filterExistingIds(ids);
@@ -71,11 +71,11 @@ class AssetMediaRepository {
       if (existingIds.isEmpty) {
         return [];
       }
-      return _deleteAll(existingIds, useTrash);
+      return _runDelete(existingIds, useTrash);
     }
   }
 
-  Future<List<String>> _deleteAll(List<String> ids, bool trash) {
+  Future<List<String>> _runDelete(List<String> ids, bool trash) {
     if (trash) {
       return PhotoManager.editor.android.moveToTrash(
         ids.map((e) => AssetEntity(id: e, width: 1, height: 1, typeInt: 0)).toList(),

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -86,10 +86,7 @@ class AssetMediaRepository {
 
   Future<List<String>> _filterExistingIds(List<String> ids) async {
     final entities = await Future.wait(ids.map(AssetEntity.fromId));
-    return [
-      for (final (index, entity) in entities.indexed)
-        if (entity != null) ids[index],
-    ];
+    return entities.nonNulls.map((e) => e.id).toList();
   }
 
   Future<bool> _restoreFromTrashById(String mediaId, int type) async {

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
@@ -48,12 +49,47 @@ class AssetMediaRepository {
   }
 
   Future<List<String>> deleteAll(List<String> ids, {bool trash = true}) async {
-    if (trash && CurrentPlatform.isAndroid && await _androidSupportsTrash()) {
+    if (ids.isEmpty) {
+      return [];
+    }
+
+    final useTrash = trash && CurrentPlatform.isAndroid && await _androidSupportsTrash();
+    try {
+      return await _deleteAll(ids, useTrash);
+    } on PlatformException catch (error, stack) {
+      // photo_manager rejects whole batch as soon as one id can't be resolved in MediaStore, see #30133
+      final existingIds = await _filterExistingIds(ids);
+      if (existingIds.length == ids.length) {
+        rethrow;
+      }
+
+      _log.warning(
+        "Skipping ${ids.length - existingIds.length} assets that no longer exist on the device",
+        error,
+        stack,
+      );
+      if (existingIds.isEmpty) {
+        return [];
+      }
+      return _deleteAll(existingIds, useTrash);
+    }
+  }
+
+  Future<List<String>> _deleteAll(List<String> ids, bool trash) {
+    if (trash) {
       return PhotoManager.editor.android.moveToTrash(
         ids.map((e) => AssetEntity(id: e, width: 1, height: 1, typeInt: 0)).toList(),
       );
     }
     return PhotoManager.editor.deleteWithIds(ids);
+  }
+
+  Future<List<String>> _filterExistingIds(List<String> ids) async {
+    final entities = await Future.wait(ids.map(AssetEntity.fromId));
+    return [
+      for (final (index, entity) in entities.indexed)
+        if (entity != null) ids[index],
+    ];
   }
 
   Future<bool> _restoreFromTrashById(String mediaId, int type) async {

--- a/mobile/test/repositories/asset_media_repository_delete_test.dart
+++ b/mobile/test/repositories/asset_media_repository_delete_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/infrastructure/repositories/storage.repository.dart';
+import 'package:immich_mobile/platform/native_sync_api.g.dart';
+import 'package:immich_mobile/repositories/asset_media.repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockNativeSyncApi extends Mock implements NativeSyncApi {}
+
+class _MockStorageRepository extends Mock implements StorageRepository {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.fluttercandies/photo_manager');
+
+  late AssetMediaRepository repository;
+  late List<List<String>> deleteCalls;
+  late Set<String> missingIds;
+  late bool failEveryDelete;
+
+  setUp(() {
+    repository = AssetMediaRepository(_MockNativeSyncApi(), _MockStorageRepository());
+    deleteCalls = [];
+    missingIds = {};
+    failEveryDelete = false;
+
+    // whole batch is rejected as soon as single ID cannot be resolved in the MediaStore
+    // happens for files removed outside of Immich (#30133)
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      final arguments = Map<Object?, Object?>.from(call.arguments as Map);
+      switch (call.method) {
+        case 'deleteWithIds':
+          final ids = (arguments['ids']! as List).cast<String>();
+          deleteCalls.add(ids);
+          if (failEveryDelete || ids.any(missingIds.contains)) {
+            throw PlatformException(code: 'deleteWithIds failed');
+          }
+          return ids;
+        case 'fetchEntityProperties':
+          final id = arguments['id']! as String;
+          if (missingIds.contains(id)) {
+            return null;
+          }
+          return <String, Object?>{'id': id, 'type': 1, 'width': 1, 'height': 1};
+      }
+      throw UnimplementedError(call.method);
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('AssetMediaRepository.deleteAll', () {
+    test('returns nothing without touching the platform for an empty list', () async {
+      final result = await repository.deleteAll([]);
+
+      expect(result, isEmpty);
+      expect(deleteCalls, isEmpty);
+    });
+
+    test('deletes whole batch in a single call when every asset exists', () async {
+      final result = await repository.deleteAll(['a', 'b', 'c']);
+
+      expect(result, ['a', 'b', 'c']);
+      expect(deleteCalls, [
+        ['a', 'b', 'c'],
+      ]);
+    });
+
+    test('retries without assets that are missing from the device when batch fails', () async {
+      missingIds = {'b'};
+
+      final result = await repository.deleteAll(['a', 'b', 'c']);
+
+      expect(result, ['a', 'c']);
+      expect(deleteCalls, [
+        ['a', 'b', 'c'],
+        ['a', 'c'],
+      ]);
+    });
+
+    test('returns nothing when every asset is missing from the device', () async {
+      missingIds = {'a', 'b'};
+
+      final result = await repository.deleteAll(['a', 'b']);
+
+      expect(result, isEmpty);
+      expect(deleteCalls, [
+        ['a', 'b'],
+      ]);
+    });
+
+    test('rethrows when the batch fails although every asset still exists', () async {
+      failEveryDelete = true;
+
+      await expectLater(repository.deleteAll(['a', 'b']), throwsA(isA<PlatformException>()));
+      expect(deleteCalls, [
+        ['a', 'b'],
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Description

`AssetMediaRepository.deleteAll` hands whole batch of local ids to `photo_manager`. It resolves every id to a `MediaStore` URI first and throws as soon as a single id cannot be resolved, e.g. because the file was removed outside of Immich (see issue [#30133](https://github.com/immich-app/immich/issues/30133)). Whole batch is then rejected with `PlatformException(deleteWithIds failed, null, null, null)` and nothing gets trashed.

`deleteAll` is shared by four callers, so one stale local asset row breaks all of them:

- "Free up space" (`CleanupService.deleteLocalAssets`) deletes nothing and fails silently.
- Local sync (`LocalSyncService.processTrashedAssets`) aborts with "Error performing device sync", so new photos stop showing up and the stale rows are never reconciled.
- Remote sync (`SyncStreamService._trashLocalAssets`) aborts with "Error in runInIsolateGentle for remote-sync".
- `AssetService.deleteLocal`.

This change makes `deleteAll` catch the `PlatformException`, look up which Ids still resolve on the device (`AssetEntity.fromId`, the same `MediaStore` lookup the native side uses, but it returns `null` instead of throwing, no clue if that is a good idea though), and retry with only those. Ids that are missing are logged and skipped so that it doesn't completely fail. If nothing was filtered out, the original error is thrown again, so that a cancelled system dialog does not trigger a second prompt. If no error is thrown, the logic is unchanged.

Fixes [#30133](https://github.com/immich-app/immich/issues/30133)

## How Has This Been Tested?

- [x] New test `mobile/test/repositories/asset_media_repository_delete_test.dart` mocks the `com.fluttercandies/photo_manager` method channel to reject the batch when any ID is missing. Without the fix it reproduces the exact `PlatformException(deleteWithIds failed, null, null, null)` from the issue. With the fix the batch is retried and successfulk without the missing ids.
- [x] Existing suites for `CleanupService`, `LocalSyncService`, `SyncStreamService` and `AssetMediaRepository` pass.
- [x] Full `flutter test` in `mobile/` passes (1342 tests), `flutter analyze` and `dart format` are clean.
- [x] On device: with local assets whose files were removed outside of Immich, "Free up space" now trashes the remaining assets, and the device/remote sync errors on app start are gone.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used GitHub Copilot to actuallly trace the source of the issue to the specific function. I used Inline Code Completion to help me in implementing the tests and fix.