### PR TITLE
fix(mobile): make shared link download toggle depend on metadata toggle

### DIFF
--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -157,8 +157,8 @@ class SharedLinkEditPage extends HookConsumerWidget {
 
     Widget buildAllowDownloadButton() {
       return SwitchListTile.adaptive(
-        value: allowDownload.value,
-        onChanged: (value) => allowDownload.value = value,
+        value: allowDownload.value && showMetadata.value,
+        onChanged: showMetadata.value ? (value) => allowDownload.value = value : null,
         dense: true,
         title: Text(
           context.t.allow_public_user_to_download,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a minimal GUI fix for the Shared Link creation page.

The fix prevents the toggle switch state combination "Metadata off, Download on" which is not allowed by the shared link backend logic. The mobile app now has the same mechanism as the web app: deactivating the "Allow public user to download" button if "Show metadata" is toggled off (see screenshots).

Fixes #31242

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested on Android device with local build (debug & release).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

<img width="520" height="1062" alt="Screenshot_20260904_131401" src="https://github.com/user-attachments/assets/94dba5e6-c85f-4c67-bbe7-43f8eaf6c85a" />

<img width="520" height="1063" alt="Screenshot_20260904_131400" src="https://github.com/user-attachments/assets/4c789d04-e8c4-40f5-abec-f64ce34d9b7f" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used.
