### PR TITLE
feat(web): rotate and flip from the asset viewer without opening the editor

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1834,6 +1834,8 @@
   "role_viewer": "Viewer",
   "rotate_api_key_prompt": "Are you sure you want to rotate this API key? The current key will stop working immediately.",
   "rotate_key": "Rotate key",
+  "rotate_left": "Rotate left",
+  "rotate_right": "Rotate right",
   "running": "Running",
   "save": "Save",
   "saved": "Saved",

--- a/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
@@ -171,6 +171,12 @@
           <SetFeaturedPhotoAction {asset} {person} {onAction} />
         {/if}
 
+        {#if isOwner && !isLocked}
+          <ActionMenuItem action={Actions.RotateLeft} />
+          <ActionMenuItem action={Actions.RotateRight} />
+          <ActionMenuItem action={Actions.FlipHorizontal} />
+          <ActionMenuItem action={Actions.FlipVertical} />
+        {/if}
         <ActionMenuItem action={Actions.SetProfilePicture} />
 
         {#if isOwner && !isLocked}

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -9,6 +9,7 @@ import {
   type AssetJobsDto,
   type AssetResponseDto,
 } from '@immich/sdk';
+import { MirrorAxis } from '@immich/sdk';
 import { modalManager, toastManager, type ActionItem } from '@immich/ui';
 import {
   mdiAccountCircleOutline,
@@ -30,8 +31,12 @@ import {
   mdiMagnifyPlusOutline,
   mdiMotionPauseOutline,
   mdiMotionPlayOutline,
+  mdiFlipHorizontal,
+  mdiFlipVertical,
   mdiPlus,
   mdiPresentationPlay,
+  mdiRotateLeft,
+  mdiRotateRight,
   mdiShareVariantOutline,
   mdiTagPlusOutline,
   mdiTune,
@@ -54,6 +59,7 @@ import { getAssetMediaUrl, getSharedLink, sleep } from '$lib/utils';
 import { downloadUrl } from '$lib/utils';
 import { handleError } from '$lib/utils/handle-error';
 import { getFormatter } from '$lib/utils/i18n';
+import { applyQuickTransform } from '$lib/utils/quick-transform';
 
 export const getAssetBulkActions = ($t: MessageFormatter) => {
   const ownedAssets = assetMultiSelectManager.ownedAssets;
@@ -234,18 +240,53 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
     shortcuts: { key: 'p' },
   };
 
+  // Quick transforms write through the same edits API as the editor, so they
+  // are valid exactly where the editor is.
+  const isEditable = () =>
+    !sharedLink &&
+    isOwner &&
+    asset.type === AssetTypeEnum.Image &&
+    !asset.livePhotoVideoId &&
+    asset.exifInfo?.projectionType !== ProjectionType.EQUIRECTANGULAR &&
+    !asset.originalPath.toLowerCase().endsWith('.insp') &&
+    !asset.originalPath.toLowerCase().endsWith('.gif') &&
+    !asset.originalPath.toLowerCase().endsWith('.svg');
+
+  const RotateLeft: ActionItem = {
+    title: $t('rotate_left'),
+    icon: mdiRotateLeft,
+    $if: isEditable,
+    onAction: () => applyQuickTransform(asset.id, { kind: 'rotate', degrees: -90 }),
+    // Same bindings the editor's transform tool uses, so there is one thing to learn.
+    shortcuts: [{ key: '[' }],
+  };
+
+  const RotateRight: ActionItem = {
+    title: $t('rotate_right'),
+    icon: mdiRotateRight,
+    $if: isEditable,
+    onAction: () => applyQuickTransform(asset.id, { kind: 'rotate', degrees: 90 }),
+    shortcuts: [{ key: ']' }],
+  };
+
+  const FlipHorizontal: ActionItem = {
+    title: $t('editor_flip_horizontal'),
+    icon: mdiFlipHorizontal,
+    $if: isEditable,
+    onAction: () => applyQuickTransform(asset.id, { kind: 'mirror', axis: MirrorAxis.Horizontal }),
+  };
+
+  const FlipVertical: ActionItem = {
+    title: $t('editor_flip_vertical'),
+    icon: mdiFlipVertical,
+    $if: isEditable,
+    onAction: () => applyQuickTransform(asset.id, { kind: 'mirror', axis: MirrorAxis.Vertical }),
+  };
+
   const Edit: ActionItem = {
     title: $t('editor'),
     icon: mdiTune,
-    $if: () =>
-      !sharedLink &&
-      isOwner &&
-      asset.type === AssetTypeEnum.Image &&
-      !asset.livePhotoVideoId &&
-      asset.exifInfo?.projectionType !== ProjectionType.EQUIRECTANGULAR &&
-      !asset.originalPath.toLowerCase().endsWith('.insp') &&
-      !asset.originalPath.toLowerCase().endsWith('.gif') &&
-      !asset.originalPath.toLowerCase().endsWith('.svg'),
+    $if: isEditable,
     onAction: () => assetViewerManager.openEditor(),
     shortcuts: [{ key: 'e' }],
   };
@@ -316,6 +357,10 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
     Tag,
     TagPeople,
     Edit,
+    RotateLeft,
+    RotateRight,
+    FlipHorizontal,
+    FlipVertical,
     SetProfilePicture,
     ViewInTimeline,
     ViewSimilar,

--- a/web/src/lib/utils/quick-transform.spec.ts
+++ b/web/src/lib/utils/quick-transform.spec.ts
@@ -1,0 +1,45 @@
+import { AssetEditAction, MirrorAxis } from '@immich/sdk';
+import { describe, expect, it } from 'vitest';
+import { foldTransform } from '$lib/utils/quick-transform';
+
+const rotate = (angle: number) => ({ action: AssetEditAction.Rotate, parameters: { angle } });
+const mirror = (axis: MirrorAxis) => ({ action: AssetEditAction.Mirror, parameters: { axis } });
+const crop = { action: AssetEditAction.Crop, parameters: { x: 1, y: 2, width: 3, height: 4 } };
+
+describe('foldTransform', () => {
+  it('adds a rotation when there are no edits', () => {
+    expect(foldTransform([], { kind: 'rotate', degrees: 90 })).toEqual([rotate(90)]);
+  });
+
+  it('merges repeated rotations into a single edit', () => {
+    expect(foldTransform([rotate(90)], { kind: 'rotate', degrees: 90 })).toEqual([rotate(180)]);
+  });
+
+  it('normalises a full turn back to no rotation', () => {
+    expect(foldTransform([rotate(270)], { kind: 'rotate', degrees: 90 })).toEqual([]);
+  });
+
+  it('normalises negative rotation into the 0-359 range', () => {
+    expect(foldTransform([], { kind: 'rotate', degrees: -90 })).toEqual([rotate(270)]);
+  });
+
+  it('toggles a mirror off when the same axis is applied twice', () => {
+    expect(foldTransform([mirror(MirrorAxis.Horizontal)], { kind: 'mirror', axis: MirrorAxis.Horizontal })).toEqual([]);
+  });
+
+  it('keeps mirrors on different axes independent', () => {
+    expect(foldTransform([mirror(MirrorAxis.Horizontal)], { kind: 'mirror', axis: MirrorAxis.Vertical })).toEqual([
+      mirror(MirrorAxis.Horizontal),
+      mirror(MirrorAxis.Vertical),
+    ]);
+  });
+
+  it('preserves unrelated edits such as a crop', () => {
+    expect(foldTransform([crop, rotate(90)], { kind: 'rotate', degrees: 90 })).toEqual([crop, rotate(180)]);
+  });
+
+  it('drops the server-assigned id so the result is a valid create payload', () => {
+    const withId = { ...crop, id: 'a2f1b6c8-0000-4000-8000-000000000000' };
+    expect(foldTransform([withId], { kind: 'rotate', degrees: 90 })).toEqual([crop, rotate(90)]);
+  });
+});

--- a/web/src/lib/utils/quick-transform.ts
+++ b/web/src/lib/utils/quick-transform.ts
@@ -1,0 +1,101 @@
+import { getAssetEdits, getAssetInfo, editAsset, removeAssetEdits, AssetEditAction, MirrorAxis } from '@immich/sdk';
+import type { AssetEditActionItemDto } from '@immich/sdk';
+import { eventManager } from '$lib/managers/event-manager.svelte';
+import { waitForWebsocketEvent } from '$lib/stores/websocket';
+import { handleError } from '$lib/utils/handle-error';
+import { getFormatter } from '$lib/utils/i18n';
+
+export type QuickTransform = { kind: 'rotate'; degrees: number } | { kind: 'mirror'; axis: MirrorAxis };
+
+/**
+ * Fold a new transform into the asset's existing edits.
+ *
+ * Rotations are summed and normalised so repeatedly rotating does not grow the
+ * edit list, and a full turn collapses back to no rotation at all. Mirrors
+ * toggle, so applying the same flip twice is an undo. Any other edit (a crop,
+ * for example) is preserved untouched and stays ahead of the transforms.
+ */
+export const foldTransform = (
+  existing: AssetEditActionItemDto[],
+  transform: QuickTransform,
+): AssetEditActionItemDto[] => {
+  const others: AssetEditActionItemDto[] = [];
+  const mirrors = new Set<MirrorAxis>();
+  let rotation = 0;
+
+  for (const edit of existing) {
+    switch (edit.action) {
+      case AssetEditAction.Rotate: {
+        rotation += (edit.parameters as { angle: number }).angle ?? 0;
+        break;
+      }
+      case AssetEditAction.Mirror: {
+        const { axis } = edit.parameters as { axis: MirrorAxis };
+        if (mirrors.has(axis)) {
+          mirrors.delete(axis);
+        } else {
+          mirrors.add(axis);
+        }
+        break;
+      }
+      default: {
+        // The GET response carries an `id` per edit; the create DTO does not
+        // accept it, so pass through only the fields we are allowed to send.
+        others.push({ action: edit.action, parameters: edit.parameters });
+      }
+    }
+  }
+
+  if (transform.kind === 'rotate') {
+    rotation += transform.degrees;
+  } else if (mirrors.has(transform.axis)) {
+    mirrors.delete(transform.axis);
+  } else {
+    mirrors.add(transform.axis);
+  }
+
+  rotation = ((rotation % 360) + 360) % 360;
+
+  const next = [...others];
+  for (const axis of mirrors) {
+    next.push({ action: AssetEditAction.Mirror, parameters: { axis } });
+  }
+  if (rotation !== 0) {
+    next.push({ action: AssetEditAction.Rotate, parameters: { angle: rotation } });
+  }
+  return next;
+};
+
+/**
+ * Apply a single rotate/flip to an asset without opening the editor.
+ *
+ * This goes through the same non-destructive edits API the editor uses, so the
+ * change is visible there and can be reverted from there.
+ */
+export const applyQuickTransform = async (assetId: string, transform: QuickTransform) => {
+  const $t = await getFormatter();
+  try {
+    const current = await getAssetEdits({ id: assetId });
+    const edits = foldTransform(current.edits ?? [], transform);
+
+    // Listen before sending, so a fast server cannot beat us to the event.
+    const editReady = waitForWebsocketEvent('AssetEditReadyV2', (event) => event.asset.id === assetId, 10_000);
+
+    await (edits.length === 0
+      ? removeAssetEdits({ id: assetId })
+      : editAsset({ id: assetId, assetEditsCreateDto: { edits } }));
+
+    await editReady;
+
+    // AssetEditsApplied only clears caches; it does not re-render anything.
+    // The editor gets away with that because it closes afterwards, which makes
+    // the viewer re-read the asset. Applying in place has no such moment, so
+    // re-fetch and publish the asset: AssetUpdate is what actually refreshes
+    // the open viewer and the timeline tile.
+    eventManager.emit('AssetEditsApplied', assetId);
+    const updated = await getAssetInfo({ id: assetId });
+    eventManager.emit('AssetUpdate', updated);
+  } catch (error) {
+    handleError(error, $t('editor_edits_applied_error'));
+  }
+};


### PR DESCRIPTION
## Description

Rotating a photo currently means opening the editor, rotating, and applying. For the common case of a single 90° correction that is a lot of steps, and it is one of the more frequently requested gaps in the viewer.

This adds rotate left/right and flip horizontal/vertical as asset actions. They appear in the viewer's context menu, and rotation is bound to [ and ] — the same keys the editor's transform tool already uses — so there is one binding to learn rather than two. r and l were deliberately avoided: l is already Add to album and r is bound in the library view.

The actions write through the existing non-destructive edits API (PUT /assets/{id}/edits), so results appear in the editor and can be reverted there. The fold logic behaves as follows:

- repeated rotations merge into a single edit rather than accumulating entries
- a full turn collapses back to no edit at all (issues DELETE)
- mirrors toggle, so applying the same flip twice is an undo
- unrelated edits (a crop) are preserved
- the server-assigned id on each returned edit is stripped before re-sending, since the create DTO does not accept it

Applying in place needs an explicit refresh. AssetEditsApplied only clears caches; the editor gets a redraw for free because it closes afterwards, which makes the viewer re-read the asset. There is no such moment here, so once the render is ready the asset is re-fetched and AssetUpdate is emitted, which refreshes both the open viewer and the timeline tile without a reload.

Eligibility reuses the editor's own predicate, so the actions appear in exactly the places the editor is available (images only, no live photos, no equirectangular, no .gif/.svg/.insp).

## How Has This Been Tested?

Verified against a local dev build of main, running isolated from any other instance.

- [x] tsc --noEmit — exit 0
- [x] svelte-check --fail-on-warnings — 0 errors, 0 warnings
- [x] eslint --max-warnings 0 on all changed files — exit 0
- [x] prettier --check on all changed files — clean
- [x] 8 new unit tests for foldTransform: rotation merge, 360° collapse, negative normalisation, mirror toggle, independent axes, crop preservation, id stripping — all passing
- [x] End-to-end: uploaded a deliberately mis-oriented test image, applied rotate from the viewer, and confirmed the rendered output came back upright (600×800 → 800×600, orientation markers in the expected places)
- [x] Fold behaviour confirmed against the running API: 90+90 produces a single {"angle": 180} edit; a full turn issues DELETE and leaves isEdited: false; mirror and rotate coexist correctly
- [x] Live refresh confirmed in the browser: viewer and grid thumbnail both update without a page reload

Tests were also performed using the web UI directly through a browser both to rotate with keyboard shortcuts as well as filp and rotate with buttons. All appeared to work fine.

To reproduce: open an image in the viewer, press ] (or use the context menu). The image should rotate in place, the grid tile should follow, and the rotation should be visible and revertible in the editor.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added)
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc. (n/a — web only, no server changes)
- [x] All code in src/repositories/ is pretty basic/simple and does not have any immich specific logic (n/a — web only, no server changes)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Substantially. The implementation, the tests and this description were written by an LLM (Claude), working from my direction and verified against a live dev build on my own hardware. I (the author, @hank) have fully reviewed the code generated by the LLM and have tested it by hand.

In case it is useful either way, the following were established by running against a live instance rather than assumed, and hold regardless of what happens to this PR:

- [ and ] are the only conflict-free keys for this in the viewer; r and l are both already taken in that context
- Immich's rotate angle is clockwise-positive, confirmed empirically and consistent with the negated angle in buildAffineFromEdits
- getAssetEdits returns edits carrying an id that editAsset rejects, so preserved edits must be stripped before being re-sent
- AssetEditsApplied does not cause a redraw anywhere; AssetUpdate is the event that does
- thumbhash changes when an edit is applied, so the derived image URL's cache key changes and the browser refetches

Happy to rewrite any of it, change the key bindings, or split the flips into a separate PR. I am also happy to add docs if necessary.