### PR TITLE
fix(web): flip the favorite heart on the server's answer, not on a later round trip

### DIFF
--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -1,4 +1,4 @@
-import { getAssetInfo } from '@immich/sdk';
+import { getAssetInfo, updateAsset } from '@immich/sdk';
 import { toastManager } from '@immich/ui';
 import { vitest } from 'vitest';
 import { authManager } from '$lib/managers/auth-manager.svelte';
@@ -68,6 +68,59 @@ describe('AssetService', () => {
       setSharedLink(sharedLinkFactory.build({ allowDownload: true }));
       const assetActions = getAssetActions(() => '', asset);
       expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(true);
+    });
+  });
+
+  describe('favorite actions', () => {
+    beforeEach(() => {
+      authManager.setPreferences(preferencesFactory.build());
+      vitest.mocked(getFormatter).mockResolvedValue(vitest.fn().mockReturnValue('formatter'));
+    });
+
+    it('flips the heart as soon as the server has answered, rather than on a later round trip', async () => {
+      // The icon is chosen by `$if: () => isOwner && asset.isFavorite`, and the handler used to
+      // leave that field untouched — so the server was updated, the toast fired, the asset left the
+      // Favorites view, and the filled heart stayed until something else replaced the object.
+      const ownerId = 'owner';
+      authManager.setUser(userAdminFactory.build({ id: ownerId }));
+      const asset = assetFactory.build({ ownerId, isFavorite: true });
+      vitest.mocked(updateAsset).mockResolvedValue({ ...asset, isFavorite: false });
+
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.Unfavorite.$if?.()).toBe(true);
+
+      await assetActions.Unfavorite.onAction?.();
+
+      expect(asset.isFavorite).toBe(false);
+      expect(assetActions.Unfavorite.$if?.()).toBe(false);
+      expect(assetActions.Favorite.$if?.()).toBe(true);
+    });
+
+    it('flips the heart the other way when favoriting', async () => {
+      const ownerId = 'owner';
+      authManager.setUser(userAdminFactory.build({ id: ownerId }));
+      const asset = assetFactory.build({ ownerId, isFavorite: false });
+      vitest.mocked(updateAsset).mockResolvedValue({ ...asset, isFavorite: true });
+
+      const assetActions = getAssetActions(() => '', asset);
+      await assetActions.Favorite.onAction?.();
+
+      expect(asset.isFavorite).toBe(true);
+      expect(assetActions.Favorite.$if?.()).toBe(false);
+    });
+
+    it("takes the server's answer rather than assuming the toggle succeeded", async () => {
+      // If the server declines the change, the icon must keep showing what the server holds. The
+      // point of this fix is that the icon follows the response, not that it follows the click.
+      const ownerId = 'owner';
+      authManager.setUser(userAdminFactory.build({ id: ownerId }));
+      const asset = assetFactory.build({ ownerId, isFavorite: true });
+      vitest.mocked(updateAsset).mockResolvedValue({ ...asset, isFavorite: true });
+
+      const assetActions = getAssetActions(() => '', asset);
+      await assetActions.Unfavorite.onAction?.();
+
+      expect(asset.isFavorite).toBe(true);
     });
   });
 

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -381,6 +381,14 @@ const handleFavorite = async (asset: AssetResponseDto) => {
 
   try {
     const response = await updateAsset({ id: asset.id, updateAssetDto: { isFavorite: true } });
+    // The Favorite/Unfavorite buttons choose their icon from `asset.isFavorite`, so the heart only
+    // changes when this object does. Emitting `AssetUpdate` is not enough on its own: the cache
+    // manager answers it by invalidating the entry rather than updating the asset the open viewer is
+    // rendering, which left the filled heart in place until some later round trip replaced it. The
+    // bulk action in the timeline already writes the field back for the same reason. Taking the
+    // value from the response rather than from the request keeps the icon showing what the server
+    // holds, not what the click asked for.
+    asset.isFavorite = response.isFavorite;
     toastManager.primary($t('added_to_favorites'));
     eventManager.emit('AssetUpdate', response);
   } catch (error) {
@@ -393,6 +401,8 @@ const handleUnfavorite = async (asset: AssetResponseDto) => {
 
   try {
     const response = await updateAsset({ id: asset.id, updateAssetDto: { isFavorite: false } });
+    // See handleFavorite: the icon follows this field, so it has to follow the server's answer.
+    asset.isFavorite = response.isFavorite;
     toastManager.primary($t('removed_from_favorites'));
     eventManager.emit('AssetUpdate', response);
   } catch (error) {


### PR DESCRIPTION
## Description

Removing a favorite from the asset detail view updated the server, showed the toast, and dropped the asset out of the Favorites view, while the heart stayed filled until a second click.

The two heart buttons choose their icon from the asset object the viewer holds:

```ts
Favorite:   $if: () => isOwner && !asset.isFavorite
Unfavorite: $if: () => isOwner && asset.isFavorite
```

The handlers never wrote that field back. `eventManager.emit('AssetUpdate', response)` does not close the gap on its own, because `AssetCacheManager` answers it with `invalidateAsset(asset.id)` — clearing the cache entry rather than updating the object being rendered. So the icon kept reading a stale `true` until some later round trip replaced the asset. The bulk action in `FavoriteAction.svelte` already assigns `asset.isFavorite` after its update, which is why this only bit in the detail view.

The fix is one line in each handler, taking the value from the **response** rather than the request, so the icon shows what the server holds rather than what the click asked for.

**On not reproducing at demo.immich.app** (@meesfrensel): `websocket.ts` also emits `AssetUpdate` from `on_asset_update`. Where that round trip lands promptly the stale object is replaced quickly enough to hide the gap; where the socket is slow or not connected — a local instance, WSL, a proxy not set up for websockets — it stays on screen. That also fits the reporter's "second click" detail: the second click is not the fix, it is simply late enough that the replacement has arrived. I proved the write-back gap from source and by test; I have not verified the websocket half, so please treat that as the likely explanation rather than as established.

Fixes #31267

## How Has This Been Tested?

- [x] Three new cases in `web/src/lib/services/asset.service.spec.ts`, using the existing harness: unfavoriting flips `Unfavorite.$if()` to false and `Favorite.$if()` to true (the icon the user sees), favoriting flips them back, and a response that still reports `isFavorite: true` keeps the server's value.
- [x] Mutation-checked: removing the two assignments reddens exactly the first two tests. The third passes either way by design — it guards against the *wrong* fix, assigning from the request instead of the response, which would make the icon lie whenever the server disagreed with the click.
- [x] `asset.service.spec.ts` passes 8/8; `prettier --check` and `eslint --max-warnings 0` clean on both files.

Note for reviewers: `src/lib/i18n.spec.ts` fails on my machine, but it fails identically on a clean checkout of `main` — an artifact of my partial clone, not of this change.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable — the change is a state write-back; the reporter's screenshots in #31267 show the symptom.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI was used for understanding the code, and help was taken in drafting the change and its tests.


