### PR TITLE
chore(mobile): correctly rename person form state class

### DIFF
--- a/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
@@ -16,10 +16,10 @@ class PersonBirthdayEditForm extends ConsumerStatefulWidget {
   const PersonBirthdayEditForm({super.key, required this.person});
 
   @override
-  ConsumerState<PersonBirthdayEditForm> createState() => _PersonNameEditFormState();
+  ConsumerState<PersonBirthdayEditForm> createState() => _PersonBirthdayEditFormState();
 }
 
-class _PersonNameEditFormState extends ConsumerState<PersonBirthdayEditForm> {
+class _PersonBirthdayEditFormState extends ConsumerState<PersonBirthdayEditForm> {
   late DateTime _selectedDate;
 
   @override


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Micro change with no logic impact. Fixes a wrong class name in the mobile person update forms, where the State class of "PersonBirthdayEditForm" was still called "_Person***Name***EditFormState".

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Mobile PR checklist

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used.