### PR TITLE
fix(web): change "View asset owners" to "Hide asset owners" when enabled

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1201,6 +1201,7 @@
   "height": "Height",
   "hi_user": "Hi {name} ({email})",
   "hide_all_people": "Hide all people",
+  "hide_asset_owners": "Hide asset owners",
   "hide_gallery": "Hide gallery",
   "hide_named_person": "Hide person {name}",
   "hide_password": "Hide password",

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -565,7 +565,7 @@
                 {#if containsEditors}
                   <MenuOption
                     icon={showAlbumUsers ? mdiAccountEye : mdiAccountEyeOutline}
-                    text={$t('view_asset_owners')}
+                    text={showAlbumUsers ? $t('hide_asset_owners') : $t('view_asset_owners')}
                     onClick={() => timelineManager.toggleShowAssetOwners()}
                   />
                 {/if}


### PR DESCRIPTION
## Description

In shared albums with editors, enabling the asset owners toggle changed the icon but the menu option text still statically displayed "View asset owners". This change updates the label dynamically so it reflects the current state:

- When asset owners are hidden: "View asset owners"
- When asset owners are visible: "Hide asset owners"

Fixes #31369

## How Has This Been Tested?

- [x] Verified menu toggle behavior and label switching in `+page.svelte`
- [x] Checked localization formatting and alphabetical sorting in `i18n/en.json` via `pnpm run format`
- [x] Ran Svelte component diagnostics with `pnpm run check:svelte` (0 errors, 0 warnings)
- [x] Ran TypeScript type checks via `tsc --noEmit`
- [x] Ran ESLint via `pnpm run lint` (0 errors, 0 warnings)
- [x] Ran unit tests with `npx vitest run src/lib/i18n.spec.ts` (95 passed)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM was only used to help format and draft this pull request description. No code was generated using an LLM.
