### PR TITLE
docs: add Yundera to one-click cloud providers

### DIFF
--- a/docs/docs/install/one-click.md
+++ b/docs/docs/install/one-click.md
@@ -25,6 +25,10 @@ https://marketplace.digitalocean.com/apps/immich
 
 https://www.vultr.com/marketplace/apps/immich
 
+### Yundera
+
+<https://yundera.com/install-immich-on-yundera>
+
 ## Issues
 
 For issues, open an issue on the associated [GitHub Repository][github].


### PR DESCRIPTION
## Description

Adds Yundera to the One-Click [Cloud Service] provider list.

Yundera provisions a managed server (CasaOS based, EU hosted) with a subdomain and HTTPS already configured. Immich is installed in one click from the built-in App Store, with automatic updates that are tested against the platform before rollout.

Support for the Yundera installation is provided by Yundera, not by the Immich team. Issues: https://github.com/Yundera/AppStore/issues

Landing page linked in the entry: https://yundera.com/install-immich-on-yundera

## How Has This Been Tested?

- [x] Verified the markdown renders correctly in local docs preview
- [x] Confirmed the landing page URL is live and accessible

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] ~~I have written tests for new code (if applicable)~~ (docs-only change)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~ (N/A)
- [ ] ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~ (N/A)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used. This is a three-line documentation addition.
