### PR TITLE
fix(server): recover person thumbnails after face deletion

### DIFF
--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -776,6 +776,7 @@ export class PersonRepository {
       .select('asset_face.id')
       .where('asset_face.assetId', '=', assetId)
       .where('asset_face.personGroupId', '=', personGroupId)
+      .where('asset_face.deletedAt', 'is', null)
       .innerJoin('asset', (join) => join.onRef('asset.id', '=', 'asset_face.assetId').on('asset.isOffline', '=', false))
       .executeTakeFirst();
   }

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -57,6 +57,7 @@ describe(MediaService.name, () => {
       mocks.assetJob.streamForThumbnailJob.mockReturnValue(makeStream([asset]));
 
       mocks.person.getAll.mockReturnValue(makeStream([person]));
+      mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue({});
 
       await sut.handleQueueGenerateThumbnails({ force: true });
 
@@ -74,6 +75,27 @@ describe(MediaService.name, () => {
           name: JobName.PersonGenerateThumbnail,
           data: { ownerId: person.ownerId, personGroupId: person.personGroupId },
         },
+      ]);
+    });
+
+    it('should recover a person with an invalid feature face', async () => {
+      const person = PersonFactory.create({ faceAssetId: newUuid() });
+      const replacement = AssetFaceFactory.create();
+      mocks.assetJob.streamForThumbnailJob.mockReturnValue(makeStream());
+      mocks.person.getAll.mockReturnValue(makeStream([person]));
+      mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue(undefined);
+      mocks.person.getRandomFace.mockResolvedValue(replacement);
+
+      await sut.handleQueueGenerateThumbnails({ force: true });
+
+      expect(mocks.person.getRandomFace).toHaveBeenCalledWith(person.personGroupId);
+      expect(mocks.person.update).toHaveBeenCalledWith({
+        ownerId: person.ownerId,
+        personGroupId: person.personGroupId,
+        faceAssetId: replacement.id,
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.PersonGenerateThumbnail, data: { ownerId: person.ownerId, personGroupId: person.personGroupId } },
       ]);
     });
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -91,9 +91,15 @@ export class MediaService extends BaseService {
       const jobs: JobItem[] = [];
       for (const person of people) {
         const { ownerId, personGroupId } = person;
-        if (!person.faceAssetId) {
+        const faceData = person.faceAssetId
+          ? await this.personRepository.getDataForThumbnailGenerationJob({ ownerId, personGroupId })
+          : undefined;
+        if (!faceData) {
           const face = await this.personRepository.getRandomFace(personGroupId);
           if (!face) {
+            if (person.faceAssetId) {
+              await this.personRepository.update({ ownerId, personGroupId, faceAssetId: null });
+            }
             continue;
           }
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -533,6 +533,42 @@ describe(PersonService.name, () => {
         },
       ]);
     });
+
+    it('should clear the feature photo when no live face remains', async () => {
+      const person = PersonFactory.create();
+
+      mocks.person.getRandomFace.mockResolvedValue(undefined);
+      await sut.createNewFeaturePhoto([person]);
+
+      expect(mocks.person.update).toHaveBeenCalledWith({
+        ownerId: person.ownerId,
+        personGroupId: person.personGroupId,
+        faceAssetId: null,
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('deleteFace', () => {
+    it('should select a replacement when deleting the featured face', async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.create();
+      const person = PersonFactory.create({ faceAssetId: face.id });
+      const replacementFace = { ...face, id: newUuid() };
+
+      mocks.access.person.checkFaceOwnerAccess.mockResolvedValue(new Set([face.id]));
+      mocks.person.getFaceById.mockResolvedValue({ ...getForAssetFace(face), person });
+      mocks.person.getRandomFace.mockResolvedValue(replacementFace);
+
+      await sut.deleteFace(auth, face.id, { force: false });
+
+      expect(mocks.person.softDeleteAssetFaces).toHaveBeenCalledWith(face.id);
+      expect(mocks.person.update).toHaveBeenCalledWith({
+        ownerId: person.ownerId,
+        personGroupId: person.personGroupId,
+        faceAssetId: replacementFace.id,
+      });
+    });
   });
 
   describe('reassignFacesById', () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -151,6 +151,8 @@ export class PersonService extends BaseService {
       if (assetFace) {
         await this.personRepository.update({ ownerId, personGroupId, faceAssetId: assetFace.id });
         jobs.push({ name: JobName.PersonGenerateThumbnail, data: { ownerId, personGroupId } });
+      } else {
+        await this.personRepository.update({ ownerId, personGroupId, faceAssetId: null });
       }
     }
 
@@ -736,6 +738,15 @@ export class PersonService extends BaseService {
   async deleteFace(auth: AuthDto, id: string, dto: AssetFaceDeleteDto): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.FaceDelete, ids: [id] });
 
-    return dto.force ? this.personRepository.deleteAssetFace(id) : this.personRepository.softDeleteAssetFaces(id);
+    const face = await this.personRepository.getFaceById(id, { viewingUserId: auth.user.id });
+    const changeFeaturePhoto = face.person?.faceAssetId === id ? [face.person] : [];
+
+    if (dto.force) {
+      await this.personRepository.deleteAssetFace(id);
+    } else {
+      await this.personRepository.softDeleteAssetFaces(id);
+    }
+
+    await this.createNewFeaturePhoto(changeFeaturePhoto);
   }
 }

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -228,4 +228,31 @@ describe(PersonRepository.name, () => {
       );
     });
   });
+
+  describe('getForFeatureFaceUpdate', () => {
+    it('should ignore soft-deleted faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { assetFace: deletedFace } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personGroupId: person.personGroupId,
+      });
+      const { assetFace: liveFace } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personGroupId: person.personGroupId,
+      });
+
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ deletedAt: new Date() })
+        .where('asset_face.id', '=', deletedFace.id)
+        .execute();
+
+      await expect(
+        sut.getForFeatureFaceUpdate({ assetId: asset.id, personGroupId: person.personGroupId }),
+      ).resolves.toEqual({ id: liveFace.id });
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #31321

A person's `faceAssetId` could continue pointing to a soft-deleted `asset_face`, causing person thumbnail generation to fail with missing data.

This change prevents stale featured-face references and allows affected people to recover automatically.

### Changes

* Filter soft-deleted faces when selecting featured photos.
* Replace the featured face when the current featured face is deleted.
* Clear `person.faceAssetId` when no live replacement face exists.
* Recover stale `faceAssetId` references during thumbnail generation.
* Add regression tests for featured-face selection, deletion, recovery, and soft-deleted faces.

## How Has This Been Tested?

* Added a repository test to verify soft-deleted faces are ignored.
* Added a service test to verify a replacement featured face is selected after deletion.
* Added a service test to verify `faceAssetId` is cleared when no live face remains.
* Added a media service test to verify stale featured-face references are recovered.
* Ran `git diff --check`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Not applicable.

</details>

## Checklist:

* [x] I have carefully read CONTRIBUTING.md
* [x] I have performed a self-review of my own code
* [x] I have made corresponding changes to the documentation if applicable
* [x] I have no unrelated changes in the PR.
* [x] I have confirmed that any new dependencies are strictly necessary.
* [x] I have written tests for new code (if applicable)
* [x] I have followed naming conventions/patterns in the surrounding code
* [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
* [x] All code in `src/repositories/` is pretty basic/simple and does not have any Immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was used to assist with understanding the issue, reviewing relevant code paths, and discussing implementation and testing approaches. I reviewed the changes and verified the resulting code and tests myself.
