### PR TITLE
fix(web): separate album description from album name in workflow album picker

### DIFF
--- a/web/src/lib/components/album-page/AlbumThumbnail.svelte
+++ b/web/src/lib/components/album-page/AlbumThumbnail.svelte
@@ -19,22 +19,25 @@
     <LoadingSpinner />
   {:then album}
     <div class="flex gap-2">
-      <AlbumCover {album} class="size-24" />
-      <p
-        class="line-clamp-2 grow text-lg/6 font-semibold text-black group-hover:text-primary dark:text-white"
-        data-testid="album-name"
-        title={album.albumName}
-      >
-        {album.albumName}
-      </p>
-      {#if album.description}
+      <AlbumCover {album} class="size-24 shrink-0" />
+      <div class="flex min-w-0 grow flex-col gap-1">
         <p
-          class="line-clamp-2 grow text-lg/6 font-semibold text-black group-hover:text-primary dark:text-white"
+          class="line-clamp-2 text-lg/6 font-semibold text-black dark:text-white"
           data-testid="album-name"
+          title={album.albumName}
         >
-          {album.description}
+          {album.albumName}
         </p>
-      {/if}
+        {#if album.description}
+          <p
+            class="line-clamp-2 text-sm text-gray-600 dark:text-gray-300"
+            data-testid="album-description"
+            title={album.description}
+          >
+            {album.description}
+          </p>
+        {/if}
+      </div>
       <div class="">
         <IconButton
           icon={mdiTrashCanOutline}

--- a/web/src/lib/components/album-page/__tests__/AlbumThumbnail.spec.ts
+++ b/web/src/lib/components/album-page/__tests__/AlbumThumbnail.spec.ts
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom';
+import { waitFor, type RenderResult } from '@testing-library/svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { renderWithTooltips } from '$tests/helpers';
+import { albumFactory } from '@test-data/factories/album-factory';
+import AlbumThumbnail from '../AlbumThumbnail.svelte';
+
+describe('AlbumThumbnail component', () => {
+  let sut: RenderResult<typeof AlbumThumbnail>;
+
+  beforeAll(async () => {
+    await init({ fallbackLocale: 'en-US' });
+    register('en-US', () => import('$i18n/en.json'));
+    await waitLocale('en-US');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('shows the album name and the description separately', async () => {
+    const album = albumFactory.build({
+      albumName: 'Holiday 2024',
+      description: 'A very long description that should never be mistaken for the album name',
+    });
+    sdkMock.getAlbumInfo.mockResolvedValue(album);
+
+    sut = renderWithTooltips(AlbumThumbnail, { albumId: album.id, onDelete: vi.fn() });
+
+    await waitFor(() => expect(sut.getByTestId('album-name')).toBeInTheDocument());
+
+    const nameElements = sut.getAllByTestId('album-name');
+    expect(nameElements).toHaveLength(1);
+    expect(nameElements[0]).toHaveTextContent('Holiday 2024');
+    expect(nameElements[0]).not.toHaveTextContent(album.description);
+
+    const descriptionElement = sut.getByTestId('album-description');
+    expect(descriptionElement).toHaveTextContent(album.description);
+    expect(descriptionElement).toHaveClass('line-clamp-2');
+  });
+
+  it('does not render a description element when the album has no description', async () => {
+    const album = albumFactory.build({ albumName: 'Holiday 2024', description: '' });
+    sdkMock.getAlbumInfo.mockResolvedValue(album);
+
+    sut = renderWithTooltips(AlbumThumbnail, { albumId: album.id, onDelete: vi.fn() });
+
+    await waitFor(() => expect(sut.getByTestId('album-name')).toHaveTextContent('Holiday 2024'));
+    expect(sut.queryByTestId('album-description')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

The album thumbnail used by the workflow album selector (`SchemaAlbumPicker` → `AlbumThumbnail`) rendered the album description in a second `<p>` with the exact same styling as the album name: `text-lg/6 font-semibold grow`, and even the same `data-testid="album-name"`. In a horizontal flex row, that put a full-size, bold description right next to the name, so long descriptions blew out the row and looked like part of the album title.

This change:

- Stacks the name over the description in a `min-w-0 grow` column so the row cannot overflow.
- Styles the description as small, muted text with `line-clamp-2` and a `title` tooltip for the full text.
- Gives the description its own `data-testid="album-description"` so the name element is unique.
- Adds `AlbumThumbnail.spec.ts` covering both the with-description and no-description cases.

Fixes #31291

## How Has This Been Tested?

- [x] New unit test `web/src/lib/components/album-page/__tests__/AlbumThumbnail.spec.ts` passes; confirmed it fails against the old component (duplicate `album-name` element containing the description).
- [x] `vitest run src/lib/components/album-page/__tests__/` — 11 passed.
- [x] `prettier --check`, `eslint --max-warnings 0` on the changed files.
- [x] `svelte-check` (0 errors, 0 warnings) and `tsc --noEmit` for the web package.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was written by Claude Code, with the change verified by unit tests, lint, and type checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

