### PR TITLE
fix(web): refactor some styling

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -34,7 +34,7 @@
 }
 
 @utility immich-form-input {
-  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-primary focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 dark:focus-within:ring-primary flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base pl-4 pr-4;
+  @apply bg-gray-100 ring-1 ring-gray-200 transition outline-none focus-within:ring-primary focus-within:ring-1 disabled:cursor-not-allowed dark:bg-gray-800 dark:ring-neutral-900 dark:focus-within:ring-primary flex w-full items-center rounded-lg disabled:bg-gray-300 disabled:text-dark dark:disabled:bg-gray-900 dark:disabled:text-gray-200 flex-1 py-2.5 text-base px-4;
 }
 
 @utility immich-form-label {

--- a/web/src/lib/components/asset-viewer/DetailPanelDescription.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelDescription.svelte
@@ -33,7 +33,7 @@
   <section class="mt-10 px-4">
     <Textarea
       bind:value={description}
-      class="max-h-40 resize-none border-b border-gray-500 bg-transparent pl-0 ring-0 outline-none focus:border-b-2 focus:border-immich-primary focus:ring-0 dark:bg-transparent dark:focus:border-immich-dark-primary"
+      class="max-h-40 resize-none border-b border-gray-500 bg-transparent ps-0 ring-0 outline-none focus:border-b-2 focus:border-immich-primary focus:ring-0 dark:bg-transparent dark:focus:border-immich-dark-primary"
       rows={1}
       grow
       shape="rectangle"

--- a/web/src/lib/managers/language-manager.svelte.ts
+++ b/web/src/lib/managers/language-manager.svelte.ts
@@ -1,3 +1,4 @@
+import { mdiChevronLeft, mdiChevronRight, mdiPageFirst, mdiPageLast } from '@mdi/js';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { lang } from '$lib/stores/preferences.store';
 import { langs } from '$lib/utils/i18n';
@@ -11,6 +12,10 @@ class LanguageManager {
 
   initialized = $state(false);
   rtl = $state(false);
+  mdiChevronNext = $derived(this.rtl ? mdiChevronLeft : mdiChevronRight);
+  mdiChevronPrevious = $derived(this.rtl ? mdiChevronRight : mdiChevronLeft);
+  mdiPageFirst = $derived(this.rtl ? mdiPageLast : mdiPageFirst);
+  mdiPageLast = $derived(this.rtl ? mdiPageFirst : mdiPageLast);
 
   init() {
     if (this.initialized) {

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -7,6 +7,7 @@
   import DuplicatesCompareControl from './DuplicatesCompareControl.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
+  import { languageManager } from '$lib/managers/language-manager.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Route } from '$lib/route';
   import { locale } from '$lib/stores/preferences.store';
@@ -14,15 +15,7 @@
   import type { AssetResponseDto } from '@immich/sdk';
   import { createStack, deleteDuplicates, resolveDuplicates, updateAssets } from '@immich/sdk';
   import { Button, HStack, IconButton, modalManager, Text, toastManager } from '@immich/ui';
-  import {
-    mdiCheckOutline,
-    mdiChevronLeft,
-    mdiChevronRight,
-    mdiKeyboard,
-    mdiPageFirst,
-    mdiPageLast,
-    mdiTrashCanOutline,
-  } from '@mdi/js';
+  import { mdiCheckOutline, mdiKeyboard, mdiTrashCanOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
 
@@ -255,7 +248,8 @@
   <div>
     {#if duplicates && duplicates.length > 0}
       <Text size="small" color="muted" class="mb-4">
-        <p>{$t('duplicates_description')} <LinkToDocs href="https://docs.immich.app/features/duplicates-utility" /></p>
+        {$t('duplicates_description')}
+        <LinkToDocs href="https://docs.immich.app/features/duplicates-utility" />
       </Text>
 
       {#key duplicates[duplicatesIndex].duplicateId}
@@ -272,8 +266,7 @@
             <div class="flex text-xs text-black">
               <Button
                 size="small"
-                leadingIcon={mdiPageFirst}
-                color="primary"
+                leadingIcon={languageManager.mdiPageFirst}
                 class="flex place-items-center gap-2 rounded-s-full px-2 sm:px-4"
                 onclick={handleFirst}
                 disabled={duplicatesIndex === 0}
@@ -282,8 +275,7 @@
               </Button>
               <Button
                 size="small"
-                leadingIcon={mdiChevronLeft}
-                color="primary"
+                leadingIcon={languageManager.mdiChevronPrevious}
                 class="flex place-items-center gap-2 rounded-e-full px-2 sm:px-4"
                 onclick={handlePrevious}
                 disabled={duplicatesIndex === 0}
@@ -297,8 +289,7 @@
             <div class="flex text-xs text-black">
               <Button
                 size="small"
-                trailingIcon={mdiChevronRight}
-                color="primary"
+                trailingIcon={languageManager.mdiChevronNext}
                 class="flex place-items-center gap-2 rounded-s-full px-2 sm:px-4"
                 onclick={handleNext}
                 disabled={duplicatesIndex === duplicates.length - 1}
@@ -307,8 +298,7 @@
               </Button>
               <Button
                 size="small"
-                trailingIcon={mdiPageLast}
-                color="primary"
+                trailingIcon={languageManager.mdiPageLast}
                 class="flex place-items-center gap-2 rounded-e-full px-2 sm:px-4"
                 onclick={handleLast}
                 disabled={duplicatesIndex === duplicates.length - 1}

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
@@ -40,7 +40,7 @@
   );
 </script>
 
-<div class="min-w-60 flex-1 rounded-lg border transition-colors">
+<div class="min-w-60 flex-1 overflow-hidden rounded-lg border transition-colors">
   <div class="relative w-full">
     <button
       type="button"
@@ -53,7 +53,7 @@
       <img
         src={getAssetMediaUrl({ id: asset.id })}
         alt={$getAltText(toTimelineAsset(asset))}
-        class="h-60 w-full rounded-t-md object-cover"
+        class="h-60 w-full object-cover"
         draggable="false"
       />
 
@@ -102,7 +102,7 @@
   </div>
 
   <div
-    class="grid place-items-start gap-y-2 rounded-b-lg py-2 text-sm transition-colors {isSelected
+    class="grid place-items-start divide-y text-sm transition-colors {isSelected
       ? 'bg-success/15 dark:bg-[#001a06]'
       : 'bg-transparent'}"
   >
@@ -113,7 +113,7 @@
     {/each}
 
     <!-- Albums always shown -->
-    <InfoRow icon={mdiBookmarkOutline} borderBottom={false} title={$t('albums')}>
+    <InfoRow icon={mdiBookmarkOutline} title={$t('albums')}>
       {#await getAllAlbums({ assetId: asset.id })}
         {$t('scanning_for_album')}
       {:then albums}

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
@@ -186,7 +186,7 @@
   </div>
 
   {#if hasMore}
-    <div class="flex justify-center pb-2">
+    <div class="flex justify-center">
       <Button size="small" variant="ghost" color="secondary" onclick={() => (showMore = !showMore)}>
         <Icon icon={showMore ? mdiChevronUp : mdiChevronDown} size="18" class="me-1" />
         {showMore

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/InfoRow.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/InfoRow.svelte
@@ -4,26 +4,23 @@
 
   interface Props {
     icon: string;
-    children?: Snippet;
-    borderBottom?: boolean;
-    title?: string;
+    children: Snippet;
+    title: string;
   }
 
-  let { icon, children, borderBottom = true, title }: Props = $props();
+  let { icon, children, title }: Props = $props();
 </script>
 
-<div class="grid w-full grid-cols-[20px_auto_1fr] overflow-hidden px-1 py-0.5" class:border-b={borderBottom} {title}>
+<div class="grid w-full grid-cols-[20px_auto_1fr] gap-1 overflow-hidden px-2 py-1.5" {title}>
   <Icon {icon} size="16" class="self-center text-dark/25" />
 
-  {#if title}
-    <Text size="tiny" class="self-center truncate px-1 pr-2 text-immich-fg/40 dark:text-immich-dark-fg/40">
-      {title}
-    </Text>
-  {/if}
+  <Text size="tiny" class="self-center truncate pe-1 text-immich-fg/40 dark:text-immich-dark-fg/40">
+    {title}
+  </Text>
 
-  <div class="justify-self-end overflow-hidden rounded-sm px-1 text-end transition-colors">
+  <div class="justify-self-end overflow-hidden rounded-sm text-end transition-colors">
     <Text size="tiny" class="break-all">
-      {@render children?.()}
+      {@render children()}
     </Text>
   </div>
 </div>


### PR DESCRIPTION
Refactors some styling, mostly in the duplicates page. ~~As a suggestion, I added 4 'RTL-aware' arrow/chevron icons to the language manager. We could reuse these across the code base, instead of doing `languageManager.rtl ? mdiArrowLeft : mdiArrowRight` everywhere. Maybe the language manager isn't really the right place, though.~~