### PR TITLE
fix(web): word-wrap long album names

### DIFF
--- a/web/src/lib/components/album-page/AlbumCard.svelte
+++ b/web/src/lib/components/album-page/AlbumCard.svelte
@@ -60,7 +60,7 @@
 
   <div class="mt-4">
     <p
-      class="line-clamp-2 w-full text-lg/6 font-semibold text-black group-hover:text-primary dark:text-white"
+      class="line-clamp-2 w-full text-lg/6 font-semibold wrap-break-word text-black group-hover:text-primary dark:text-white"
       data-testid="album-name"
       title={album.albumName}
     >


### PR DESCRIPTION
Fixes #31235 by word-wrapping very long words in album names

| Before | After |
|---|---|
| <img width="241" height="344" alt="image" src="https://github.com/user-attachments/assets/7e0ca2a1-e3c5-4ea2-acdb-04fd89323281" /> | <img width="241" height="344" alt="image" src="https://github.com/user-attachments/assets/cf862141-29c3-408d-8d0d-e2e14eded45f" /> |