### PR TITLE
fix(server): use the edited preview when encoding CLIP embeddings

### DIFF
--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -425,7 +425,7 @@ select
   "asset"."visibility",
   (
     select
-      coalesce(json_agg(agg), '[]')
+      to_json(obj)
     from
       (
         select
@@ -437,13 +437,17 @@ select
           "asset_file"
         where
           "asset_file"."assetId" = "asset"."id"
-          and "asset_file"."type" = $1
-      ) as agg
-  ) as "files"
+          and "asset_file"."type" = 'preview'
+        order by
+          "asset_file"."isEdited" desc
+        limit
+          1
+      ) as obj
+  ) as "previewFile"
 from
   "asset"
 where
-  "asset"."id" = $2
+  "asset"."id" = $1
 
 -- AssetJobRepository.getForDetectFacesJob
 select

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -224,7 +224,17 @@ export class AssetJobRepository {
     return this.db
       .selectFrom('asset')
       .select(['asset.id', 'asset.visibility'])
-      .select((eb) => withFiles(eb, AssetFileType.Preview))
+      .select((eb) =>
+        jsonObjectFrom(
+          eb
+            .selectFrom('asset_file')
+            .select(columns.assetFiles)
+            .whereRef('asset_file.assetId', '=', 'asset.id')
+            .where('asset_file.type', '=', sql.lit(AssetFileType.Preview))
+            .orderBy('asset_file.isEdited', 'desc')
+            .limit(sql.lit(1)),
+        ).as('previewFile'),
+      )
       .where('asset.id', '=', id)
       .executeTakeFirst();
   }

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -4,6 +4,7 @@ import { SmartInfoService } from 'src/services/smart-info.service';
 import { getCLIPModelInfo } from 'src/utils/misc';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { systemConfigStub } from 'test/fixtures/system-config.stub';
