### PR TITLE
fix(server): fall back to EXIF Orientation for HEIF without irot

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1874,6 +1874,110 @@ describe(MetadataService.name, () => {
         }),
       );
     });
+
+    // Fixes https://github.com/immich-app/immich/issues/30509
+    //
+    // The `.heic` tag values below (Orientation/dimension/MIME/FileType fields only, no
+    // GPS/date/serial/etc.) come from running Immich's own bundled exiftool-vendored binary
+    // against Tanner's real repro asset (asset id 7b8c0746-955a-4942-a1b3-6543b567f4b3,
+    // IMG_3863.heic). That run revealed the file is actually JPEG-encoded content
+    // (FileType: 'JPEG', FileTypeExtension: 'jpg', MIMEType: 'image/jpeg') saved with a
+    // `.heic` extension - the same "extension lies about content" scenario open PR #30393
+    // targets - not a genuine HEIF/HEIC container. `mimeTypes.isHeifImage()` is
+    // extension-only, so it still routes this file through the HEIF orientation branch; no
+    // Rotation/irot atom exists (it isn't a real HEIF box), so `getHeifOrientation()` returns
+    // null and, before this fix, its valid classic EXIF Orientation tag was deleted.
+    describe('HEIF orientation fallback (issue #30509)', () => {
+      it('does not touch Orientation when a HEIF Rotation/irot atom is present', async () => {
+        const asset = AssetFactory.create({ originalFileName: 'IMG_1234.heic' });
+        mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+        // Rotation: 1 -> ExifOrientation.Rotate270CW (8); a conflicting classic Orientation
+        // tag must be overwritten, never merged, to avoid double-rotating the image.
+        mockReadTags({ ImageWidth: 4032, ImageHeight: 3024, Rotation: 1, Orientation: 6 });
+
+        await sut.handleMetadataExtraction({ id: asset.id });
+
+        expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exif: expect.objectContaining({ orientation: ExifOrientation.Rotate270CW.toString() }),
+          }),
+        );
+        expect(mocks.asset.update).toHaveBeenCalledWith(expect.objectContaining({ width: 3024, height: 4032 }));
+      });
+
+      it('falls back to classic EXIF Orientation 6 when no irot atom is present', async () => {
+        const asset = AssetFactory.create({ originalFileName: 'IMG_1234.heic' });
+        mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+        mockReadTags({ ImageWidth: 4032, ImageHeight: 3024, Orientation: 6 });
+
+        await sut.handleMetadataExtraction({ id: asset.id });
+
+        expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exif: expect.objectContaining({ orientation: ExifOrientation.Rotate90CW.toString() }),
+          }),
+        );
+        expect(mocks.asset.update).toHaveBeenCalledWith(expect.objectContaining({ width: 3024, height: 4032 }));
+      });
+
+      it('falls back to classic EXIF Orientation 8 when no irot atom is present', async () => {
+        const asset = AssetFactory.create({ originalFileName: 'IMG_1234.heic' });
+        mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+        mockReadTags({ ImageWidth: 4032, ImageHeight: 3024, Orientation: 8 });
+
+        await sut.handleMetadataExtraction({ id: asset.id });
+
+        expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exif: expect.objectContaining({ orientation: ExifOrientation.Rotate270CW.toString() }),
+          }),
+        );
+        expect(mocks.asset.update).toHaveBeenCalledWith(expect.objectContaining({ width: 3024, height: 4032 }));
+      });
+
+      it('leaves orientation null and dimensions unswapped when neither irot nor a classic tag exists', async () => {
+        const asset = AssetFactory.create({ originalFileName: 'IMG_1234.heic' });
+        mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+        mockReadTags({ ImageWidth: 4032, ImageHeight: 3024 });
+
+        await sut.handleMetadataExtraction({ id: asset.id });
+
+        expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exif: expect.objectContaining({ orientation: null }),
+          }),
+        );
+        expect(mocks.asset.update).toHaveBeenCalledWith(expect.objectContaining({ width: 4032, height: 3024 }));
+      });
+
+      it('preserves classic Orientation for a real-world JPEG misnamed with a .heic extension (issue #30509 repro asset)', async () => {
+        const asset = AssetFactory.create({ originalFileName: 'IMG_3863.heic' });
+        mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+        // Real tag values (orientation/dimension/mime/format fields only) from exiftool-vendored
+        // against the actual repro file. FileType/FileTypeExtension/MIMEType show it is really
+        // JPEG-encoded content, not a genuine HEIF container - the scenario open PR #30393
+        // addresses by content-sniffing the extension. This test only proves this fix's
+        // narrower guarantee: it stops discarding the classic Orientation tag; it does not
+        // implement #30393's content-type detection.
+        mockReadTags({
+          ImageWidth: 4032,
+          ImageHeight: 3024,
+          Orientation: 6,
+          MIMEType: 'image/jpeg',
+          FileType: 'JPEG',
+          FileTypeExtension: 'jpg',
+        });
+
+        await sut.handleMetadataExtraction({ id: asset.id });
+
+        expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+          expect.objectContaining({
+            exif: expect.objectContaining({ orientation: ExifOrientation.Rotate90CW.toString() }),
+          }),
+        );
+        expect(mocks.asset.update).toHaveBeenCalledWith(expect.objectContaining({ width: 3024, height: 4032 }));
+      });
+    });
   });
 
   describe('handleQueueSidecar', () => {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -605,7 +605,12 @@ export class MetadataService extends BaseService {
     if (mimeTypes.isHeifImage(asset.originalPath)) {
       const orientation = this.getHeifOrientation(mediaTags);
       if (orientation === null) {
-        delete mediaTags.Orientation;
+        // No irot/Rotation atom was found, so there's nothing it could disagree with - keep any
+        // classic EXIF Orientation tag instead of discarding it, since the thumbnail/preview
+        // pipeline already honors that tag here and dropping it just desyncs stored width/height
+        // from what's actually rendered. When irot IS present (the `else` branch) we must keep
+        // overwriting rather than merging, or a classic Orientation tag on the same file would
+        // get applied on top of it and double-rotate the image.
       } else {
         mediaTags.Orientation = orientation;
       }


### PR DESCRIPTION
## Description

Fixes the case in #30509 where the stored `asset.width`/`asset.height` end up unrotated for an image routed through the HEIF-specific orientation branch of `getExifTags()` in `server/src/services/metadata.service.ts`.

That branch (`mimeTypes.isHeifImage(asset.originalPath)`, gated purely on filename extension) derives orientation only from `getHeifOrientation()`, which looks for a QuickTime `Rotation`/`irot` atom. When that atom is absent, the code unconditionally deleted any classic EXIF `Orientation` tag instead of falling back to it - even on files where that tag is present and valid. Because `asset.width`/`asset.height` are swapped for "sidewards" orientations at extraction time (see `isOrientationSidewards`/`isSidewards` a few lines below), losing the tag means the raw, unrotated dimensions get stored. The pixel pipeline (sharp/libvips) generating thumbnails and previews already honors that same classic tag when there's no `irot`, which is why the thumbnail/preview endpoints render correctly while only the viewer - which trusts `asset.width`/`asset.height` for its box - ends up stretched.

This change makes metadata extraction agree with what the pixel pipeline already renders: when no `Rotation`/`irot` atom is found, keep the classic `Orientation` tag instead of discarding it. When `Rotation`/`irot` **is** present, behavior is byte-for-byte unchanged - it still unconditionally overwrites `Orientation` (never merges), since combining the two would double-rotate the image.

Confirmed against a real repro asset (portrait iPhone photo, orientation 6, DB showed `orientation: null` and unrotated `width`/`height` before this fix). Note: that specific file's own tag set (used in one of the added tests) turned out to be JPEG-encoded content saved with a `.heic` extension - the "extension lies about content" scenario open PR #30393 targets by content-sniffing `FileTypeExtension`. This fix is narrower and independent of #30393: it does not change the `isHeifImage()` gate at all, only what happens once inside it when no rotation atom is found, so it does not duplicate or conflict with that PR.

**Possible follow-up (not included in this PR):** `web/src/lib/components/AdaptiveImage.svelte` sizes the viewer's box from raw `asset.width`/`asset.height` only (`imageDimensions`, derived a few lines below the props), rather than the orientation-aware `getDimensions()`/`isFlipped()` helpers in `web/src/lib/utils/asset-utils.ts` that `DetailPanel.svelte` already uses. That's a separate, web-only defense against a server ever storing unswapped dimensions with a valid orientation still attached, and is out of scope here.

Fixes #30509

## How Has This Been Tested?

- [x] Added unit tests to `server/src/services/metadata.service.spec.ts` covering: HEIF with `Rotation`/`irot` present (unchanged), HEIF with no `irot` and classic `Orientation` 6, same with `Orientation` 8, HEIF with neither present (still null/unswapped, unchanged), and a real-world JPEG-misnamed-as-`.heic` case built from actual `exiftool-vendored` output (orientation/dimension/mime/format tags only) against the reporter's repro file.
- [x] `pnpm lint` (eslint on the changed files, `--max-warnings 0`) - clean.
- [x] `pnpm check` (`tsc --noEmit` for `server`) - clean.
- [x] Full `server/src/services/metadata.service.spec.ts` suite - 121/121 passed, both on the v3.2.0 base this was diagnosed against and after cherry-picking onto current `main`.
- [ ] Live end-to-end re-extraction against a running server was not performed - the host this was developed on was at 0 free RAM / fully-committed swap at the time, so a server image build was skipped rather than risking an OOM on a shared box. Verified by unit tests against the real file's tag set instead.

## Compatibility

- No API or DB schema change - this only affects what `asset_exif.orientation` and `asset.width`/`height` get set to during metadata extraction.
- Assets already affected by this bug need **Administration → Jobs → Metadata Extraction → run All** (not just "Missing") to pick up the corrected orientation/dimensions. Thumbnail/preview regeneration is **not** needed - those were already rendering correctly, since the pixel pipeline already honored the classic tag.
- Files that do have a `Rotation`/`irot` atom are completely unaffected - that code path is unchanged.
- Older server versions and non-web clients (mobile, CLI) are unaffected: mobile and other clients already read `asset.width`/`asset.height` directly and this only changes what value gets computed and stored server-side going forward.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This PR was prepared by an LLM (Claude) working from Tanner's local Immich instance and DB, under his direction, after he reviewed the root-cause analysis and explicitly chose this fix location over the alternative (a web-only viewer fix). He reviewed the diff and this description before it was opened. Trailers below are automatic session attribution from that tooling.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfMGTgUdBrZigPca7GNtiC
