### PR TITLE
fix(mobile): share RAW/HEIF originals with an image MIME type

### DIFF
--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:immich_mobile/utils/share_mime_type.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 import 'package:path/path.dart' as p;
@@ -401,7 +402,12 @@ class AssetMediaRepository {
       await cleanupTempFiles(tempFiles);
       return 0;
     }
-    final downloadedXFiles = shareFiles.map((shareFile) => XFile(shareFile.file.path)).toList();
+    // Pass the MIME type explicitly for RAW/HEIF originals: share_plus would
+    // otherwise send application/octet-stream and image editors would be
+    // missing from the share sheet (immich-app/immich#31198).
+    final downloadedXFiles = shareFiles
+        .map((shareFile) => XFile(shareFile.file.path, mimeType: shareMimeTypeForPath(shareFile.file.path)))
+        .toList();
 
     // we dont want to await the share result since the
     // "preparing" dialog will not disappear until

--- a/mobile/lib/utils/share_mime_type.dart
+++ b/mobile/lib/utils/share_mime_type.dart
@@ -1,0 +1,45 @@
+import 'package:path/path.dart' as p;
+
+/// MIME types for extensions that `share_plus` (via `package:mime`) does not
+/// know. Without an explicit type, share_plus sends `ACTION_SEND` with
+/// `application/octet-stream`, so apps that register `image/*` share targets
+/// (Lightroom, Snapseed, ...) are not offered for RAW/HEIF originals.
+///
+/// Values mirror the vendor forms in `server/src/utils/mime-types.ts` and
+/// Android's own `MimeTypeMap`, so a shared file is typed the same way the
+/// system gallery would type it.
+const Map<String, String> _shareMimeOverrides = {
+  '.3fr': 'image/x-hasselblad-3fr',
+  '.ari': 'image/x-arriflex-ari',
+  '.arw': 'image/x-sony-arw',
+  '.cap': 'image/x-phaseone-cap',
+  '.cr2': 'image/x-canon-cr2',
+  '.cr3': 'image/x-canon-cr3',
+  '.crw': 'image/x-canon-crw',
+  '.dcr': 'image/x-kodak-dcr',
+  '.dng': 'image/x-adobe-dng',
+  '.erf': 'image/x-epson-erf',
+  '.fff': 'image/x-hasselblad-fff',
+  '.iiq': 'image/x-phaseone-iiq',
+  '.k25': 'image/x-kodak-k25',
+  '.kdc': 'image/x-kodak-kdc',
+  '.mrw': 'image/x-minolta-mrw',
+  '.nef': 'image/x-nikon-nef',
+  '.nrw': 'image/x-nikon-nrw',
+  '.orf': 'image/x-olympus-orf',
+  '.pef': 'image/x-pentax-pef',
+  '.raf': 'image/x-fuji-raf',
+  '.raw': 'image/x-panasonic-raw',
+  '.rw2': 'image/x-panasonic-rw2',
+  '.sr2': 'image/x-sony-sr2',
+  '.srf': 'image/x-sony-srf',
+  '.srw': 'image/x-samsung-srw',
+  '.x3f': 'image/x-sigma-x3f',
+  // Nikon writes HEIF as .HIF; package:mime only knows .heic/.heif.
+  '.hif': 'image/heif',
+};
+
+/// Returns an explicit MIME type for [path] when the default lookup used by
+/// `share_plus` would fall back to `application/octet-stream`, or null to let
+/// share_plus derive it (jpg, png, heic, mp4, ... are all known to it).
+String? shareMimeTypeForPath(String path) => _shareMimeOverrides[p.extension(path).toLowerCase()];


### PR DESCRIPTION
## Description

Sharing an **original** RAW/HEIF asset from the Android app sends `ACTION_SEND` with `type=application/octet-stream`, so apps that register `image/*` share targets (Lightroom's "Add to Lr", Snapseed, ...) are not offered in the share sheet. Sharing the same file from Google Photos sends `image/x-adobe-dng` / `image/x-nikon-nef` and they appear.

Cause: `AssetMediaRepository.shareAssets` builds `XFile(path)` without a `mimeType`, so `share_plus` falls back to `package:mime`'s `lookupMimeType(path) ?? 'application/octet-stream'`, and `package:mime` has no entries for camera RAW extensions or Nikon's `.hif`.

Fix: a small extension → MIME table (`lib/utils/share_mime_type.dart`, values mirror `server/src/utils/mime-types.ts` and Android's own `MimeTypeMap`) and pass it as `XFile(..., mimeType:)`. Only extensions `package:mime` does not know are listed; everything else keeps the existing behaviour.

Scope note: the existing "Share → Preview" path already yields `<name>-preview.jpg` (`image/jpeg`) and works; this only touches the "Share → Original" path, where the vendor MIME type was being dropped.

Fixes #31198

## How Has This Been Tested?

Verified on Linux (Flutter 3.47.2, Android SDK 36, Java 21 — the versions pinned in `mobile/mise.toml`): `mise //mobile:codegen`-equivalent steps, `dart format --line-length 120 --set-exit-if-changed` (clean), `flutter analyze` (no issues), `flutter build apk --debug` (succeeds). **Not yet tested on a device.**

- [ ] On-device: share a `.NEF`/`.DNG` original from the Android app and confirm Lightroom's "Add to Lr" appears (verify the outgoing intent type with Intent Intercept) — **not done by the author yet**
- [ ] Share a `.jpg` original and a preview and confirm behaviour is unchanged

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code (see LLM disclosure below)
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (none added; `path` is already a direct dependency)
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

**Fully LLM-authored.** The code (`share_mime_type.dart`, the `XFile(..., mimeType:)` change), the commit message and this description were all written by an LLM (Claude Code) operated by the PR author; the LLM also did the root-cause tracing through `share_plus` -> `package:mime`.

What has been verified, by the LLM run on Linux with the toolchain versions pinned in `mobile/mise.toml`:
- `dart format --line-length 120 --set-exit-if-changed` clean, `flutter analyze` clean
- `flutter build apk --debug` succeeds
- the MIME values were cross-checked against `server/src/utils/mime-types.ts` and Android's `MimeTypeMap`

What has **not** been verified: the change has never been run on a device. The expected share-sheet behaviour (Lightroom appearing for a `.NEF`/`.DNG` original) is inferred from the code path, not observed. A human line-by-line review of the diff has not been done yet, which is why the self-review box above is unchecked.

The author is aware of the LLM policy in CONTRIBUTING.md and chose to open this anyway because it is a 52-line, mechanically checkable fix to an open issue; closing it on policy grounds is understood and accepted.
