### PR TITLE
docs(server): document the UTC timestamp format for timeBucket

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -15946,9 +15946,9 @@
             "name": "timeBucket",
             "required": true,
             "in": "query",
-            "description": "Time bucket identifier in YYYY-MM-DD format",
+            "description": "Time bucket identifier in YYYY-MM-DDT00:00:00.000Z format",
             "schema": {
-              "example": "2024-01-01",
+              "example": "2024-01-01T00:00:00.000Z",
               "type": "string"
             }
           },

--- a/server/src/dtos/time-bucket.dto.ts
+++ b/server/src/dtos/time-bucket.dto.ts
@@ -66,7 +66,10 @@ const TimeBucketQueryBaseSchema = z
 
 const TimeBucketSchema = TimeBucketQueryBaseSchema;
 const TimeBucketAssetSchema = TimeBucketQueryBaseSchema.extend({
-  timeBucket: z.string().describe('Time bucket identifier in YYYY-MM-DDT00:00:00.000Z format').meta({ example: '2024-01-01T00:00:00.000Z' }),
+  timeBucket: z
+    .string()
+    .describe('Time bucket identifier in YYYY-MM-DDT00:00:00.000Z format')
+    .meta({ example: '2024-01-01T00:00:00.000Z' }),
 }).meta({ id: 'TimeBucketAssetDto' });
 
 const stackTupleSchema = z.array(z.string()).length(2).nullable();

--- a/server/src/dtos/time-bucket.dto.ts
+++ b/server/src/dtos/time-bucket.dto.ts
@@ -66,7 +66,7 @@ const TimeBucketQueryBaseSchema = z
 
 const TimeBucketSchema = TimeBucketQueryBaseSchema;
 const TimeBucketAssetSchema = TimeBucketQueryBaseSchema.extend({
-  timeBucket: z.string().describe('Time bucket identifier in YYYY-MM-DD format').meta({ example: '2024-01-01' }),
+  timeBucket: z.string().describe('Time bucket identifier in YYYY-MM-DDT00:00:00.000Z format').meta({ example: '2024-01-01T00:00:00.000Z' }),
 }).meta({ id: 'TimeBucketAssetDto' });
 
 const stackTupleSchema = z.array(z.string()).length(2).nullable();


### PR DESCRIPTION
## Description

The format for `timeBucket` on [`GET /timeline/bucket` API docs](https://api.immich.app/endpoints/timeline/getTimeBucket) says `YYYY-MM-DD`, but the official web client sends `YYYY-MM-DDT00:00:00.000Z`

This causes an issue for third-party clients which follow the docs:

`getTimeBucket()` compares the truncated `localDateTime` against the raw string ([asset.repository.ts#L870](https://github.com/immich-app/immich/blob/2a626220415ea4f22da6846e26d37852664254bf/server/src/repositories/asset.repository.ts#L870)). The left side is `date_trunc(...) AT TIME ZONE 'UTC'`, a timestamptz ([database.ts#L356-L358](https://github.com/immich-app/immich/blob/2a626220415ea4f22da6846e26d37852664254bf/server/src/utils/database.ts#L356-L358)), so Postgres casts a bare `YYYY-MM-DD` in the session timezone. On a non-UTC database, that lands in the previous month and every bucket comes back empty (#22672). The `Z` suffix pins the cast to UTC, which is why the web client's form works everywhere. 

This PR updates the description and example to the form the server actually expects, and regenerates the spec.

Fixes #22672

## How Has This Been Tested?

- [x] `mise //:open-api` regenerated `open-api/immich-openapi-specs.json`; no SDK output changed.
- [x] Confirmed against a v3.2.0 instance that the timestamp form returns assets where the bare date returns none on a non-UTC database.

## API Changes

Description and example only. No schema or behaviour change.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude was used to trace the web client and server code paths, and to help me get the commit title + PR description into the expected format.