+import { getForClipEncoding } from 'test/mappers';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 
 describe(SmartInfoService.name, () => {
@@ -189,7 +190,7 @@ describe(SmartInfoService.name, () => {
 
     it('should skip assets without a resize path', async () => {
       const asset = AssetFactory.create();
-      mocks.assetJob.getForClipEncoding.mockResolvedValue(asset);
+      mocks.assetJob.getForClipEncoding.mockResolvedValue(getForClipEncoding(asset));
 
       expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Failed);
 
@@ -200,7 +201,7 @@ describe(SmartInfoService.name, () => {
     it('should save the returned objects', async () => {
       const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).build();
       mocks.machineLearning.encodeImage.mockResolvedValue('[0.01, 0.02, 0.03]');
-      mocks.assetJob.getForClipEncoding.mockResolvedValue(asset);
+      mocks.assetJob.getForClipEncoding.mockResolvedValue(getForClipEncoding(asset));
 
       expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Success);
 
@@ -211,11 +212,29 @@ describe(SmartInfoService.name, () => {
       expect(mocks.search.upsert).toHaveBeenCalledWith(asset.id, '[0.01, 0.02, 0.03]');
     });
 
+    it('should prefer the edited preview file of an edited asset', async () => {
+      const asset = AssetFactory.from()
+        .file({ type: AssetFileType.Preview, isEdited: false })
+        .file({ type: AssetFileType.Preview, isEdited: true })
+        .build();
+      const editedPreview = asset.files.find((file) => file.isEdited)!;
+      mocks.machineLearning.encodeImage.mockResolvedValue('[0.01, 0.02, 0.03]');
+      mocks.assetJob.getForClipEncoding.mockResolvedValue(getForClipEncoding(asset));
+
+      expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Success);
+
+      expect(mocks.machineLearning.encodeImage).toHaveBeenCalledWith(
+        editedPreview.path,
+        expect.objectContaining({ modelName: 'ViT-B-32__openai' }),
+      );
+      expect(mocks.search.upsert).toHaveBeenCalledWith(asset.id, '[0.01, 0.02, 0.03]');
+    });
+
     it('should skip invisible assets', async () => {
       const asset = AssetFactory.from({ visibility: AssetVisibility.Hidden })
         .file({ type: AssetFileType.Preview })
         .build();
-      mocks.assetJob.getForClipEncoding.mockResolvedValue(asset);
+      mocks.assetJob.getForClipEncoding.mockResolvedValue(getForClipEncoding(asset));
 
       expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Skipped);
 
@@ -236,7 +255,7 @@ describe(SmartInfoService.name, () => {
       const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).build();
       mocks.machineLearning.encodeImage.mockResolvedValue('[0.01, 0.02, 0.03]');
       mocks.database.isBusy.mockReturnValue(true);
-      mocks.assetJob.getForClipEncoding.mockResolvedValue(asset);
+      mocks.assetJob.getForClipEncoding.mockResolvedValue(getForClipEncoding(asset));
 
       expect(await sut.handleEncodeClip({ id: asset.id })).toEqual(JobStatus.Success);
 

--- a/server/src/services/smart-info.service.ts
+++ b/server/src/services/smart-info.service.ts
@@ -92,7 +92,8 @@ export class SmartInfoService extends BaseService {
     }
 
     const asset = await this.assetJobRepository.getForClipEncoding(id);
-    if (!asset || asset.files.length !== 1) {
+    const previewFile = asset?.previewFile;
+    if (!asset || !previewFile) {
       return JobStatus.Failed;
     }
 
@@ -100,7 +101,7 @@ export class SmartInfoService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    const embedding = await this.machineLearningRepository.encodeImage(asset.files[0].path, machineLearning.clip);
+    const embedding = await this.machineLearningRepository.encodeImage(previewFile.path, machineLearning.clip);
 
     if (this.databaseRepository.isBusy(DatabaseLock.CLIPDimSize)) {
       this.logger.verbose(`Waiting for CLIP dimension size to be updated`);

--- a/server/test/mappers.ts
+++ b/server/test/mappers.ts
@@ -195,6 +195,15 @@ export const getForDetectedFaces = (asset: ReturnType<AssetFactory['build']>) =>
     .map((file) => getDehydrated(file))[0],
 });
 
+export const getForClipEncoding = (asset: ReturnType<AssetFactory['build']>) => ({
+  id: asset.id,
+  visibility: asset.visibility,
+  previewFile: asset.files
+    .filter((file) => file.type === AssetFileType.Preview)
+    .toSorted((a, b) => Number(b.isEdited) - Number(a.isEdited))
+    .map((file) => getDehydrated(file))[0],
+});
+
 export const getForSidecarWrite = (asset: ReturnType<AssetFactory['build']>) => ({
   id: asset.id,
   originalPath: asset.originalPath,

--- a/server/test/medium/specs/services/smart-info.service.spec.ts
+++ b/server/test/medium/specs/services/smart-info.service.spec.ts
@@ -1,0 +1,127 @@
+import { Kysely } from 'kysely';
+import { AssetFileType, JobName, JobStatus } from 'src/enum';
+import { AssetJobRepository } from 'src/repositories/asset-job.repository';
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { DatabaseRepository } from 'src/repositories/database.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { MachineLearningRepository } from 'src/repositories/machine-learning.repository';
+import { SearchRepository } from 'src/repositories/search.repository';
+import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
+import { DB } from 'src/schema';
+import { SmartInfoService } from 'src/services/smart-info.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const embedding = `[${Array.from({ length: 512 }, () => 0.01).join(', ')}]`;
+
+const setup = (db?: Kysely<DB>) => {
+  return newMediumService(SmartInfoService, {
+    database: db || defaultDatabase,
+    real: [
+      AssetRepository,
+      AssetJobRepository,
+      ConfigRepository,
+      DatabaseRepository,
+      SearchRepository,
+      SystemMetadataRepository,
+    ],
+    mock: [JobRepository, LoggingRepository, MachineLearningRepository],
+  });
+};
+
+const getEmbeddingCount = async (db: Kysely<DB>, assetId: string) => {
+  const rows = await db.selectFrom('smart_search').select('assetId').where('assetId', '=', assetId).execute();
+  return rows.length;
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(SmartInfoService.name, () => {
+  it('should work', () => {
+    const { sut } = setup();
+    expect(sut).toBeDefined();
+  });
+
+  describe('handleQueueEncodeClip', () => {
+    it('should queue an edited asset that has a preview but no embedding', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id, isEdited: true });
+      await ctx.newJobStatus({ assetId: asset.id });
+      await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, isEdited: false, path: 'preview.jpg' });
+      await ctx.newAssetFile({
+        assetId: asset.id,
+        type: AssetFileType.Preview,
+        isEdited: true,
+        path: 'preview_edited.jpg',
+      });
+
+      ctx.getMock(JobRepository).queueAll.mockResolvedValue();
+
+      await expect(sut.handleQueueEncodeClip({ force: false })).resolves.toBe(JobStatus.Success);
+
+      expect(ctx.getMock(JobRepository).queueAll).toHaveBeenCalledWith([
+        { name: JobName.SmartSearch, data: { id: asset.id } },
+      ]);
+    });
+  });
+
+  describe('handleEncodeClip', () => {
+    it('should encode the preview of an unedited asset', async () => {
+      const { sut, ctx } = setup();
+      const config = await ctx.getConfig();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
+      ctx.getMock(MachineLearningRepository).encodeImage.mockResolvedValue(embedding);
+
+      await expect(sut.handleEncodeClip({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(ctx.getMock(MachineLearningRepository).encodeImage).toHaveBeenCalledWith(
+        'preview.jpg',
+        config.machineLearning.clip,
+      );
+      await expect(getEmbeddingCount(ctx.database, asset.id)).resolves.toBe(1);
+    });
+
+    it('should encode the edited preview of an edited asset', async () => {
+      const { sut, ctx } = setup();
+      const config = await ctx.getConfig();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id, isEdited: true });
+      await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, isEdited: false, path: 'preview.jpg' });
+      await ctx.newAssetFile({
+        assetId: asset.id,
+        type: AssetFileType.Preview,
+        isEdited: true,
+        path: 'preview_edited.jpg',
+      });
+      ctx.getMock(MachineLearningRepository).encodeImage.mockResolvedValue(embedding);
+
+      await expect(sut.handleEncodeClip({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(ctx.getMock(MachineLearningRepository).encodeImage).toHaveBeenCalledWith(
+        'preview_edited.jpg',
+        config.machineLearning.clip,
+      );
+      await expect(getEmbeddingCount(ctx.database, asset.id)).resolves.toBe(1);
+    });
+
+    it('should fail when the asset has no preview file', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await expect(sut.handleEncodeClip({ id: asset.id })).resolves.toBe(JobStatus.Failed);
+
+      expect(ctx.getMock(MachineLearningRepository).encodeImage).not.toHaveBeenCalled();
+      await expect(getEmbeddingCount(ctx.database, asset.id)).resolves.toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Assets edited in the built-in editor have two `preview` rows in `asset_file` (one with `isEdited = false`, one with `isEdited = true`). `AssetJobRepository.getForClipEncoding` returned all preview files for the asset, and `SmartInfoService.handleEncodeClip` treated anything other than exactly one file as a failure. Every edited asset therefore failed the smart search job: a full re-index dropped their embeddings, and a "missing" run could never restore them. Reverting the edit removed the second row, which is why that workaround from the issue worked.

This change selects a single preview file, preferring the edited one so the embedding matches what the user sees, and fails the job only when no preview exists. It mirrors the face detection fix in #31240.

Changes:

- `asset-job.repository.ts`: `getForClipEncoding` returns a single `previewFile` (edited preferred) instead of a `files` array.
- `smart-info.service.ts`: use `previewFile`; fail only when it is missing.
- `asset.job.repository.sql`: updated snapshot.
- Tests: updated unit tests plus a new edited-asset case, a shared `getForClipEncoding` mapper, and a new medium spec for `SmartInfoService`.

Fixes #31332

## How Has This Been Tested?

- [x] `tsc --noEmit`, eslint, and prettier pass for the touched files.
- [x] `src/services/smart-info.service.spec.ts`: 24 tests pass, including the new "prefer the edited preview" case.
- [x] New `test/medium/specs/services/smart-info.service.spec.ts` (real Postgres via testcontainers): 5 tests pass, including one that inserts an edited asset with both preview rows and asserts a row is written to `smart_search`.
- [x] With the source fix reverted, that medium test fails with `expected 'failed' to be 'success'`, matching the reported symptom.

Note: the SQL snapshot was updated by hand to match the generated form of the analogous `getForDetectFacesJob` query; the SQL sync check in CI will confirm it.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

The investigation, code change, tests, and this description were produced with Claude Code (Claude Fable 5.1), directed and reviewed by the author. All tests were run locally as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
