### PR TITLE
fix(web): show the full path on hover in duplicate review

### DIFF
--- a/web/src/lib/utils/duplicate-utils.spec.ts
+++ b/web/src/lib/utils/duplicate-utils.spec.ts
@@ -1,0 +1,54 @@
+import { getAllMetadataItems } from '$lib/utils/duplicate-utils';
+import { assetFactory } from '@test-data/factories/asset-factory';
+
+/**
+ * The duplicate review rows shorten a long path to fit, and the row's own `title` attribute is the
+ * field LABEL — so hovering a shortened path showed the word "Path". The value that was cut had no
+ * way back on screen, and choosing between two duplicates is usually exactly the part that was cut.
+ */
+
+const $t = ((key: string) => key) as never;
+
+const itemFor = (asset: Parameters<typeof getAllMetadataItems>[0], title: string) =>
+  getAllMetadataItems(asset, $t, 'en').find((item) => item.title === title);
+
+describe('getAllMetadataItems', () => {
+  it('carries the full path even when the displayed one is shortened', () => {
+    const originalPath = '/mnt/media/photos/library/2024/holidays/iceland/day-07-jokulsarlon/DSC_0912_edited_final.jpg';
+    const asset = assetFactory.build({ originalPath });
+
+    const item = itemFor(asset, 'path');
+
+    expect(item?.tooltip).toBe(originalPath);
+    // The row still shows the shortened form; this fix restores access, it does not widen the row.
+    expect(item?.render).not.toBe(originalPath);
+    expect(item?.render.length).toBeLessThan(originalPath.length);
+  });
+
+  it('leaves a path short enough to display without a redundant tooltip difference', () => {
+    const originalPath = '/photos/a.jpg';
+    const asset = assetFactory.build({ originalPath });
+
+    const item = itemFor(asset, 'path');
+
+    expect(item?.render).toBe(originalPath);
+    expect(item?.tooltip).toBe(originalPath);
+  });
+
+  it('offers no tooltip for a field that is never shortened', () => {
+    // Only the path opts in. A tooltip repeating a value that is already fully visible is noise,
+    // and it would also override the row label tooltip for no reason.
+    const asset = assetFactory.build({ originalFileName: 'a.jpg' });
+
+    expect(itemFor(asset, 'file_name_text')?.tooltip).toBeUndefined();
+    expect(itemFor(asset, 'file_size')?.tooltip).toBeUndefined();
+  });
+
+  it('has no path tooltip when the asset has no path', () => {
+    // `render` falls back to "unknown" here, and a tooltip of an empty string would leave the
+    // browser showing an empty box on hover.
+    const asset = assetFactory.build({ originalPath: '' });
+
+    expect(itemFor(asset, 'path')?.tooltip).toBeUndefined();
+  });
+});

--- a/web/src/lib/utils/duplicate-utils.ts
+++ b/web/src/lib/utils/duplicate-utils.ts
@@ -59,6 +59,14 @@ type MetadataFieldDefinition = {
   titleKey: string;
   keys: readonly string[];
   render: (asset: AssetResponseDto, $t: MessageFormatter, locale: string | undefined) => string;
+  /**
+   * The full value, for fields whose `render` shortens it to fit the row.
+   *
+   * Without this a truncated value is simply unreachable: the row's own `title` is the field LABEL,
+   * so hovering a shortened path shows the word "Path" rather than the path. Deciding between two
+   * duplicates is often exactly the part of the path that was cut.
+   */
+  tooltip?: (asset: AssetResponseDto) => string | undefined;
 };
 
 const metadataFields = [
@@ -73,6 +81,7 @@ const metadataFields = [
     titleKey: 'path',
     keys: ['originalPath'],
     render: (asset, $t) => truncateMiddle(asset.originalPath) || $t('unknown'),
+    tooltip: (asset) => asset.originalPath || undefined,
   },
   {
     icon: mdiWeightKilogram,
@@ -233,10 +242,11 @@ export const countDifferingMetadataItems = (differing: DifferingMetadataFields):
   metadataFields.filter(({ keys }) => keys.some((k) => differing[k as MetadataFieldKey])).length;
 
 export const getAllMetadataItems = (asset: AssetResponseDto, $t: MessageFormatter, locale: string | undefined) =>
-  metadataFields.map(({ icon, titleKey, keys, render }) => ({
+  metadataFields.map(({ icon, titleKey, keys, render, tooltip }) => ({
     icon,
     title: $t(titleKey),
     render: render(asset, $t, locale),
+    tooltip: tooltip?.(asset),
     keys,
   }));
 

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicateAsset.svelte
@@ -106,9 +106,10 @@
       ? 'bg-success/15 dark:bg-[#001a06]'
       : 'bg-transparent'}"
   >
-    {#each visibleMetadataItems as { icon, title, render, keys } (keys[0])}
+    {#each visibleMetadataItems as { icon, title, render, tooltip, keys } (keys[0])}
       <InfoRow {icon} {title}>
-        {render}
+        <!-- The row's own `title` is the field label, so a shortened value needs its own. -->
+        <span title={tooltip}>{render}</span>
       </InfoRow>
     {/each}
 


### PR DESCRIPTION
## Description

Duplicate review shortens a long path with `truncateMiddle` so the row stays narrow, and the part it cuts is usually the part that decides which copy to keep.

The cut value had no way back on screen. `InfoRow` puts the field **label** in the row's `title` attribute, so hovering a shortened path shows the word "Path" — which is what @stappel described as the tooltip showing `[path]` rather than the path itself.

Metadata fields can now supply the untruncated value, and the path field does. The rendered value is wrapped in a span carrying it, so hovering the value shows the whole path while hovering the rest of the row still names the field.

**The truncation is unchanged.** This restores access to what was cut rather than changing the layout — @markycee and @JDMBIRD83 also asked for wrapping or an expander, and that is a design decision I did not want to make on your behalf. If you would rather have the row grow, say so and I will redo it that way instead.

Only the path opts in. A tooltip repeating a value that is already fully visible is noise, and it would shadow the row's label tooltip for nothing.

Fixes #30925

## How Has This Been Tested?

- [x] New `duplicate-utils.spec.ts` (4 cases): a long path carries the full value while still rendering shortened; a short path is unaffected; fields that are never shortened offer no tooltip; and an asset with no path gets no tooltip rather than an empty one, which would otherwise show an empty box on hover.
- [x] Mutation-checked: removing the `tooltip` on the path field reddens exactly the two cases that assert it, and leaves the two guards green.
- [x] `prettier --check` and `eslint --max-warnings 0` clean on all three files.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

No visual change at rest — the row renders exactly as before. The difference is only on hover over the path value.

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An AI was used for understanding the code, and help was taken in drafting the change and its tests.
