### PR TITLE
feat(oauth): add OAuth client env secret support

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -152,6 +152,13 @@ Redis (Sentinel) URL example JSON before encoding:
 
 </details>
 
+## OAuth
+
+| Variable                | Description         | Default | Containers |
+| :---------------------- | :------------------ | :-----: | :--------- |
+| `OAUTH_CLIENT_ID`       | OAuth client ID     |         | server     |
+| `OAUTH_CLIENT_SECRET`   | OAuth client secret |         | server     |
+
 ## Machine Learning
 
 | Variable                                                    | Description                                                                                                                                                  |           Default            | Containers       |
@@ -213,14 +220,16 @@ The following variables support reading from files, either via [Systemd Credenti
 
 To use any of these, either set `CREDENTIALS_DIRECTORY` to a directory that contains files whose name is the “regular variable” name, and whose content is the secret. If using Docker Secrets, setting `CREDENTIALS_DIRECTORY=/run/secrets` will cause all secrets present to be used. Alternatively, replace the regular variable with the equivalent `_FILE` environment variable as below. The value of the `_FILE` variable should be set to the path of a file containing the variable value.
 
-| Regular Variable   | Equivalent Docker Secrets '\_FILE' Variable |
-| :----------------- | :------------------------------------------ |
-| `DB_HOSTNAME`      | `DB_HOSTNAME_FILE`<sup>\*1</sup>            |
-| `DB_DATABASE_NAME` | `DB_DATABASE_NAME_FILE`<sup>\*1</sup>       |
-| `DB_USERNAME`      | `DB_USERNAME_FILE`<sup>\*1</sup>            |
-| `DB_PASSWORD`      | `DB_PASSWORD_FILE`<sup>\*1</sup>            |
-| `DB_URL`           | `DB_URL_FILE`<sup>\*1</sup>                 |
-| `REDIS_PASSWORD`   | `REDIS_PASSWORD_FILE`<sup>\*2</sup>         |
+| Regular Variable      | Equivalent Docker Secrets '\_FILE' Variable |
+| :-------------------- | :------------------------------------------ |
+| `DB_HOSTNAME`         | `DB_HOSTNAME_FILE`<sup>\*1</sup>            |
+| `DB_DATABASE_NAME`    | `DB_DATABASE_NAME_FILE`<sup>\*1</sup>       |
+| `DB_USERNAME`         | `DB_USERNAME_FILE`<sup>\*1</sup>            |
+| `DB_PASSWORD`         | `DB_PASSWORD_FILE`<sup>\*1</sup>            |
+| `DB_URL`              | `DB_URL_FILE`<sup>\*1</sup>                 |
+| `REDIS_PASSWORD`      | `REDIS_PASSWORD_FILE`<sup>\*2</sup>         |
+| `OAUTH_CLIENT_ID`     | `OAUTH_CLIENT_ID_FILE`                      |
+| `OAUTH_CLIENT_SECRET` | `OAUTH_CLIENT_SECRET_FILE`                  |
 
 \*1: See the [official documentation][docker-secrets-docs] for
 details on how to use Docker Secrets in the Postgres image.

--- a/server/bin/start.sh
+++ b/server/bin/start.sh
@@ -40,6 +40,8 @@ read_file_and_export "DB_DATABASE_NAME_FILE" "DB_DATABASE_NAME"
 read_file_and_export "DB_USERNAME_FILE" "DB_USERNAME"
 read_file_and_export "DB_PASSWORD_FILE" "DB_PASSWORD"
 read_file_and_export "REDIS_PASSWORD_FILE" "REDIS_PASSWORD"
+read_file_and_export "OAUTH_CLIENT_ID_FILE" "OAUTH_CLIENT_ID"
+read_file_and_export "OAUTH_CLIENT_SECRET_FILE" "OAUTH_CLIENT_SECRET"
 
 if CPU_CORES="${CPU_CORES:=$(get-cpus.sh 2>/dev/null)}"; then
   log_message "Detected CPU Cores: $CPU_CORES"

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -78,6 +78,8 @@ export const EnvSchema = z
     DB_URL: z.string().optional(),
     DB_USERNAME: z.string().optional(),
     DB_VECTOR_EXTENSION: z.enum(['pgvector', 'vectorchord']).optional(),
+    OAUTH_CLIENT_ID: z.string().optional(),
+    OAUTH_CLIENT_SECRET: z.string().optional(),
     NO_COLOR: z.string().optional(),
     REDIS_HOSTNAME: z.string().optional(),
     REDIS_PORT: z.coerce.number().int().optional(),

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -30,6 +30,9 @@ const resetEnv = () => {
     'DB_SKIP_MIGRATIONS',
     'DB_VECTOR_EXTENSION',
 
+    'OAUTH_CLIENT_ID',
+    'OAUTH_CLIENT_SECRET',
+
     'REDIS_HOSTNAME',
     'REDIS_PORT',
     'REDIS_DBINDEX',
@@ -184,6 +187,27 @@ describe('getEnv', () => {
     it('should reject invalid json', () => {
       process.env.REDIS_URL = `ioredis://${Buffer.from('{ "invalid json"').toString('base64')}`;
       expect(() => getEnv()).toThrowError('Failed to decode redis options');
+    });
+  });
+
+  describe('oauth', () => {
+    it('should use defaults', () => {
+      const { oauth } = getEnv();
+      expect(oauth).toEqual({
+        clientId: undefined,
+        clientSecret: undefined,
+      });
+    });
+
+    it('should read OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET', () => {
+      process.env.OAUTH_CLIENT_ID = 'oauth-client-id';
+      process.env.OAUTH_CLIENT_SECRET = 'oauth-client-secret';
+
+      const { oauth } = getEnv();
+      expect(oauth).toEqual({
+        clientId: 'oauth-client-id',
+        clientSecret: 'oauth-client-secret',
+      });
     });
   });
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -101,6 +101,11 @@ export interface EnvData {
 
   redis: RedisOptions;
 
+  oauth: {
+    clientId?: string;
+    clientSecret?: string;
+  };
+
   setup: {
     allow: boolean;
   };
@@ -334,6 +339,10 @@ const getEnv = (): EnvData => {
     },
 
     redis: redisConfig,
+    oauth: {
+      clientId: dto.OAUTH_CLIENT_ID,
+      clientSecret: dto.OAUTH_CLIENT_SECRET,
+    },
 
     resourcePaths: {
       lockFile: join(buildFolder, 'build-lock.json'),

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -293,6 +293,37 @@ describe(SystemConfigService.name, () => {
       await expect(sut.getAdminConfig()).resolves.toEqual(updatedConfig);
     });
 
+    it('should override oauth client credentials from environment variables', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        oauth: {
+          clientId: 'config-client-id',
+          clientSecret: 'config-client-secret',
+        },
+      });
+      mocks.config.getEnv.mockReturnValue(
+        mockEnvData({
+          oauth: { clientId: 'env-client-id', clientSecret: 'env-client-secret' },
+        }),
+      );
+
+      const config = await sut.getAdminConfig();
+      expect(config.oauth.clientId).toBe('env-client-id');
+      expect(config.oauth.clientSecret).toBe('env-client-secret');
+    });
+
+    it('should keep oauth client credentials from system config when environment variables are not set', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        oauth: {
+          clientId: 'config-client-id',
+          clientSecret: 'config-client-secret',
+        },
+      });
+
+      const config = await sut.getAdminConfig();
+      expect(config.oauth.clientId).toBe('config-client-id');
+      expect(config.oauth.clientSecret).toBe('config-client-secret');
+    });
+
     it('should load the config from a json file', async () => {
       mocks.config.getEnv.mockReturnValue(mockEnvData({ configFile: 'immich-config.json' }));
       mocks.systemMetadata.readFile.mockResolvedValue(JSON.stringify(partialConfig));

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -75,7 +75,7 @@ const loadFromFile = async ({ metadataRepo, logger }: RepoDeps, filepath: string
 
 const buildConfig = async (repos: RepoDeps) => {
   const { configRepo, metadataRepo, logger } = repos;
-  const { configFile } = configRepo.getEnv();
+  const { configFile, oauth } = configRepo.getEnv();
 
   // load partial
   const partial = configFile
@@ -86,6 +86,13 @@ const buildConfig = async (repos: RepoDeps) => {
   const rawConfig = _.cloneDeep(defaults);
   for (const property of getKeysDeep(partial)) {
     _.set(rawConfig, property, _.get(partial, property));
+  }
+
+  if (oauth.clientId !== undefined) {
+    rawConfig.oauth.clientId = oauth.clientId;
+  }
+  if (oauth.clientSecret !== undefined) {
+    rawConfig.oauth.clientSecret = oauth.clientSecret;
   }
 
   // check for extra properties

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -63,6 +63,11 @@ export const envData: EnvData = {
     db: 0,
   },
 
+  oauth: {
+    clientId: undefined,
+    clientSecret: undefined,
+  },
+
   resourcePaths: {
     lockFile: 'build-lock.json',
     geodata: {


### PR DESCRIPTION
## Description

Support `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` as runtime overrides for `oauth.clientId` and `oauth.clientSecret`, including `*_FILE` handling in `server/bin/start.sh`.

This enables Immich administrators to use Docker secrets, systemd credentials, and other similar file-based secrets for sensitive OAuth settings.

It follows the already existing practice for settings such as the database credentials and the Redis password.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An initial survey of the code base was done manually. The documentation changes were performed manually.

GitHub Copilot was being used to perform the code changes which were afterwards adapted to match the style of the project.

### Used prompts

```text
Check @server/src/repositories/config.repository.ts and `ENV_SCHEMA` in @server/src/dtos/env.dto.ts and @server/src/dtos/config.dto.ts                                       
                                                                                                                                                                             
Create a plan to add environment variables for `oauth.clientId` and `oauth.clientSecret` from `AdminConfigSchemaWithVisibility` named OAUTH_CLIENT_ID and                    
OAUTH_CLIENT_SECRET which work like `DB_PASSWORD` and `REDIS_PASSWORD` and can be read from files, like `DB_PASSWORD_FILE` and `REDIS_PASSWORD_FILE` (see                    
@server/bin/start.sh).
```

(manual review of the plan with minor changes, see [`plan.md`](https://github.com/user-attachments/files/31978914/plan.md))

```text
Implement the plan.
```