### PR TITLE
fix(mobile): properly handle safeareas in landscape mode

### DIFF
--- a/mobile/lib/presentation/pages/album.page.dart
+++ b/mobile/lib/presentation/pages/album.page.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.d
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/immich_sliver_app_bar.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 @RoutePage()
 class AlbumsPage extends ConsumerStatefulWidget {
@@ -51,10 +52,12 @@ class _AlbumsPageState extends ConsumerState<AlbumsPage> {
           ],
           showUploadButton: false,
         ),
-        AlbumSelector(
-          onAlbumSelected: (album) {
-            unawaited(context.router.push(RemoteAlbumRoute(album: album)));
-          },
+        ImmichSliverHorizontalSafeArea(
+          sliver: AlbumSelector(
+            onAlbumSelected: (album) {
+              unawaited(context.router.push(RemoteAlbumRoute(album: album)));
+            },
+          ),
         ),
       ],
     );

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dar
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/feature_message.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 @RoutePage()
 class MainTimelinePage extends ConsumerStatefulWidget {
@@ -41,7 +42,7 @@ class _MainTimelinePageState extends ConsumerState<MainTimelinePage> {
   Widget build(BuildContext context) {
     final hasMemories = ref.watch(memoryLaneProvider.select((state) => state.value?.isNotEmpty ?? false));
     return Timeline(
-      topSliverWidget: const SliverToBoxAdapter(child: MemoryLane()),
+      topSliverWidget: const SliverToBoxAdapter(child: ImmichHorizontalSafeArea(child: MemoryLane())),
       topSliverWidgetHeight: hasMemories ? 200 : 0,
       showStorageIndicator: true,
     );

--- a/mobile/lib/presentation/pages/library.page.dart
+++ b/mobile/lib/presentation/pages/library.page.dart
@@ -19,6 +19,7 @@ import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:immich_mobile/widgets/common/immich_sliver_app_bar.dart';
 import 'package:immich_mobile/widgets/map/map_thumbnail.dart';
+import 'package:immich_ui/immich_ui.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 @RoutePage()
@@ -31,9 +32,9 @@ class LibraryPage extends StatelessWidget {
       body: CustomScrollView(
         slivers: [
           ImmichSliverAppBar(snap: false, floating: false, pinned: true, showUploadButton: false),
-          _ActionButtonGrid(),
-          _CollectionCards(),
-          _QuickAccessButtonList(),
+          ImmichSliverHorizontalSafeArea(
+            sliver: SliverMainAxisGroup(slivers: [_ActionButtonGrid(), _CollectionCards(), _QuickAccessButtonList()]),
+          ),
         ],
       ),
     );

--- a/mobile/lib/presentation/pages/local_album.page.dart
+++ b/mobile/lib/presentation/pages/local_album.page.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/presentation/widgets/images/local_album_thumbnail.
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/local_album_sliver_app_bar.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 @RoutePage()
 class LocalAlbumsPage extends StatelessWidget {
@@ -16,7 +17,14 @@ class LocalAlbumsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: CustomScrollView(slivers: [LocalAlbumsSliverAppBar(), _AlbumList()]));
+    return const Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          LocalAlbumsSliverAppBar(),
+          ImmichSliverHorizontalSafeArea(sliver: _AlbumList()),
+        ],
+      ),
+    );
   }
 }
 

