### PR TITLE
fix(mobile): resume after the app was launched in the background

### DIFF
--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -228,7 +228,8 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
 
   void handleAppHidden() {
     state = AppLifeCycleEnum.hidden;
-    // do not stop/clean up anything on inactivity: issued on every orientation change
+    // only issued on the way to or from paused, so the app really was in the background
+    _wasPaused = true;
   }
 }
 

--- a/mobile/test/providers/app_life_cycle_provider_test.dart
+++ b/mobile/test/providers/app_life_cycle_provider_test.dart
@@ -229,4 +229,15 @@ void main() {
 
     expect(memoryLaneBuilds, 2);
   });
+
+  test('resume after hidden runs without a pause', () async {
+    lifeCycle.handleAppHidden();
+    unawaited(lifeCycle.handleAppResume());
+    await releaseResume();
+    await websocket.connectCalled.future;
+
+    expect(lifeCycle.state, AppLifeCycleEnum.resumed);
+    expect(serverVersionCount, 1);
+    expect(websocket.connectCount, 1);
+  });
 }


### PR DESCRIPTION
when the system launched the app in the background we never got paused, so the first resume was skipped. now hidden sets the flag too, one test added.
