### PR TITLE
fix(web): browser back scroll restoration

### DIFF
--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -100,6 +100,22 @@ test.describe('Timeline', () => {
       const scrollTopAfter = await timelineUtils.getScrollTop(page);
       expect(scrollTopAfter).toBe(scrollTopBefore);
     });
+    test('Open /photos, scroll to another asset, open asset-viewer, browser back', async ({ page }) => {
+      const firstAsset = assets[0];
+      const targetAsset = assets[20];
+
+      await pageUtils.deepLinkPhotosPage(page, firstAsset.id);
+      await pageUtils.goToAsset(page, targetAsset.fileCreatedAt);
+      await thumbnailUtils.expectInViewport(page, targetAsset.id);
+
+      await thumbnailUtils.clickAssetId(page, targetAsset.id);
+      await assetViewerUtils.waitForViewerLoad(page, targetAsset);
+
+      await page.goBack();
+      await page.waitForURL(`**/photos?at=${targetAsset.id}`);
+
+      await thumbnailUtils.expectInViewport(page, targetAsset.id);
+    });
     test('Open /photos, open asset-viewer, next photo, browser back, back', async ({ page }) => {
       const rng = new SeededRandom(49);
       const asset = selectRandom(assets, rng);
@@ -439,6 +455,23 @@ test.describe('Timeline', () => {
       await pageUtils.goToAsset(page, asset.fileCreatedAt);
       await thumbnailUtils.expectInViewport(page, asset.id);
       await thumbnailUtils.expectSelectedDisabled(page, asset.id);
+    });
+    test('Open album, scroll to another asset, open asset-viewer, browser back', async ({ page }) => {
+      const album = timelineRestData.album;
+      const firstAsset = assets.find((asset) => asset.id === album.assetIds[0])!;
+      const targetAsset = assets.find((asset) => asset.id === album.assetIds[20])!;
+
+      await pageUtils.deepLinkAlbumPage(page, album.id, firstAsset.id);
+      await pageUtils.goToAsset(page, targetAsset.fileCreatedAt);
+      await thumbnailUtils.expectInViewport(page, targetAsset.id);
+
+      await thumbnailUtils.clickAssetId(page, targetAsset.id);
+      await assetViewerUtils.waitForViewerLoad(page, targetAsset);
+
+      await page.goBack();
+      await page.waitForURL(`**/albums/${album.id}?at=${targetAsset.id}`);
+
+      await thumbnailUtils.expectInViewport(page, targetAsset.id);
     });
     test.skip('Add photos to album', async ({ page }) => {
       const album = timelineRestData.album;

--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -102,11 +102,13 @@ test.describe('Timeline', () => {
     });
     test('Open /photos, scroll to another asset, open asset-viewer, browser back', async ({ page }) => {
       const firstAsset = assets[0];
-      const targetAsset = assets[20];
 
       await pageUtils.deepLinkPhotosPage(page, firstAsset.id);
-      await pageUtils.goToAsset(page, targetAsset.fileCreatedAt);
-      await thumbnailUtils.expectInViewport(page, targetAsset.id);
+      await timelineUtils.locator(page).hover();
+      await page.mouse.wheel(0, 3000);
+
+      const [targetAssetId] = (await thumbnailUtils.getFirstInViewport(page))!;
+      const targetAsset = assets.find((asset) => asset.id === targetAssetId)!;
 
       await thumbnailUtils.clickAssetId(page, targetAsset.id);
       await assetViewerUtils.waitForViewerLoad(page, targetAsset);
@@ -459,11 +461,13 @@ test.describe('Timeline', () => {
     test('Open album, scroll to another asset, open asset-viewer, browser back', async ({ page }) => {
       const album = timelineRestData.album;
       const firstAsset = assets.find((asset) => asset.id === album.assetIds[0])!;
-      const targetAsset = assets.find((asset) => asset.id === album.assetIds[20])!;
 
       await pageUtils.deepLinkAlbumPage(page, album.id, firstAsset.id);
-      await pageUtils.goToAsset(page, targetAsset.fileCreatedAt);
-      await thumbnailUtils.expectInViewport(page, targetAsset.id);
+      await timelineUtils.locator(page).hover();
+      await page.mouse.wheel(0, 3000);
+
+      const [targetAssetId] = (await thumbnailUtils.getFirstInViewport(page))!;
+      const targetAsset = assets.find((asset) => asset.id === targetAssetId)!;
 
       await thumbnailUtils.clickAssetId(page, targetAsset.id);
       await assetViewerUtils.waitForViewerLoad(page, targetAsset);

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -551,7 +551,7 @@
       assetViewerManager.gridScrollTarget = { at: asset.id };
       await navigate(
         { targetRoute: 'current', assetId: null, assetGridRouteSearchParams: assetViewerManager.gridScrollTarget },
-        { replaceState: true },
+        { replaceState: true, noScroll: true, keepFocus: true },
       );
       await navigate({ targetRoute: 'current', assetId: asset.id });
     })();

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -547,7 +547,14 @@
       assetSelectHandler(timelineManager, asset, assets, groupTitle);
       return;
     }
-    void navigate({ targetRoute: 'current', assetId: asset.id });
+    void (async () => {
+      assetViewerManager.gridScrollTarget = { at: asset.id };
+      await navigate(
+        { targetRoute: 'current', assetId: null, assetGridRouteSearchParams: assetViewerManager.gridScrollTarget },
+        { replaceState: true },
+      );
+      await navigate({ targetRoute: 'current', assetId: asset.id });
+    })();
   };
 </script>
 


### PR DESCRIPTION
## Description

Problem:
When a user opens an asset from photo or album timeline and then click the browser back button, the timeline does not go back to the right last scroll position. the in-app back button already restores the correct position because it updates the timeline scroll position before navigating back. This update of browser history entry then only occur when the user use in-app back button. As a result, browser back button could return to a stale '?at=' value or to a timeline URL without a scroll target.

Change made:
The change i made now update the current timeline history entry with the clicked asset as the new '?at=' target before navigating to asset viewer. I specially add parameter so the history entry is replaced without adding hidden scrolling or change of focus to avoid any side effect.

This then work on both main photo and album timeline without changing the existing in-app back button's logic.

Fixes #16117

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Wrote and ran 2 additional E2E test about the cases. (passed)
- [x] Ran E2E test - e2e/src/ui/specs/timeline/timeline.e2e-spec.ts (most of them passed, failed tests are not related to the change)
- [x] Lint check (failed due to tscompat/tscompat, unrelated to changes)
- [x] Format check (passed)
- [x] Svelte check (passed)
- [x] TS check (passed)
- [x] Unit test (all passed)
- [x] Manual check on local to make sure the issues fix (using reproduce steps)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used LLM to help me understand the issue and locate relevant parts of the codebase. The changes and tests are written by me. I then only ask LLM for other side effects of the issues of the code.
...