--- a/mobile/lib/presentation/pages/search/search.page.dart
+++ b/mobile/lib/presentation/pages/search/search.page.dart
@@ -35,6 +35,7 @@ import 'package:immich_mobile/widgets/search/search_filter/people_picker.dart';
 import 'package:immich_mobile/widgets/search/search_filter/search_filter_chip.dart';
 import 'package:immich_mobile/widgets/search/search_filter/search_filter_utils.dart';
 import 'package:immich_mobile/widgets/search/search_filter/star_rating_picker.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 @RoutePage()
 class SearchPage extends HookConsumerWidget {
@@ -655,7 +656,9 @@ class SearchPage extends HookConsumerWidget {
                   key: const Key('search_filter_chip_list'),
                   shrinkWrap: true,
                   scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  // Results take up the full area, so we have to separately pad the search filters
+                  // Since this scrolls horizontally, we cannot use [ImmichSliverHorizontalSafeArea], which clips
+                  padding: const EdgeInsets.symmetric(horizontal: 16) + context.padding.copyWith(top: 0, bottom: 0),
                   children: [
                     SearchFilterChip(
                       icon: Icons.people_alt_outlined,
@@ -713,8 +716,10 @@ class SearchPage extends HookConsumerWidget {
               ),
             ),
           ),
+          // Suggestions are text, so they inset; the result grid is photos and
+          // stays full bleed like the timeline.
           if (filter.value.isEmpty)
-            const _SearchSuggestions()
+            const ImmichSliverHorizontalSafeArea(sliver: _SearchSuggestions())
           else
             _SearchResultGrid(onScrollEnd: () => loadMoreSearchResults()),
         ],

--- a/mobile/lib/presentation/pages/search/search.page.dart
+++ b/mobile/lib/presentation/pages/search/search.page.dart
@@ -716,8 +716,6 @@ class SearchPage extends HookConsumerWidget {
               ),
             ),
           ),
-          // Suggestions are text, so they inset; the result grid is photos and
-          // stays full bleed like the timeline.
           if (filter.value.isEmpty)
             const ImmichSliverHorizontalSafeArea(sliver: _SearchSuggestions())
           else

