### PR TITLE
fix(server): incorrect scaling of rotated videos when transcoding

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -2201,6 +2201,45 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should scale horizontally when a vertical video is rotated to landscape', async () => {
+      mocks.assetJob.getForVideoConversion.mockResolvedValue({
+        ...asset,
+        ...probeStub.videoStreamRotatedHorizontal2160p,
+      });
+      mocks.systemMetadata.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.Optimal } });
+      await sut.handleVideoConversion({ id: 'video-id' });
+      expect(mocks.media.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        expect.any(String),
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=-2:720/)]),
+          twoPass: false,
+        }),
+      );
+    });
+
+    it.each([
+      { accel: TranscodeHardwareAcceleration.Nvenc, scaling: 'scale_cuda=-2:720' },
+      { accel: TranscodeHardwareAcceleration.Qsv, scaling: 'scale_qsv=-1:720' },
+      { accel: TranscodeHardwareAcceleration.Vaapi, scaling: 'scale_vaapi=-2:720' },
+      { accel: TranscodeHardwareAcceleration.Rkmpp, scaling: 'scale_rkrga=-2:720' },
+    ])('should scale rotated video by its stored dimensions when decoding with $accel', async ({ accel, scaling }) => {
+      mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.videoStreamVertical2160p });
+      mocks.systemMetadata.get.mockResolvedValue({
+        ffmpeg: { accel, accelDecode: true, transcode: TranscodePolicy.Optimal },
+      });
+      await sut.handleVideoConversion({ id: 'video-id' });
+      expect(mocks.media.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        expect.any(String),
+        expect.objectContaining({
+          inputOptions: expect.arrayContaining(['-noautorotate']),
+          outputOptions: expect.arrayContaining([expect.stringContaining(scaling)]),
+        }),
+      );
+    });
+
     it('should always scale video if height is uneven', async () => {
       mocks.assetJob.getForVideoConversion.mockResolvedValue({ ...asset, ...probeStub.videoStreamOddHeight });
       mocks.systemMetadata.get.mockResolvedValue({

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -31,8 +31,9 @@ import type {
 
 export const isVideoRotated = (videoStream: VideoStreamInfo): boolean => Math.abs(videoStream.rotation) === 90;
 
+// whether the video is portrait once its rotation is applied
 export const isVideoVertical = (videoStream: VideoStreamInfo): boolean =>
-  videoStream.height > videoStream.width || isVideoRotated(videoStream);
+  videoStream.height > videoStream.width !== isVideoRotated(videoStream);
 
 export const getOutputSize = (videoStream: VideoStreamInfo, targetRes: number) => {
   const factor = Math.max(videoStream.height, videoStream.width) / Math.min(videoStream.height, videoStream.width);
@@ -364,7 +365,12 @@ export class BaseConfig implements VideoCodecSWConfig {
 
   getScaling(videoStream: VideoStreamInfo, mult = 2) {
     const targetResolution = this.getTargetResolution(videoStream);
-    return isVideoVertical(videoStream) ? `${targetResolution}:-${mult}` : `-${mult}:${targetResolution}`;
+    return this.isFrameVertical(videoStream) ? `${targetResolution}:-${mult}` : `-${mult}:${targetResolution}`;
+  }
+
+  // frames reach the filters already rotated, unless decoding with -noautorotate
+  isFrameVertical(videoStream: VideoStreamInfo) {
+    return isVideoVertical(videoStream);
   }
 
   isBitrateConstrained() {
@@ -741,6 +747,11 @@ export class NvencHwDecodeConfig extends NvencSwDecodeConfig {
     return ['-hwaccel', 'cuda', '-hwaccel_output_format', 'cuda', '-noautorotate', ...this.getInputThreadOptions()];
   }
 
+  // -noautorotate keeps frames in their stored orientation
+  isFrameVertical(videoStream: VideoStreamInfo) {
+    return videoStream.height > videoStream.width;
+  }
+
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     const tonemapOptions = this.getToneMapping(videoStream);
@@ -878,6 +889,11 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
     ];
   }
 
+  // -noautorotate keeps frames in their stored orientation
+  isFrameVertical(videoStream: VideoStreamInfo) {
+    return videoStream.height > videoStream.width;
+  }
+
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     const tonemapOptions = this.getToneMapping(videoStream);
@@ -1000,6 +1016,11 @@ export class VaapiHwDecodeConfig extends VaapiSwDecodeConfig {
     ];
   }
 
+  // -noautorotate keeps frames in their stored orientation
+  isFrameVertical(videoStream: VideoStreamInfo) {
+    return videoStream.height > videoStream.width;
+  }
+
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     const tonemapOptions = this.getToneMapping(videoStream);
@@ -1085,6 +1106,11 @@ export class RkmppSwDecodeConfig extends BaseHWConfig {
 export class RkmppHwDecodeConfig extends RkmppSwDecodeConfig {
   getBaseInputOptions() {
     return ['-hwaccel', 'rkmpp', '-hwaccel_output_format', 'drm_prime', '-afbc', 'rga', '-noautorotate'];
+  }
+
+  // -noautorotate keeps frames in their stored orientation
+  isFrameVertical(videoStream: VideoStreamInfo) {
+    return videoStream.height > videoStream.width;
   }
 
   getFilterOptions(videoStream: VideoStreamInfo) {

--- a/server/test/fixtures/media.stub.ts
+++ b/server/test/fixtures/media.stub.ts
@@ -288,6 +288,31 @@ export const videoInfoStub = {
       },
     ],
   }),
+  videoStreamRotatedHorizontal2160p: Object.freeze<VideoInfo>({
+    ...probeStubDefault,
+    videoStreams: [
+      {
+        index: 0,
+        height: 3840,
+        width: 2160,
+        codecName: 'h264',
+        frameCount: 100,
+        rotation: 90,
+        bitrate: 0,
+        colorPrimaries: ColorPrimaries.Bt709,
+        colorTransfer: ColorTransfer.Bt709,
+        colorMatrix: ColorMatrix.Bt709,
+        pixelFormat: 'yuv420p',
+        frameRate: 60,
+        timeBase: 600,
+        profile: H264Profile.High,
+        level: null,
+        dvBlSignalCompatibilityId: null,
+        dvLevel: null,
+        dvProfile: null,
+      },
+    ],
+  }),
   videoStreamOddHeight: Object.freeze<VideoInfo>({
     ...probeStubDefault,
     videoStreams: [


### PR DESCRIPTION
## Description

Rotated videos transcode to the wrong size. Two separate causes in `server/src/utils/media.ts`:

1. **The hardware-decode configs scale the frame as if it had been rotated.** `NvencHwDecodeConfig`, `QsvHwDecodeConfig`, `VaapiHwDecodeConfig` and `RkmppHwDecodeConfig` pass `-noautorotate` (added in #10905), so the frame reaches the scaler in its stored orientation and the display matrix is copied to the output — but `getScaling()` decided orientation from the rotation flag. A video from a phone held upright — the sensor writes a landscape 3840x2160 frame and tags it "rotate 90° on playback", so it plays portrait — got `scale_*=720:-1` at a 720p target, came out 720x404 and plays as 404x720, where 720x1280 was due. `getScaling()` now asks `isFrameVertical()`, which those four configs answer from the stored dimensions. **Hardware decoding only.**

2. **`isVideoVertical()` was wrong for the opposite case: a portrait frame carrying a ±90° flag, which therefore plays landscape.** `height > width || rotated` called it vertical, so it was scaled as portrait — 1080x608 instead of 1920x1080 at a 1080p target. It is now an exclusive or. **This one affects every path, including software decoding and no acceleration at all**, because there the frame is auto-rotated to landscape and then scaled by the wrong axis.

The same scaling runs in the real-time HLS path (`transcoding.service.ts` → `BaseConfig.create`), and `getOutputSize()`, which writes each variant's `RESOLUTION`, goes through the same helper. #30010 shows the effect there: a 480p variant whose init segment is 480x270 and plays 270x480.

Fixes #22294

## How Has This Been Tested?

- [x] **I set up the full Immich stack on three machines, to cover three hardware accelerators:** an Intel i9-12900H (QSV and VAAPI), a Rockchip RK3588 (RKMPP) and an NVIDIA RTX 3060 Ti (NVENC) — plus software-only transcoding on each. **Not tested: VAAPI on an AMD GPU**, since I have no AMD hardware. That is the one open point; it runs the same code as the three accelerators I measured, and the unit tests cover it.
- [x] **End to end, through Immich's own job pipeline.** Every run is **Immich Server v3.2.0 as released, versus the same image with one file replaced**: `dist/utils/media.js` — the compiled form of `server/src/utils/media.ts`, the only file this PR touches outside tests — built from the v3.2.0 source with this change applied. Nothing else differs between the two, so any difference in output can only come from the change — and a diff of that file against the official one shows only these hunks. Both images ran the same seven videos through Transcode Videos → All, policy `all`, target 720p: five synthetic 3 s HEVC clips (`testsrc2`, rotation set with `-display_rotation`) and two phone videos.

A rotated video stores one geometry and plays another, so both are given below: **stored** is the frame as written in the file, **plays as** is what the viewer sees once the rotation flag is applied.

| the video | stored in the file | plays as | v3.2.0, software decode | v3.2.0, hardware decode | this change, every path |
|---|---|---|---|---|---|
| **A phone held upright.** The sensor writes a landscape frame and tags it "rotate 90° on playback" | 3840x2160, rotation −90 | portrait 2160x3840 | 720x1280 ✓ | **404x720** QSV, **406x720** VAAPI, RKMPP and NVENC | 720x1280 ✓ |
| **The opposite case.** A portrait frame tagged "rotate 90°", so it plays landscape — a phone rotating mid-clip, or anything remuxed with a rotation flag | 2160x3840, rotation +90 | landscape 3840x2160 | **720x406** VAAPI, RKMPP, NVENC and no acceleration, **720x404** QSV | 1280x720 ✓ | 1280x720 ✓ |
| **Controls**, with no rotation flag or a 180° one, played exactly as stored | 1920x1080 · 1080x1920 · 3840x2160 @180° | as stored | ✓ | ✓ | ✓ |

  Eleven configurations over the three machines — no acceleration on each, plus each accelerator with software and hardware decode. **Cause 1 appears only in the hardware-decode column**, which is why the first row is fine under software decode. **Cause 2 appears everywhere else**, including with no acceleration at all, which is why the software column is not clean on the second row: there the frame is auto-rotated to landscape, and then the wrong axis is scaled to the target. **v3.2.0 got 22 of 77 cases wrong, this change 0 of 77.** No transcode fell back to another path. Cause 2 is not an acceleration problem, so it shows up with acceleration switched off entirely as well: software-only transcoding was wrong in 6 of 21 cases on v3.2.0 and right in all 21 with this change.

- [x] **Nothing outside rotated videos changes.** Only a video with a ±90° flag can reach either branch. The other 55 transcode cases produce an identical filter string and identical output geometry. Video thumbnails (the other caller of `getScaling()`) and the HLS main playlist are identical on 5 of the 7 videos; for the stored-portrait-plus-90° shape both improve — the 1440px preview goes from 1440x810 to 2560x1440, the size the equivalent landscape video already got, and `main.m3u8` from `480x852 / 720x1280 / 1080x1920` to `852x480 / 1280x720 / 1920x1080`, which is what it actually plays.

- [x] **Unit tests.** The `server` suite passes (105 files, 2276 tests). Five tests are added — one per hardware-decode backend, plus the stored-portrait case — and all five fail against the unmodified `media.ts` while the other 194 media tests pass.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude Code) wrote the patch, the tests and this description. I reviewed the change: one operator, one method, four three-line overrides.

CONTRIBUTING.md says you cannot have confidence in LLM output and that verifying it is not worth your time. So rather than ask you to take it on trust, I set up the full Immich stack on three machines and ran the fix against three hardware accelerators:

- **Intel i9-12900H** — QSV and VAAPI
- **Rockchip RK3588** — RKMPP
- **NVIDIA RTX 3060 Ti** — NVENC

plus software-only transcoding on each, and a run with the unmodified v3.2.0 image on every one of them for comparison. The numbers, the controls that must not change, and the effect on thumbnails and HLS playlists are in the section above.

#22294 has been open since September 2025 with no PR. It silently halves the resolution of portrait phone videos for everyone transcoding with hardware decoding.

I kept the per-case record of every run — the ffmpeg filter Immich built, the output geometry, and whether it fell back to another path — and can attach it, or the harness that produced it, if that is useful. Ask for any configuration and I will re-run it on any of the three machines.

If you would rather write this yourselves, close it — the measurements are yours to use.
