### PR TITLE
fix(docs): add needed mobile app developer setup step

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -100,6 +100,10 @@ To see local changes to `@immich/ui` in Immich, do the following:
 3. Run `mise //mobile:checkout` to update the environment and codegen artifacts.
 4. Change to the `mobile/` directory and run `flutter run` to start the app.
 
+:::important Workflow
+Always run `mise //mobile:checkout` after switching branches.
+:::
+
 ##### iOS Code Signing
 
 The Immich Apple Team ID and bundle IDs are specified in `mobile/ios/Signing.xcconfig`. For local development, we provide an override mechanism.

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -97,7 +97,7 @@ To see local changes to `@immich/ui` in Immich, do the following:
 
 1. Run `mise //mobile:install` to install Flutter dependencies.
 2. Run `mise //mobile:translation` to generate the translation file.
-3. Run `mise //mobile:checkout` to update the environment and codegen artifacts.
+3. Run `mise //mobile:checkout` to update the dependencies and codegen artifacts.
 4. Change to the `mobile/` directory and run `flutter run` to start the app.
 
 :::important Workflow

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -97,7 +97,8 @@ To see local changes to `@immich/ui` in Immich, do the following:
 
 1. Run `mise //mobile:install` to install Flutter dependencies.
 2. Run `mise //mobile:translation` to generate the translation file.
-3. Change to the `mobile/` directory and run `flutter run` to start the app.
+3. Run `mise //mobile:checkout` to update the environment and codegen artifacts.
+4. Change to the `mobile/` directory and run `flutter run` to start the app.
 
 ##### iOS Code Signing
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The mobile app flutter build only works after executing the `mise //mobile:checkout` command. I added this step to the Developer Setup documentation.

Additionally, I included a hint about repeating the command, taken from the checkout task description in `mobile/mise.toml` ("Bring a checkout up to date after switching branches").

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Markdown syntax checks and previews

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used, except for the initial hint towards finding the codegen/checkout task after my build failed.
