### PR TITLE
feat(server): resend welcome email on admin password reset

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -477,6 +477,7 @@
     "user_management": "User Management",
     "user_password_has_been_reset": "The user's password has been reset:",
     "user_password_reset_description": "Please provide the temporary password to the user and inform them they will need to change the password at their next login.",
+    "user_password_reset_notify_checkbox": "Send welcome email with new password",
     "user_restore_description": "<b>{user}</b>'s account will be restored.",
     "user_restore_scheduled_removal": "Restore user - scheduled removal on {date, date, long}",
     "user_settings": "User Settings",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -32174,6 +32174,16 @@
             "description": "User name",
             "type": "string"
           },
+          "notify": {
+            "description": "Send a welcome email with the new password when resetting it",
+            "type": "boolean",
+            "x-immich-history": [
+              {
+                "version": "v3.3.0",
+                "state": "Added"
+              }
+            ]
+          },
           "password": {
             "description": "User password",
             "type": "string"

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -621,6 +621,8 @@ export type UserAdminUpdateDto = {
     isAdmin?: boolean;
     /** User name */
     name?: string;
+    /** Send a welcome email with the new password when resetting it */
+    notify?: boolean;
     /** User password */
     password?: string;
     /** PIN code */

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -103,6 +103,11 @@ const UserAdminUpdateSchema = z
     shouldChangePassword: z.boolean().optional().describe('Require password change on next login'),
     quotaSizeInBytes: z.int().min(0).nullish().describe('Storage quota in bytes'),
     isAdmin: z.boolean().optional().describe('Grant admin privileges'),
+    notify: z
+      .boolean()
+      .optional()
+      .describe('Send a welcome email with the new password when resetting it')
+      .meta(new HistoryBuilder().added('v3.3.0').getExtensions()),
   })
   .meta({ id: 'UserAdminUpdateDto' });
 

--- a/server/src/services/user-admin.service.spec.ts
+++ b/server/src/services/user-admin.service.spec.ts
@@ -113,6 +113,42 @@ describe(UserAdminService.name, () => {
         sut.update(authStub.admin, userStub.user1.id, { shouldChangePassword: true }),
       ).rejects.toBeInstanceOf(BadRequestException);
     });
