### PR TITLE
fix(server): live photo transcode visibility

### DIFF
--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -595,7 +595,6 @@ where
       "asset_file"."assetId" = "asset"."id"
       and "asset_file"."type" = 'encoded_video'
   )
-  and "asset"."visibility" != 'hidden'
   and "asset"."deletedAt" is null
 
 -- AssetJobRepository.getForVideoConversion

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -329,19 +329,17 @@ export class AssetJobRepository {
       .select(['asset.id'])
       .where('asset.type', '=', sql.lit(AssetType.Video))
       .$if(!force, (qb) =>
-        qb
-          .where((eb) =>
-            eb.not(
-              eb.exists(
-                eb
-                  .selectFrom('asset_file')
-                  .select('asset_file.id')
-                  .whereRef('asset_file.assetId', '=', 'asset.id')
-                  .where('asset_file.type', '=', sql.lit(AssetFileType.EncodedVideo)),
-              ),
+        qb.where((eb) =>
+          eb.not(
+            eb.exists(
+              eb
+                .selectFrom('asset_file')
+                .select('asset_file.id')
+                .whereRef('asset_file.assetId', '=', 'asset.id')
+                .where('asset_file.type', '=', sql.lit(AssetFileType.EncodedVideo)),
             ),
-          )
-          .where('asset.visibility', '!=', sql.lit(AssetVisibility.Hidden)),
+          ),
+        ),
       )
       .where('asset.deletedAt', 'is', null)
       .stream();

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1981,6 +1981,20 @@ describe(MediaService.name, () => {
         },
       ]);
     });
+
+    it('should queue hidden assets when force is not set', async () => {
+      const asset = AssetFactory.create({ type: AssetType.Video, visibility: AssetVisibility.Hidden });
+      mocks.assetJob.streamForVideoConversion.mockReturnValue(makeStream([asset]));
+
+      await sut.handleQueueVideoConversion({});
+      expect(mocks.assetJob.streamForVideoConversion).toHaveBeenCalledWith(void 0);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.AssetEncodeVideo,
+          data: { id: asset.id },
+        },
+      ]);
+    });
   });
 
   describe('handleVideoConversion', () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The live photos .mov file wouldn't re-transcode when the user clicked the re-transcode missing files because the db query filtered out visibility != hidden. Since the .mov file for live photos is hidden this appeared to the user as a bug. I eliminated that line and regenerated the SQL files. 

<!-x-- Why is this change required? What problem does it solve? -->
This change is required because if a user changes their when to transcode settings after uploading live photos then those photos can't be transcoded without the user applying the force param and retranscoding all videos. 

I believe eliminating this line will better match users expectations of this feature. When a user queues  a job to retranscode all missing videos they would likely expect that to include hidden videos as well especially if they expect to unhide these videos in the future. This is why I believe this change is more correct than doing a more granular search to pick out .mov correlated to a live photo. 

<!--- If it fixes an open issue, please link to the issue here. -->
Open Issue: https://github.com/immich-app/immich/issues/22985


Fixes #22985
## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A  -
1.  started the server, changed transcode settings to never transcode.
2. Uploaded a live photo, and changed back settings to transcode all
3. Manually triggered a transcode missing job, and ran this queyr against the db

  select * from asset_file
  where type = 'encoded_video'
4. No rows appear, so I switch to my new branch and run the same process and now a row with 'encoded_video' for the live photo appears. 

- [x] Test B - added a unit test to prevent regression, this sends a mock hidden asset through to verify it is returned. 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None. 
...
