### PR TITLE
fix(web,mobile): preserve stack primary asset selection

### DIFF
--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -58,9 +58,10 @@ class AssetService {
       return const [];
     }
 
-    final stack = await _remoteRepository.getStackChildren(asset);
-    // Include the primary asset in the stack as the first item
-    return [asset, ...stack];
+    // Sort by creation time
+    final stack = [asset, ...await _remoteRepository.getStackChildren(asset)];
+    stack.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return stack;
   }
 
   Future<ExifInfo?> getExif(BaseAsset asset) async {

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -421,8 +421,11 @@ class _AssetPageState extends ConsumerState<AssetPage> {
     final showAssetStack = ref.watch(timelineServiceProvider.select((s) => s.origin != TimelineOrigin.trash));
     final stackChildren = showAssetStack ? ref.watch(stackChildrenNotifier(asset)).valueOrNull : null;
     if (stackChildren != null && stackChildren.isNotEmpty) {
-      final safeStackIndex = stackIndex.clamp(0, stackChildren.length - 1);
-      displayAsset = stackChildren.elementAt(safeStackIndex);
+      final currentAssetIndex = stackChildren.indexWhere(
+        (asset) => currentAsset?.refersToSameAsset(asset) ?? false,
+      );
+      final displayAssetIndex = currentAssetIndex < 0 ? stackIndex : currentAssetIndex;
+      displayAsset = stackChildren.elementAt(displayAssetIndex.clamp(0, stackChildren.length - 1));
     }
 
     final isCurrent = currentAsset != null && currentAsset.refersToSameAsset(displayAsset);

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_stack.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_stack.widget.dart
@@ -98,7 +98,9 @@ class _StackItemState extends ConsumerState<_StackItem> {
       thumbnail = Stack(children: [thumbnail, playIcon]);
     }
     thumbnail = ClipRRect(borderRadius: const BorderRadius.all(Radius.circular(10)), child: thumbnail);
-    final isSelected = ref.watch(assetViewerProvider.select((s) => s.stackIndex == widget.index));
+    final isSelected = ref.watch(
+      assetViewerProvider.select((s) => s.currentAsset?.refersToSameAsset(widget.asset) ?? false),
+    );
     return SizedBox(
       width: 60,
       height: 40,

--- a/mobile/test/unit/services/asset_service_test.dart
+++ b/mobile/test/unit/services/asset_service_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../infrastructure/repository.mock.dart';
 import '../../repository.mocks.dart';
+import '../factories/remote_asset_factory.dart';
 import '../mocks.dart';
 
 void main() {
@@ -53,6 +54,28 @@ void main() {
 
   tearDown(() async {
     await Store.delete(StoreKey.manageLocalMediaAndroid);
+  });
+
+  group('AssetService.getStack', () {
+    test('sorts all stack assets from newest to oldest', () async {
+      final primary = RemoteAssetFactory.create(
+        id: 'primary',
+        stackId: 'stack',
+      ).copyWith(createdAt: DateTime(2026, 1, 2));
+      final beforePrimary = RemoteAssetFactory.create(
+        id: 'before-primary',
+        stackId: 'stack',
+      ).copyWith(createdAt: DateTime(2026, 1, 1));
+      final afterPrimary = RemoteAssetFactory.create(
+        id: 'after-primary',
+        stackId: 'stack',
+      ).copyWith(createdAt: DateTime(2026, 1, 3));
+      when(() => remoteRepository.getStackChildren(primary)).thenAnswer((_) async => [beforePrimary, afterPrimary]);
+
+      final stack = await sut.getStack(primary);
+
+      expect(stack.map((asset) => asset.id), ['after-primary', 'primary', 'before-primary']);
+    });
   });
 
   group('AssetService.updateDateTime', () {

--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -22,7 +22,7 @@
   import { SlideshowNavigation, SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
   import { getSharedLink, handlePromiseError } from '$lib/utils';
   import type { OnUndoDelete } from '$lib/utils/actions';
-  import { navigateToAsset } from '$lib/utils/asset-utils';
+  import { navigateToAsset, orderStackAssets } from '$lib/utils/asset-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { navigate } from '$lib/utils/navigation';
   import { InvocationTracker } from '$lib/utils/invocationTracker';
@@ -106,6 +106,7 @@
 
   let previewStackedAsset: AssetResponseDto | undefined = $state();
   let stack: StackResponseDto | null = $state(null);
+  const stackedAssets = $derived.by(() => (stack ? orderStackAssets(stack.assets) : []));
 
   const asset = $derived(previewStackedAsset ?? cursor.current);
   const nextAsset = $derived(cursor.nextAsset);
@@ -267,7 +268,7 @@
     if (!stack || !withStacked || assetViewerManager.isShowEditor) {
       return;
     }
-    const assets = stack.assets;
+    const assets = stackedAssets;
     const currentIndex = assets.findIndex(({ id }) => id === asset.id);
     if (currentIndex === -1) {
       return;
@@ -641,7 +642,6 @@
   {/if}
 
   {#if stack && withStacked && !assetViewerManager.isShowEditor && $slideshowState === SlideshowState.None}
-    {@const stackedAssets = stack.assets}
     <div id="stack-slideshow" class="absolute bottom-0 col-span-4 col-start-1 w-fit max-w-full">
       <div class="no-wrap horizontal-scrollbar relative flex flex-row overflow-x-auto overflow-y-hidden">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}

--- a/web/src/lib/utils/asset-utils.spec.ts
+++ b/web/src/lib/utils/asset-utils.spec.ts
@@ -1,5 +1,5 @@
 import type { AssetResponseDto } from '@immich/sdk';
-import { canCopyImageToClipboard, getAssetFilename, getFilenameExtension } from './asset-utils';
+import { canCopyImageToClipboard, getAssetFilename, getFilenameExtension, orderStackAssets } from './asset-utils';
 
 describe('get file extension from filename', () => {
   it('returns the extension without including the dot', () => {
@@ -61,5 +61,17 @@ describe('copy image to clipboard', () => {
   // This test is dubious, as it totally on the environment where the test is run which is mocked.
   it('should allow copy image to clipboard', () => {
     expect(canCopyImageToClipboard()).toEqual(true);
+  });
+});
+
+describe('order stack assets', () => {
+  it('orders assets from newest to oldest independently of the primary asset', () => {
+    const assets = [
+      { id: 'primary', fileCreatedAt: '2026-01-02T00:00:00.000Z' },
+      { id: 'before-primary', fileCreatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'after-primary', fileCreatedAt: '2026-01-03T00:00:00.000Z' },
+    ] as AssetResponseDto[];
+
+    expect(orderStackAssets(assets).map(({ id }) => id)).toEqual(['after-primary', 'primary', 'before-primary']);
   });
 });

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -273,6 +273,9 @@ export const getAssetType = (type: AssetTypeEnum) => {
   }
 };
 
+export const orderStackAssets = (assets: AssetResponseDto[]) =>
+  [...assets].sort((a, b) => b.fileCreatedAt.localeCompare(a.fileCreatedAt));
+
 export const getOwnedAssetsWithWarning = (assets: TimelineAsset[], user: UserResponseDto | null): string[] => {
   const ids = [...assets].filter((a) => user && a.ownerId === user.id).map((a) => a.id);
 

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
@@ -94,7 +94,9 @@
   };
 
   const handleStack = () => {
-    onStack(assets);
+    const selectedAssets = assets.filter(({ id }) => selectedAssetIds.has(id));
+    const unselectedAssets = assets.filter(({ id }) => !selectedAssetIds.has(id));
+    onStack([...selectedAssets, ...unselectedAssets]);
   };
 
   const assetCursor = $derived({


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #24033.

The duplicate page asks the user to select a primary asset, but stack creation assets in their existing order. Since the first asset is treated as the stack primary, the user's selection could be ignored.

Change:

- Places the selected asset as primary asset when creating a stack from the duplicate page
- Sorts stack items by capture time

Related to #16250 and #24033.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Pass unit tests for stack ordering
- [x] Pass lint, ts, dart checks

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have carefully read CONTRIBUTING.md
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