--- a/mobile/lib/presentation/widgets/timeline/header.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/header.widget.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 class TimelineHeader extends HookWidget {
   final Bucket bucket;
@@ -51,35 +52,38 @@ class TimelineHeader extends HookWidget {
 
     return Padding(
       padding: EdgeInsets.only(top: isMonthHeader ? 8.0 : 0.0, left: 12.0, right: 12.0),
-      child: SizedBox(
-        height: height,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            if (isMonthHeader)
-              Row(
-                children: [
-                  Text(
-                    toBeginningOfSentenceCase(_formatMonth(context, date)),
-                    style: context.textTheme.labelLarge?.copyWith(fontSize: 24),
-                  ),
-                  const Spacer(),
-                  if (header != HeaderType.monthAndDay) _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
-                ],
-              ),
-            if (isDayHeader)
-              Row(
-                children: [
-                  Text(
-                    toBeginningOfSentenceCase(_formatDay(context, date)),
-                    style: context.textTheme.labelLarge?.copyWith(fontSize: 15),
-                  ),
-                  const Spacer(),
-                  _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
-                ],
-              ),
-          ],
+      child: ImmichHorizontalSafeArea(
+        child: SizedBox(
+          height: height,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              if (isMonthHeader)
+                Row(
+                  children: [
+                    Text(
+                      toBeginningOfSentenceCase(_formatMonth(context, date)),
+                      style: context.textTheme.labelLarge?.copyWith(fontSize: 24),
+                    ),
+                    const Spacer(),
+                    if (header != HeaderType.monthAndDay)
+                      _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
+                  ],
+                ),
+              if (isDayHeader)
+                Row(
+                  children: [
+                    Text(
+                      toBeginningOfSentenceCase(_formatDay(context, date)),
+                      style: context.textTheme.labelLarge?.copyWith(fontSize: 15),
+                    ),
+                    const Spacer(),
+                    _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
+                  ],
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
@@ -19,6 +19,7 @@ import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/album/remote_album_shared_user_icons.dart';
+import 'package:immich_ui/immich_ui.dart';
 
 class RemoteAlbumSliverAppBar extends ConsumerStatefulWidget {
   const RemoteAlbumSliverAppBar({
@@ -226,61 +227,63 @@ class _ExpandedBackgroundState extends ConsumerState<_ExpandedBackground> with S
           bottom: 16,
           left: 16,
           right: 16,
-          child: SlideTransition(
-            position: _slideAnimation,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  children: [
-                    if (dateRange.hasValue)
-                      Text(
-                        DateRangeFormatting.formatDateRange(
-                          dateRange.value!.$1.toLocal(),
-                          dateRange.value!.$2.toLocal(),
+          child: ImmichHorizontalSafeArea(
+            child: SlideTransition(
+              position: _slideAnimation,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      if (dateRange.hasValue)
+                        Text(
+                          DateRangeFormatting.formatDateRange(
+                            dateRange.value!.$1.toLocal(),
+                            dateRange.value!.$2.toLocal(),
+                          ),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            shadows: [Shadow(offset: Offset(0, 2), blurRadius: 12, color: Colors.black87)],
+                          ),
                         ),
-                        style: const TextStyle(
+                      const Text(
+                        " • ",
+                        style: TextStyle(
                           color: Colors.white,
                           shadows: [Shadow(offset: Offset(0, 2), blurRadius: 12, color: Colors.black87)],
                         ),
                       ),
-                    const Text(
-                      " • ",
-                      style: TextStyle(
-                        color: Colors.white,
-                        shadows: [Shadow(offset: Offset(0, 2), blurRadius: 12, color: Colors.black87)],
-                      ),
-                    ),
-                    AnimatedContainer(duration: const Duration(milliseconds: 300), child: const _ItemCountText()),
-                  ],
-                ),
-                GestureDetector(
-                  onTap: widget.onEditTitle,
-                  child: LayoutBuilder(
-                    builder: (context, constraints) =>
-                        _DynamicText(text: currentAlbum.name, maxWidth: constraints.maxWidth),
+                      AnimatedContainer(duration: const Duration(milliseconds: 300), child: const _ItemCountText()),
+                    ],
                   ),
-                ),
-                if (currentAlbum.description.isNotEmpty)
                   GestureDetector(
                     onTap: widget.onEditTitle,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 80),
-                      child: SingleChildScrollView(
-                        child: Text(
-                          currentAlbum.description,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 14,
-                            shadows: [Shadow(offset: Offset(0, 2), blurRadius: 8, color: Colors.black54)],
+                    child: LayoutBuilder(
+                      builder: (context, constraints) =>
+                          _DynamicText(text: currentAlbum.name, maxWidth: constraints.maxWidth),
+                    ),
+                  ),
+                  if (currentAlbum.description.isNotEmpty)
+                    GestureDetector(
+                      onTap: widget.onEditTitle,
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxHeight: 80),
+                        child: SingleChildScrollView(
+                          child: Text(
+                            currentAlbum.description,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                              shadows: [Shadow(offset: Offset(0, 2), blurRadius: 8, color: Colors.black54)],
+                            ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                const Padding(padding: EdgeInsets.only(top: 8.0), child: RemoteAlbumSharedUserIcons()),
-              ],
+                  const Padding(padding: EdgeInsets.only(top: 8.0), child: RemoteAlbumSharedUserIcons()),
+                ],
+              ),
             ),
           ),
         ),

--- a/mobile/packages/ui/lib/immich_ui.dart
+++ b/mobile/packages/ui/lib/immich_ui.dart
@@ -7,6 +7,7 @@ export 'src/components/formatted_text.dart';
 export 'src/components/icon_button.dart';
 export 'src/components/menu_item.dart';
 export 'src/components/password_input.dart';
+export 'src/components/safe_area.dart';
 export 'src/components/text_button.dart';
 export 'src/components/text_input.dart';
 export 'src/components/url_input.dart';

--- a/mobile/packages/ui/lib/src/components/safe_area.dart
+++ b/mobile/packages/ui/lib/src/components/safe_area.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// A [SafeArea] that only applies padding to the horizontal sides of the view
+class ImmichHorizontalSafeArea extends StatelessWidget {
+  final Widget child;
+
+  const ImmichHorizontalSafeArea({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) => SafeArea(top: false, bottom: false, child: child);
+}
+
+/// The sliver equivalent of [ImmichHorizontalSafeArea]
+class ImmichSliverHorizontalSafeArea extends StatelessWidget {
+  final Widget sliver;
+
+  const ImmichSliverHorizontalSafeArea({super.key, required this.sliver});
+
+  @override
+  Widget build(BuildContext context) => SliverSafeArea(top: false, bottom: false, sliver: sliver);
+}


### PR DESCRIPTION
Fixed safearea handling in the main pages of the app. Due to how Flutter doesn't consider safeareas as a core concept, pages will have to be incrementally fixed over time.

I walked through the app in portrait and landscape and did not notice any regressions. However, landscape support is generally not in a great condition overall, so lots of things are in various states of disrepair.

<img width="1204" height="623" alt="image" src="https://github.com/user-attachments/assets/352ce4ca-f665-475c-98eb-df5773dee736" />