+
+    it('should not allow notify without a new password', async () => {
+      await expect(sut.update(authStub.admin, userStub.user1.id, { notify: true })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+
+      expect(mocks.user.update).not.toHaveBeenCalled();
+      expect(mocks.event.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit a UserSignup event when resetting the password with notify', async () => {
+      mocks.user.update.mockResolvedValue(userStub.user1);
+
+      await sut.update(authStub.admin, userStub.user1.id, {
+        password: 'new-password',
+        shouldChangePassword: true,
+        notify: true,
+      });
+
+      expect(mocks.event.emit).toHaveBeenCalledWith('UserSignup', {
+        notify: true,
+        id: userStub.user1.id,
+        password: 'new-password',
+      });
+    });
+
+    it('should not emit a UserSignup event when resetting the password without notify', async () => {
+      mocks.user.update.mockResolvedValue(userStub.user1);
+
+      await sut.update(authStub.admin, userStub.user1.id, {
+        password: 'new-password',
+        shouldChangePassword: true,
+      });
+
+      expect(mocks.event.emit).not.toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -54,44 +54,59 @@ export class UserAdminService extends BaseService {
   }
 
   async update(auth: AuthDto, id: string, dto: UserAdminUpdateDto): Promise<UserAdminResponseDto> {
+    const { notify, ...userDto } = dto;
     const user = await this.findOrFail(id, {});
 
-    if (dto.isAdmin !== undefined && dto.isAdmin !== auth.user.isAdmin && auth.user.id === id) {
+    if (notify && !userDto.password) {
+      throw new BadRequestException('notify requires a new password to be set');
+    }
+
+    if (userDto.isAdmin !== undefined && userDto.isAdmin !== auth.user.isAdmin && auth.user.id === id) {
       throw new BadRequestException('Admin status can only be changed by another admin');
     }
 
-    if (dto.quotaSizeInBytes && user.quotaSizeInBytes !== dto.quotaSizeInBytes) {
+    if (userDto.quotaSizeInBytes && user.quotaSizeInBytes !== userDto.quotaSizeInBytes) {
       await this.userRepository.syncUsage(id);
     }
 
-    if (dto.email) {
-      const duplicate = await this.userRepository.getByEmail(dto.email);
+    if (userDto.email) {
+      const duplicate = await this.userRepository.getByEmail(userDto.email);
       if (duplicate && duplicate.id !== id) {
         this.logger.debug('Email already in use by another account');
         throw new BadRequestException('Email is not available');
       }
     }
 
-    if (dto.storageLabel) {
-      const duplicate = await this.userRepository.getByStorageLabel(dto.storageLabel);
+    if (userDto.storageLabel) {
+      const duplicate = await this.userRepository.getByStorageLabel(userDto.storageLabel);
       if (duplicate && duplicate.id !== id) {
         throw new BadRequestException('Storage label already in use by another account');
       }
     }
 
-    if (dto.password) {
-      dto.password = await this.cryptoRepository.hashBcrypt(dto.password, SALT_ROUNDS);
+    const plainTextPassword = userDto.password;
+
+    if (userDto.password) {
+      userDto.password = await this.cryptoRepository.hashBcrypt(userDto.password, SALT_ROUNDS);
     }
 
-    if (dto.pinCode) {
-      dto.pinCode = await this.cryptoRepository.hashBcrypt(dto.pinCode, SALT_ROUNDS);
+    if (userDto.pinCode) {
+      userDto.pinCode = await this.cryptoRepository.hashBcrypt(userDto.pinCode, SALT_ROUNDS);
     }
 
-    if (dto.storageLabel === '') {
-      dto.storageLabel = null;
+    if (userDto.storageLabel === '') {
+      userDto.storageLabel = null;
     }
 
-    const updatedUser = await this.userRepository.update(id, { ...dto, updatedAt: new Date() });
+    const updatedUser = await this.userRepository.update(id, { ...userDto, updatedAt: new Date() });
+
+    if (notify && plainTextPassword) {
+      await this.eventRepository.emit('UserSignup', {
+        notify: true,
+        id: updatedUser.id,
+        password: plainTextPassword,
+      });
+    }
 
     return mapUserAdmin(updatedUser);
   }

--- a/web/src/lib/modals/PasswordResetConfirmModal.svelte
+++ b/web/src/lib/modals/PasswordResetConfirmModal.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { handleResetPasswordUserAdmin } from '$lib/services/user-admin.service';
+  import { type UserAdminResponseDto } from '@immich/sdk';
+  import { Checkbox, ConfirmModal, Label, Text } from '@immich/ui';
+  import { mdiLockReset } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  type Props = {
+    user: UserAdminResponseDto;
+    onClose: () => void;
+  };
+
+  let { user, onClose }: Props = $props();
+
+  let notify = $state(false);
+
+  const handleClose = async (confirmed?: boolean) => {
+    if (!confirmed) {
+      onClose();
+      return;
+    }
+
+    await handleResetPasswordUserAdmin(user, notify);
+    onClose();
+  };
+</script>
+
+<ConfirmModal icon={mdiLockReset} title={$t('reset_password')} confirmText={$t('reset_password')} onClose={handleClose}>
+  {#snippet prompt()}
+    <div class="flex flex-col gap-4">
+      <Text>{$t('admin.confirm_user_password_reset', { values: { user: user.name } })}</Text>
+
+      <div class="flex items-center gap-2">
+        <Checkbox id="notify-user-password-reset-checkbox" color="secondary" bind:checked={notify} />
+        <Label label={$t('admin.user_password_reset_notify_checkbox')} for="notify-user-password-reset-checkbox" />
+      </div>
+    </div>
+  {/snippet}
+</ConfirmModal>

--- a/web/src/lib/services/user-admin.service.ts
+++ b/web/src/lib/services/user-admin.service.ts
@@ -25,6 +25,7 @@ import { goto } from '$app/navigation';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { serverConfigManager } from '$lib/managers/server-config-manager.svelte';
+import PasswordResetConfirmModal from '$lib/modals/PasswordResetConfirmModal.svelte';
 import PasswordResetSuccessModal from '$lib/modals/PasswordResetSuccessModal.svelte';
 import UserDeleteConfirmModal from '$lib/modals/UserDeleteConfirmModal.svelte';
 import UserRestoreConfirmModal from '$lib/modals/UserRestoreConfirmModal.svelte';
@@ -85,7 +86,7 @@ export const getUserAdminActions = ($t: MessageFormatter, user: UserAdminRespons
     icon: mdiLockReset,
     title: $t('reset_password'),
     $if: () => authManager.user.id !== user.id,
-    onAction: () => handleResetPasswordUserAdmin(user),
+    onAction: () => modalManager.show(PasswordResetConfirmModal, { user }),
   };
 
   const ResetPinCode: ActionItem = {
@@ -168,16 +169,11 @@ const generatePassword = (length: number = 16) => {
   return generatedPassword;
 };
 
-const handleResetPasswordUserAdmin = async (user: UserAdminResponseDto) => {
+export const handleResetPasswordUserAdmin = async (user: UserAdminResponseDto, notify: boolean = false) => {
   const $t = await getFormatter();
-  const prompt = $t('admin.confirm_user_password_reset', { values: { user: user.name } });
-  const success = await modalManager.showDialog({ prompt });
-  if (!success) {
-    return;
-  }
 
   try {
-    const dto = { password: generatePassword(), shouldChangePassword: true };
+    const dto = { password: generatePassword(), shouldChangePassword: true, notify };
     const response = await updateUserAdmin({ id: user.id, userAdminUpdateDto: dto });
     eventManager.emit('UserAdminUpdate', response);
     toastManager.primary();


### PR DESCRIPTION
## Description

Adds an optional `notify` flag to the admin user-update endpoint (`PUT /admin/users/{id}`). When an admin resets a user's password with `notify: true`, the same welcome-email pipeline used at account creation fires again with the new password — reusing the existing `UserSignup` event/job rather than introducing a new email template or endpoint.

The admin web UI's password-reset confirmation dialog gains a "Send welcome email with new password" checkbox that opts into this.

**Why:** there's currently no way to (re)send the welcome email to a user after their account already exists — e.g. a user created with a throwaway email who later gets their real email set, or simply an admin who wants to hand over fresh credentials via email instead of manually. Sending it requires a new password (the email includes the plaintext password, same as at account creation), so this is implemented as an add-on to the existing admin password-reset flow rather than a bare "resend" button with no new credentials to show.

Fixes #25544

## How Has This Been Tested?

- [x] Unit tests added to `user-admin.service.spec.ts` covering: `notify: true` without a password throws `BadRequestException`; `notify: true` with a password reset emits the `UserSignup` event with the new plaintext password; `notify` omitted/false does not emit the event.
- [x] `server`: `pnpm run check` (tsc), `pnpm run lint`, `pnpm run test` all pass clean.
- [x] `web`: `pnpm run check:svelte`, `pnpm run check:typescript`, `pnpm run lint` all pass clean.
- [x] `pnpm run format` clean on both `server` and `web`.
- [ ] Not yet tested against a live SMTP-configured instance end-to-end (no dev environment with mail configured on hand) — would appreciate a maintainer or reviewer smoke-testing the actual email send if that's a blocking concern.

## API Changes

`UserAdminUpdateDto` gains an optional `notify: boolean` field (mirrors the field that already exists on `UserAdminCreateDto`). No endpoint path/shape changes otherwise.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. I used Claude (Anthropic) to trace the existing welcome-email code path (`UserSignup` event → `NotifyUserSignup` job → `EmailTemplate.WELCOME`), design this addition to reuse that pipeline instead of adding a new one, and write the implementation, tests, and this description. I reviewed and validated the result myself (ran the full check/lint/test suite locally per the checklist above) before opening this PR.