### PR TITLE
fix(web): invalidate the workflow album-name cache when an album changes

### DIFF
--- a/web/src/routes/(user)/workflows/[workflowId]/WorkflowStepCard.spec.ts
+++ b/web/src/routes/(user)/workflows/[workflowId]/WorkflowStepCard.spec.ts
@@ -1,0 +1,123 @@
+import { getAlbumInfo } from '@immich/sdk';
+import '@testing-library/jest-dom';
+import { cleanup, screen } from '@testing-library/svelte';
+import { eventManager } from '$lib/managers/event-manager.svelte';
+import { renderWithTooltips } from '$tests/helpers';
+import WorkflowStepCard from './WorkflowStepCard.svelte';
+
+/**
+ * The album name shown on a step comes from a cache that lives at module scope, so it outlives the
+ * component and every navigation inside the app. Nothing invalidated it, which meant a renamed
+ * album kept its old name on the step for the life of the page — and re-picking the same album
+ * showed the stale name too, because the picker's fresh value went back through the same cache.
+ * Only a full reload fixed it, which is exactly what clearing module state does.
+ */
+
+vi.mock('@immich/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@immich/sdk')>()),
+  getAlbumInfo: vi.fn(),
+  getTagById: vi.fn(),
+}));
+
+vi.mock('$lib/managers/plugin-manager.svelte', () => ({
+  pluginManager: {
+    getMethod: () => ({
+      uiHints: [],
+      schema: { properties: { albumId: { uiHint: { type: 'AlbumId' } } } },
+    }),
+    getMethodLabel: () => 'Add to album',
+  },
+}));
+
+/**
+ * A fresh id per test. The cache under test is module scoped by design, so it survives between
+ * tests in one file — sharing an id would let one test's rename decide what the next one starts
+ * from, and the failure would look like the bug rather than like the fixture.
+ */
+let nextAlbumId = 0;
+const freshAlbumId = () => `album-${++nextAlbumId}`;
+
+const renderCard = (albumId: string) =>
+  renderWithTooltips(WorkflowStepCard, {
+    step: { id: 'step-1', method: 'immich:add-to-album', config: { albumId } },
+    index: 0,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onInsertBefore: vi.fn(),
+    onDragOver: vi.fn(),
+    onDrop: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragStart: vi.fn(),
+  } as never);
+
+describe('WorkflowStepCard album name', () => {
+  beforeEach(() => {
+    vi.mocked(getAlbumInfo).mockImplementation((({ id }: { id: string }) =>
+      Promise.resolve({ id, albumName: 'Latest Uploads' })) as never);
+  });
+
+  it('shows the renamed album when the step is looked at again', async () => {
+    // The reported flow: open the workflow, rename the album elsewhere, come back to the workflow.
+    const albumId = freshAlbumId();
+    renderCard(albumId);
+    expect(await screen.findByText(/Latest Uploads/)).toBeInTheDocument();
+
+    eventManager.emit('AlbumUpdate', { id: albumId, albumName: 'Recent Uploads' } as never);
+
+    cleanup();
+    renderCard(albumId);
+
+    expect(await screen.findByText(/Recent Uploads/)).toBeInTheDocument();
+    expect(screen.queryByText(/Latest Uploads/)).not.toBeInTheDocument();
+  });
+
+  it('does not refetch the album it was told about', async () => {
+    // The event carries the new album, so the refresh costs no request. Fetching again here would
+    // work too, but it would make every rename anywhere re-request every album on the page.
+    const albumId = freshAlbumId();
+    renderCard(albumId);
+    await screen.findByText(/Latest Uploads/);
+    vi.mocked(getAlbumInfo).mockClear();
+
+    eventManager.emit('AlbumUpdate', { id: albumId, albumName: 'Recent Uploads' } as never);
+    cleanup();
+    renderCard(albumId);
+    await screen.findByText(/Recent Uploads/);
+
+    expect(getAlbumInfo).not.toHaveBeenCalled();
+  });
+
+  it('fetches again after the album is deleted from under it', async () => {
+    // Deletion drops the entry rather than rewriting it: there is no name to hold, and whatever
+    // replaces that id must be read from the server rather than from a stale entry.
+    const albumId = freshAlbumId();
+    renderCard(albumId);
+    await screen.findByText(/Latest Uploads/);
+    vi.mocked(getAlbumInfo).mockClear();
+    vi.mocked(getAlbumInfo).mockResolvedValue({ id: albumId, albumName: 'Rebuilt' } as never);
+
+    eventManager.emit('AlbumDelete', { id: albumId } as never);
+    cleanup();
+    renderCard(albumId);
+
+    expect(await screen.findByText(/Rebuilt/)).toBeInTheDocument();
+    expect(getAlbumInfo).toHaveBeenCalled();
+  });
+
+  it('leaves an album it has never shown out of the cache', async () => {
+    // Only ids already on screen are refreshed. Caching every album that is ever updated would
+    // grow the map with entries no step refers to.
+    const albumId = freshAlbumId();
+    renderCard(albumId);
+    await screen.findByText(/Latest Uploads/);
+    vi.mocked(getAlbumInfo).mockClear();
+
+    eventManager.emit('AlbumUpdate', { id: 'never-shown', albumName: 'Untouched' } as never);
+    cleanup();
+    renderCard(albumId);
+    await screen.findByText(/Latest Uploads/);
+
+    // The displayed album was not re-requested, and the unrelated one was not cached either.
+    expect(getAlbumInfo).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/routes/(user)/workflows/[workflowId]/WorkflowStepCard.svelte
+++ b/web/src/routes/(user)/workflows/[workflowId]/WorkflowStepCard.svelte
@@ -1,4 +1,5 @@
 <script module lang="ts">
+  import { eventManager } from '$lib/managers/event-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { getAlbumInfo, getTagById } from '@immich/sdk';
 
@@ -14,6 +15,24 @@
     }
     return albumName;
   };
+
+  // This cache lives at module scope, so without these it is never invalidated: a renamed album
+  // kept its old name in every workflow step for the life of the page, and re-picking the same
+  // album hit the cached entry rather than the name the picker had just shown. Only a full reload
+  // fixed it, which is what clearing module state does.
+  //
+  // `AlbumUpdate` already carries the updated album, so the new name is taken from the event
+  // rather than refetched. Only ids already cached are refreshed — an album this page has never
+  // displayed is fetched on first use anyway, and adding it here would grow the map with entries
+  // no step refers to.
+  eventManager.on({
+    AlbumUpdate: (album) => {
+      if (albumNameCache.has(album.id)) {
+        albumNameCache.set(album.id, Promise.resolve(album.albumName));
+      }
+    },
+    AlbumDelete: (album) => albumNameCache.delete(album.id),
+  });
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Description

A workflow step showed the album name it was first given, forever. After renaming an album, every "Add to album" step still displayed the old name — and removing the selection and picking the same album again *still* showed the old name, even though the picker itself listed the new one. Only a full page reload fixed it.

`WorkflowStepCard` caches album names in a `Map` declared in its `<script module>` block:

```ts
const albumNameCache = new Map<string, Promise<string>>();
const getAlbumName = (id: string): Promise<string> => {
  let albumName = albumNameCache.get(id);
  if (!albumName) { … albumNameCache.set(id, albumName); }
  return albumName;
};
```

Module scope means it outlives the component and every client-side navigation, and nothing invalidated an entry. A reload is what cleared it, which is exactly why @bo0tzz's question got "yes, refreshing fixes it" — and it also explains the re-pick case, since the picker's fresh value goes back through the same cache on the next render.

`AlbumUpdate` already carries the updated album, so the refresh takes the new name from the event rather than refetching; an event-driven refetch would make one rename re-request every album on the page. `AlbumDelete` drops the entry instead. Only ids already cached are refreshed, since adding every updated album would fill the map with entries no step refers to.

Fixes #31203

## How Has This Been Tested?

- [x] New `WorkflowStepCard.spec.ts` (4 cases) using the existing `renderWithTooltips` helper: the reported flow (render, rename elsewhere, look again) now shows the new name; the refresh costs no extra request; a delete makes the next use refetch; and an album this page has never shown is not cached.
- [x] Mutation-checked: removing the invalidation reddens 3 of the 4. The fourth stays green by design — it guards the "don't cache what was never shown" behaviour, which this change must not alter.
- [x] `prettier --check` and `eslint --max-warnings 0` clean on both files.

One note on the test file, since it looks like an odd thing to do: each case allocates its own album id. The cache is module scoped *by design*, so it survives between tests in a file — sharing an id would let one test's rename decide what the next one starts from, and that failure would look like the bug rather than like the fixture.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable — the change is cache invalidation; the reporter's steps in #31203 describe the symptom.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI was used for understanding the code, and help was taken in drafting the change and its tests.
